### PR TITLE
Updated CSRF cookie name in JS

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -399,3 +399,12 @@ REST_FRAMEWORK = {
 
 # Resolving deprecation warning
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
+
+# COOKIE CONFIGURATION
+# The purpose of customizing the cookie names is to avoid conflicts when
+# multiple Django services are running behind the same hostname.
+# Detailed information at: https://docs.djangoproject.com/en/dev/ref/settings/
+SESSION_COOKIE_NAME = 'ecommerce_sessionid'
+CSRF_COOKIE_NAME = 'ecommerce_csrftoken'
+LANGUAGE_COOKIE_NAME = 'ecommerce_language'
+# END COOKIE CONFIGURATION

--- a/ecommerce/settings/local.py
+++ b/ecommerce/settings/local.py
@@ -16,15 +16,6 @@ DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 # END DEBUG CONFIGURATION
 
-# COOKIE CONFIGURATION
-# The purpose of customizing the cookie names is to avoid conflicts when
-# multiple Django services are running behind the same hostname.
-# Detailed information at: https://docs.djangoproject.com/en/dev/ref/settings/
-SESSION_COOKIE_NAME = 'ecommerce_sessionid'
-CSRF_COOKIE_NAME = 'ecommerce_csrftoken'
-LANGUAGE_COOKIE_NAME = 'ecommerce_language'
-# END COOKIE CONFIGURATION
-
 # EMAIL CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#email-backend
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/ecommerce/static/oscar/js/order_list.js
+++ b/ecommerce/static/oscar/js/order_list.js
@@ -12,7 +12,7 @@ $(document).ready(function () {
         $.ajax({
             url: '/api/v2/orders/' + order_number + '/fulfill/',
             method: 'PUT',
-            headers: {'X-CSRFToken': $.cookie('csrftoken')}
+            headers: {'X-CSRFToken': $.cookie('ecommerce_csrftoken')}
         }).success(function (data) {
             $('tr[data-order-number=' + order_number + '] .order-status').text(data.status);
             addMessage('alert-success', 'icon-check-sign', 'Order ' + order_number + ' has been fulfilled.');

--- a/ecommerce/static/oscar/js/refund_list.js
+++ b/ecommerce/static/oscar/js/refund_list.js
@@ -16,7 +16,7 @@ $(document).ready(function () {
             url: '/api/v2/refunds/' + refund_id + '/process/',
             data: { action: decision },
             method: 'PUT',
-            headers: {'X-CSRFToken': $.cookie('csrftoken')}
+            headers: {'X-CSRFToken': $.cookie('ecommerce_csrftoken')}
         }).success(function (data) {
             $('tr[data-refund-id=' + refund_id + '] .refund-status').text(data.status);
             addMessage('alert-success', 'icon-check-sign', 'Refund #' + refund_id + ' has been processed.');


### PR DESCRIPTION
This was missed when the CSRF_COOKIE_NAME setting was changed. The settings changes have been moved to base.py so that they work across all environments, and we avoid the need to modify JS solely for local usage.

@jimabramson @rlucioni 
