### PR TITLE
Bump extensions version to 0.0.7

### DIFF
--- a/requirements/not_editable.txt
+++ b/requirements/not_editable.txt
@@ -1,3 +1,3 @@
 # Oscar requirements
 git+https://github.com/edx/django-oscar.git@1ce871a29b97789354b422ca559de956c6762aee#egg=django-oscar
-git+https://github.com/edx/django-oscar-extensions.git@v0.0.6#egg=django-oscar-extensions==0.0.6
+git+https://github.com/edx/django-oscar-extensions.git@v0.0.7#egg=django-oscar-extensions==0.0.7


### PR DESCRIPTION
Accompanies [#40](https://github.com/edx/django-oscar-extensions/pull/40) over in extensions. I'll need to tag a new extensions release before merging this.

@clintonb or @stephensanchez, please review.
