### PR TITLE
fix dashboard page path in acceptance tests

### DIFF
--- a/acceptance_tests/pages.py
+++ b/acceptance_tests/pages.py
@@ -22,7 +22,7 @@ class EcommerceAppPage(PageObject):  # pylint: disable=abstract-method
 
 
 class DashboardHomePage(EcommerceAppPage):
-    path = ''
+    path = 'dashboard'
 
     def is_browser_on_page(self):
         return self.browser.title.startswith('Dashboard | Oscar')


### PR DESCRIPTION
XCOM-378

this change is necessary because requests for / no longer redirect to /dashboard.

@rlucioni please review
