### PR TITLE
Gracefully handling checkout errors during basket creation

### DIFF
--- a/ecommerce/extensions/payment/processors/paypal.py
+++ b/ecommerce/extensions/payment/processors/paypal.py
@@ -12,7 +12,6 @@ import paypalrestsdk
 from ecommerce.extensions.order.constants import PaymentEventTypeName
 from ecommerce.extensions.payment.processors import BasePaymentProcessor
 
-
 logger = logging.getLogger(__name__)
 
 PaymentEvent = get_model('order', 'PaymentEvent')
@@ -109,12 +108,11 @@ class Paypal(BasePaymentProcessor):
                 entry.id
             )
 
-            raise GatewayError
+            raise GatewayError(error)
 
         entry = self.record_processor_response(payment.to_dict(), transaction_id=payment.id, basket=basket)
         logger.info(u"Successfully created PayPal payment [%s] for basket [%d].", payment.id, basket.id)
 
-        # Dat HATEOAS
         for link in payment.links:
             if link.rel == 'approval_url':
                 approval_url = link.href
@@ -125,7 +123,8 @@ class Paypal(BasePaymentProcessor):
                 payment.id,
                 entry.id
             )
-            raise GatewayError
+            raise GatewayError(
+                'Approval URL missing from PayPal payment response. See entry [{}] for details.'.format(entry.id))
 
         parameters = {
             'payment_page_url': approval_url,

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -62,8 +62,9 @@ class BasketCreationMixin(JwtMixin):
     PATH = reverse('api:v2:baskets:create')
     SHIPPING_EVENT_NAME = FulfillmentMixin.SHIPPING_EVENT_NAME
     FREE_SKU = u'𝑭𝑹𝑬𝑬-𝑷𝑹𝑶𝑫𝑼𝑪𝑻'
+    USERNAME = 'sgoodman'
     USER_DATA = {
-        'username': 'sgoodman',
+        'username': USERNAME,
         'email': 'saul@bettercallsaul.com',
     }
 


### PR DESCRIPTION
If an exception is raised during checkout initiation, the view will log it and return HTTP status 500. This ensures that all payment processor responses are recorded, while not having to sacrifice the benefits of autocommit.

XCOM-418

@rlucioni @jimabramson @Nickersoft 
