### PR TITLE
Unified Course Seat Creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ clean:
 test_python: clean
 	python manage.py compress --settings=ecommerce.settings.test
 	DISABLE_MIGRATIONS=True coverage run --branch --source=ecommerce ./manage.py test ecommerce \
-	--settings=ecommerce.settings.test --with-ignore-docstrings
+	--settings=ecommerce.settings.test --with-ignore-docstrings --logging-level=DEBUG
 	coverage report
 
 quality:

--- a/ecommerce/courses/models.py
+++ b/ecommerce/courses/models.py
@@ -1,15 +1,23 @@
+from __future__ import unicode_literals
 import logging
 
 from django.db import models, transaction
+from django.utils.text import slugify
 from oscar.core.loading import get_model
 from simple_history.models import HistoricalRecords
 import waffle
 
 from ecommerce.courses.exceptions import PublishFailed
 from ecommerce.courses.publishers import LMSPublisher
+from ecommerce.extensions.catalogue.utils import generate_sku
 
 logger = logging.getLogger(__name__)
+Category = get_model('catalogue', 'Category')
+Partner = get_model('partner', 'Partner')
+Product = get_model('catalogue', 'Product')
+ProductCategory = get_model('catalogue', 'ProductCategory')
 ProductClass = get_model('catalogue', 'ProductClass')
+StockRecord = get_model('partner', 'StockRecord')
 
 
 class Course(models.Model):
@@ -18,10 +26,34 @@ class Course(models.Model):
     history = HistoricalRecords()
     thumbnail_url = models.URLField(null=True, blank=True)
 
+    def __unicode__(self):
+        return unicode(self.id)
+
+    def _create_parent_seat(self):
+        """ Create the parent seat product if it does not already exist. """
+        slug = 'parent-cs-{}'.format(slugify(unicode(self.id)))
+        defaults = {
+            'is_discountable': True,
+            'structure': Product.PARENT,
+            'product_class': ProductClass.objects.get(slug='seat')
+        }
+        parent, created = self.products.get_or_create(slug=slug, defaults=defaults)
+        ProductCategory.objects.get_or_create(category=Category.objects.get(name='Seats'), product=parent)
+        parent.title = 'Seat in {}'.format(self.name)
+        parent.attr.course_key = self.id
+        parent.save()
+
+        if created:
+            logger.debug('Created new parent seat [%d] for [%s].', parent.id, self.id)
+        else:
+            logger.debug('Parent seat [%d] already exists for [%s].', parent.id, self.id)
+
     # pylint: disable=arguments-differ
     @transaction.atomic
     def save(self, force_insert=False, force_update=False, using=None, update_fields=None, publish=True):
         super(Course, self).save(force_insert, force_update, using, update_fields)
+
+        self._create_parent_seat()
 
         if publish and waffle.switch_is_active('publish_course_modes_to_lms'):
             if not self.publish_to_lms():
@@ -49,19 +81,83 @@ class Course(models.Model):
         return mode
 
     @property
+    def parent_seat_product(self):
+        """ Returns the course seat parent Product. """
+        return self.products.get(product_class__slug='seat', structure=Product.PARENT)
+
+    @property
     def seat_products(self):
         """ Returns a list of course seat Products related to this course. """
-        seat_product_class = ProductClass.objects.get(slug='seat')
-        products = set()
+        return list(self.parent_seat_product.children.all().prefetch_related('stockrecords'))
 
-        for product in self.products.all():
-            if product.get_product_class() == seat_product_class:
-                if product.is_parent:
-                    products.update(product.children.all())
-                else:
-                    products.add(product)
+    def _get_course_seat_name(self, certificate_type, id_verification_required):
+        """ Returns the name for a course seat. """
+        name = 'Seat in {course_name} with {certificate_type} certificate'.format(
+            course_name=self.name,
+            certificate_type=certificate_type)
 
-        return list(products)
+        if id_verification_required:
+            name += ' (and ID verification)'
 
