### PR TITLE
Ensure that newly-created enrollments are always active

### DIFF
--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -160,6 +160,7 @@ class EnrollmentFulfillmentModule(BaseFulfillmentModule):
 
             data = {
                 'user': order.user.username,
+                'is_active': True,
                 'mode': certificate_type,
                 'course_details': {
                     'course_id': course_key

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -58,6 +58,17 @@ class EnrollmentFulfillmentModuleTests(CourseCatalogTestMixin, FulfillmentTestMi
         EnrollmentFulfillmentModule().fulfill_product(self.order, list(self.order.lines.all()))
         self.assertEqual(LINE.COMPLETE, self.order.lines.all()[0].status)
 
+        actual = json.loads(httpretty.last_request().body)
+        expected = {
+            'user': self.order.user.username,
+            'is_active': True,
+            'mode': self.certificate_type,
+            'course_details': {
+                'course_id': self.course_id,
+            },
+        }
+        self.assertEqual(actual, expected)
+
     @override_settings(ENROLLMENT_API_URL='')
     def test_enrollment_module_not_configured(self):
         """Test that lines receive a configuration error status if fulfillment configuration is invalid."""


### PR DESCRIPTION
The old LMS `shoppingcart` app creates _inactive_ "honor" enrollments in courses for which the user is trying to purchase a certificate. These default "honor" enrollments could be left in the system between migrating a course from `shoppingcart` to Otto. Since Otto didn't previously specify an activation status, only a mode, the enrollment API would update the mode of the user's existing enrollment, but not the activation status.

@jimabramson or @clintonb, please review.
