### PR TITLE
Redirect unauthorized users to the LMS dashboard

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -201,6 +201,12 @@ MIDDLEWARE_CLASSES = (
 ########## URL CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#root-urlconf
 ROOT_URLCONF = '%s.urls' % SITE_NAME
+
+# Used to construct LMS URLs; must include a trailing slash
+LMS_URL_ROOT = None
+
+# The location of the LMS student dashboard
+LMS_DASHBOARD_URL = None
 ########## END URL CONFIGURATION
 
 
@@ -339,7 +345,8 @@ SOCIAL_AUTH_EDX_OIDC_URL_ROOT = None
 # This value should be the same as SOCIAL_AUTH_EDX_OIDC_SECRET
 SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY = SOCIAL_AUTH_EDX_OIDC_SECRET
 
-LOGIN_REDIRECT_URL = '/dashboard/'
+# Redirect successfully authenticated users to the Oscar dashboard, located at the root
+LOGIN_REDIRECT_URL = ''
 
 EXTRA_SCOPE = ['permissions']
 ########## END AUTHENTICATION

--- a/ecommerce/settings/local.py
+++ b/ecommerce/settings/local.py
@@ -67,11 +67,20 @@ INTERNAL_IPS = ('127.0.0.1',)
 ########## END TOOLBAR CONFIGURATION
 
 
+########## URL CONFIGURATION
+# Used to construct LMS URLs; must include a trailing slash
+LMS_URL_ROOT = 'http://127.0.0.1:8000/'
+
+# The location of the LMS student dashboard
+LMS_DASHBOARD_URL = LMS_URL_ROOT + 'dashboard'
+########## END URL CONFIGURATION
+
+
 ########## AUTHENTICATION
 # Set these to the correct values for your OAuth2/OpenID Connect provider (e.g., devstack)
 SOCIAL_AUTH_EDX_OIDC_KEY = 'replace-me'
 SOCIAL_AUTH_EDX_OIDC_SECRET = 'replace-me'
-SOCIAL_AUTH_EDX_OIDC_URL_ROOT = 'http://127.0.0.1:8000/oauth2'
+SOCIAL_AUTH_EDX_OIDC_URL_ROOT = LMS_URL_ROOT + 'oauth2'
 SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY = SOCIAL_AUTH_EDX_OIDC_SECRET
 ########## END AUTHENTICATION
 

--- a/ecommerce/settings/test.py
+++ b/ecommerce/settings/test.py
@@ -5,6 +5,15 @@ import os
 from ecommerce.settings.base import *
 
 
+########## URL CONFIGURATION
+# Used to construct LMS URLs; must include a trailing slash
+LMS_URL_ROOT = 'http://127.0.0.1:8000/'
+
+# The location of the LMS student dashboard
+LMS_DASHBOARD_URL = LMS_URL_ROOT + 'dashboard'
+########## END URL CONFIGURATION
+
+
 ########## TEST SETTINGS
 INSTALLED_APPS += (
     'django_nose',

--- a/ecommerce/tests/test_urls.py
+++ b/ecommerce/tests/test_urls.py
@@ -1,0 +1,27 @@
+from django.test import TestCase
+from django.conf import settings
+from django.core.urlresolvers import reverse
+from django.contrib.auth import get_user_model
+from rest_framework import status
+
+
+User = get_user_model()
+
+
+class TestUrls(TestCase):
+    USERNAME = 'jmcgill'
+    PASSWORD = 'slippin_jimmy'
+    PROTECTED_URL_NAME = 'dashboard:index'
+
+    def test_unauthorized_redirection(self):
+        """Test that users not authorized to access the Oscar front-end are redirected to the LMS dashboard."""
+        User.objects.create_user(self.USERNAME, password=self.PASSWORD)
+        success = self.client.login(username=self.USERNAME, password=self.PASSWORD)
+        # Verify that login was successful
+        self.assertTrue(success)
+        
+        # Verify that `handler403` returns an `HttpResponseRedirect` with status code 302
+        response = self.client.get(reverse(self.PROTECTED_URL_NAME))
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        # See: https://docs.djangoproject.com/en/1.7/ref/request-response/#django.http.HttpResponseRedirect.url
+        self.assertEqual(response.url, settings.LMS_DASHBOARD_URL)

--- a/ecommerce/urls.py
+++ b/ecommerce/urls.py
@@ -4,15 +4,35 @@ from django.conf import settings
 from django.conf.urls import patterns, url, include
 from django.conf.urls.static import static
 from django.core.urlresolvers import reverse_lazy
+from django.shortcuts import redirect
 from django.views.generic import RedirectView
 from extensions.urls import urlpatterns as extensions_patterns
+
+
+def handler403(request):
+    """Redirect unauthorized users to the LMS student dashboard.
+
+    Removing URLs isn't the most elegant way to hide Oscar's front-end from
+    public view. It would require revising templates and parts of the Oscar core
+    which assume that these URLs exist. However, a clean way to, in effect,
+    disable these URLs is to only make them available to users with staff
+    permissions, the same protection used to guard the management dashboard from
+    public access.
+
+    This minimally invasive approach allows us to protect Oscar's front-end
+    without sacrificing any internal functionality. Users not authorized to view
+    Oscar's front-end are redirected to the LMS student dashboard, as one would
+    usually be after signing into the LMS.
+    """
+    return redirect(settings.LMS_DASHBOARD_URL)
 
 
 # Uncomment the next two lines to enable the admin
 # from django.contrib import admin
 # admin.autodiscover()
 
-urlpatterns = patterns('',
+urlpatterns = patterns(
+    '',
     # Uncomment the next line to enable the admin
     # url(r'^admin/', include(admin.site.urls)),
 
@@ -40,11 +60,12 @@ if settings.DEBUG and settings.MEDIA_ROOT:  # pragma: no cover
         document_root=settings.MEDIA_ROOT)
 
 if settings.DEBUG:  # pragma: no cover
+    # Allow error pages to be tested
     urlpatterns += patterns(
         '',
-        url(r'^403/$', 'django.views.defaults.permission_denied'),
-        url(r'^404/$', 'django.views.defaults.page_not_found'),
-        url(r'^500/$', 'django.views.defaults.server_error'),
+        url(r'^403$', handler403, name='403'),
+        url(r'^404$', 'django.views.defaults.page_not_found', name='404'),
+        url(r'^500$', 'django.views.defaults.server_error', name='500'),
     )
 
     if os.environ.get('ENABLE_DJANGO_TOOLBAR', False):

--- a/requirements/not_editable.txt
+++ b/requirements/not_editable.txt
@@ -1,3 +1,3 @@
 # Oscar requirements
 git+https://github.com/edx/django-oscar.git@1ce871a29b97789354b422ca559de956c6762aee#egg=django-oscar
-git+https://github.com/edx/django-oscar-extensions.git@1bd87db2b0703f55c56d1266b09da59aa9d8439e#egg=django-oscar-extensions
+git+https://github.com/edx/django-oscar-extensions.git@6127bfd7a5cf5d454de7a31ea4c463f907c6fc59#egg=django-oscar-extensions


### PR DESCRIPTION
Accompanied by [#26](https://github.com/edx/django-oscar-extensions/pull/26) in the edx/django-oscar-extensions repo.

The changes in this PR redirect users not authorized to view Oscar's front-end to the LMS student dashboard. All users must authenticate via the LMS before attempting to view Oscar; those with staff access see the Oscar management dashboard, while those without see the LMS student dashboard, as one usually would after logging into the LMS.

@clintonb and/or @dianakhuang, could you please review this when you're able?