-    def __unicode__(self):
-        return self.id
+        return name
+
+    def create_or_update_seat(self, certificate_type, id_verification_required, price, credit_provider=None,
+                              expires=None):
+        """
+        Creates course seat products.
+
+        Returns:
+            Product:  The seat that has been created or updated.
+        """
+
+        certificate_type = certificate_type.lower()
+        course_id = unicode(self.id)
+        slug = 'child-cs-{}-{}'.format(certificate_type, slugify(course_id))
+
+        if id_verification_required:
+            slug += '-id-verified'
+
+        try:
+            seat = Product.objects.get(slug=slug)
+            logger.info('Retrieved [%s] course seat child product for [%s] from database.', certificate_type,
+                        course_id)
+        except Product.DoesNotExist:
+            seat = Product(slug=slug)
+            logger.info('[%s] course seat product for [%s] does not exist. Instantiated a new instance.',
+                        certificate_type, course_id)
+
+        seat.course = self
+        seat.parent = self.parent_seat_product
+        seat.is_discountable = True
+        seat.structure = Product.CHILD
+        seat.title = self._get_course_seat_name(certificate_type, id_verification_required)
+        seat.expires = expires
+        seat.attr.certificate_type = certificate_type
+        seat.attr.course_key = course_id
+        seat.attr.id_verification_required = id_verification_required
+
+        if credit_provider:
+            seat.attr.credit_provider = credit_provider
+
+        seat.save()
+
+        # TODO Expose via setting
+        partner = Partner.objects.get(code='edx')
+        try:
+            stock_record = StockRecord.objects.get(product=seat, partner=partner)
+            logger.info('Retrieved [%s] course seat child product stock record for [%s] from database.',
+                        certificate_type, course_id)
+        except StockRecord.DoesNotExist:
+            partner_sku = generate_sku(seat)
+            stock_record = StockRecord(product=seat, partner=partner, partner_sku=partner_sku)
+            logger.info(
+                '[%s] course seat product stock record for [%s] does not exist. Instantiated a new instance.',
+                certificate_type, course_id)
+
+        stock_record.price_excl_tax = price
+
+        # TODO Expose via setting
+        stock_record.price_currency = 'USD'
+        stock_record.save()
+
+        return seat

--- a/ecommerce/courses/publishers.py
+++ b/ecommerce/courses/publishers.py
@@ -8,11 +8,17 @@ logger = logging.getLogger(__name__)
 
 
 class LMSPublisher(object):
