### PR TITLE
Add refund detail view

### DIFF
--- a/ecommerce/extensions/dashboard/refunds/tests/test_acceptance.py
+++ b/ecommerce/extensions/dashboard/refunds/tests/test_acceptance.py
@@ -1,0 +1,177 @@
+from unittest import skip
+
+import ddt
+from django.core.urlresolvers import reverse
+from django.test import LiveServerTestCase
+from oscar.core.loading import get_model
+from oscar.test import factories
+from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.firefox.webdriver import WebDriver
+from selenium.webdriver.support.wait import WebDriverWait
+
+from ecommerce.extensions.refund.status import REFUND
+from ecommerce.extensions.refund.tests.factories import RefundFactory
+
+
+Refund = get_model('refund', 'Refund')
+
+
+@ddt.ddt
+class RefundAcceptanceTestMixin(object):
+    @classmethod
+    def setUpClass(cls):
+        cls.selenium = WebDriver()
+        super(RefundAcceptanceTestMixin, cls).setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.selenium.quit()
+        super(RefundAcceptanceTestMixin, cls).tearDownClass()
+
+    def setUp(self):
+        super(RefundAcceptanceTestMixin, self).setUp()
+
+        self.refund = RefundFactory()
+        self.approve_button_selector = '[data-refund-id="{}"] [data-decision="approve"]'.format(self.refund.id)
+        self.deny_button_selector = '[data-refund-id="{}"] [data-decision="deny"]'.format(self.refund.id)
+
+        self.password = 'test'
+        self.user = factories.UserFactory(password=self.password, is_superuser=True, is_staff=True)
+
+    def _login(self):
+        """Log into the service and navigate to the refund list view."""
+        self.selenium.get(self.live_server_url + reverse('auto_auth'))
+        self.selenium.get(self.live_server_url + self.path)
+
+    def _decide(self, approve):
+        """Click the Approve or Deny button and wait for the AJAX call to finish."""
+        selector = self.approve_button_selector if approve else self.deny_button_selector
+        button = self.selenium.find_element_by_css_selector(selector)
+        button.click()
+
+        # Wait for the AJAX call to finish and display an alert
+        WebDriverWait(self.selenium, 0.1).until(lambda d: d.find_element_by_css_selector('#messages .alert'))
+
+    def assert_alert_displayed(self, alert_class, text):
+        """Verifies that the most recent alert has the given class and message."""
+        alert = self.selenium.find_elements_by_css_selector('#messages .alert')[-1]
+        classes = alert.get_attribute('class').split(' ')
+        self.assertIn(alert_class, classes)
+        self.assertEqual(alert.find_element_by_css_selector('.message').text, text)
+
+    @skip("Requires refund processing endpoint.")
+    @ddt.data(True, False)
+    def test_processing_success(self, approve):
+        """
+        Verify behavior when refund processing succeeds.
+
+        The refund list should display "Approve" and "Deny buttons next to each refund. Clicking either button
+        should call the refund processing API endpoint via AJAX. When a refund is processed successfully, the refund's
+        status should be updated, an alert should displayed, and both buttons should be removed.
+        """
+        self._login()
+        self._decide(approve)
+
+        # Verify that both buttons have been removed from the DOM.
+        self.assertRaises(
+            NoSuchElementException,
+            self.selenium.find_element_by_css_selector,
+            self.approve_button_selector
+        )
+        self.assertRaises(
+            NoSuchElementException,
+            self.selenium.find_element_by_css_selector,
+            self.deny_button_selector
+        )
+
+        # Verify that the refund's status is updated.
+        selector = 'tr[data-refund-id="{}"] .refund-status'.format(self.refund.id)
+        status = self.selenium.find_element_by_css_selector(selector)
+        if approve:
+            self.assertEqual(REFUND.COMPLETE, status.text)
+        else:
+            self.assertEqual(REFUND.DENIED, status.text)
+
+        # Verify that an alert is displayed.
+        self.assert_alert_displayed('alert-success', 'Refund {} has been processed.'.format(self.refund.id))
+
+    @ddt.data(True, False)
+    def test_processing_failure(self, approve):
+        """
+        Verify behavior when refund processing fails.
+
+        The refund list should display "Approve" and "Deny" buttons next to each refund. Clicking either button
+        should call the refund processing API endpoint via AJAX. When refund processing fails, the refund's
+        status should be updated, an alert should displayed, and both buttons should be reactivated.
+        """
+        self._login()
+
+        # Before clicking any buttons, delete the refund from the system to cause a processing error.
+        refund_id = self.refund.id
+        Refund.objects.get(id=refund_id).delete()
+
+        self._decide(approve)
+
+        # Verify that both buttons are active.
+        for button_selector in [self.approve_button_selector, self.deny_button_selector]:
+            button = self.selenium.find_element_by_css_selector(button_selector)
+            classes = button.get_attribute('class').split(' ')
+            self.assertNotIn(
+                'disabled',
+                classes,
+                'Refund processing button is disabled, but should have been re-enabled!'
+            )
+
+        # Verify that the refund's status is updated.
+        selector = 'tr[data-refund-id="{}"] .refund-status'.format(refund_id)
+        status = self.selenium.find_element_by_css_selector(selector)
+        self.assertEqual(REFUND.ERROR, status.text)
+
+        # Verify that an alert is displayed.
+        self.assert_alert_displayed(
+            'alert-error',
+            'Failed to process refund #{refund_id}: NOT FOUND. '
+            'Please try again, or contact the E-Commerce Development Team.'.format(refund_id=refund_id)
+        )
+
+    @ddt.data(REFUND.OPEN, REFUND.DENIED, REFUND.ERROR, REFUND.COMPLETE)
+    def test_button_configurations(self, status):
+        """
+        Verify correct button configurations for different refund statuses.
+        """
+        self.refund.status = status
+        self.refund.save()
+
+        self._login()
+
+        if self.refund.can_approve:
+            self.selenium.find_element_by_css_selector(self.approve_button_selector)
+        else:
+            self.assertRaises(
+                NoSuchElementException,
+                self.selenium.find_element_by_css_selector,
+                self.approve_button_selector
+            )
+
+        if self.refund.can_deny:
+            self.selenium.find_element_by_css_selector(self.deny_button_selector)
+        else:
+            self.assertRaises(
+                NoSuchElementException,
+                self.selenium.find_element_by_css_selector,
+                self.deny_button_selector
+            )
+
+
+class RefundListViewTests(RefundAcceptanceTestMixin, LiveServerTestCase):
+    """Acceptance tests of the refund list view."""
+    def setUp(self):
+        super(RefundListViewTests, self).setUp()
+        self.path = reverse('dashboard:refunds:list')
+
+
+class RefundDetailViewTests(RefundAcceptanceTestMixin, LiveServerTestCase):
+    """Acceptance tests of the refund detail view."""
+    def setUp(self):
+        super(RefundDetailViewTests, self).setUp()
+        self.path = reverse('dashboard:refunds:detail', args=[self.refund.id])

