### PR TITLE
Updated django-oscar-extensions to 0.0.6

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -1,11 +1,11 @@
 """Common settings and globals."""
-import ConfigParser
 
 import os
-from os.path import abspath, basename, dirname, join, normpath
+from os.path import basename, normpath
 from sys import path
 
 from extensions.settings._oscar import *
+from oscar import OSCAR_MAIN_TEMPLATE_DIR
 
 
 # PATH CONFIGURATION
@@ -99,6 +99,7 @@ STATIC_URL = '/static/'
 # See: https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#std:setting-STATICFILES_DIRS
 STATICFILES_DIRS = (
     normpath(join(DJANGO_ROOT, 'static')),
+    OSCAR_EXTENSIONS_STATIC_DIR,
 )
 
 # See: https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#staticfiles-finders
@@ -165,6 +166,7 @@ TEMPLATE_LOADERS = (
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#template-dirs
 TEMPLATE_DIRS = (
     normpath(join(SITE_ROOT, 'templates')),
+    OSCAR_EXTENSIONS_TEMPLATE_DIR,
     OSCAR_MAIN_TEMPLATE_DIR,
 )
 

--- a/requirements/editable.txt
+++ b/requirements/editable.txt
@@ -1,3 +1,3 @@
 # Local editable sources of django-oscar and django-oscar-extensions
--e ../../depends/django-oscar
--e ../../depends/django-oscar-extensions
+-e ../depends/django-oscar
+-e ../depends/django-oscar-extensions

--- a/requirements/not_editable.txt
+++ b/requirements/not_editable.txt
@@ -1,3 +1,3 @@
 # Oscar requirements
 git+https://github.com/edx/django-oscar.git@1ce871a29b97789354b422ca559de956c6762aee#egg=django-oscar
-git+https://github.com/edx/django-oscar-extensions.git@v0.0.5#egg=django-oscar-extensions==0.0.5
+git+https://github.com/edx/django-oscar-extensions.git@v0.0.6#egg=django-oscar-extensions==0.0.6


### PR DESCRIPTION
@rlucioni @dianakhuang @stephensanchez 

The primary changes here are updating the dependency and adding settings so that we retrieve static files and templates from the extensions project. In addition, I removed a few unused imports and updated the editable requirements location.

@feanil let me know if the requirements change breaks anything on your end with sandboxes or devstack.