+    # TODO Test this and update SKU generation
+    def mode_for_seat(self, seat):
+        if seat.attr.certificate_type == 'professional' and not seat.attr.id_verification_required:
+            return 'no-id-professional'
+        return seat.attr.certificate_type
+
     def serialize_seat_for_commerce_api(self, seat):
         """ Serializes a course seat product to a dict that can be further serialized to JSON. """
         stock_record = seat.stockrecords.first()
         return {
-            'name': seat.attr.certificate_type,
+            'name': self.mode_for_seat(seat),
             'currency': stock_record.price_currency,
             'price': int(stock_record.price_excl_tax),
             'sku': stock_record.partner_sku,

--- a/ecommerce/courses/tests/test_models.py
+++ b/ecommerce/courses/tests/test_models.py
@@ -2,12 +2,16 @@ import ddt
 from django.test import TestCase
 from django_dynamic_fixture import G, N
 import mock
+from oscar.core.loading import get_model
 from testfixtures import LogCapture
 from waffle import Switch
 
 from ecommerce.courses.models import Course
 from ecommerce.courses.publishers import LMSPublisher
 from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
+
+Product = get_model('catalogue', 'Product')
+ProductClass = get_model('catalogue', 'ProductClass')
 
 
 @ddt.ddt
@@ -24,19 +28,18 @@ class CourseTests(CourseCatalogTestMixin, TestCase):
 
         These seats should be the child products.
         """
-        # Create a new course and verify it has no existing products.
+        # Create a new course and verify it has a parent product, but no children.
         course = G(Course)
-        self.assertEqual(course.products.count(), 0)
+        self.assertEqual(course.products.count(), 1)
         self.assertEqual(len(course.seat_products), 0)
 
         # Create the seat products
-        seats = self.create_course_seats(course.id, ('honor', 'verified'))
+        seats = [course.create_or_update_seat('honor', False, 0),
+                 course.create_or_update_seat('verified', True, 50)]
         self.assertEqual(course.products.count(), 3)
 
-        # The method should return only the child seats.
-        # We do not necessarily care about the order, but must sort to check equality.
-        expected = seats.values().sort()
-        self.assertEqual(course.seat_products.sort(), expected)
+        # The property should return only the child seats.
+        self.assertEqual(set(course.seat_products), set(seats))
 
     @ddt.data(
         ('verified', True),
@@ -82,8 +85,12 @@ class CourseTests(CourseCatalogTestMixin, TestCase):
             logger_name = 'ecommerce.courses.models'
             with LogCapture(logger_name) as l:
                 course.save()
-                l.check((logger_name, 'DEBUG',
-                         'Course mode publishing is not enabled. Commerce changes will not be published!'))
+                l.check(
+                    (logger_name, 'DEBUG',
+                     'Parent seat [{}] already exists for [{}].'.format(course.parent_seat_product.id, course.id)),
+                    (logger_name, 'DEBUG',
+                     'Course mode publishing is not enabled. Commerce changes will not be published!')
+                )
 
             self.assertFalse(mock_publish.called)
 
@@ -118,3 +125,54 @@ class CourseTests(CourseCatalogTestMixin, TestCase):
         with mock.patch.object(LMSPublisher, 'publish') as mock_publish:
             course.save(publish=False)
             self.assertFalse(mock_publish.called)
+
+    def test_save_creates_parent_seat(self):
+        """ Verify the save method creates a parent seat if one does not exist. """
+        course = Course.objects.create(id='a/b/c', name='Test Course')
+        self.assertEqual(course.products.count(), 1)
+
+        parent = course.parent_seat_product
+        self.assertEqual(parent.structure, Product.PARENT)
+        self.assertEqual(parent.title, 'Seat in Test Course')
+        self.assertEqual(parent.get_product_class(), self.seat_product_class)
+        self.assertEqual(parent.attr.course_key, course.id)
+
+    def assert_course_seat_valid(self, seat, course, certificate_type, id_verification_required, price,
+                                 credit_provider=None):
+        """ Ensure the given seat has the correct attribute values. """
+        self.assertEqual(seat.structure, Product.CHILD)
+        # pylint: disable=protected-access
+        self.assertEqual(seat.title, course._get_course_seat_name(certificate_type, id_verification_required))
+        self.assertEqual(seat.get_product_class(), self.seat_product_class)
+        self.assertEqual(seat.attr.certificate_type, certificate_type)
+        self.assertEqual(seat.attr.course_key, course.id)
+        self.assertEqual(seat.attr.id_verification_required, id_verification_required)
+        self.assertEqual(seat.stockrecords.first().price_excl_tax, price)
+
+        if credit_provider:
+            self.assertEqual(seat.attr.credit_provider, credit_provider)
+
+    def test_create_or_update_seat(self):
+        """ Verify the method creates or updates a seat Product. """
+        course = Course.objects.create(id='a/b/c', name='Test Course')
+
+        # Test creation
+        certificate_type = 'honor'
+        id_verification_required = True
+        price = 0
+        course.create_or_update_seat(certificate_type, id_verification_required, price)
+
+        # Two seats: one honor, the other the parent seat product
+        self.assertEqual(course.products.count(), 2)
+        seat = course.seat_products[0]
+        self.assert_course_seat_valid(seat, course, certificate_type, id_verification_required, price)
+
+        # Test update
+        price = 100
+        credit_provider = 'MIT'
+        course.create_or_update_seat(certificate_type, id_verification_required, price, credit_provider)
+
+        # Again, only two seats with one being the parent seat product.
+        self.assertEqual(course.products.count(), 2)
+        seat = course.seat_products[0]
+        self.assert_course_seat_valid(seat, course, certificate_type, id_verification_required, price, credit_provider)

--- a/ecommerce/credit/tests/test_views.py
+++ b/ecommerce/credit/tests/test_views.py
@@ -34,24 +34,8 @@ class CheckoutPageTest(UserMixin, CourseCatalogTestMixin, TestCase):
             thumbnail_url=self.thumbnail_url
         )
 
-        # Create the seat products
-        self.seats = self.create_course_seats(self.course.id, ('credit', 'honor', 'verified'))
-
-        # Associate the parent and child products with the course. The method should be able to filter out the parent.
-        parent = self.seats.values()[0].parent
-        parent.course = self.course
-        parent.save()
-
-        seat = self.seats['credit']
-        seat.attr.credit_provider = self.provider
-        seat.save()
-
-        partner, _created = Partner.objects.get_or_create(code='edx')
-        for stock_record in seat.stockrecords.all():
-            stock_record.price_currency = 'USD'
-            stock_record.price_excl_tax = self.price
-            stock_record.partner = partner
-            stock_record.save()
+        # Create the credit seat
+        self.seat = self.course.create_or_update_seat('credit', True, self.price, self.provider)
 
     @property
     def path(self):
@@ -83,7 +67,7 @@ class CheckoutPageTest(UserMixin, CourseCatalogTestMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         expected = {
             'course': self.course,
-            'credit_seats': [self.seats['credit']],
+            'credit_seats': [self.seat],
         }
         self.assertDictContainsSubset(expected, response.context)
 

--- a/ecommerce/extensions/analytics/utils.py
+++ b/ecommerce/extensions/analytics/utils.py
@@ -78,7 +78,7 @@ def audit_log(name, **kwargs):
     """
     # Joins sorted keyword argument keys and values with an "=", wraps each value
     # in quotes, and separates each pair with a comma and a space.
-    payload = u', '.join(['{k}="{v}"'.format(k=k, v=v) for k, v in sorted(kwargs.items())])
+    payload = u', '.join([u'{k}="{v}"'.format(k=k, v=v) for k, v in sorted(kwargs.items())])
     message = u'{name}: {payload}'.format(name=name, payload=payload)
 
     logger.info(message)

--- a/ecommerce/extensions/catalogue/management/commands/migrate_course.py
+++ b/ecommerce/extensions/catalogue/management/commands/migrate_course.py
@@ -6,60 +6,16 @@ import dateutil.parser
 from django.conf import settings
 from django.core.management import BaseCommand
 from django.db import transaction
-from django.utils.text import slugify
-from oscar.core.loading import get_model
 import requests
 
 from ecommerce.courses.models import Course
-from ecommerce.extensions.catalogue.utils import generate_sku
 
 logger = logging.getLogger(__name__)
-
-Category = get_model('catalogue', 'Category')
-Partner = get_model('partner', 'Partner')
-Product = get_model('catalogue', 'Product')
-ProductCategory = get_model('catalogue', 'ProductCategory')
-ProductClass = get_model('catalogue', 'ProductClass')
-StockRecord = get_model('partner', 'StockRecord')
 
 
 class MigratedCourse(object):
     def __init__(self, course_id):
-        # Ensure this value is Unicode to avoid issues with slugify.
-        self.course_id = unicode(course_id)
-
-        self.parent_seat = None
-        self.child_seats = {}
-        self._unsaved_stock_records = {}
-
-        try:
-            self.course = Course.objects.get(id=self.course_id)
-        except Course.DoesNotExist:
-            self.course = Course(id=self.course_id)
-
-    @transaction.atomic
-    def save(self):
-        # Do NOT publish back to LMS until all data has been saved.
-        self.course.save(publish=False)
-
-        self.parent_seat.course = self.course
-        self.parent_seat.save()
-        category = Category.objects.get(name='Seats')
-        ProductCategory.objects.get_or_create(category=category, product=self.parent_seat)
-
-        for product in self.child_seats.values():
-            product.parent = self.parent_seat
-            product.course = self.course
-            product.save()
-
-        for seat_type, stock_record in self._unsaved_stock_records.iteritems():
-            stock_record.product = self.child_seats[seat_type]
-            stock_record.save()
-
-        self._unsaved_stock_records = {}
-
-        # Publish to LMS
-        self.course.publish_to_lms()
+        self.course, __ = Course.objects.get_or_create(id=course_id)
 
     def load_from_lms(self, access_token):
         """
@@ -69,7 +25,8 @@ class MigratedCourse(object):
         """
         name, modes = self._retrieve_data_from_lms(access_token)
         self.course.name = name
-        self._get_products(name, modes)
+        self.course.save()
+        self._get_products(modes)
 
     def _build_lms_url(self, path):
         # We avoid using urljoin here because it URL-encodes the path, and some LMS APIs
@@ -87,7 +44,7 @@ class MigratedCourse(object):
         }
 
         # Get course name from Course Structure API
