### PR TITLE
Use libsass 0.8.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,6 +11,7 @@ djangorestframework==3.1.2
 djangorestframework-jwt==1.5.0
 edx-auth-backends==0.1.3
 jsonfield==1.0.3
+libsass==0.8.2
 paypalrestsdk==1.9.0
 pycountry==1.10
 requests==2.6.0


### PR DESCRIPTION
This will force an upgrade on all machines with an older version of libsass installed.

XCOM-367
