### PR TITLE
XCOM-167: Adding logic to allow direction to the LMS receipt page.

### DIFF
--- a/ecommerce/extensions/payment/errors.py
+++ b/ecommerce/extensions/payment/errors.py
@@ -39,3 +39,8 @@ class UserCancelled(CybersourceError):
 class PaymentDeclined(CybersourceError):
     """Payment declined."""
     pass
+
+
+class UnsupportedProductError(CybersourceError):
+    """Cannot generate a receipt for the given product type in this order. """
+    pass

--- a/ecommerce/settings/_oscar.py
+++ b/ecommerce/settings/_oscar.py
@@ -117,7 +117,7 @@ ORDERS_ENDPOINT_RATE_LIMIT = '40/minute'
 
 # PAYMENT PROCESSING
 PAYMENT_PROCESSORS = (
-    'ecommerce.extensions.payment.processors.Cybersource',
+    'ecommerce.extensions.payment.processors.SingleSeatCybersource',
 )
 
 PAYMENT_PROCESSOR_CONFIG = {
@@ -126,6 +126,10 @@ PAYMENT_PROCESSOR_CONFIG = {
         'access_key': 'set-me-please',
         'secret_key': 'set-me-please',
         'pay_endpoint': 'https://replace-me/',
+        # TODO: XCOM-202 must be completed before any other receipt page is used.
+        # By design this specific receipt page is expected.
+        'receipt_page_url': 'https://replace-me/verify_student/payment-confirmation/',
+        'cancel_page_url': 'https://replace-me/',
     }
 }
 # END PAYMENT PROCESSING

--- a/ecommerce/settings/local.py
+++ b/ecommerce/settings/local.py
@@ -106,6 +106,10 @@ PAYMENT_PROCESSOR_CONFIG = {
         'access_key': 'fake-access-key',
         'secret_key': 'fake-secret-key',
         'pay_endpoint': 'https://replace-me/',
+        # TODO: XCOM-202 must be completed before any other receipt page is used.
+        # By design this specific receipt page is expected.
+        'receipt_page_url': 'https://replace-me/verify_student/payment-confirmation/',
+        'cancel_page_url': 'https://replace-me/',
     }
 }
 # END PAYMENT PROCESSING

--- a/ecommerce/settings/test.py
+++ b/ecommerce/settings/test.py
@@ -82,12 +82,20 @@ EDX_API_KEY = 'replace-me'
 
 
 # PAYMENT PROCESSING
+PAYMENT_PROCESSORS = (
+    'ecommerce.extensions.payment.processors.Cybersource',
+)
+
 PAYMENT_PROCESSOR_CONFIG = {
     'cybersource': {
         'profile_id': 'fake-profile-id',
         'access_key': 'fake-access-key',
         'secret_key': 'fake-secret-key',
         'pay_endpoint': 'https://replace-me/',
+        # TODO: XCOM-202 must be completed before any other receipt page is used.
+        # By design this specific receipt page is expected.
+        'receipt_page_url': 'https://replace-me/verify_student/payment-confirmation/',
+        'cancel_page_url': 'https://replace-me/',
     }
 }
 # END PAYMENT PROCESSING


### PR DESCRIPTION
This PR allows the E-Commerce service to construct a callback URL the LMS receipt page. While I tried to make this configurable, you can see that the URL construction relies on a single product, and the product being a seat. 

TODOs were added to cover this, and once we have a better receipt page, this code should be replaced to have a receipt page that supports any number of products. 

Let me know what you think
@rlucioni @jimabramson @clintonb 
