### PR TITLE
Upgrade to djangorestframework-jwt 1.5.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ django-oscar==1.0.2
 django_simple_history==1.6.1
 django-waffle==0.10
 djangorestframework==3.1.0
-djangorestframework-jwt==1.4.0
+djangorestframework-jwt==1.5.0
 edx-auth-backends==0.1.3
 jsonfield==1.0.3
 logutils==0.3.3


### PR DESCRIPTION
I noticed we were out of date. djangorestframework-jwt 1.5.0 requires PyJWT 1.1.0 or greater. Since PSA no longer pins the required version of PyJWT (only requiring 1.0.0 or better), this doesn't require upgrading the auth-backends repo.

@clintonb or @jimabramson  