--- a/ecommerce/extensions/dashboard/refunds/tests/test_views.py
+++ b/ecommerce/extensions/dashboard/refunds/tests/test_views.py
@@ -3,15 +3,13 @@ from django.test import TestCase
 
 from ecommerce.extensions.refund.status import REFUND
 from ecommerce.extensions.refund.tests.factories import RefundFactory
-
 from ecommerce.tests.mixins import UserMixin
 
 
-class RefundListViewTests(UserMixin, TestCase):
-    path = reverse('dashboard:refunds:list')
+class RefundViewTestMixin(UserMixin):
 
     def setUp(self):
-        super(RefundListViewTests, self).setUp()
+        super(RefundViewTestMixin, self).setUp()
         self.user = self.create_user(is_superuser=True, is_staff=True)
 
     def assert_successful_response(self, response, refunds=None):
@@ -40,6 +38,14 @@ class RefundListViewTests(UserMixin, TestCase):
         self.client.login(username=superuser.username, password=self.password)
         response = self.client.get(self.path)
         self.assert_successful_response(response)
+
+
+class RefundListViewTests(RefundViewTestMixin, TestCase):
+    path = reverse('dashboard:refunds:list')
+
+    def setUp(self):
+        super(RefundListViewTests, self).setUp()
+        self.user = self.create_user(is_superuser=True, is_staff=True)
 
     def test_filtering(self):
         """ The view should allow filtering by ID and status. """
@@ -71,3 +77,13 @@ class RefundListViewTests(UserMixin, TestCase):
 
         response = self.client.get('{path}?sort=id&dir=desc'.format(path=self.path))
         self.assert_successful_response(response, list(reversed(refunds)))
