### PR TITLE
XCOM-281: JWT issuer and expiration date are now validated

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -15,4 +15,4 @@ pylint==1.4.1
 selenium==2.45.0
 testfixtures==4.1.2
 
-git+https://github.com/edx/ecommerce-api-client.git@1.0.0#egg=ecommerce-api-client==1.0.0
+git+https://github.com/edx/ecommerce-api-client.git@1.1.0#egg=ecommerce-api-client==1.1.0


### PR DESCRIPTION
In order to enable this feature in production, the following settings must be set in base.py under JWT_AUTH:

'JWT_ISSUER': <issuer passed in LMS>
'JWT_VERIFY_EXPIRATION': True

@clintonb @rlucioni @wedaly @jimabramson 
