### PR TITLE
Automatically approve refunds corresponding to a total credit of $0

### DIFF
--- a/ecommerce/extensions/dashboard/refunds/forms.py
+++ b/ecommerce/extensions/dashboard/refunds/forms.py
@@ -2,10 +2,20 @@ from django import forms
 from django.utils.translation import ugettext_lazy as _
 from oscar.core.loading import get_model
 
+from ecommerce.extensions.refund.status import REFUND
+
+
 Refund = get_model('refund', 'Refund')
 
 
 class RefundSearchForm(forms.Form):
     id = forms.IntegerField(required=False, label=_('Refund ID'))
-    status_choices = (('', '---------'),) + tuple([(status, status) for status in Refund.all_statuses()])
-    status = forms.ChoiceField(choices=status_choices, label=_("Status"), required=False)
+    status_choices = tuple([(status, status) for status in Refund.all_statuses()])
+    status = forms.MultipleChoiceField(choices=status_choices, label=_("Status"), required=False)
+
+    def clean(self):
+        cleaned_data = super(RefundSearchForm, self).clean()
+
+        if not cleaned_data.get('status'):
+            # If no statuses are specified, default to displaying all those refunds requiring action.
+            cleaned_data['status'] = list(set(Refund.all_statuses()) - set((REFUND.COMPLETE, REFUND.DENIED)))

--- a/ecommerce/extensions/dashboard/refunds/views.py
+++ b/ecommerce/extensions/dashboard/refunds/views.py
@@ -25,7 +25,9 @@ class RefundListView(ListView):
 
         if self.form.is_valid():
             for field, value in self.form.cleaned_data.iteritems():
-                if value:
+                if field == 'status' and value:
+                    queryset = queryset.filter(status__in=value)
+                elif value:
                     queryset = queryset.filter(**{field: value})
 
         return queryset

--- a/ecommerce/extensions/refund/tests/mixins.py
+++ b/ecommerce/extensions/refund/tests/mixins.py
@@ -26,13 +26,17 @@ class RefundTestMixin(object):
         self.honor_product = self.course.add_mode('honor', 0)
         self.verified_product = self.course.add_mode('verified', Decimal(10.00), id_verification_required=True)
 
-    def create_order(self, user=None, multiple_lines=False):
+    def create_order(self, user=None, multiple_lines=False, free=False):
         user = user or self.user
         basket = BasketFactory(owner=user)
-        basket.add_product(self.verified_product)
 
         if multiple_lines:
+            basket.add_product(self.verified_product)
             basket.add_product(self.honor_product)
+        elif free:
+            basket.add_product(self.honor_product)
+        else:
+            basket.add_product(self.verified_product)
 
         order = create_order(basket=basket, user=user)
         order.status = ORDER.COMPLETE


### PR DESCRIPTION
Also prevents completed and denied refunds from appearing in the default refund list view, and allows filtering of refunds by multiple statuses.

@jimabramson or @clintonb, could you please review this when you're able?