-        url = self._build_lms_url('api/course_structure/v0/courses/{}/'.format(self.course_id))
+        url = self._build_lms_url('api/course_structure/v0/courses/{}/'.format(self.course.id))
         response = requests.get(url, headers=headers)
 
         if response.status_code != 200:
@@ -99,7 +56,7 @@ class MigratedCourse(object):
         course_name = data['name']
 
         # Get modes and pricing from Enrollment API
-        url = self._build_lms_url('api/enrollment/v1/course/{}'.format(self.course_id))
+        url = self._build_lms_url('api/enrollment/v1/course/{}'.format(self.course.id))
         response = requests.get(url, headers=headers)
 
         if response.status_code != 200:
@@ -112,86 +69,15 @@ class MigratedCourse(object):
 
         return course_name, modes
 
-    def _get_product_name(self, course_name, mode):
-        name = 'Seat in {course_name} with {certificate_type} certificate'.format(
-            course_name=course_name,
-            certificate_type=Course.certificate_type_for_mode(mode))
-
-        if Course.is_mode_verified(mode):
-            name += ' (and ID verification)'
-
-        return name
-
-    def _get_products(self, course_name, modes):
-        """
-        Creates course seat products.
-
-        Returns:
-            seats (dict):  Mapping of seat types to seat Products
-            stock_records (dict):  Mapping of seat types to StockRecords
-        """
-
-        course_id = self.course_id
-
-        seats = {}
-        stock_records = {}
-        slug = 'parent-cs-{}'.format(slugify(course_id))
-        partner = Partner.objects.get(code='edx')
-
-        try:
-            parent = Product.objects.get(slug=slug)
-            logger.info('Retrieved parent seat product for [%s] from database.', course_id)
-        except Product.DoesNotExist:
-            product_class = ProductClass.objects.get(slug='seat')
-            parent = Product(slug=slug, is_discountable=True, structure=Product.PARENT, product_class=product_class)
-            logger.info('Parent seat product for [%s] does not exist. Instantiated a new instance.', course_id)
-
-        parent.title = 'Seat in {}'.format(course_name)
-        parent.attr.course_key = course_id
-
-        # Create the child products
+    def _get_products(self, modes):
+        """ Creates/updates course seat products. """
         for mode in modes:
