### PR TITLE
PayPal payment creation and execution

### DIFF
--- a/ecommerce/extensions/checkout/mixins.py
+++ b/ecommerce/extensions/checkout/mixins.py
@@ -11,7 +11,7 @@ post_checkout = get_class('checkout.signals', 'post_checkout')
 class EdxOrderPlacementMixin(OrderPlacementMixin):
     """ Mixin for edX-specific order placement. """
 
-    # Note: Subclasses should set this value
+    # Instance of a payment processor with which to handle payment. Subclasses should set this value.
     payment_processor = None
 
     __metaclass__ = abc.ABCMeta

--- a/ecommerce/extensions/payment/config.py
+++ b/ecommerce/extensions/payment/config.py
@@ -1,5 +1,17 @@
+from django.conf import settings
 from oscar.apps.payment import config
+import paypalrestsdk
 
 
 class PaymentConfig(config.PaymentConfig):
     name = 'ecommerce.extensions.payment'
+
+    def ready(self):
+        paypal_configuration = settings.PAYMENT_PROCESSOR_CONFIG.get('paypal')
+        if paypal_configuration:
+            # Initialize the PayPal REST SDK
+            paypalrestsdk.configure({
+                'mode': paypal_configuration['mode'],
+                'client_id': paypal_configuration['client_id'],
+                'client_secret': paypal_configuration['client_secret']
+            })

--- a/ecommerce/extensions/payment/exceptions.py
+++ b/ecommerce/extensions/payment/exceptions.py
@@ -2,6 +2,7 @@
 from django.utils.translation import ugettext_lazy as _
 from oscar.apps.payment.exceptions import GatewayError, PaymentError
 
+
 PROCESSOR_NOT_FOUND_DEVELOPER_MESSAGE = u"Lookup for a payment processor with name [{name}] failed"
 PROCESSOR_NOT_FOUND_USER_MESSAGE = _("We don't support the payment option you selected.")
 
@@ -12,15 +13,15 @@ class ProcessorNotFoundError(Exception):
 
 
 class InvalidSignatureError(GatewayError):
-    """ The signature of the payment processor's response is invalid. """
+    """The signature of the payment processor's response is invalid."""
     pass
 
 
 class InvalidCybersourceDecision(GatewayError):
-    """ The decision returned by CyberSource was not recognized. """
+    """The decision returned by CyberSource was not recognized."""
     pass
 
 
 class PartialAuthorizationError(PaymentError):
-    """ The amount authorized by the payment processor differs from the requested amount. """
+    """The amount authorized by the payment processor differs from the requested amount."""
     pass

--- a/ecommerce/extensions/payment/processors.py
+++ b/ecommerce/extensions/payment/processors.py
@@ -6,13 +6,18 @@ import logging
 import uuid
 
 from django.conf import settings
+from django.core.urlresolvers import reverse
 from oscar.apps.payment.exceptions import UserCancelled, GatewayError, TransactionDeclined
 from oscar.core.loading import get_model
+import paypalrestsdk
 
 from ecommerce.extensions.order.constants import PaymentEventTypeName
 from ecommerce.extensions.payment.constants import ISO_8601_FORMAT, CYBERSOURCE_CARD_TYPE_MAP
-from ecommerce.extensions.payment.exceptions import (InvalidSignatureError, InvalidCybersourceDecision,
-                                                     PartialAuthorizationError)
+from ecommerce.extensions.payment.exceptions import (
+    InvalidSignatureError,
+    InvalidCybersourceDecision,
+    PartialAuthorizationError,
+)
 from ecommerce.extensions.payment.helpers import sign
 
 
@@ -33,15 +38,21 @@ class BasePaymentProcessor(object):  # pragma: no cover
     NAME = None
 
     @abc.abstractmethod
-    def get_transaction_parameters(self, basket):
+    def get_transaction_parameters(self, basket, request=None):
         """
         Generate a dictionary of signed parameters required for this processor to complete a transaction.
 
         Arguments:
             basket (Basket): The basket of products being purchased.
 
+        Keyword Arguments:
+            request (Request): A Request object which can be used to construct an absolute URL in
+                cases where one is required.
+
         Returns:
-            dict: Payment processor-specific parameters required to complete a transaction.
+            dict: Payment processor-specific parameters required to complete a transaction. At a minimum,
+                this dict must include a `payment_page_url` indicating the location of the processor's
+                hosted payment page.
         """
         raise NotImplementedError
 
