### PR TITLE
URL Trailing Slash is Optional

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -202,9 +202,6 @@ MIDDLEWARE_CLASSES = (
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#root-urlconf
 ROOT_URLCONF = '{}.urls'.format(SITE_NAME)
 
-# See: https://docs.djangoproject.com/en/1.7/ref/settings/#append-slash
-APPEND_SLASH = False
-
 # Used to construct LMS URLs; must include a trailing slash
 LMS_URL_ROOT = None
 

--- a/ecommerce/urls.py
+++ b/ecommerce/urls.py
@@ -65,9 +65,9 @@ if settings.DEBUG:  # pragma: no cover
     # Allow error pages to be tested
     urlpatterns += patterns(
         '',
-        url(r'^403$', handler403, name='403'),
-        url(r'^404$', 'django.views.defaults.page_not_found', name='404'),
-        url(r'^500$', 'django.views.defaults.server_error', name='500'),
+        url(r'^403/$', handler403, name='403'),
+        url(r'^404/$', 'django.views.defaults.page_not_found', name='404'),
+        url(r'^500/$', 'django.views.defaults.server_error', name='500'),
     )
 
     if os.environ.get('ENABLE_DJANGO_TOOLBAR', False):


### PR DESCRIPTION
Django will handle automatic redirection for all requests. POST requests not using the trailing slash will fail, so use the trailing slash.

@rlucioni just lost a few minutes' time due to trailing slash issues. I lose time when testing locally and I forget the trailing slash. We can easily avoid this wasted time, so let's do so.

@rlucioni @jimabramson 