-            seat_type = mode['slug']
-            slug = 'child-cs-{}-{}'.format(seat_type, slugify(course_id))
-            try:
-                seat = Product.objects.get(slug=slug)
-                logger.info('Retrieved [%s] course seat child product for [%s] from database.', seat_type, course_id)
-            except Product.DoesNotExist:
-                seat = Product(slug=slug)
-                logger.info('[%s] course seat product for [%s] does not exist. Instantiated a new instance.',
-                            seat_type, course_id)
-
-            seat.parent = parent
-            seat.is_discountable = True
-            seat.structure = Product.CHILD
-            seat.title = self._get_product_name(course_name, seat_type)
+            certificate_type = Course.certificate_type_for_mode(mode['slug'])
+            id_verification_required = Course.is_mode_verified(mode['slug'])
+            price = mode['min_price']
             expires = mode.get('expiration_datetime')
-            seat.expires = dateutil.parser.parse(expires) if expires else None
-            seat.attr.certificate_type = seat_type
-            seat.attr.course_key = course_id
-            seat.attr.id_verification_required = Course.is_mode_verified(seat_type)
-
-            seats[seat_type] = seat
-
-            try:
-                stock_record = StockRecord.objects.get(product=seat, partner=partner)
-                logger.info('Retrieved [%s] course seat child product stock record for [%s] from database.',
-                            seat_type, course_id)
-            except StockRecord.DoesNotExist:
-                partner_sku = generate_sku(seat)
-                stock_record = StockRecord(product=seat, partner=partner, partner_sku=partner_sku)
-                logger.info(
-                    '[%s] course seat product stock record for [%s] does not exist. Instantiated a new instance.',
-                    seat_type, course_id)
-
-            stock_record.price_excl_tax = mode['min_price']
-            stock_record.price_currency = 'USD'
-
-            stock_records[seat_type] = stock_record
-
-        self.parent_seat = parent
-        self.child_seats = seats
-        self._unsaved_stock_records = stock_records
+            expires = dateutil.parser.parse(expires) if expires else None
+            self.course.create_or_update_seat(certificate_type, id_verification_required, price, expires=expires)
 
 
 class Command(BaseCommand):