@@ -50,9 +61,7 @@ class BasePaymentProcessor(object):  # pragma: no cover
         """
         Handle a response from the payment processor.
 
-        This method does the following:
-            1. Verify the validity of the response.
-            2. Create PaymentEvents and Sources for successful payments.
+        This method creates PaymentEvents and Sources for successful payments.
 
         Arguments:
             response (dict): Dictionary of parameters received from the payment processor
@@ -60,11 +69,6 @@ class BasePaymentProcessor(object):  # pragma: no cover
         Keyword Arguments:
             basket (Basket): Basket whose contents have been purchased via the payment processor
         """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def is_signature_valid(self, response):
-        """ Returns a boolean indicating if the response's signature (indicating potential tampering) is valid. """
         raise NotImplementedError
 
     @property
@@ -99,7 +103,8 @@ class BasePaymentProcessor(object):  # pragma: no cover
 
 
 class Cybersource(BasePaymentProcessor):
-    """CyberSource Secure Acceptance Web/Mobile (February 2015)
+    """
+    CyberSource Secure Acceptance Web/Mobile (February 2015)
 
     For reference, see
     http://apps.cybersource.com/library/documentation/dev_guides/Secure_Acceptance_WM/Secure_Acceptance_WM.pdf.
@@ -123,12 +128,16 @@ class Cybersource(BasePaymentProcessor):
         self.cancel_page_url = configuration['cancel_page_url']
         self.language_code = settings.LANGUAGE_CODE
 
-    def get_transaction_parameters(self, basket):
+    def get_transaction_parameters(self, basket, request=None):
         """
         Generate a dictionary of signed parameters CyberSource requires to complete a transaction.
 
         Arguments:
             basket (Basket): The basket of products being purchased.
+
+        Keyword Arguments:
+            request (Request): A Request object which could be used to construct an absolute URL; not
+                used by this method.
 
         Returns:
             dict: CyberSource-specific parameters required to complete a transaction, including a signature.
@@ -163,6 +172,8 @@ class Cybersource(BasePaymentProcessor):
         parameters[u'signed_field_names'] = u','.join(sorted(signed_field_names))
         parameters[u'signature'] = self._generate_signature(parameters)
 
+        parameters[u'payment_page_url'] = self.payment_page_url
+
         return parameters
 
     @staticmethod
@@ -181,14 +192,16 @@ class Cybersource(BasePaymentProcessor):
 
     def handle_processor_response(self, response, basket=None):
         """
-        Handle a response from the payment processor.
+        Handle a response (i.e., "merchant notification") from CyberSource.
 
         This method does the following:
             1. Verify the validity of the response.
             2. Create PaymentEvents and Sources for successful payments.
 
-        Args:
+        Arguments:
             response (dict): Dictionary of parameters received from the payment processor.
+
+        Keyword Arguments:
             basket (Basket): Basket being purchased via the payment processor.
 
         Raises:
@@ -246,7 +259,8 @@ class Cybersource(BasePaymentProcessor):
         return source, event
 
     def _generate_signature(self, parameters):
-        """Sign the contents of the provided transaction parameters dictionary.
+        """
+        Sign the contents of the provided transaction parameters dictionary.
 
         This allows CyberSource to verify that the transaction parameters have not been tampered with
         during transit. The parameters dictionary should contain a key 'signed_field_names' which CyberSource
@@ -270,4 +284,181 @@ class Cybersource(BasePaymentProcessor):
         return sign(message, self.secret_key)
 
     def is_signature_valid(self, response):
+        """Returns a boolean indicating if the response's signature (indicating potential tampering) is valid."""
         return response and (self._generate_signature(response) == response.get(u'signature'))
