### PR TITLE
Display and filter by username for orders and refunds

### DIFF
--- a/ecommerce/extensions/dashboard/orders/forms.py
+++ b/ecommerce/extensions/dashboard/orders/forms.py
@@ -1,0 +1,7 @@
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+from oscar.apps.dashboard.orders.forms import OrderSearchForm as CoreOrderSearchForm
+
+
+class OrderSearchForm(CoreOrderSearchForm):
+    username = forms.CharField(required=False, label=_("Username"))

--- a/ecommerce/extensions/dashboard/orders/views.py
+++ b/ecommerce/extensions/dashboard/orders/views.py
@@ -2,10 +2,26 @@ from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
-from oscar.apps.dashboard.orders.views import OrderDetailView as CoreOrderDetailView
+from oscar.apps.dashboard.orders.views import (
+    OrderListView as CoreOrderListView, OrderDetailView as CoreOrderDetailView
+)
 from oscar.core.loading import get_model
 
+
 Refund = get_model('refund', 'Refund')
+
+
+class OrderListView(CoreOrderListView):
+    def get_queryset(self):
+        queryset = super(OrderListView, self).get_queryset()
+
+        form = self.form_class(self.request.GET)
+        if form.is_valid():
+            for field, value in form.cleaned_data.iteritems():
+                if field == 'username' and value:
+                    queryset = queryset.filter(user__username__istartswith=value)
+
+        return queryset
 
 
 class OrderDetailView(CoreOrderDetailView):

--- a/ecommerce/extensions/dashboard/refunds/forms.py
+++ b/ecommerce/extensions/dashboard/refunds/forms.py
@@ -10,6 +10,8 @@ Refund = get_model('refund', 'Refund')
 
 class RefundSearchForm(forms.Form):
     id = forms.IntegerField(required=False, label=_('Refund ID'))
+    username = forms.CharField(required=False, label=_("Username"))
+
     status_choices = tuple([(status, status) for status in Refund.all_statuses()])
     status = forms.MultipleChoiceField(choices=status_choices, label=_("Status"), required=False)
 

--- a/ecommerce/extensions/dashboard/refunds/views.py
+++ b/ecommerce/extensions/dashboard/refunds/views.py
@@ -22,11 +22,12 @@ class RefundListView(ListView):
         queryset = sort_queryset(queryset, self.request, ['id'], 'id')
 
         self.form = self.form_class(self.request.GET)
-
         if self.form.is_valid():
             for field, value in self.form.cleaned_data.iteritems():
                 if field == 'status' and value:
                     queryset = queryset.filter(status__in=value)
+                elif field == 'username' and value:
+                    queryset = queryset.filter(user__username__istartswith=value)
                 elif value:
                     queryset = queryset.filter(**{field: value})
 

--- a/ecommerce/templates/oscar/dashboard/orders/order_detail.html
+++ b/ecommerce/templates/oscar/dashboard/orders/order_detail.html
@@ -30,31 +30,22 @@
   {% block customer_information %}
       <table class="table  table-bordered table-hover">
           <caption><i class="icon-group icon-large"></i>{% trans "Customer Information" %}</caption>
-        {% if order.guest_email %}
-            <tr>
-                <th>{% trans "Name" %}</th>
-                <td>
-                  {% trans "Customer checked out as a guest." %}
-                </td>
-            </tr>
-            <tr>
-                <th>{% trans "Email address" %}</th>
-                <td>{{ order.email }}</td>
-            </tr>
-          {% elif order.user %}
-            <tr>
-                <th>{% trans "Name" %}</th>
-                <th>{% trans "Email address" %}</th>
-            </tr>
-            <tr>
-                <td>{{ order.user.get_full_name|default:"-" }}</td>
-                <td>{{ order.user.email|default:"-" }}</td>
-            </tr>
-        {% else %}
-            <tr>
-                <td>{% trans "Customer has deleted their account." %}</td>
-            </tr>
-        {% endif %}
+          {% if order.user %}
+              <tr>
+                  <th>{% trans "Username" %}</th>
+                  <th>{% trans "Full name" %}</th>
+                  <th>{% trans "Email address" %}</th>
+              </tr>
+              <tr>
+                  <td><a href="{% url 'dashboard:user-detail' pk=order.user.id %}">{{ order.user.username }}</a></td>
+                  <td>{{ order.user.get_full_name }}</td>
+                  <td>{{ order.user.email }}</td>
+              </tr>
+          {% else %}
+              <tr>
+                  <td>{% trans "Customer has deleted their account." %}</td>
+              </tr>
+          {% endif %}
       </table>
   {% endblock customer_information %}
 

--- a/ecommerce/templates/oscar/dashboard/orders/order_list.html
+++ b/ecommerce/templates/oscar/dashboard/orders/order_list.html
@@ -44,7 +44,7 @@
     <div class="well">
         <form action="" method="get" class="form-inline" id="search_form">
           {% for field in form %}
-            {% if "order" in field.id_for_label %}
+            {% if field.id_for_label == 'id_username' %}
               {% if field.is_hidden %}
                 {{ field }}
               {% else %}
@@ -109,7 +109,7 @@
                     <th>{% anchor 'total_incl_tax' _("Total inc tax") %}</th>
                     <th>{% trans "Number of items" %}</th>
                     <th>{% trans "Status" %}</th>
-                    <th>{% trans "Customer" %}</th>
+                    <th>{% trans "Username" %}</th>
                     <th>{% trans "Shipping address" %}</th>
                     <th>{% trans "Billing address" %}</th>
                     <th>{% trans "Date of purchase" %}</th>
