### PR TITLE
Enabling Auto-Auth by Default for Local Users

### DIFF
--- a/ecommerce/settings/local.py
+++ b/ecommerce/settings/local.py
@@ -115,4 +115,5 @@ PAYMENT_PROCESSOR_CONFIG = {
 # END PAYMENT PROCESSING
 
 
+ENABLE_AUTO_AUTH = True
 LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel='DEBUG')

--- a/ecommerce/user/tests/test_views.py
+++ b/ecommerce/user/tests/test_views.py
@@ -39,10 +39,3 @@ class AutoAuthTests(TestCase):
 
         # Verify that the user has superuser permissions
         self.assertTrue(user.is_superuser)
-
-    @override_settings(ENABLE_AUTO_AUTH=True, AUTO_AUTH_USERNAME_PREFIX=None)
-    def test_prefix_invalid(self):
-        """When AUTO_AUTH_USERNAME_PREFIX is not set, the view should raises a ValueError."""
-        original_user_count = User.objects.count()
-        self.assertRaises(ValueError, self.client.get, self.AUTO_AUTH_PATH)
-        self.assertEqual(User.objects.count(), original_user_count)

--- a/ecommerce/user/views.py
+++ b/ecommerce/user/views.py
@@ -19,11 +19,10 @@ class AutoAuth(View):
         if not getattr(settings, 'ENABLE_AUTO_AUTH', None):
             raise Http404
 
-        if not getattr(settings, 'AUTO_AUTH_USERNAME_PREFIX', None):
-            raise ValueError('AUTO_AUTH_USERNAME_PREFIX must be set.')
+        username_prefix = getattr(settings, 'AUTO_AUTH_USERNAME_PREFIX', 'auto_auth_')
 
         # Create a new user with staff permissions
-        username = password = settings.AUTO_AUTH_USERNAME_PREFIX + uuid.uuid4().hex[0:20]
+        username = password = username_prefix + uuid.uuid4().hex[0:20]
         User.objects.create_superuser(username, email=None, password=password)
 
         # Log in the new user


### PR DESCRIPTION
This functionality is safe for local usage. Additionally, I have set a sane default for the prefix.

@rlucioni @jimabramson 
