### PR TITLE
Suppress emission of business intelligence events for free orders

### DIFF
--- a/ecommerce/extensions/checkout/signals.py
+++ b/ecommerce/extensions/checkout/signals.py
@@ -12,7 +12,7 @@ post_checkout = get_class('checkout.signals', 'post_checkout')
 @log_exceptions("Failed to emit tracking event upon order completion.")
 def track_completed_order(sender, order=None, **kwargs):  # pylint: disable=unused-argument
     """Emit a tracking event when an order is placed."""
-    if not is_segment_configured():
+    if not (is_segment_configured() and order.total_excl_tax > 0):
         return
 
     user_tracking_id, lms_client_id = parse_tracking_context(order.user)

--- a/ecommerce/extensions/refund/signals.py
+++ b/ecommerce/extensions/refund/signals.py
@@ -12,7 +12,7 @@ post_refund = Signal(providing_args=["refund"])
 @log_exceptions("Failed to emit tracking event upon refund completion.")
 def track_completed_refund(sender, refund=None, **kwargs):  # pylint: disable=unused-argument
     """Emit a tracking event when a refund is completed."""
-    if not is_segment_configured():
+    if not (is_segment_configured() and refund.total_credit_excl_tax > 0):
         return
 
     user_tracking_id, lms_client_id = parse_tracking_context(refund.user)

--- a/ecommerce/extensions/refund/tests/test_signals.py
+++ b/ecommerce/extensions/refund/tests/test_signals.py
@@ -42,6 +42,18 @@ class RefundTrackingTests(BusinessIntelligenceMixin, CourseCatalogTestMixin, Ref
             self.refund.total_credit_excl_tax
         )
 
+    def test_successful_zero_dollar_refund_no_tracking(self, mock_track):
+        """
+        Verify that tracking events are not emitted for refunds corresponding
+        to a total credit of 0.
+        """
+        order = self.create_order(free=True)
+        create_refunds([order], self.course_id)
+
+        # Verify that no business intelligence event was emitted. Refunds corresponding
+        # to a total credit of 0 are automatically approved upon creation.
+        self.assertFalse(mock_track.called)
+
     def test_successful_refund_tracking_without_context(self, mock_track):
         """Verify that a successfully placed refund is tracked, even if no tracking context is available."""
         # Approve the refund.

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -175,7 +175,7 @@ class BusinessIntelligenceMixin(object):
         tracked_products_dict = {product['sku']: product for product in event_payload['products']}
 
         if model_name == 'Order':
-            self.assertEqual(event_payload['total'], total)
+            self.assertEqual(event_payload['total'], str(total))
 
             for line in lines:
                 tracked_product = tracked_products_dict.get(line.partner_sku)


### PR DESCRIPTION
Pursuant to [XCOM-412](https://openedx.atlassian.net/browse/XCOM-412); this is a change requested by marketing, which consumes these events.

@clintonb or @jimabramson, please review.
