### PR TITLE
Add URL root setting used to construct URLs pointing back to the service.

### DIFF
--- a/ecommerce/extensions/payment/processors.py
+++ b/ecommerce/extensions/payment/processors.py
@@ -3,6 +3,7 @@ import abc
 import datetime
 from decimal import Decimal
 import logging
+from urlparse import urljoin
 import uuid
 
 from django.conf import settings
@@ -302,10 +303,13 @@ class Paypal(BasePaymentProcessor):
 
         Raises:
             KeyError: If a required setting is not configured for this payment processor
+            AttributeError: If ECOMMERCE_URL_ROOT setting is not set.
         """
         configuration = self.configuration
         self.receipt_url = configuration['receipt_url']
         self.cancel_url = configuration['cancel_url']
+
+        self.ecommerce_url_root = settings.ECOMMERCE_URL_ROOT
 
     def get_transaction_parameters(self, basket, request=None):
         """
@@ -325,7 +329,7 @@ class Paypal(BasePaymentProcessor):
             GatewayError: Indicates a general error or unexpected behavior on the part of PayPal which prevented
                 a payment from being created.
         """
-        return_url = request.build_absolute_uri(reverse('paypal_execute'))
+        return_url = urljoin(self.ecommerce_url_root, reverse('paypal_execute'))
         data = {
             'intent': 'sale',
             'redirect_urls': {

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -204,6 +204,9 @@ MIDDLEWARE_CLASSES = (
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#root-urlconf
 ROOT_URLCONF = '{}.urls'.format(SITE_NAME)
 
+# Absolute URL used to construct URLs pointing back to the ecommerce service.
+ECOMMERCE_URL_ROOT = None
+
 # Absolute URL used to construct LMS URLs.
 LMS_URL_ROOT = None
 

--- a/ecommerce/settings/local.py
+++ b/ecommerce/settings/local.py
@@ -68,6 +68,8 @@ INTERNAL_IPS = ('127.0.0.1',)
 
 
 # URL CONFIGURATION
+ECOMMERCE_URL_ROOT = 'http://localhost:8002'
+
 LMS_URL_ROOT = 'http://127.0.0.1:8000'
 
 # The location of the LMS heartbeat page

--- a/ecommerce/settings/test.py
+++ b/ecommerce/settings/test.py
@@ -56,6 +56,8 @@ DATABASES = {
 
 
 # URL CONFIGURATION
+ECOMMERCE_URL_ROOT = 'http://localhost:8002'
+
 LMS_URL_ROOT = 'http://127.0.0.1:8000'
 
 # The location of the LMS heartbeat page


### PR DESCRIPTION
Addresses an issue observed on stage with the construction of URLs pointing back to the ecommerce service. I'll create an accompanying PR against configuration shortly.

@clintonb or @jimabramson, could you please take a look at this when you're able? @Nickersoft FYI.
