### PR TITLE
Refund analytics

### DIFF
--- a/ecommerce/extensions/analytics/utils.py
+++ b/ecommerce/extensions/analytics/utils.py
@@ -1,0 +1,55 @@
+from functools import wraps
+import logging
+
+from django.conf import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+def is_segment_configured():
+    """Returns a Boolean indicating if Segment has been configured for use."""
+    return bool(settings.SEGMENT_KEY)
+
+
+def parse_tracking_context(user):
+    """Extract user and client IDs from a user's tracking context.
+
+    Arguments:
+        user (User): An instance of the User model.
+
+    Returns:
+        Tuple of strings, user_tracking_id and lms_client_id
+    """
+    tracking_context = user.tracking_context or {}
+
+    user_tracking_id = tracking_context.get('lms_user_id')
+    if user_tracking_id is None:
+        # Even if we cannot extract a good platform user ID from the context, we can still track the
+        # event with an arbitrary local user ID. However, we need to disambiguate the ID we choose
+        # since there's no guarantee it won't collide with a platform user ID that may be tracked
+        # at some point.
+        user_tracking_id = 'ecommerce-{}'.format(user.id)
+
+    lms_client_id = tracking_context.get('lms_client_id')
+
+    return user_tracking_id, lms_client_id
+
+
+def log_exceptions(msg):
+    """Log exceptions (avoiding clutter/indentation).
+
+    Exceptions are still raised. This module assumes that signal receivers are
+    being invoked with `send_robust`, or that callers will otherwise mute
+    exceptions as needed.
+    """
+    def decorator(func):  # pylint: disable=missing-docstring
+        @wraps(func)
+        def wrapper(*args, **kwargs):  # pylint: disable=missing-docstring
+            try:
+                return func(*args, **kwargs)
+            except:  # pylint: disable=bare-except
+                logger.exception(msg)
+                raise
+        return wrapper
+    return decorator

--- a/ecommerce/extensions/api/v2/tests/test_views.py
+++ b/ecommerce/extensions/api/v2/tests/test_views.py
@@ -29,7 +29,7 @@ from ecommerce.extensions.payment import exceptions as payment_exceptions
 from ecommerce.extensions.payment.processors.cybersource import Cybersource
 from ecommerce.extensions.payment.tests.processors import DummyProcessor, AnotherDummyProcessor
 from ecommerce.extensions.refund.tests.factories import RefundLineFactory, RefundFactory
-from ecommerce.extensions.refund.tests.test_api import RefundTestMixin
+from ecommerce.extensions.refund.tests.mixins import RefundTestMixin
 from ecommerce.tests.mixins import UserMixin, ThrottlingMixin, BasketCreationMixin, JwtMixin
 
 Basket = get_model('basket', 'Basket')

--- a/ecommerce/extensions/fulfillment/tests/mixins.py
+++ b/ecommerce/extensions/fulfillment/tests/mixins.py
@@ -1,12 +1,14 @@
 from oscar.test import factories
 
 from ecommerce.extensions.fulfillment.status import ORDER, LINE
+from ecommerce.tests.mixins import UserMixin
 
 
-class FulfillmentTestMixin(object):
+class FulfillmentTestMixin(UserMixin):
     def generate_open_order(self):
         """ Returns an open order, ready to be fulfilled. """
