### PR TITLE
BI events contain product's certificate_type in the 'sku' field

### DIFF
--- a/ecommerce/extensions/checkout/signals.py
+++ b/ecommerce/extensions/checkout/signals.py
@@ -26,8 +26,12 @@ def track_completed_order(sender, order=None, **kwargs):  # pylint: disable=unus
             'currency': order.currency,
             'products': [
                 {
-                    'id': line.upc,
-                    'sku': line.partner_sku,
+                    # For backwards-compatibility with older events the `sku` field is (ab)used to
+                    # store the product's `certificate_type`, while the `id` field holds the product's
+                    # SKU. Marketing is aware that this approach will not scale once we start selling
+                    # products other than courses, and will need to change in the future.
+                    'id': line.partner_sku,
+                    'sku': line.product.attr.certificate_type,
                     'name': line.product.title,
                     'price': str(line.line_price_excl_tax),
                     'quantity': line.quantity,

--- a/ecommerce/extensions/refund/signals.py
+++ b/ecommerce/extensions/refund/signals.py
@@ -29,8 +29,12 @@ def track_completed_refund(sender, refund=None, **kwargs):  # pylint: disable=un
             'currency': refund.currency,
             'products': [
                 {
-                    'id': line.order_line.upc,
-                    'sku': line.order_line.partner_sku,
+                    # For backwards-compatibility with older events the `sku` field is (ab)used to
+                    # store the product's `certificate_type`, while the `id` field holds the product's
+                    # SKU. Marketing is aware that this approach will not scale once we start selling
+                    # products other than courses, and will need to change in the future.
+                    'id': line.order_line.partner_sku,
+                    'sku': line.order_line.product.attr.certificate_type,
                     'name': line.order_line.product.title,
                     'price': str(line.line_credit_excl_tax),
                     'quantity': -1 * line.quantity,

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -172,7 +172,7 @@ class BusinessIntelligenceMixin(object):
         self.assertEqual(len(lines), len(event_payload['products']))
 
         model_name = instance.__class__.__name__
-        tracked_products_dict = {product['sku']: product for product in event_payload['products']}
+        tracked_products_dict = {product['id']: product for product in event_payload['products']}
 
         if model_name == 'Order':
             self.assertEqual(event_payload['total'], str(total))
@@ -183,6 +183,7 @@ class BusinessIntelligenceMixin(object):
                 self.assertEqual(line.product.title, tracked_product['name'])
                 self.assertEqual(str(line.line_price_excl_tax), tracked_product['price'])
                 self.assertEqual(line.quantity, tracked_product['quantity'])
+                self.assertEqual(line.product.attr.certificate_type, tracked_product['sku'])
                 self.assertEqual(line.product.get_product_class().name, tracked_product['category'])
         elif model_name == 'Refund':
             self.assertEqual(event_payload['total'], '-{}'.format(total))
@@ -193,6 +194,7 @@ class BusinessIntelligenceMixin(object):
                 self.assertEqual(line.order_line.product.title, tracked_product['name'])
                 self.assertEqual(str(line.line_credit_excl_tax), tracked_product['price'])
                 self.assertEqual(-1 * line.quantity, tracked_product['quantity'])
+                self.assertEqual(line.order_line.product.attr.certificate_type, tracked_product['sku'])
                 self.assertEqual(line.order_line.product.get_product_class().name, tracked_product['category'])
         else:
             # Payload validation is currently limited to order and refund events


### PR DESCRIPTION
For backwards-compatibility with older events, Segment's `sku` field is (ab)used to store the product's `certificate_type`, while the `id` field holds the product's SKU. Marketing is aware that this approach will not scale once we start selling products other than courses, and that it will need to change in the future.

Meets the requirements of [XCOM-413](https://openedx.atlassian.net/browse/XCOM-413). @jimabramson or @clintonb, please review.