@@ -221,25 +107,27 @@ class Command(BaseCommand):
         for course_id in course_ids:
             course_id = unicode(course_id)
             try:
-                migrated_course = MigratedCourse(course_id)
-                migrated_course.load_from_lms(access_token)
+                with transaction.atomic():
+                    migrated_course = MigratedCourse(course_id)
+                    migrated_course.load_from_lms(access_token)
 
-                course = migrated_course.course
-                msg = 'Retrieved info for {0} ({1}):\n'.format(course.id, course.name)
+                    course = migrated_course.course
+                    msg = 'Retrieved info for {0} ({1}):\n'.format(course.id, course.name)
 
-                for seat_type, seat in migrated_course.child_seats.iteritems():
-                    stock_record = migrated_course._unsaved_stock_records[seat_type]  # pylint: disable=protected-access
-                    data = (seat_type, seat.attr.id_verification_required,
-                            '{0} {1}'.format(stock_record.price_currency, stock_record.price_excl_tax),
-                            stock_record.partner_sku, seat.slug, seat.expires)
-                    msg += '\t{}\n'.format(data)
+                    for seat in course.seat_products:
+                        stock_record = seat.stockrecords.first()
+                        data = (seat.attr.certificate_type, seat.attr.id_verification_required,
+                                '{0} {1}'.format(stock_record.price_currency, stock_record.price_excl_tax),
+                                stock_record.partner_sku, seat.slug, seat.expires)
+                        msg += '\t{}\n'.format(data)
 
-                logger.info(msg)
+                    logger.info(msg)
 
-                if options.get('commit', False):
-                    migrated_course.save()
-                    logger.info('Course [%s] was saved to the database.', migrated_course.course.id)
-                else:
-                    logger.info('Course [%s] was NOT saved to the database.', migrated_course.course.id)
+                    if options.get('commit', False):
+                        logger.info('Course [%s] was saved to the database.', migrated_course.course.id)
+                        transaction.commit()
+                    else:
+                        logger.info('Course [%s] was NOT saved to the database.', migrated_course.course.id)
+                        raise Exception('Forced rollback.')
             except Exception:  # pylint: disable=broad-except
                 logger.exception('Failed to migrate [%s]!', course_id)

--- a/ecommerce/extensions/catalogue/tests/mixins.py
+++ b/ecommerce/extensions/catalogue/tests/mixins.py
@@ -1,19 +1,23 @@
+from __future__ import unicode_literals
 import logging
 
 from oscar.core.loading import get_model
 from oscar.test import factories
-
-from ecommerce.courses.models import Course
 
 logger = logging.getLogger(__name__)
 
 Category = get_model('catalogue', 'Category')
 Partner = get_model('partner', 'Partner')
 ProductClass = get_model('catalogue', 'ProductClass')
-ProductAttribute = get_model('catalogue', 'ProductAttribute')
 
 
 class CourseCatalogTestMixin(object):
+    """
+    Mixin for all tests involving the course catalog or course seats.
+
+    The setup method guarantees the requisite product class, partner, and category will be in place. This is especially
+    useful when running tests without database migrations (which normally create these objects).
+    """
     def setUp(self):
         super(CourseCatalogTestMixin, self).setUp()
 
@@ -28,50 +32,14 @@ class CourseCatalogTestMixin(object):
         pc, created = ProductClass.objects.get_or_create(slug='seat', defaults=defaults)
 
         if created:
