### PR TITLE
XCOM-138:  Updating logging settings.

### DIFF
--- a/ecommerce/settings/logger.py
+++ b/ecommerce/settings/logger.py
@@ -68,6 +68,16 @@ def get_logger_config(log_dir='/var/tmp',
                 'propagate': True,
                 'level': 'INFO'
             },
+            'requests': {
+                'handlers': handlers,
+                'propagate': True,
+                'level': 'WARNING'
+            },
+            'django.request': {
+                'handlers': handlers,
+                'propagate': True,
+                'level': 'WARNING'
+            },
             '': {
                 'handlers': handlers,
                 'level': 'DEBUG',


### PR DESCRIPTION
This is for the following JIRA Ticket:
https://openedx.atlassian.net/browse/XCOM-138

We want to avoid logging every single connection made through the requests library. In addition, I added warn-level logging for the standard django.request package. 

Let me know if this looks right to you guys. If you want to test it locally, just update your local.py settings and change the logger to something like this:
`LOGGING = get_logger_config(log_dir="/Users/stephensanchez/Environments/ecommerce/src/django-oscar-extensions",
                            debug=False, dev_env=True, local_loglevel='DEBUG')`

@clintonb @rlucioni @dianakhuang @feanil 
