### PR TITLE
Fix STATICFILES_DIRS path

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -104,7 +104,7 @@ STATIC_URL = '/static/'
 
 # See: https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#std:setting-STATICFILES_DIRS
 STATICFILES_DIRS = (
-    normpath(join(SITE_ROOT, 'static')),
+    normpath(join(DJANGO_ROOT, 'static')),
 )
 
 # See: https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#staticfiles-finders

--- a/ecommerce/settings/production.py
+++ b/ecommerce/settings/production.py
@@ -1,5 +1,4 @@
 """Production settings and globals."""
-
 from os import environ
 
 # Normally you should not import ANYTHING from Django directly
@@ -10,6 +9,7 @@ import yaml
 
 from ecommerce.settings.base import *
 from ecommerce.settings.logger import get_logger_config
+
 
 # Enable offline compression of CSS/JS
 COMPRESS_ENABLED = True
@@ -30,6 +30,7 @@ def get_env_setting(setting):
     except KeyError:
         error_msg = "Set the %s env variable" % setting
         raise ImproperlyConfigured(error_msg)
+
 
 # ######### HOST CONFIGURATION
 # See: https://docs.djangoproject.com/en/1.5/releases/1.5/#allowed-hosts-required-in-production


### PR DESCRIPTION
@feanil, this fixes `STATICFILES_DIRS` in our base settings. I've also added a README to `ecommerce/static` so that git will track the otherwise-empty directory.

Do you think it would be okay to remove the `STATICFILES_DIRS` override from the production settings? There shouldn't be a need to override with an empty list anymore.
