### PR TITLE
Remove option to override receipt and cancel page URLs

### DIFF
--- a/ecommerce/extensions/payment/tests/processors.py
+++ b/ecommerce/extensions/payment/tests/processors.py
@@ -4,10 +4,10 @@ from ecommerce.extensions.payment.processors import BasePaymentProcessor
 class DummyProcessor(BasePaymentProcessor):
     NAME = 'dummy'
 
-    def handle_processor_response(self, response, basket=None):
+    def get_transaction_parameters(self, basket):
         pass
 
-    def get_transaction_parameters(self, basket, receipt_page_url=None, cancel_page_url=None, **kwargs):
+    def handle_processor_response(self, response, basket=None):
         pass
 
     def is_signature_valid(self, response):


### PR DESCRIPTION
These overrides are the result of an incomplete understanding of how to provide custom redirect URLs to CyberSource and other payment processors. Knowing now that we'll always use the URLs configured in settings, these overrides provide no value and only serve to complicate our code.

@clintonb or @jimabramson 