-            factories.ProductAttributeFactory(code='certificate_type', product_class=pc, type='text')
-            factories.ProductAttributeFactory(code='course_key', product_class=pc, type='text')
-            factories.ProductAttributeFactory(code='id_verification_required', product_class=pc, type='boolean')
-            factories.ProductAttributeFactory(code='credit_provider', product_class=pc, type='text')
+            attributes = (
+                ('certificate_type', 'text'),
+                ('course_key', 'text'),
+                ('credit_provider', 'text'),
+                ('id_verification_required', 'boolean'),
+            )
+
+            for code, attr_type in attributes:
+                factories.ProductAttributeFactory(code=code, name=code, product_class=pc, type=attr_type)
 
         return pc
-
-    def _link_course_and_seats(self, course_id, seats):
-        """ Associated a course with seats. """
-        try:
-            course = Course.objects.get(id=course_id)
-        except Course.DoesNotExist:
-            logger.warning('Course [%s] does not exist. Unable to link to seats.', course_id)
-            return
-
-        # Associate the parent and child products with the course. The method should be able to filter out the parent.
-        parent = seats.values()[0].parent
-        parent.course = course
-        parent.save()
-
-        for seat in seats.itervalues():
-            seat.course = course
-            seat.save()
-
-    def create_course_seats(self, course_id, certificate_types, provider=None):
-        title = 'Seat in {}'.format(course_id)
-        parent_product = factories.ProductFactory(structure='parent', title=title,
-                                                  product_class=self.seat_product_class)
-
-        seats = {}
-        for certificate_type in certificate_types:
-            seat_title = '{title} with {type} certificate'.format(title=title, type=certificate_type)
-            seat = factories.ProductFactory(structure='child', title=seat_title, product_class=None,
-                                            parent=parent_product)
-
-            seat.attr.certificate_type = certificate_type
-            seat.attr.course_key = course_id
-            seat.attr.credit_provider = provider
-            seat.save()
-
-            factories.StockRecordFactory(product=seat)
-
-            seats[certificate_type] = seat
-
-        self._link_course_and_seats(course_id, seats)
-
-        return seats

--- a/ecommerce/extensions/catalogue/tests/test_utils.py
+++ b/ecommerce/extensions/catalogue/tests/test_utils.py
@@ -1,6 +1,7 @@
 from hashlib import md5
 
 from django.test import TestCase
+from ecommerce.courses.models import Course
 
 from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
 from ecommerce.extensions.catalogue.utils import generate_sku
@@ -10,10 +11,11 @@ class UtilsTests(CourseCatalogTestMixin, TestCase):
     def test_generate_sku_for_course_seat(self):
         """Verify the method generates a SKU for a course seat."""
         course_id = 'sku/test/course'
+        course = Course.objects.create(id=course_id, name='Test Course')
         certificate_type = 'honor'
-        product = self.create_course_seats(course_id, [certificate_type])[certificate_type]
+        product = course.create_or_update_seat(certificate_type, False, 0)
 
-        _hash = md5(u'{} {}'.format(certificate_type, course_id)).hexdigest()[-7:]
+        _hash = md5(u'{} {} {}'.format(certificate_type, course_id, 'False')).hexdigest()[-7:]
         expected = _hash.upper()
         actual = generate_sku(product)
         self.assertEqual(actual, expected)