+
+
+class RefundDetailViewTests(RefundViewTestMixin, TestCase):
+
+    def setUp(self):
+        super(RefundDetailViewTests, self).setUp()
+        self.user = self.create_user(is_superuser=True, is_staff=True)
+
+        refund = RefundFactory()
+        self.path = reverse('dashboard:refunds:detail', args=[refund.id])

--- a/ecommerce/static/oscar/css/buttons.css
+++ b/ecommerce/static/oscar/css/buttons.css
@@ -1,0 +1,46 @@
+.btn-success {
+    color: #fff;
+    text-shadow: 0 -1px 0 rgba(0,0,0,0.25);
+    background-color: #5bb75b;
+    background-image: -moz-linear-gradient(top,#62c462,#51a351);
+    background-image: -webkit-gradient(linear,0 0,0 100%,from(#62c462),to(#51a351));
+    background-image: -webkit-linear-gradient(top,#62c462,#51a351);
+    background-image: -o-linear-gradient(top,#62c462,#51a351);
+    background-image: linear-gradient(to bottom,#62c462,#51a351);
+    background-repeat: repeat-x;
+    border-color: #51a351 #51a351 #387038;
+    border-color: rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);
+}
+
+.btn-success:hover,.btn-success:focus,.btn-success:active,.btn-success.active,.btn-success.disabled,.btn-success[disabled] {
+    color: #fff;
+    background-color: #51a351;
+}
+
+.btn-success:active,.btn-success.active {
+    background-color: #408140;
+}
+
+.btn-danger {
+    color: #fff;
+    font-weight: normal;
+    text-shadow: 0 -1px 0 rgba(0,0,0,0.25);
+    background-color: #da4f49;
+    background-image: -moz-linear-gradient(top,#ee5f5b,#bd362f);
+    background-image: -webkit-gradient(linear,0 0,0 100%,from(#ee5f5b),to(#bd362f));
+    background-image: -webkit-linear-gradient(top,#ee5f5b,#bd362f);
+    background-image: -o-linear-gradient(top,#ee5f5b,#bd362f);
+    background-image: linear-gradient(to bottom,#ee5f5b,#bd362f);
+    background-repeat: repeat-x;
+    border-color: #bd362f #bd362f #802420;
+    border-color: rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);
+}
+
+.btn-danger:hover,.btn-danger:focus,.btn-danger:active,.btn-danger.active,.btn-danger.disabled,.btn-danger[disabled] {
+    color: #fff;
+    background-color: #bd362f;
+}
+
+.btn-danger:active,.btn-danger.active {
+    background-color: #942a25;
+}

--- a/ecommerce/static/oscar/js/add_message.js
+++ b/ecommerce/static/oscar/js/add_message.js
@@ -1,0 +1,7 @@
+function addMessage(type, icon, msg) {
+    var html = '<div class="alert ' + type + '">\
+            <a class="close" data-dismiss="alert" href="#">×</a>\
+            <div class="alertinner wicon"><span class="message">' + msg + '</span><i class="' + icon + '"></i></div></div>';
+
+    $('#messages').append(html).hide().fadeIn(500);
+}

--- a/ecommerce/static/oscar/js/order_list.js
+++ b/ecommerce/static/oscar/js/order_list.js
@@ -1,11 +1,3 @@
-function addMessage(type, icon, msg) {
-    var html = '<div class="alert ' + type + '">\
-            <a class="close" data-dismiss="alert" href="#">×</a>\
-            <div class="alertinner wicon"><span class="message">' + msg + '</span><i class="' + icon + '"></i></div></div>';
-
-    $('#messages').append(html).hide().fadeIn(500);
-}
-
 $(document).ready(function () {
     var retryFulfillment = function (e) {
         var $btn = $(e.target),

--- a/ecommerce/static/oscar/js/refund_list.js
+++ b/ecommerce/static/oscar/js/refund_list.js
@@ -1,0 +1,42 @@
+$(document).ready(function () {
+    var processRefund = function (e) {
+        var $btn = $(e.target),
+            refund_id = $btn.data('refund-id');
+            decision = $btn.data('decision');
+
+        // Disable button
+        e.preventDefault();
+        $btn.addClass('disabled');
+        $btn.unbind('click');
+
+        // Make AJAX call and update status
+        $.ajax({
+            url: '/api/v2/refunds/' + refund_id + '/process/',
+            data: { action: decision },
+            method: 'PUT',
+            headers: {'X-CSRFToken': $.cookie('csrftoken')}
+        }).success(function (data) {
+            $('tr[data-refund-id=' + refund_id + '] .refund-status').text(data.status);
+            addMessage('alert-success', 'icon-check-sign', 'Refund ' + refund_id + ' has been processed.');
+            $('[data-action=process-refund]').remove();
+        }).fail(function (jqXHR, textStatus, errorThrown) {
+            // NOTE (RFL): For an MVP, changing the displayed refund state on any error may be viable.
+            // Ideally, the displayed refund state would only change if the refund were to enter an
+            // error state. This would be easiest if the processing endpoint returned 200 and a serialized
+            // refund, even when the refund has entered an error state during processing.
+            $('tr[data-refund-id=' + refund_id + '] .refund-status').text('Error');
+
+            addMessage(
+                'alert-error',
+                'icon-exclamation-sign',
+                'Failed to process refund #' + refund_id + ': ' + errorThrown + '. Please try again, or contact the E-Commerce Development Team.'
+            );
+
+            // Re-enable the button
+            $btn.click(processRefund);
+            $btn.removeClass('disabled');
+        });
+    };
+
+    $('[data-action=process-refund]').click(processRefund);
+});

--- a/ecommerce/templates/oscar/dashboard/orders/order_list.html
+++ b/ecommerce/templates/oscar/dashboard/orders/order_list.html
@@ -16,6 +16,7 @@
 
   {% compress js %}
       <script src="{% static "vendor/js/jquery.cookie-1.4.1.min.js" %}" type="text/javascript"></script>
+      <script src="{% static "oscar/js/add_message.js" %}" type="text/javascript"></script>
       <script src="{% static "oscar/js/order_list.js" %}" type="text/javascript"></script>
   {% endcompress %}
 {% endblock %}

--- a/ecommerce/templates/oscar/dashboard/partials/refund_buttons.html
+++ b/ecommerce/templates/oscar/dashboard/partials/refund_buttons.html
@@ -1,0 +1,13 @@
+{% load i18n %}
+
+{% if refund.can_approve %}
+<a class="btn btn-success" data-refund-id="{{ refund.id }}" data-decision="approve" data-action="process-refund">
+    {% trans "Approve" %}
+</a>
+{% endif %}
+
+{% if refund.can_deny %}
+<a class="btn btn-danger" data-refund-id="{{ refund.id }}" data-decision="deny" data-action="process-refund">
+    {% trans "Deny" %}
+</a>
+{% endif %}

--- a/ecommerce/templates/oscar/dashboard/partials/refund_table.html
+++ b/ecommerce/templates/oscar/dashboard/partials/refund_table.html
@@ -9,7 +9,7 @@
           <th>{% trans "Refund ID" %}</th>
           <th>{% trans "Number of Items" %}</th>
           <th>{% trans "Total Credit" %}</th>
-          <th>{% trans "Date Created" %}</th>
+          <th>{% trans "Created" %}</th>
           <th>{% trans "Status" %}</th>
           <th></th>
       </tr>

--- a/ecommerce/templates/oscar/dashboard/refunds/refund_detail.html
+++ b/ecommerce/templates/oscar/dashboard/refunds/refund_detail.html
@@ -1,0 +1,192 @@
+{% extends 'dashboard/layout.html' %}
+{% load compress %}
+{% load staticfiles %}
+{% load currency_filters %}
+{% load i18n %}
+
+{% block body_class %}{{ block.super }} refunds{% endblock %}
+
+{% block title %}
+    {% blocktrans with id=refund.id %}Refund #{{ id }}{% endblocktrans %} | {{ block.super }}
+{% endblock title %}
+
+{% block extrascripts %}
+    {{ block.super }}
+
+    {% compress css %}
+    <link rel="stylesheet" type="text/css" href="{% static 'oscar/css/buttons.css' %}" />
+    {% endcompress %}
+
+    {% compress js %}
+    <script src="{% static 'vendor/js/jquery.cookie-1.4.1.min.js' %}" type="text/javascript"></script>
+    <script src="{% static 'oscar/js/add_message.js' %}" type="text/javascript"></script>
+    <script src="{% static 'oscar/js/refund_list.js' %}" type="text/javascript"></script>
+    {% endcompress %}
+{% endblock extrascripts %}
+
+{% block breadcrumbs %}
+<ul class="breadcrumb">
+    <li>
+        <a href="{% url 'dashboard:index' %}">{% trans "Dashboard" %}</a>
+        <span class="divider">/</span>
+    </li>
+    <li>
+        <a href="{% url 'dashboard:refunds:list' %}">{% trans "Refunds" %}</a>
+        <span class="divider">/</span>
+    </li>
+    <li class="active">#{{ refund.id }}</li>
+</ul>
+{% endblock breadcrumbs %}
+
+{% block headertext %}
+    {% blocktrans with id=refund.id %}Refund #{{ id }}{% endblocktrans %}
+{% endblock headertext %}
+
+{% block dashboard_content %}
+    {% block customer_information %}
+    <table class="table table-bordered table-hover">
+        <caption><i class="icon-group icon-large"></i>{% trans "Customer Information" %}</caption>
+        <tr>
+            <th>{% trans "Name" %}</th>
+            <th>{% trans "Email address" %}</th>
+        </tr>
+        <tr>
+            <td>{{ refund.user.get_full_name|default:"-" }}</td>
+            <td>{{ refund.user.email|default:"-" }}</td>
+        </tr>
+    </table>
+    {% endblock customer_information %}
+
+    {% block refund_overview %}
+    <table class="table table-striped table-bordered table-hover">
+        <caption><i class="icon-shopping-cart icon-large"></i>{% trans "Refund Overview" %}</caption>
+        <tr>
+            <th>{% trans "Total Credit" %}</th>
+            <th>{% trans "Created" %}</th>
+            <th>{% trans "Status" %}</th>
+            <th>{% trans "Associated Order" %}</th>
+            <th>{% trans "Actions" %}</th>
+        </tr>
+        <tr data-refund-id="{{ refund.id }}">
+            <td>{{ refund.total_credit_excl_tax|currency:refund.currency }}</td>
+            <td>{{ refund.created }}</td>
+            <td class="refund-status">{{ refund.status }}</td>
+            <td>
+                <a href="{% url 'dashboard:order-detail' number=refund.order.number %}">{{ refund.order.number }}</a>
+            </td>
+            <td>
+                {% include "dashboard/partials/refund_buttons.html" %}
+            </td>
+        </tr>
+    </table>
+    {% endblock refund_overview %}
+
+    {% block refund_details %}
+    <div class="table-header">
+        <h3>{% trans "Refund Items" %}</h3>
+    </div>
+
+    <form id="refund_lines_form" action="." method="post" class="form-inline">
+        {% csrf_token %}
+        {% block refund_lines %}
+        <table class="table table-striped table-bordered table-hover">
+            <thead>
+                <tr>
+                    <th>{% trans "Refund Line ID" %}</th>
+                    <th>{% trans "Associated Order Line" %}</th>
+                    <th>{% trans "Quantity" %}</th>
+                    <th>{% trans "Product" %}</th>
+                    <th>{% trans "UPC" %}</th>
+                    <th>{% trans "Status" %}</th>
+                    <th>{% trans "Supplier" %}</th>
+                    <th>{% trans "Supplier SKU" %}</th>
+                    <th>{% trans "Credit (excl. tax)" %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for line in refund.lines.all %}
+                <tr>
+                    <td>{{ line.id }}</td>
+                    <td>
+                        <a href="{% url 'dashboard:order-line-detail' number=refund.order.number line_id=line.order_line.id %}">{{ line.order_line.id }}</a>
+                    </td>
+                    <td>{{ line.quantity }}</td>
+                    <td>
+                        {% if line.order_line.product %}
+                        <a href="{% url 'dashboard:catalogue-product' pk=line.order_line.product.id %}">{{ line.order_line.title }}</a>
+                        {% else %}
+                        {{ line.order_line.title }}
+                        {% endif %}
+                    </td>
+                    <td>{{ line.order_line.upc|default:"-" }}</td>
+                    <td>{{ line.status }}</td>
+                    <td>
+                        {% if line.order_line.partner %}
+                        <a href="{% url 'dashboard:partner-manage' pk=line.order_line.partner.id %}">{{ line.order_line.partner_name }}</a>
+                        {% else %}
+                        {{ line.order_line.partner_name }}
+                        {% endif %}
+                    </td>
+                    <td>{{ line.order_line.partner_sku }}</td>
+                    <td style="text-align: right">{{ line.line_credit_excl_tax|currency:refund.currency }}</td>
+                </tr>
+                {% endfor %}
+
+                <tr>
+                    <td colspan="7"></td>
+                    <th>{% trans "Total Credit" %}</th>
+                    <th style="text-align: right">{{ refund.total_credit_excl_tax|currency:refund.currency }}</th>
+                </tr>
+            </tbody>
+        </table>
+        {% endblock refund_lines %}
+    </form>
+    {% endblock refund_details %}
+
+    {% block payment_events %}
+    <div class="table-header">
+        <h3>{% trans "Payment Events" %}</h3>
+    </div>
+
+    {% with events=refund.order.payment_events.all %}
+    <table class="table table-striped table-bordered table-hover">
+        {% if events %}
+        <thead>
+            <tr>
+                <th>{% trans "Date" %}</th>
+                <th>{% trans "Event" %}</th>
+                <th>{% trans "Amount" %}</th>
+                <th>{% trans "Lines" %}</th>
+                <th>{% trans "Processor" %}</th>
+                <th>{% trans "Reference" %}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for event in events %}
+            {% with line_qtys=event.line_quantities.all %}
+            <tr>
+                <td>{{ event.date_created }}</td>
+                <td>{{ event.event_type.name }}</td>
+                <td>{{ event.amount|currency:refund.order.currency }}</td>
+                <td>
+                    {% for line_qty in event.line_quantities.all %}
+                    {% trans "Product:" %} {{ line_qty.line.title }}. {% trans "Quantity:" %} {{ line_qty.quantity }}.</br>
+                    {% endfor %}
+                </td>
+                <td>{{ event.processor_name }}</td>
+                <td>{{ event.reference|default:"-" }}</td>
+            </tr>
+            {% endwith %}
+            {% endfor %}
+        </tbody>
+        {% else %}
+        <tbody>
+            <tr>
+                <td>{% trans "No payment events." %}</td>
+            </tr>
+        </tbody>
+        {% endif %}
+    </table>
+    {% endwith %}
+    {% endblock payment_events %}
+{% endblock dashboard_content %}

--- a/ecommerce/templates/oscar/dashboard/refunds/refund_list.html
+++ b/ecommerce/templates/oscar/dashboard/refunds/refund_list.html
@@ -1,5 +1,6 @@
 {% extends 'dashboard/layout.html' %}
 {% load compress %}
+{% load staticfiles %}
 {% load currency_filters %}
 {% load sorting_tags %}
 {% load i18n %}
@@ -9,6 +10,20 @@
 {% block title %}
   {% trans "Refunds" %} | {{ block.super }}
 {% endblock %}
+
+{% block extrascripts %}
+    {{ block.super }}
+
+    {% compress css %}
+    <link rel="stylesheet" type="text/css" href="{% static 'oscar/css/buttons.css' %}" />
+    {% endcompress %}
+
+    {% compress js %}
+    <script src="{% static 'vendor/js/jquery.cookie-1.4.1.min.js' %}" type="text/javascript"></script>
+    <script src="{% static 'oscar/js/add_message.js' %}" type="text/javascript"></script>
+    <script src="{% static 'oscar/js/refund_list.js' %}" type="text/javascript"></script>
+    {% endcompress %}
+{% endblock extrascripts %}
 
 {% block breadcrumbs %}
     <ul class="breadcrumb">
@@ -84,7 +99,8 @@
                 <th>{% trans "Number of Items" %}</th>
                 <th>{% trans "Status" %}</th>
                 <th>{% trans "Customer" %}</th>
-                <th>{% trans "Date Created" %}</th>
+                <th>{% trans "Created" %}</th>
+                <th>{% trans "Actions" %}</th>
                 <th></th>
             </tr>
             </thead>
@@ -102,8 +118,8 @@
                     </td>
                     <td>{{ refund.created }}</td>
                     <td>
-                        <a class="btn btn-info"
-                           href="{% url 'dashboard:refunds:detail' pk=refund.id %}">{% trans "View" %}</a>
+                        <a class="btn btn-info" href="{% url 'dashboard:refunds:detail' pk=refund.id %}">{% trans "View" %}</a>
+                        {% include "dashboard/partials/refund_buttons.html" %}
                     </td>
                 </tr>
             {% endfor %}


### PR DESCRIPTION
Adds a refund detail view to Oscar which displays information about a single refund and allows a support team member to approve or deny that refund. Also provides UI elements on the refund list view which can be used to approve or deny a refund. Credit and revocation are coupled as far as the UI is concerned.

@clintonb and @jimabramson, could you please review this when you have the time? @Nickersoft, FYI.

@cptvitamin, this is the second half of the refund dashboard requiring an accessibility review. Whoever takes ownership of making your suggested changes (separate of getting this feature merged) will consider your comments on #100 in addition to any comments you may add here. Thank you for your help!
