### PR TITLE
Recover from 400 on enrollment revocation when due to mode mismatch.

### DIFF
--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -216,9 +216,16 @@ class EnrollmentFulfillmentModule(BaseFulfillmentModule):
                 logger.info('Successfully revoked line [%d].', line.id)
                 return True
             else:
+                # check if the error / message are something we can recover from.
                 data = response.json()
                 detail = data.get('message', '(No details provided.)')
-                logger.error('Failed to revoke fulfillment of Line [%d]: %s', line.id, detail)
+                if response.status_code == 400 and "Enrollment mode mismatch" in detail:
+                    # The user is currently enrolled in different mode than the one
+                    # we are refunding an order for.  Don't revoke that enrollment.
+                    logger.info('Skipping revocation for line [%d]: %s', line.id, detail)
+                    return True
+                else:
+                    logger.error('Failed to revoke fulfillment of Line [%d]: %s', line.id, detail)
         except Exception:  # pylint: disable=broad-except
             logger.exception('Failed to revoke fulfillment of Line [%d].', line.id)
 


### PR DESCRIPTION
XCOM-396

related to https://github.com/edx/edx-platform/pull/8379 - this avoids an error in otto if we approve a refund request for one course mode but the student has already re-enrolled in another course mode.

@rlucioni @clintonb please have a look
