### PR TITLE
in acceptance tests, make LMS’ payment buttons more findable.

### DIFF
--- a/acceptance_tests/test_payment.py
+++ b/acceptance_tests/test_payment.py
@@ -68,7 +68,7 @@ class VerifiedCertificatePaymentTests(EcommerceApiMixin, EnrollmentApiMixin, Lms
         """ Completes the checkout process via CyberSource. """
 
         # Click the payment button
-        self.browser.find_element_by_css_selector('a#cybersource').click()
+        self.browser.find_element_by_css_selector('#cybersource').click()
 
         self._dismiss_alert()
 
@@ -122,7 +122,7 @@ class VerifiedCertificatePaymentTests(EcommerceApiMixin, EnrollmentApiMixin, Lms
         """ Completes the checkout process via PayPal. """
 
         # Click the payment button
-        self.browser.find_element_by_css_selector('a#paypal').click()
+        self.browser.find_element_by_css_selector('#paypal').click()
 
         # Make sure we are checking out with a PayPal account, instead of credit card
         try:


### PR DESCRIPTION
the LMS cybersource and paypal buttons were once implemented as A elements, but recently switched to BUTTON elements.  The change in the PR, instead of expecting any particular DOM element tag, just uses css classes and IDs.

@rlucioni or @clintonb please review
