### PR TITLE
Dependencies are hard

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,3 +9,9 @@ djangorestframework==3.1.0  # MIT
 logutils==0.3.3             # BSD
 requests==2.6.0             # Apache2
 edx-auth-backends==0.1.2    # AGPL
+
+# PSA's PyJWT dependency conflicts with djangorestframework-jwt's.
+# Explicitly specifying a version of PyJWT here resolves the conflict
+# and is a temporary measure until a new version of PSA is released;
+# PSA is compatible with PyJWT 1.0.0.
+PyJWT==1.0.0


### PR DESCRIPTION
Resolves a dependency conflict between [PSA](https://github.com/omab/python-social-auth/blob/8561dc45680d00a683fa1d91c5ecf63df60e42c9/setup.py#L49) and [djangorestframework-jwt](https://github.com/GetBlimp/django-rest-framework-jwt/blob/master/setup.py#L21). PSA resolved this issue in [#557](https://github.com/omab/python-social-auth/pull/557), but a new version has yet to be released.

@feanil or @clintonb, could I get a thumb?
