### PR TITLE
Using Docker and caching for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: python
 python:
     - "2.7"
+sudo: false
+
+# Cache the pip directory. "cache: pip" doesn't work due to install override. See https://github.com/travis-ci/travis-ci/issues/3239.
+cache:
+  directories:
+    - $HOME/.cache/pip
 before_install:
     - "export DISPLAY=:99.0"
     - "sh -e /etc/init.d/xvfb start"


### PR DESCRIPTION
Added Docker and caching support should help decrease build time.

@rlucioni @jimabramson 