+
+
+class Paypal(BasePaymentProcessor):
+    """
+    PayPal REST API (May 2015)
+
+    For reference, see https://developer.paypal.com/docs/api/.
+    """
+    NAME = u'paypal'
+
+    def __init__(self):
+        """
+        Constructs a new instance of the PayPal processor.
+
+        Raises:
+            KeyError: If a required setting is not configured for this payment processor
+        """
+        configuration = self.configuration
+        self.receipt_url = configuration['receipt_url']
+        self.cancel_url = configuration['cancel_url']
+
+    def get_transaction_parameters(self, basket, request=None):
+        """
+        Create a new PayPal payment.
+
+        Arguments:
+            basket (Basket): The basket of products being purchased.
+
+        Keyword Arguments:
+            request (Request): A Request object which is used to construct PayPal's `return_url`.
+
+        Returns:
+            dict: PayPal-specific parameters required to complete a transaction. Must contain a URL
+                to which users can be directed in order to approve a newly created payment.
+
+        Raises:
+            GatewayError: Indicates a general error or unexpected behavior on the part of PayPal which prevented
+                a payment from being created.
+        """
+        return_url = request.build_absolute_uri(reverse('paypal_execute'))
+        data = {
+            'intent': 'sale',
+            'redirect_urls': {
+                'return_url': return_url,
+                'cancel_url': self.cancel_url,
+            },
+            'payer': {
+                'payment_method': 'paypal',
+            },
+            'transactions': [{
+                'amount': {
+                    'total': unicode(basket.total_incl_tax),
+                    'currency': basket.currency,
+                },
+                'item_list': {
+                    'items': [
+                        {
+                            'quantity': line.quantity,
+                            'name': line.product.title,
+                            'price': unicode(line.price_incl_tax),
+                            'currency': line.stockrecord.price_currency,
+                        }
+                        for line in basket.all_lines()
+                    ],
+                },
+            }],
+        }
+
+        payment = paypalrestsdk.Payment(data)
+        payment.create()
+
+        # Raise an exception for payments that were not successfully created. Consuming code is
+        # responsible for handling the exception.
+        if not payment.success():
+            error = self._get_error(payment)
+            entry = self.record_processor_response(error, transaction_id=error['debug_id'], basket=basket)
+
+            logger.error(
+                u"Failed to create PayPal payment for basket [%d]. PayPal's response was recorded in entry [%d].",
+                basket.id,
+                entry.id
+            )
+
+            raise GatewayError
+
+        entry = self.record_processor_response(payment.to_dict(), transaction_id=payment.id, basket=basket)
+        logger.info(u"Successfully created PayPal payment [%s] for basket [%d].", payment.id, basket.id)
+
+        # Dat HATEOAS
+        for link in payment.links:
+            if link.rel == 'approval_url':
+                approval_url = link.href
+                break
+        else:
+            logger.error(
+                u"Approval URL missing from PayPal payment [%s]. PayPal's response was recorded in entry [%d].",
+                payment.id,
+                entry.id
+            )
+            raise GatewayError
+
+        parameters = {
+            'payment_page_url': approval_url,
+        }
+
+        return parameters
+
+    def handle_processor_response(self, response, basket=None):
+        """
+        Execute an approved PayPal payment.
+
+        This method creates PaymentEvents and Sources for approved payments.
+
+        Arguments:
+            response (dict): Dictionary of parameters returned by PayPal in the `return_url` query string.
+
+        Keyword Arguments:
+            basket (Basket): Basket being purchased via the payment processor.
+
+        Raises:
+            GatewayError: Indicates a general error or unexpected behavior on the part of PayPal which prevented
+                an approved payment from being executed.
+        """
+        data = {'payer_id': response.get('PayerID')}
+
+        payment = paypalrestsdk.Payment.find(response.get('paymentId'))
+        payment.execute(data)
+
+        # Raise an exception for payments that were not successfully executed. Consuming code is
+        # responsible for handling the exception.
+        if not payment.success():
+            error = self._get_error(payment)
+            entry = self.record_processor_response(error, transaction_id=error['debug_id'], basket=basket)
+
+            logger.error(
+                u"Failed to execute PayPal payment [%s]. PayPal's response was recorded in entry [%d].",
+                payment.id,
+                entry.id
+            )
+
+            raise GatewayError
+
+        entry = self.record_processor_response(payment.to_dict(), transaction_id=payment.id, basket=basket)
+        logger.info(u"Successfully executed PayPal payment [%s] for basket [%d].", payment.id, basket.id)
+
+        # Get or create Source used to track transactions related to PayPal
+        source_type, __ = SourceType.objects.get_or_create(name=self.NAME)
+        currency = payment.transactions[0].amount.currency
+        total = Decimal(payment.transactions[0].amount.total)
+        transaction_id = payment.id
+        email = payment.payer.payer_info.email
+
+        source = Source(
+            source_type=source_type,
+            currency=currency,
+            amount_allocated=total,
+            amount_debited=total,
+            reference=transaction_id,
+            label=email,
+            card_type=None
+        )
+
+        # Create PaymentEvent to track payment
+        event_type, __ = PaymentEventType.objects.get_or_create(name=PaymentEventTypeName.PAID)
+        event = PaymentEvent(event_type=event_type, amount=total, reference=transaction_id, processor_name=self.NAME)
+
+        return source, event
+
+    def _get_error(self, payment):
+        """
+        Shameful workaround for mocking the `error` attribute on instances of
+        `paypalrestsdk.Payment`. The `error` attribute is created at runtime,
+        but passing `create=True` to `patch()` isn't enough to mock the
+        attribute in this module.
+        """
+        return payment.error  # pragma: no cover

