### PR TITLE
Fix issue removing all refund actions after a successfully processed refund

### DIFF
--- a/ecommerce/static/oscar/js/refund_list.js
+++ b/ecommerce/static/oscar/js/refund_list.js
@@ -20,7 +20,7 @@ $(document).ready(function () {
         }).success(function (data) {
             $('tr[data-refund-id=' + refund_id + '] .refund-status').text(data.status);
             addMessage('alert-success', 'icon-check-sign', 'Refund #' + refund_id + ' has been processed.');
-            $actions.remove();
+            $('tr[data-refund-id=' + refund_id + '] [data-action=process-refund]').remove();
         }).fail(function (jqXHR, textStatus, errorThrown) {
             // NOTE (RFL): For an MVP, changing the displayed refund state on any error may be viable.
             // Ideally, the displayed refund state would only change if the refund were to enter an


### PR DESCRIPTION
The selector being used to identify buttons to remove from the DOM after successfully processing a refund was too broad. This change narrows the selector to only those buttons with the correct refund ID. Addresses [XCOM-355](https://openedx.atlassian.net/browse/XCOM-355).

@clintonb or @jimabramson, please review.
