### PR TITLE
Added Tests for Payment Helpers

### DIFF
--- a/ecommerce/extensions/payment/tests/processors.py
+++ b/ecommerce/extensions/payment/tests/processors.py
@@ -1,0 +1,16 @@
+from ecommerce.extensions.payment.processors import BasePaymentProcessor
+
+
+class DummyProcessor(BasePaymentProcessor):
+    NAME = 'dummy'
+
+    def handle_processor_response(self, params):
+        pass
+
+    def get_transaction_parameters(self, basket, receipt_page_url=None, cancel_page_url=None,
+                                   merchant_defined_data=None):
+        pass
+
+
+class AnotherDummyProcessor(DummyProcessor):
+    NAME = 'another-dummy'

--- a/ecommerce/extensions/payment/tests/test_helpers.py
+++ b/ecommerce/extensions/payment/tests/test_helpers.py
@@ -1,0 +1,42 @@
+import ddt
+
+from django.test import TestCase, override_settings
+
+from ecommerce.extensions.payment import helpers
+from ecommerce.extensions.payment.exceptions import ProcessorNotFoundError
+from ecommerce.extensions.payment.tests.processors import DummyProcessor, AnotherDummyProcessor
+
+
+@ddt.ddt
+@override_settings(PAYMENT_PROCESSORS=[
+    'ecommerce.extensions.payment.tests.processors.DummyProcessor',
+    'ecommerce.extensions.payment.tests.processors.AnotherDummyProcessor',
+])
+class HelperTests(TestCase):
+    def test_get_processor_class(self):
+        """ Verify that the method retrieves the correct class. """
+        actual = helpers.get_processor_class('ecommerce.extensions.payment.tests.processors.DummyProcessor')
+        self.assertIs(actual, DummyProcessor)
+
+    def test_get_default_processor_class(self):
+        """ Verify the function returns the first processor class defined in settings. """
+        self.assertIs(helpers.get_default_processor_class(), DummyProcessor)
+
+    @ddt.data(DummyProcessor, AnotherDummyProcessor)
+    def test_get_processor_class_by_name(self, processor):
+        """ Verify the function returns the appropriate processor class or raises an exception, if not found. """
+        self.assertIs(helpers.get_processor_class_by_name(processor.NAME), processor)
+
+    def test_get_processor_class_by_name_not_found(self):
+        """
+        If get_processor_class_by_name is called with the name of a non-existent processor,
+        ProcessorNotFoundError should be raised.
+        """
+        self.assertRaises(ProcessorNotFoundError, helpers.get_processor_class_by_name, 'foo')
+
+    def test_sign(self):
+        """ Verify the function returns a valid HMAC SHA-256 signature. """
+        message = "This is a super-secret message!"
+        secret = "password"
+        expected = "qU4fRskS/R9yZx/yPq62sFGOUzX0GSUtmeI6bPVsqao="
+        self.assertEqual(helpers.sign(message, secret), expected)


### PR DESCRIPTION
We are currently relying on consumers of these functions to test them. Adding direct tests will offer verification that these functions work regardless of consumer, and allow us to trust them for usage in other tests.

@jimabramson @rlucioni 