--- a/ecommerce/extensions/payment/tests/processors.py
+++ b/ecommerce/extensions/payment/tests/processors.py
@@ -4,7 +4,7 @@ from ecommerce.extensions.payment.processors import BasePaymentProcessor
 class DummyProcessor(BasePaymentProcessor):
     NAME = 'dummy'
 
-    def get_transaction_parameters(self, basket):
+    def get_transaction_parameters(self, basket, request=None):
         pass
 
     def handle_processor_response(self, response, basket=None):

--- a/ecommerce/extensions/payment/urls.py
+++ b/ecommerce/extensions/payment/urls.py
@@ -6,4 +6,5 @@ from ecommerce.extensions.payment import views
 urlpatterns = patterns(
     '',
     url(r'^cybersource/notify/$', views.CybersourceNotifyView.as_view(), name='cybersource_notify'),
+    url(r'^paypal/execute/$', views.PaypalPaymentExecutionView.as_view(), name='paypal_execute'),
 )

--- a/ecommerce/settings/_oscar.py
+++ b/ecommerce/settings/_oscar.py
@@ -91,19 +91,26 @@ OSCAR_DEFAULT_CURRENCY = 'USD'
 # PAYMENT PROCESSING
 PAYMENT_PROCESSORS = (
     'ecommerce.extensions.payment.processors.Cybersource',
+    'ecommerce.extensions.payment.processors.Paypal',
 )
 
 PAYMENT_PROCESSOR_CONFIG = {
     'cybersource': {
-        'profile_id': 'set-me-please',
-        'access_key': 'set-me-please',
-        'secret_key': 'set-me-please',
-        'payment_page_url': 'https://replace-me/',
-        # TODO: XCOM-202 must be completed before any other receipt page is used.
-        # By design this specific receipt page is expected.
-        'receipt_page_url': 'https://replace-me/verify_student/payment-confirmation/',
-        'cancel_page_url': 'https://replace-me/',
-    }
+        'profile_id': None,
+        'access_key': None,
+        'secret_key': None,
+        'payment_page_url': None,
+        'receipt_page_url': None,
+        'cancel_page_url': None,
+    },
+    'paypal': {
+        # 'mode' can be either 'sandbox' or 'live'
+        'mode': None,
+        'client_id': None,
+        'client_secret': None,
+        'receipt_url': None,
+        'cancel_url': None,
+    },
 }
 # END PAYMENT PROCESSING
 

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -2,7 +2,9 @@
 import os
 from os.path import basename, normpath
 from sys import path
+from urlparse import urljoin
 
+from django.conf import settings
 from oscar import OSCAR_MAIN_TEMPLATE_DIR
 
 from ecommerce.settings._oscar import *
