### PR TITLE
Improve performance of refund and processor response admin views

### DIFF
--- a/ecommerce/extensions/payment/admin.py
+++ b/ecommerce/extensions/payment/admin.py
@@ -8,6 +8,8 @@ PaymentProcessorResponse = get_model('payment', 'PaymentProcessorResponse')
 class PaymentProcessorResponseAdmin(admin.ModelAdmin):
     list_display = ('id', 'processor_name', 'transaction_id', 'basket', 'created')
 
+    readonly_fields = ('processor_name', 'transaction_id', 'basket', 'response')
+
 
 admin.site.register(PaymentProcessorResponse, PaymentProcessorResponseAdmin)
 

--- a/ecommerce/extensions/refund/admin.py
+++ b/ecommerce/extensions/refund/admin.py
@@ -8,11 +8,17 @@ RefundLine = get_model('refund', 'RefundLine')
 
 class RefundLineInline(admin.TabularInline):
     model = RefundLine
+    fields = ('order_line', 'line_credit_excl_tax', 'quantity', 'status')
+    readonly_fields = ('order_line', 'line_credit_excl_tax', 'quantity')
+    extra = 0
 
 
 class RefundAdmin(admin.ModelAdmin):
     list_display = ('id', 'order', 'user', 'status', 'total_credit_excl_tax', 'currency')
     list_filter = ('status',)
+
+    fields = ('order', 'user', 'status', 'total_credit_excl_tax', 'currency')
+    readonly_fields = ('order', 'user', 'total_credit_excl_tax', 'currency')
     inlines = (RefundLineInline,)
 
 


### PR DESCRIPTION
Formerly, these views rendered `<select>` elements for every basket, user, and order line in the system. These changes avoid that overhead, and come with the added benefit of making sensitive fields which shouldn't be edited read-only.

@jimabramson or @clintonb, please review.
