### PR TITLE
Drop payment_processor field from the Order model

### DIFF
--- a/ecommerce/extensions/order/migrations/0008_delete_order_payment_processor.py
+++ b/ecommerce/extensions/order/migrations/0008_delete_order_payment_processor.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('order', '0007_create_history_tables'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='historicalorder',
+            name='payment_processor',
+        ),
+        migrations.RemoveField(
+            model_name='order',
+            name='payment_processor',
+        ),
+    ]

--- a/ecommerce/extensions/order/models.py
+++ b/ecommerce/extensions/order/models.py
@@ -8,7 +8,6 @@ from ecommerce.extensions.fulfillment.status import ORDER
 
 
 class Order(AbstractOrder):
-    payment_processor = models.CharField(_("Payment Processor"), max_length=32, blank=True, null=True)
     history = HistoricalRecords()
 
     @property


### PR DESCRIPTION
Drops the now-unused `payment_processor` field from the Order model.

@jimabramson and @clintonb, please review when able.
