### PR TITLE
Customize session cookie name when running locally.

### DIFF
--- a/ecommerce/settings/local.py
+++ b/ecommerce/settings/local.py
@@ -16,6 +16,14 @@ DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 # END DEBUG CONFIGURATION
 
+# COOKIE CONFIGURATION
+# The purpose of customizing the cookie names is to avoid conflicts when
+# multiple Django services are running behind the same hostname.
+# Detailed information at: https://docs.djangoproject.com/en/dev/ref/settings/
+SESSION_COOKIE_NAME = 'ecommerce_sessionid'
+CSRF_COOKIE_NAME = 'ecommerce_csrftoken'
+LANGUAGE_COOKIE_NAME = 'ecommerce_language'
+# END COOKIE CONFIGURATION
 
 # EMAIL CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#email-backend


### PR DESCRIPTION
This prevents browser sessions from breaking when running both edx-platform and ecommerce locally (without having to invent distinct hostnames for each service).

@rlucioni @clintonb at your convenience.
@Nickersoft FYI.
