### PR TITLE
Courses urls.py cleanup

### DIFF
--- a/ecommerce/courses/tests/test_views.py
+++ b/ecommerce/courses/tests/test_views.py
@@ -6,7 +6,7 @@ from ecommerce.tests.mixins import UserMixin
 
 
 class CourseMigrationViewTests(UserMixin, TestCase):
-    path = reverse('migrate_course')
+    path = reverse('courses:migrate')
 
     def test_superuser_required(self):
         """ Verify the view is only accessible to superusers. """
@@ -38,7 +38,7 @@ class CourseMigrationViewTests(UserMixin, TestCase):
 
 
 class CourseListViewTests(UserMixin, TestCase):
-    path = reverse('courses_list')
+    path = reverse('courses:list')
 
     def test_login_required(self):
         """ Users are required to login before accessing the view. """

--- a/ecommerce/courses/urls.py
+++ b/ecommerce/courses/urls.py
@@ -1,0 +1,9 @@
+from django.conf.urls import patterns, url
+
+from ecommerce.courses import views
+
+urlpatterns = patterns(
+    '',
+    url(r'^$', views.CourseListView.as_view(), name='list'),
+    url(r'^migrate/$', views.CourseMigrationView.as_view(), name='migrate'),
+)

--- a/ecommerce/urls.py
+++ b/ecommerce/urls.py
@@ -8,7 +8,6 @@ from django.core.urlresolvers import reverse_lazy
 from django.shortcuts import redirect
 from django.views.generic import RedirectView, TemplateView
 
-from ecommerce.courses import views as course_views
 from ecommerce.core import views as core_views
 from ecommerce.extensions.urls import urlpatterns as extensions_patterns
 
@@ -41,14 +40,9 @@ urlpatterns = patterns(
     '',
     url(r'^i18n/', include('django.conf.urls.i18n')),
     url(r'^jsi18n/$', 'django.views.i18n.javascript_catalog', js_info_dict),
-    url(r'^admin/courses/migrate/$', course_views.CourseMigrationView.as_view(), name='migrate_course'),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),
-    url(r'^courses/$', course_views.CourseListView.as_view(), name='courses_list'),
     url(r'^health/$', core_views.health, name='health'),
-
-    # Social auth
-    url('', include('social.apps.django_app.urls', namespace='social')),
     url(
         r'^accounts/login/$',
         RedirectView.as_view(
@@ -59,9 +53,9 @@ urlpatterns = patterns(
         name='login'
     ),
 
-    # Credit app
+    url('', include('social.apps.django_app.urls', namespace='social')),
+    url(r'^courses/', include('ecommerce.courses.urls', namespace='courses')),
     url(r'^credit/', include('ecommerce.credit.urls', namespace='credit')),
-
 )
 
 # Install Oscar extension URLs


### PR DESCRIPTION
Reorganized URLs in preparation for course administration tool. Moved migration view from /admin/courses/migrate/ to /courses/migrate/.

FYI @rlucioni @jimabramson @Nickersoft 
