### PR TITLE
Upgrade edx-auth-backends to 0.1.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,4 +8,4 @@ django-waffle==0.10         # BSD
 djangorestframework==3.1.0  # MIT
 logutils==0.3.3             # BSD
 requests==2.6.0             # Apache2
-edx-auth-backends==0.1.2    # AGPL
+edx-auth-backends==0.1.3    # AGPL


### PR DESCRIPTION
Meant to accompany [#6](https://github.com/edx/auth-backends/pull/6) over in the auth-backends repo. This will resolve PyJWT dependency conflicts between PSA and djangorestframework-jwt.

@clintonb or @stephensanchez, could you take a look?

@feanil, FYI.
