### PR TITLE
Fixed URL decoding bug

### DIFF
--- a/ecommerce/courses/views.py
+++ b/ecommerce/courses/views.py
@@ -18,6 +18,7 @@ class CourseMigrationView(View):
 
     def get(self, request, *_args, **_kwargs):
         course_ids = request.GET.get('course_ids')
+        course_ids = course_ids.replace(' ', '+')   # Undo Django's URL decoding since we want the '+'.
         commit = request.GET.get('commit', False)
         commit = commit in ('1', 'true')
 


### PR DESCRIPTION
Django is being too helpful when decoding params. We want to keep the '+' instead of converting it to a space.

XCOM-336

@jimabramson @rlucioni This is the last merge needed to finalize the migration.
