### PR TITLE
Course list view now requires staff permissions to view

### DIFF
--- a/ecommerce/courses/tests/test_views.py
+++ b/ecommerce/courses/tests/test_views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 
@@ -33,4 +34,26 @@ class CourseMigrationViewTests(UserMixin, TestCase):
         self.assertEqual(response.status_code, 400)
 
         response = self.client.get(self.path + '?course_ids=foo')
+        self.assertEqual(response.status_code, 200)
+
+
+class CourseListViewTests(UserMixin, TestCase):
+    path = reverse('courses_list')
+
+    def test_login_required(self):
+        """ Users are required to login before accessing the view. """
+        response = self.client.get(self.path)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(settings.LOGIN_URL, response.url)
+
+    def test_staff_user_required(self):
+        """ Verify the view is only accessible to staff users. """
+        user = self.create_user(is_staff=False)
+        self.client.login(username=user.username, password=self.password)
+        response = self.client.get(self.path)
+        self.assertEqual(response.status_code, 404)
+
+        user = self.create_user(is_staff=True)
+        self.client.login(username=user.username, password=self.password)
+        response = self.client.get(self.path)
         self.assertEqual(response.status_code, 200)

--- a/ecommerce/courses/views.py
+++ b/ecommerce/courses/views.py
@@ -2,8 +2,10 @@ from StringIO import StringIO
 import logging
 import os
 
+from django.contrib.auth.decorators import login_required
 from django.core.management import call_command
 from django.http import Http404, HttpResponse
+from django.utils.decorators import method_decorator
 from django.views.generic import View, ListView
 
 from ecommerce.courses.models import Course
@@ -14,6 +16,13 @@ logger = logging.getLogger(__name__)
 class CourseListView(ListView):
     model = Course
     context_object_name = 'courses'
+
+    @method_decorator(login_required)
+    def dispatch(self, request, *args, **kwargs):
+        if not request.user.is_staff:
+            raise Http404
+
+        return super(CourseListView, self).dispatch(request, *args, **kwargs)
 
 
 class CourseMigrationView(View):


### PR DESCRIPTION
The list view of the course admin tool now requires that you be logged in and have staff member permissions in order to view. If you do not have staff permissions, you are redirected to a 404 page. If you are not logged in, you are redirected to the login page.

@clintonb @rlucioni FYI: @wedaly @jimabramson 
