### PR TITLE
BUG: Fixed Unicode support for migration command and view

### DIFF
--- a/ecommerce/courses/views.py
+++ b/ecommerce/courses/views.py
@@ -1,4 +1,4 @@
-from StringIO import StringIO
+from io import StringIO
 import logging
 import os
 

--- a/ecommerce/extensions/catalogue/management/commands/migrate_course.py
+++ b/ecommerce/extensions/catalogue/management/commands/migrate_course.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import logging
 from optparse import make_option
 
@@ -112,12 +113,12 @@ class MigratedCourse(object):
         return course_name, modes
 
     def _get_product_name(self, course_name, mode):
-        name = u'Seat in {course_name} with {certificate_type} certificate'.format(
+        name = 'Seat in {course_name} with {certificate_type} certificate'.format(
             course_name=course_name,
             certificate_type=Course.certificate_type_for_mode(mode))
 
         if Course.is_mode_verified(mode):
-            name += u' (and ID verification)'
+            name += ' (and ID verification)'
 
         return name
 
@@ -134,30 +135,30 @@ class MigratedCourse(object):
 
         seats = {}
         stock_records = {}
-        slug = u'parent-cs-{}'.format(slugify(course_id))
+        slug = 'parent-cs-{}'.format(slugify(course_id))
         partner = Partner.objects.get(code='edx')
 
         try:
             parent = Product.objects.get(slug=slug)
-            logger.info(u'Retrieved parent seat product for [%s] from database.', course_id)
+            logger.info('Retrieved parent seat product for [%s] from database.', course_id)
         except Product.DoesNotExist:
             product_class = ProductClass.objects.get(slug='seat')
             parent = Product(slug=slug, is_discountable=True, structure=Product.PARENT, product_class=product_class)
-            logger.info(u'Parent seat product for [%s] does not exist. Instantiated a new instance.', course_id)
+            logger.info('Parent seat product for [%s] does not exist. Instantiated a new instance.', course_id)
 
-        parent.title = u'Seat in {}'.format(course_name)
+        parent.title = 'Seat in {}'.format(course_name)
         parent.attr.course_key = course_id
 
         # Create the child products
         for mode in modes:
             seat_type = mode['slug']
-            slug = u'child-cs-{}-{}'.format(seat_type, slugify(course_id))
+            slug = 'child-cs-{}-{}'.format(seat_type, slugify(course_id))
             try:
                 seat = Product.objects.get(slug=slug)
-                logger.info(u'Retrieved [%s] course seat child product for [%s] from database.', seat_type, course_id)
+                logger.info('Retrieved [%s] course seat child product for [%s] from database.', seat_type, course_id)
             except Product.DoesNotExist:
                 seat = Product(slug=slug)
-                logger.info(u'[%s] course seat product for [%s] does not exist. Instantiated a new instance.',
+                logger.info('[%s] course seat product for [%s] does not exist. Instantiated a new instance.',
                             seat_type, course_id)
 
             seat.parent = parent
@@ -174,13 +175,13 @@ class MigratedCourse(object):
 
             try:
                 stock_record = StockRecord.objects.get(product=seat, partner=partner)
-                logger.info(u'Retrieved [%s] course seat child product stock record for [%s] from database.',
+                logger.info('Retrieved [%s] course seat child product stock record for [%s] from database.',
                             seat_type, course_id)
             except StockRecord.DoesNotExist:
                 partner_sku = generate_sku(seat)
                 stock_record = StockRecord(product=seat, partner=partner, partner_sku=partner_sku)
                 logger.info(
-                    u'[%s] course seat product stock record for [%s] does not exist. Instantiated a new instance.',
+                    '[%s] course seat product stock record for [%s] does not exist. Instantiated a new instance.',
                     seat_type, course_id)
 
             stock_record.price_excl_tax = mode['min_price']

--- a/ecommerce/extensions/catalogue/tests/test_migrate_course.py
+++ b/ecommerce/extensions/catalogue/tests/test_migrate_course.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+from __future__ import unicode_literals
 import datetime
 import json
 import logging
@@ -42,7 +44,7 @@ class CourseMigrationTestMixin(CourseCatalogTestMixin):
 
         # Mock Course Structure API
         url = urljoin(settings.LMS_URL_ROOT, 'api/course_structure/v0/courses/{}/'.format(self.course_id))
-        httpretty.register_uri(httpretty.GET, url, body='{"name": "A Test Course"}', content_type=JSON)
+        httpretty.register_uri(httpretty.GET, url, body='{"name": "A Tést Côurse"}', content_type=JSON)
 
         # Mock Enrollment API
         url = urljoin(settings.LMS_URL_ROOT, 'api/enrollment/v1/course/{}'.format(self.course_id))
@@ -64,9 +66,9 @@ class CourseMigrationTestMixin(CourseCatalogTestMixin):
         """ Verify the given seat is configured correctly. """
         certificate_type = Course.certificate_type_for_mode(seat_type)
 
-        expected_title = u'Seat in A Test Course with {} certificate'.format(certificate_type)
+        expected_title = 'Seat in A Tést Côurse with {} certificate'.format(certificate_type)
         if Course.is_mode_verified(seat_type):
-            expected_title += u' (and ID verification)'
+            expected_title += ' (and ID verification)'
 
         self.assertEqual(seat.title, expected_title)
         self.assertEqual(seat.expires, EXPIRES)
@@ -125,7 +127,7 @@ class MigratedCourseTests(CourseMigrationTestMixin, TestCase):
 
         # Verify created objects match mocked data
         parent_seat = migrated_course.parent_seat
-        self.assertEqual(parent_seat.title, 'Seat in A Test Course')
+        self.assertEqual(parent_seat.title, 'Seat in A Tést Côurse')
 
         for seat_type, price in self.prices.iteritems():
             logger.info('Validating objects for %s certificate type...', seat_type)


### PR DESCRIPTION
The migration command now uses Unicode exclusively, and the view has been updated to use io.StringIO which also uses Unicode.

@rlucioni @jimabramson @Nickersoft 
