### PR TITLE
Pass mode when revoking course seat fulfillment.

### DIFF
--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -204,9 +204,10 @@ class EnrollmentFulfillmentModule(BaseFulfillmentModule):
             data = {
                 'user': line.order.user.username,
                 'is_active': False,
+                'mode': line.product.attr.certificate_type,
                 'course_details': {
-                    'course_id': line.product.attr.course_key
-                }
+                    'course_id': line.product.attr.course_key,
+                },
             }
 
             response = self._post_to_enrollment_api(data)

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -28,13 +28,13 @@ User = get_user_model()
 class EnrollmentFulfillmentModuleTests(CourseCatalogTestMixin, FulfillmentTestMixin, TestCase):
     """Test course seat fulfillment."""
     course_id = 'edX/DemoX/Demo_Course'
+    certificate_type = 'test-certificate-type'
 
     def setUp(self):
         user = UserFactory()
 
-        certificate_type = 'honor'
-        seats = self.create_course_seats(self.course_id, (certificate_type,))
-        self.seat = seats[certificate_type]
+        seats = self.create_course_seats(self.course_id, (self.certificate_type,))
+        self.seat = seats[self.certificate_type]
 
         for stock_record in self.seat.stockrecords.all():
             stock_record.price_currency = 'USD'
@@ -103,9 +103,10 @@ class EnrollmentFulfillmentModuleTests(CourseCatalogTestMixin, FulfillmentTestMi
         expected = {
             'user': self.order.user.username,
             'is_active': False,
+            'mode': self.certificate_type,
             'course_details': {
-                'course_id': self.course_id
-            }
+                'course_id': self.course_id,
+            },
         }
         self.assertEqual(actual, expected)
 


### PR DESCRIPTION
XCOM-388

This change solves HTTP 400 errors when attempting to revoke a course seat in a course that has no honor mode configured.

@rlucioni @clintonb please review.