--- a/ecommerce/extensions/catalogue/utils.py
+++ b/ecommerce/extensions/catalogue/utils.py
@@ -9,7 +9,9 @@ def generate_sku(product):
     """
     # Note: This currently supports seats. In the future, this should
     # be updated to accommodate other product classes.
-    _hash = u' '.join((product.attr.certificate_type.lower(), product.attr.course_key.lower()))
+    _hash = u' '.join((product.attr.certificate_type.lower(),
+                       product.attr.course_key.lower(),
+                       unicode(product.attr.id_verification_required)))
     _hash = md5(_hash)
     _hash = _hash.hexdigest()[-7:]
     return _hash.upper()

--- a/ecommerce/extensions/partner/tests/test_strategy.py
+++ b/ecommerce/extensions/partner/tests/test_strategy.py
@@ -4,6 +4,7 @@ from django.test import TestCase
 from oscar.apps.partner import availability
 import pytz
 
+from ecommerce.courses.models import Course
 from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
 from ecommerce.extensions.partner.strategy import DefaultStrategy, Selector
 
@@ -12,7 +13,8 @@ class DefaultStrategyTests(CourseCatalogTestMixin, TestCase):
     def setUp(self):
         super(DefaultStrategyTests, self).setUp()
         self.strategy = DefaultStrategy()
-        self.honor_seat = self.create_course_seats('a/b/c', ('honor',))['honor']
+        course = Course.objects.create(id='a/b/c', name='Demo Course')
+        self.honor_seat = course.create_or_update_seat('honor', False, 0)
 
     def test_seat_class(self):
         """ Verify the property returns the course seat Product Class. """

--- a/ecommerce/extensions/payment/tests/mixins.py
+++ b/ecommerce/extensions/payment/tests/mixins.py
@@ -13,6 +13,7 @@ from ecommerce.extensions.payment.constants import CARD_TYPES
 from ecommerce.extensions.payment.helpers import sign
 
 
+CURRENCY = u'USD'
 Order = get_model('order', 'Order')
 PaymentProcessorResponse = get_model('payment', 'PaymentProcessorResponse')
 
@@ -149,7 +150,7 @@ class CybersourceMixin(object):
             url = urljoin(settings.PAYMENT_PROCESSOR_CONFIG['cybersource']['soap_api_url'], filename)
             httpretty.register_uri(httpretty.GET, url, body=body)
 
-    def get_soap_mock(self, amount=100, currency='GBP', transaction_id=None, basket_id=None, decision='ACCEPT'):
+    def get_soap_mock(self, amount=100, currency=CURRENCY, transaction_id=None, basket_id=None, decision='ACCEPT'):
         class CybersourceSoapMock(mock.MagicMock):
             def runTransaction(self, **kwargs):     # pylint: disable=unused-argument
                 cc_reply_items = {
@@ -253,7 +254,7 @@ class PaypalMixin(object):
             u'state': state,
             u'transactions': [{
                 u'amount': {
-                    u'currency': u'GBP',
+                    u'currency': CURRENCY,
                     u'details': {u'subtotal': total},
                     u'total': total
                 },
@@ -316,7 +317,7 @@ class PaypalMixin(object):
             u'state': state,
             u'transactions': [{
                 u'amount': {
-                    u'currency': u'GBP',
+                    u'currency': CURRENCY,
                     u'details': {u'subtotal': total},
                     u'total': total
                 },
@@ -335,7 +336,7 @@ class PaypalMixin(object):
                 u'related_resources': [{
                     u'sale': {
                         u'amount': {
-                            u'currency': u'GBP',
+                            u'currency': CURRENCY,
                             u'total': total
                         },
                         u'create_time': u'2015-05-04T15:55:27Z',
@@ -367,7 +368,7 @@ class PaypalMixin(object):
                         u'protection_eligibility_type': u'ITEM_NOT_RECEIVED_ELIGIBLE,UNAUTHORIZED_PAYMENT_ELIGIBLE',
                         u'state': u'completed',
                         u'transaction_fee': {
-                            u'currency': u'GBP',
+                            u'currency': CURRENCY,
                             u'value': u'0.50'
                         },
                         u'update_time': u'2015-05-04T15:58:47Z'

--- a/ecommerce/extensions/refund/tests/mixins.py
+++ b/ecommerce/extensions/refund/tests/mixins.py
@@ -23,6 +23,7 @@ SourceType = get_model('payment', 'SourceType')
 
 class RefundTestMixin(object):
     def setUp(self):
+        super(RefundTestMixin, self).setUp()
         self.course_id = u'edX/DemoX/Demo_Course'
         self.course = CourseFactory(self.course_id, u'edX Demó Course')
         self.honor_product = self.course.add_mode('honor', 0)


### PR DESCRIPTION
The creation of all course seats (for tests, via migration, etc.) is now handled via Course.create_or_update_seat(). Consolidating this logic into a single location removes duplicate code and ensures we are fully testing the actual code paths used in production.
