### PR TITLE
Nonatomic payment processing

### DIFF
--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -12,8 +12,8 @@ from oscar.test import factories
 from oscar.test.newfactories import UserFactory, BasketFactory
 from requests.exceptions import ConnectionError, Timeout
 from testfixtures import LogCapture
-from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
 
+from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
 from ecommerce.extensions.fulfillment.modules import EnrollmentFulfillmentModule
 from ecommerce.extensions.fulfillment.status import LINE
 from ecommerce.extensions.fulfillment.tests.mixins import FulfillmentTestMixin

--- a/ecommerce/extensions/payment/tests/mixins.py
+++ b/ecommerce/extensions/payment/tests/mixins.py
@@ -24,9 +24,14 @@ class PaymentEventsMixin(object):
 
     def assert_processor_response_recorded(self, processor_name, transaction_id, response, basket=None):
         """ Ensures a PaymentProcessorResponse exists for the corresponding processor and response. """
-        ppr = PaymentProcessorResponse.objects.get(processor_name=processor_name, transaction_id=transaction_id)
+        ppr = PaymentProcessorResponse.objects.filter(
+            processor_name=processor_name,
+            transaction_id=transaction_id
+        ).latest('created')
         self.assertEqual(ppr.response, response)
         self.assertEqual(ppr.basket, basket)
+
+        return ppr.id
 
     def assert_valid_payment_event_fields(self, payment_event, amount, payment_event_type, processor_name, reference):
         """ Ensures the given PaymentEvent's fields match the specified values. """


### PR DESCRIPTION
Allows payment processing views to commit to the database at each step along the way to order placement. These views perform three major functions: 1) recording raw processor responses, 2) recording successful payments by creating payment events and sources, and 3) placing orders. If any of these operations fails, we don't want any prior operations to be rolled back.

Additionally, if a failure occurs at any point in this process, dirty data shouldn't be introduced to the system. Processor responses, payment events and sources, and orders can each be introduced independently, one after the other. We don't rely on the atomic creation of these data; in fact, it's exactly what we'd like to avoid.

This addresses [XCOM-415](https://openedx.atlassian.net/browse/XCOM-415). @jimabramson or @clintonb, please review.