@@ -127,14 +127,11 @@
                         <td>{{ order.num_items }}</td>
                         <td class="order-status">{{ order.status|default:"-" }}</td>
                         <td>
-                          {% if order.guest_email %}
-                            {{ order.guest_email }}
-                          {% elif order.user %}
-                              <a href="{% url 'dashboard:user-detail' pk=order.user.id %}">
-                                {{ order.user.get_full_name|default:"-" }}</a>
-                          {% else %}
-                              &lt;{% trans "Deleted" %}&gt;
-                          {% endif %}
+                            {% if order.user %}
+                                <a href="{% url 'dashboard:user-detail' pk=order.user.id %}">{{ order.user.username }}</a>
+                            {% else %}
+                                &lt;{% trans "Deleted" %}&gt;
+                            {% endif %}
                         </td>
                         <td>{{ order.shipping_address|default:"-" }}</td>
                         <td>{{ order.billing_address|default:"-" }}</td>

--- a/ecommerce/templates/oscar/dashboard/refunds/refund_detail.html
+++ b/ecommerce/templates/oscar/dashboard/refunds/refund_detail.html
@@ -46,14 +46,22 @@
     {% block customer_information %}
     <table class="table table-bordered table-hover">
         <caption><i class="icon-group icon-large"></i>{% trans "Customer Information" %}</caption>
-        <tr>
-            <th>{% trans "Name" %}</th>
-            <th>{% trans "Email address" %}</th>
-        </tr>
-        <tr>
-            <td>{{ refund.user.get_full_name|default:"-" }}</td>
-            <td>{{ refund.user.email|default:"-" }}</td>
-        </tr>
+        {% if refund.user %}
+            <tr>
+                <th>{% trans "Username" %}</th>
+                <th>{% trans "Full name" %}</th>
+                <th>{% trans "Email address" %}</th>
+            </tr>
+            <tr>
+                <td><a href="{% url 'dashboard:user-detail' pk=refund.user.id %}">{{ refund.user.username }}</a></td>
+                <td>{{ refund.user.get_full_name }}</td>
+                <td>{{ refund.user.email }}</td>
+            </tr>
+        {% else %}
+            <tr>
+                <td>{% trans "Customer has deleted their account." %}</td>
+            </tr>
+        {% endif %}
     </table>
     {% endblock customer_information %}
 

--- a/ecommerce/templates/oscar/dashboard/refunds/refund_list.html
+++ b/ecommerce/templates/oscar/dashboard/refunds/refund_list.html
@@ -49,7 +49,7 @@
 <div class="well">
     <form action="" method="get" class="form-inline" id="search_form">
         {% for field in form %}
-            {% if field.id_for_label == 'id_id' %}
+            {% if field.id_for_label == 'id_username' %}
                 {% if field.is_hidden %}
                     {{ field }}
                 {% else %}
@@ -99,7 +99,7 @@
                     <th>{% trans "Total Credit" %}</th>
                     <th>{% trans "Number of Items" %}</th>
                     <th>{% trans "Status" %}</th>
-                    <th>{% trans "Customer" %}</th>
+                    <th>{% trans "Username" %}</th>
                     <th>{% trans "Created" %}</th>
                     <th>{% trans "Actions" %}</th>
                 </tr>
@@ -114,7 +114,11 @@
                     <td>{{ refund.num_items }}</td>
                     <td class="refund-status">{{ refund.status }}</td>
                     <td>
-                        <a href="{% url 'dashboard:user-detail' pk=refund.user.id %}">{{ refund.user.get_full_name|default:"-" }}</a>
+                        {% if refund.user %}
+                            <a href="{% url 'dashboard:user-detail' pk=refund.user.id %}">{{ refund.user.username }}</a>
+                        {% else %}
+                            &lt;{% trans "Deleted" %}&gt;
+                        {% endif %}
                     </td>
                     <td>{{ refund.created }}</td>
                     <td>

--- a/ecommerce/templates/oscar/dashboard/users/detail.html
+++ b/ecommerce/templates/oscar/dashboard/users/detail.html
@@ -4,7 +4,7 @@
 
 {% block body_class %}{{ block.super }} users{% endblock %}
 
-{% block title %}{{ customer.email }} | {{ block.super }}{% endblock %}
+{% block title %}{{ customer.username }} | {{ block.super }}{% endblock %}
 
 {% block breadcrumbs %}
     <ul class="breadcrumb">
@@ -16,11 +16,11 @@
             <a href="{% url 'dashboard:users-index' %}">{% trans "Customers" %}</a>
             <span class="divider">/</span>
         </li>
-        <li class="active">{{ customer.email }}</li>
+        <li class="active">{{ customer.username }}</li>
     </ul>
 {% endblock %}
 
-{% block headertext %}{{ customer.email }}{% endblock %}
+{% block headertext %}{{ customer.username }}{% endblock %}
 
 {% block dashboard_content %}
     <div class="row-fluid">
@@ -31,7 +31,11 @@
               </div>
               <table class="table table-bordered">
                   <tr>
-                      <th>{% trans "Name" %}</th>
+                      <th>{% trans "Username" %}</th>
+                      <td>{{ customer.username|default:"-" }}</td>
+                  </tr>
+                  <tr>
+                      <th>{% trans "Full name" %}</th>
                       <td>{{ customer.get_full_name|default:"-" }}</td>
                   </tr>
                   <tr>


### PR DESCRIPTION
Customer usernames are now displayed on order list and detail pages, refund list and detail pages, and user detail pages. Order and refund lists can also be filtered by username. Pursuant to [XCOM-390](https://openedx.atlassian.net/browse/XCOM-390).

@clintonb and @jimabramson, please review when able. @Nickersoft, FYI.