-        return factories.create_order(status=ORDER.OPEN)
+        user = self.create_user()
+        return factories.create_order(user=user, status=ORDER.OPEN)
 
     def assert_order_fulfilled(self, order):
         """

--- a/ecommerce/extensions/refund/models.py
+++ b/ecommerce/extensions/refund/models.py
@@ -128,7 +128,7 @@ class Refund(StatusMixin, TimeStampedModel):
             self._revoke_lines()
 
         if self.status == REFUND.COMPLETE:
-            post_refund.send(sender=self.__class__, refund=self)
+            post_refund.send_robust(sender=self.__class__, refund=self)
             return True
 
         return False

--- a/ecommerce/extensions/refund/signals.py
+++ b/ecommerce/extensions/refund/signals.py
@@ -1,6 +1,46 @@
-from django.dispatch import Signal
+import analytics
+from django.dispatch import receiver, Signal
 
-# This signal should be emitted after a refund is completed--payment credited AND fulfillment revoked.
+from ecommerce.extensions.analytics.utils import is_segment_configured, parse_tracking_context, log_exceptions
+
+
+# This signal should be emitted after a refund is completed - payment credited AND fulfillment revoked.
 post_refund = Signal(providing_args=["refund"])
 
-# TODO Track refund: https://support.google.com/analytics/answer/1037443?hl=en
+
+@receiver(post_refund, dispatch_uid='tracking.post_refund_callback')
+@log_exceptions("Failed to emit tracking event upon refund completion.")
+def track_completed_refund(sender, refund=None, **kwargs):  # pylint: disable=unused-argument
+    """Emit a tracking event when a refund is completed."""
+    if not is_segment_configured():
+        return
+
+    user_tracking_id, lms_client_id = parse_tracking_context(refund.user)
+
+    # Ecommerce transaction reversal, performed by emitting an event which is the inverse of an
+    # order completion event emitted previously.
+    # See: https://support.google.com/analytics/answer/1037443?hl=en
+    analytics.track(
+        user_tracking_id,
+        'Completed Order',
+        {
+            'orderId': refund.order.number,
+            'total': '-{}'.format(refund.total_credit_excl_tax),
+            'currency': refund.currency,
+            'products': [
+                {
+                    'id': line.order_line.upc,
+                    'sku': line.order_line.partner_sku,
+                    'name': line.order_line.product.attr.course_key,
+                    'price': str(line.line_credit_excl_tax),
+                    'quantity': -1 * line.quantity,
+                    'category': line.order_line.product.get_product_class().name,
+                } for line in refund.lines.all()
+            ],
+        },
+        context={
+            'Google Analytics': {
+                'clientId': lms_client_id
+            }
+        },
+    )

--- a/ecommerce/extensions/refund/tests/mixins.py
+++ b/ecommerce/extensions/refund/tests/mixins.py
@@ -1,12 +1,55 @@
-from oscar.core.loading import get_model
+# coding=utf-8
+from decimal import Decimal
 
-from ecommerce.extensions.refund.tests.factories import RefundFactory
+from django.conf import settings
+import mock
+from mock_django import mock_signal_receiver
+from oscar.core.loading import get_model, get_class
+from oscar.test.factories import create_order
+from oscar.test.newfactories import BasketFactory
 
+from ecommerce.extensions.fulfillment.status import ORDER
+from ecommerce.extensions.refund.status import REFUND, REFUND_LINE
+from ecommerce.extensions.refund.tests.factories import CourseFactory, RefundFactory
+
+
+post_refund = get_class('refund.signals', 'post_refund')
+Refund = get_model('refund', 'Refund')
 Source = get_model('payment', 'Source')
 SourceType = get_model('payment', 'SourceType')
 
 
 class RefundTestMixin(object):
+    def setUp(self):
+        self.course_id = u'edX/DemoX/Demo_Course'
+        self.course = CourseFactory(self.course_id, u'edX Demó Course')
+        self.honor_product = self.course.add_mode('honor', 0)
+        self.verified_product = self.course.add_mode('verified', Decimal(10.00), id_verification_required=True)
+
+    def create_order(self, user=None):
+        user = user or self.user
+        basket = BasketFactory(owner=user)
+        basket.add_product(self.verified_product)
+        order = create_order(basket=basket, user=user)
+        order.status = ORDER.COMPLETE
+        order.save()
+        return order
+
+    def assert_refund_matches_order(self, refund, order):
+        """ Verify the refund corresponds to the given order. """
+        self.assertEqual(refund.order, order)
+        self.assertEqual(refund.user, order.user)
+        self.assertEqual(refund.status, settings.OSCAR_INITIAL_REFUND_STATUS)
+        self.assertEqual(refund.total_credit_excl_tax, order.total_excl_tax)
+        self.assertEqual(refund.lines.count(), 1)
+
+        refund_line = refund.lines.first()
+        line = order.lines.first()
+        self.assertEqual(refund_line.status, settings.OSCAR_INITIAL_REFUND_LINE_STATUS)
+        self.assertEqual(refund_line.order_line, line)
+        self.assertEqual(refund_line.line_credit_excl_tax, line.line_price_excl_tax)
+        self.assertEqual(refund_line.quantity, 1)
+
     def create_refund(self, processor_name='cybersource'):
         refund = RefundFactory()
         order = refund.order
@@ -15,3 +58,17 @@ class RefundTestMixin(object):
                               amount_allocated=order.total_incl_tax, amount_debited=order.total_incl_tax)
 
         return refund
+
+    def approve(self, refund):
+        def _revoke_lines(r):
+            for line in r.lines.all():
+                line.set_status(REFUND_LINE.COMPLETE)
+
+            r.set_status(REFUND.COMPLETE)
+
+        with mock.patch.object(Refund, '_issue_credit', return_value=None):
+            with mock.patch.object(Refund, '_revoke_lines', side_effect=_revoke_lines, autospec=True):
+                with mock_signal_receiver(post_refund) as receiver:
+                    self.assertEqual(receiver.call_count, 0)
+                    self.assertTrue(refund.approve())
+                    self.assertEqual(receiver.call_count, 1)

--- a/ecommerce/extensions/refund/tests/test_signals.py
+++ b/ecommerce/extensions/refund/tests/test_signals.py
@@ -1,0 +1,84 @@
+from django.test import TestCase, override_settings
+from mock import patch
+from oscar.test.newfactories import UserFactory
+
+from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
+from ecommerce.extensions.refund.api import create_refunds
+from ecommerce.extensions.refund.tests.mixins import RefundTestMixin
+from ecommerce.tests.mixins import BusinessIntelligenceMixin
+
+
+@override_settings(SEGMENT_KEY='dummy-key')
+@patch('analytics.track')
+class RefundTrackingTests(BusinessIntelligenceMixin, CourseCatalogTestMixin, RefundTestMixin, TestCase):
+    """Tests verifying the behavior of refund tracking."""
+    def setUp(self):
+        super(RefundTrackingTests, self).setUp()
+
+        self.user = UserFactory()
+        self.order = self.create_order()
+        self.refund = create_refunds([self.order], self.course_id)[0]
+
+    def test_successful_refund_tracking(self, mock_track):
+        """Verify that a successfully placed refund is tracked when Segment is enabled."""
+        tracking_context = {'lms_user_id': 'test-user-id', 'lms_client_id': 'test-client-id'}
+        self.refund.user.tracking_context = tracking_context
+        self.refund.user.save()
+
+        # Approve the refund.
+        self.approve(self.refund)
+
+        # Verify that a corresponding business intelligence event was emitted.
+        self.assertTrue(mock_track.called)
+
+        # Verify the event's payload.
+        self.assert_correct_event(
+            mock_track,
+            self.refund,
+            tracking_context['lms_user_id'],
+            tracking_context['lms_client_id'],
+            self.order.number,
+            self.refund.currency,
+            self.refund.total_credit_excl_tax
+        )
+
+    def test_successful_refund_tracking_without_context(self, mock_track):
+        """Verify that a successfully placed refund is tracked, even if no tracking context is available."""
+        # Approve the refund.
+        self.approve(self.refund)
+
+        # Verify that a corresponding business intelligence event was emitted.
+        self.assertTrue(mock_track.called)
+
+        # Verify the event's payload.
+        self.assert_correct_event(
+            mock_track,
+            self.refund,
+            'ecommerce-{}'.format(self.user.id),
+            None,
+            self.order.number,
+            self.refund.currency,
+            self.refund.total_credit_excl_tax
+        )
+
+    @override_settings(SEGMENT_KEY=None)
+    def test_successful_refund_no_segment_key(self, mock_track):
+        """Verify that a successfully placed refund is not tracked when Segment is disabled."""
+        # Approve the refund.
+        self.approve(self.refund)
+
+        # Verify that no business intelligence event was emitted.
+        self.assertFalse(mock_track.called)
+
+    def test_successful_refund_tracking_segment_error(self, mock_track):
+        """Verify that errors during refund tracking are logged."""
+        # Approve the refund, forcing an exception to be raised when attempting to emit a corresponding event
+        with patch('ecommerce.extensions.analytics.utils.logger.exception') as mock_log_exc:
+            mock_track.side_effect = Exception("boom!")
+            self.approve(self.refund)
+
+        # Verify that an attempt was made to emit a business intelligence event.
+        self.assertTrue(mock_track.called)
+
+        # Verify that an error message was logged.
+        self.assertTrue(mock_log_exc.called_with("Failed to emit tracking event upon refund completion."))


### PR DESCRIPTION
Adds a receiver of the post_refund signal which emits a business intelligence event if Segment is enabled. I revised the existing post_checkout receiver as well as the tests to make emitting and testing business intelligence events easier. We also had two different RefundTestMixins, which I've consolidated.

@jimabramson, could you please review this? @clintonb and @Nickersoft, FYI.
