### PR TITLE
Refrain from loading post_checkout signal unnecessarily in payment views

### DIFF
--- a/ecommerce/extensions/payment/views.py
+++ b/ecommerce/extensions/payment/views.py
@@ -23,7 +23,6 @@ Basket = get_model('basket', 'Basket')
 BillingAddress = get_model('order', 'BillingAddress')
 Country = get_model('address', 'Country')
 OrderTotalCalculator = get_class('checkout.calculators', 'OrderTotalCalculator')
-post_checkout = get_class('checkout.signals', 'post_checkout')
 
 
 class CybersourceNotifyView(EdxOrderPlacementMixin, View):


### PR DESCRIPTION
Just some minor clean-up; ran across this while looking for something else.

@clintonb or @jimabramson 