@@ -202,8 +204,15 @@ MIDDLEWARE_CLASSES = (
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#root-urlconf
 ROOT_URLCONF = '{}.urls'.format(SITE_NAME)
 
-# Used to construct LMS URLs; must include a trailing slash
+# Absolute URL used to construct LMS URLs.
 LMS_URL_ROOT = None
+
+
+def get_lms_url(path):
+    # This function accesses Django settings because other settings modules override
+    # LMS_URL_ROOT; we don't always want this function to use the value of LMS_URL_ROOT
+    # defined in this module.
+    return urljoin(settings.LMS_URL_ROOT, path)
 
 # The location of the LMS heartbeat page
 LMS_HEARTBEAT_URL = None

--- a/ecommerce/settings/local.py
+++ b/ecommerce/settings/local.py
@@ -68,12 +68,7 @@ INTERNAL_IPS = ('127.0.0.1',)
 
 
 # URL CONFIGURATION
-# Do not include a trailing slash.
 LMS_URL_ROOT = 'http://127.0.0.1:8000'
-
-
-def get_lms_url(path):
-    return LMS_URL_ROOT + path
 
 # The location of the LMS heartbeat page
 LMS_HEARTBEAT_URL = get_lms_url('/heartbeat')
@@ -112,8 +107,15 @@ PAYMENT_PROCESSOR_CONFIG = {
         'secret_key': 'fake-secret-key',
         'payment_page_url': 'https://replace-me/',
         'receipt_page_url': get_lms_url('/commerce/checkout/receipt/'),
-        'cancel_page_url': get_lms_url('/commerce/checkout/cancel/')
-    }
+        'cancel_page_url': get_lms_url('/commerce/checkout/cancel/'),
+    },
+    'paypal': {
+        'mode': 'sandbox',
+        'client_id': 'fake-client-id',
+        'client_secret': 'fake-client-secret',
+        'receipt_url': get_lms_url('/commerce/checkout/receipt/'),
+        'cancel_url': get_lms_url('/commerce/checkout/cancel/'),
+    },
 }
 # END PAYMENT PROCESSING
 

--- a/ecommerce/settings/test.py
+++ b/ecommerce/settings/test.py
@@ -56,14 +56,13 @@ DATABASES = {
 
 
 # URL CONFIGURATION
-# Do not include a trailing slash.
 LMS_URL_ROOT = 'http://127.0.0.1:8000'
 
 # The location of the LMS heartbeat page
-LMS_HEARTBEAT_URL = LMS_URL_ROOT + '/heartbeat'
+LMS_HEARTBEAT_URL = get_lms_url('/heartbeat')
 
 # The location of the LMS student dashboard
-LMS_DASHBOARD_URL = LMS_URL_ROOT + '/dashboard'
+LMS_DASHBOARD_URL = get_lms_url('/dashboard')
 # END URL CONFIGURATION
 
 
@@ -82,20 +81,21 @@ EDX_API_KEY = 'replace-me'
 
 
 # PAYMENT PROCESSING
-PAYMENT_PROCESSORS = (
-    'ecommerce.extensions.payment.processors.Cybersource',
-)
-
 PAYMENT_PROCESSOR_CONFIG = {
     'cybersource': {
         'profile_id': 'fake-profile-id',
         'access_key': 'fake-access-key',
         'secret_key': 'fake-secret-key',
         'payment_page_url': 'https://replace-me/',
-        # TODO: XCOM-202 must be completed before any other receipt page is used.
-        # By design this specific receipt page is expected.
-        'receipt_page_url': 'https://replace-me/verify_student/payment-confirmation/',
-        'cancel_page_url': 'https://replace-me/',
-    }
+        'receipt_page_url': get_lms_url('/commerce/checkout/receipt/'),
+        'cancel_page_url': get_lms_url('/commerce/checkout/cancel/'),
+    },
+    'paypal': {
+        'mode': 'sandbox',
+        'client_id': 'fake-client-id',
+        'client_secret': 'fake-client-secret',
+        'receipt_url': get_lms_url('/commerce/checkout/receipt/'),
+        'cancel_url': get_lms_url('/commerce/checkout/cancel/'),
+    },
 }
 # END PAYMENT PROCESSING

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,6 +12,7 @@ djangorestframework-jwt==1.5.0
 edx-auth-backends==0.1.3
 jsonfield==1.0.3
 logutils==0.3.3
+paypalrestsdk==1.9.0
 pycountry==1.10
 requests==2.6.0
 


### PR DESCRIPTION
This PR includes a PayPal payment processor responsible for payment creation as well as a view responsible for payment execution. At a high level, the PayPal payment process is as follows:
1. Otto contacts the PayPal API to create a new payment.
2. The PayPal API response includes an `approval_url` to which the user should be sent.
3. Once the user approves the created payment, PayPal sends them to a page on Otto located at the `return_url` provided during payment creation.
4. Otto contacts the PayPal API to execute the approved payment, and redirects the user to a receipt page on the LMS.

@jimabramson and @clintonb, could you please review this when you're able?
