### PR TITLE
Audit logging tweaks

### DIFF
--- a/ecommerce/extensions/analytics/utils.py
+++ b/ecommerce/extensions/analytics/utils.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from functools import wraps
 import logging
 
@@ -72,16 +71,14 @@ def audit_log(name, **kwargs):
 
     Keyword Arguments:
         Indefinite. Keyword arguments are strung together as comma-separated key-value
-        pairs alphabetically ordered by key in the resulting log message.
+        pairs ordered alphabetically by key in the resulting log message.
 
     Returns:
         None
     """
-    d = OrderedDict(sorted(kwargs.items(), key=lambda i: i[0]))
-
-    # Joins keys and values from the sorted dictionary above with an "=", wraps each value
+    # Joins sorted keyword argument keys and values with an "=", wraps each value
     # in quotes, and separates each pair with a comma and a space.
-    payload = u', '.join(['{k}="{v}"'.format(k=k, v=v) for k, v in d.iteritems()])
+    payload = u', '.join(['{k}="{v}"'.format(k=k, v=v) for k, v in sorted(kwargs.items())])
     message = u'{name}: {payload}'.format(name=name, payload=payload)
 
     logger.info(message)

--- a/ecommerce/extensions/checkout/mixins.py
+++ b/ecommerce/extensions/checkout/mixins.py
@@ -50,8 +50,6 @@ class EdxOrderPlacementMixin(OrderPlacementMixin):
 
     def handle_successful_order(self, order):
         """Send a signal so that receivers can perform relevant tasks (e.g., fulfill the order)."""
-        post_checkout.send_robust(sender=self, order=order)
-
         audit_log(
             'order_placed',
             amount=order.total_excl_tax,
@@ -60,5 +58,7 @@ class EdxOrderPlacementMixin(OrderPlacementMixin):
             order_number=order.number,
             user_id=order.user.id
         )
+
+        post_checkout.send_robust(sender=self, order=order)
 
         return order

--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -180,6 +180,8 @@ class EnrollmentFulfillmentModule(BaseFulfillmentModule):
                         order_line_id=line.id,
                         order_number=order.number,
                         product_class=line.product.get_product_class().name,
+                        course_id=course_key,
+                        certificate_type=certificate_type,
                         user_id=order.user.id
                     )
                 else:
@@ -211,12 +213,14 @@ class EnrollmentFulfillmentModule(BaseFulfillmentModule):
         try:
             logger.info('Attempting to revoke fulfillment of Line [%d]...', line.id)
 
+            certificate_type = line.product.attr.certificate_type
+            course_key = line.product.attr.course_key
             data = {
                 'user': line.order.user.username,
                 'is_active': False,
-                'mode': line.product.attr.certificate_type,
+                'mode': certificate_type,
                 'course_details': {
-                    'course_id': line.product.attr.course_key,
+                    'course_id': course_key,
                 },
             }
 
@@ -228,6 +232,8 @@ class EnrollmentFulfillmentModule(BaseFulfillmentModule):
                     order_line_id=line.id,
                     order_number=line.order.number,
                     product_class=line.product.get_product_class().name,
+                    course_id=course_key,
+                    certificate_type=certificate_type,
                     user_id=line.order.user.id
                 )
 

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -61,21 +61,24 @@ class EnrollmentFulfillmentModuleTests(CourseCatalogTestMixin, FulfillmentTestMi
         with LogCapture(LOGGER_NAME) as l:
             EnrollmentFulfillmentModule().fulfill_product(self.order, list(self.order.lines.all()))
 
-            order_line = self.order.lines.get()
+            line = self.order.lines.get()
             l.check(
                 (
                     LOGGER_NAME,
                     'INFO',
-                    'line_fulfilled: order_line_id="{}", order_number="{}", product_class="{}", user_id="{}"'.format(
-                        order_line.id,
-                        self.order.number,
-                        order_line.product.get_product_class().name,
-                        self.order.user.id
+                    'line_fulfilled: certificate_type="{}", course_id="{}", order_line_id="{}", order_number="{}", '
+                    'product_class="{}", user_id="{}"'.format(
+                        line.product.attr.certificate_type,
+                        line.product.attr.course_key,
+                        line.id,
+                        line.order.number,
+                        line.product.get_product_class().name,
+                        line.order.user.id
                     )
                 )
             )
 
-        self.assertEqual(LINE.COMPLETE, order_line.status)
+        self.assertEqual(LINE.COMPLETE, line.status)
 
         actual = json.loads(httpretty.last_request().body)
         expected = {
@@ -135,7 +138,10 @@ class EnrollmentFulfillmentModuleTests(CourseCatalogTestMixin, FulfillmentTestMi
                 (
                     LOGGER_NAME,
                     'INFO',
-                    'line_revoked: order_line_id="{}", order_number="{}", product_class="{}", user_id="{}"'.format(
+                    'line_revoked: certificate_type="{}", course_id="{}", order_line_id="{}", order_number="{}", '
+                    'product_class="{}", user_id="{}"'.format(
+                        line.product.attr.certificate_type,
+                        line.product.attr.course_key,
                         line.id,
                         line.order.number,
                         line.product.get_product_class().name,


### PR DESCRIPTION
Simplify audit logging utility, log order_placed message prior to order fulfillment, and include course ID and certificate type in messages logged by the EnrollmentFulfillmentModule. XCOM-426.

@jimabramson or @clintonb, I'd appreciate a review when you get a chance.
