### PR TITLE
Upgrade Django to 1.7.9

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 analytics-python==1.0.3
-Django==1.7.7
+Django==1.7.9
 django-appconf==0.6
 django-compressor==1.5
 django_extensions==1.5.5


### PR DESCRIPTION
The Django team recently issued a security release. [Release notes](https://www.djangoproject.com/weblog/2015/jul/08/security-releases/).

FYI @jimabramson @clintonb @Nickersoft 
