### PR TITLE
Removed changed_by fields from all models

### DIFF
--- a/ecommerce/extensions/catalogue/migrations/0005_auto_20150610_1355.py
+++ b/ecommerce/extensions/catalogue/migrations/0005_auto_20150610_1355.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('catalogue', '0004_auto_20150609_0129'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='historicalproduct',
+            name='changed_by',
+        ),
+        migrations.RemoveField(
+            model_name='historicalproductattributevalue',
+            name='changed_by',
+        ),
+        migrations.RemoveField(
+            model_name='product',
+            name='changed_by',
+        ),
+        migrations.RemoveField(
+            model_name='productattributevalue',
+            name='changed_by',
+        ),
+    ]

--- a/ecommerce/extensions/catalogue/models.py
+++ b/ecommerce/extensions/catalogue/models.py
@@ -6,29 +6,11 @@ from simple_history.models import HistoricalRecords
 
 class Product(AbstractProduct):
     course = models.ForeignKey('courses.Course', null=True, blank=True, related_name='products')
-    changed_by = models.ForeignKey('user.User', null=True, blank=True)
     history = HistoricalRecords()
-
-    @property
-    def _history_user(self):  # pragma: no cover
-        return self.changed_by
-
-    @_history_user.setter
-    def _history_user(self, value):  # pragma: no cover
-        self.changed_by = value
 
 
 class ProductAttributeValue(AbstractProductAttributeValue):
-    changed_by = models.ForeignKey('user.User', null=True, blank=True)
     history = HistoricalRecords()
-
-    @property
-    def _history_user(self):  # pragma: no cover
-        return self.changed_by
-
-    @_history_user.setter
-    def _history_user(self, value):  # pragma: no cover
-        self.changed_by = value
 
 # noinspection PyUnresolvedReferences
 from oscar.apps.catalogue.models import *  # noqa pylint: disable=wildcard-import,unused-wildcard-import

--- a/ecommerce/extensions/partner/migrations/0005_auto_20150610_1355.py
+++ b/ecommerce/extensions/partner/migrations/0005_auto_20150610_1355.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('partner', '0004_auto_20150609_1215'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='historicalstockrecord',
+            name='changed_by',
+        ),
+        migrations.RemoveField(
+            model_name='stockrecord',
+            name='changed_by',
+        ),
+    ]

--- a/ecommerce/extensions/partner/models.py
+++ b/ecommerce/extensions/partner/models.py
@@ -1,19 +1,9 @@
-from django.db import models
 from oscar.apps.partner.abstract_models import AbstractStockRecord
 from simple_history.models import HistoricalRecords
 
 
 class StockRecord(AbstractStockRecord):
-    changed_by = models.ForeignKey('user.User', null=True, blank=True)
     history = HistoricalRecords()
-
-    @property
-    def _history_user(self):  # pragma: no cover
-        return self.changed_by
-
-    @_history_user.setter
-    def _history_user(self, value):  # pragma: no cover
-        self.changed_by = value
 
 # noinspection PyUnresolvedReferences
 from oscar.apps.partner.models import *  # noqa pylint: disable=wildcard-import,unused-wildcard-import


### PR DESCRIPTION
This field unnecessarily duplicates behavior from simple history, and prevents us from using the middleware to get the user making the change.

XCOM-193

@jimabramson @rlucioni 
