### PR TITLE
Display refund lines inline with their parent refund in the admin

### DIFF
--- a/ecommerce/extensions/refund/admin.py
+++ b/ecommerce/extensions/refund/admin.py
@@ -1,12 +1,19 @@
 from django.contrib import admin
 from oscar.core.loading import get_model
 
+
 Refund = get_model('refund', 'Refund')
+RefundLine = get_model('refund', 'RefundLine')
+
+
+class RefundLineInline(admin.TabularInline):
+    model = RefundLine
 
 
 class RefundAdmin(admin.ModelAdmin):
     list_display = ('id', 'order', 'user', 'status', 'total_credit_excl_tax', 'currency')
     list_filter = ('status',)
+    inlines = (RefundLineInline,)
 
 
 admin.site.register(Refund, RefundAdmin)


### PR DESCRIPTION
This is convenient, and is also required to fully manually correct refunds in a revocation error state.

@clintonb or @jimabramson, please review.
