### PR TITLE
Enable ATOMIC_REQUESTS for local development

### DIFF
--- a/ecommerce/health/views.py
+++ b/ecommerce/health/views.py
@@ -5,7 +5,7 @@ import requests
 from requests.exceptions import RequestException
 from rest_framework import status
 from django.conf import settings
-from django.db import connection, DatabaseError
+from django.db import transaction, connection, DatabaseError
 from django.http import JsonResponse
 
 from ecommerce.health.constants import Status, UnavailabilityMessage
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 LMS_HEALTH_PAGE = getattr(settings, 'LMS_HEARTBEAT_URL')
 
 
+@transaction.non_atomic_requests
 def health(_):
     """Allows a load balancer to verify that the ecommerce front-end service is up.
 
@@ -44,7 +45,6 @@ def health(_):
         cursor.close()
         database_status = Status.OK
     except DatabaseError:
-
         database_status = Status.UNAVAILABLE
 
     try:

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -46,6 +46,8 @@ MANAGERS = ADMINS
 
 # DATABASE CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#databases
+# Note that we use connection pooling/persistent connections (CONN_MAX_AGE)
+# in production, but the Django docs discourage its use in development.
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.',
@@ -54,6 +56,7 @@ DATABASES = {
         'PASSWORD': '',
         'HOST': '',
         'PORT': '',
+        'ATOMIC_REQUESTS': True,
     }
 }
 # END DATABASE CONFIGURATION

--- a/ecommerce/settings/local.py
+++ b/ecommerce/settings/local.py
@@ -33,6 +33,7 @@ DATABASES = {
         'PASSWORD': '',
         'HOST': '',
         'PORT': '',
+        'ATOMIC_REQUESTS': True,
     }
 }
 # END DATABASE CONFIGURATION

--- a/ecommerce/settings/test.py
+++ b/ecommerce/settings/test.py
@@ -54,13 +54,14 @@ if str(os.environ.get('DISABLE_MIGRATIONS')) == 'True':
 
 # IN-MEMORY TEST DATABASE
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": ":memory:",
-        "USER": "",
-        "PASSWORD": "",
-        "HOST": "",
-        "PORT": "",
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+        'USER': '',
+        'PASSWORD': '',
+        'HOST': '',
+        'PORT': '',
+        'ATOMIC_REQUESTS': True,
     },
 }
 # END IN-MEMORY TEST DATABASE


### PR DESCRIPTION
Wraps views in a transaction to more closely mirror production config. Connection pooling is also used in production, but Django docs discourage its use in development.

The health endpoint doesn't require atomicity, and as such is decorated with `non_atomic_requests()`, which negates the effect of ATOMIC_REQUESTS for the view.

@clintonb or @dianakhuang, could one or both of you take a quick look? This accompanies [#34](https://github.com/edx/django-oscar-extensions/pull/34) over in the extensions repo.
