### PR TITLE
Moved ISO_8601_FORMAT to core app

### DIFF
--- a/ecommerce/core/constants.py
+++ b/ecommerce/core/constants.py
@@ -1,5 +1,7 @@
 """Health check constants."""
 
+ISO_8601_FORMAT = u'%Y-%m-%dT%H:%M:%SZ'
+
 
 class Status(object):
     """Health statuses."""

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -4,8 +4,8 @@ from oscar.core.loading import get_model, get_class
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 
+from ecommerce.core.constants import ISO_8601_FORMAT
 from ecommerce.courses.models import Course
-from ecommerce.extensions.payment.constants import ISO_8601_FORMAT
 
 BillingAddress = get_model('order', 'BillingAddress')
 Line = get_model('order', 'Line')

--- a/ecommerce/extensions/api/v2/tests/views/test_products.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_products.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from oscar.core.loading import get_model, get_class
 import pytz
 
+from ecommerce.core.constants import ISO_8601_FORMAT
 from ecommerce.courses.models import Course
 from ecommerce.extensions.api.v2.tests.views import JSON_CONTENT_TYPE, TestServerUrlMixin
 from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
@@ -38,7 +39,7 @@ class ProductViewSetTests(TestServerUrlMixin, CourseCatalogTestMixin, UserMixin,
             'url': self.get_full_url(reverse('api:v2:product-detail', kwargs={'pk': product.id})),
             'product_class': unicode(product.get_product_class()),
             'title': product.title,
-            'expires': product.expires.isoformat()[:-6] + 'Z' if product.expires else None,
+            'expires': product.expires.strftime(ISO_8601_FORMAT) if product.expires else None,
             'attribute_values': attribute_values
         }
 

--- a/ecommerce/extensions/catalogue/tests/test_migrate_course.py
+++ b/ecommerce/extensions/catalogue/tests/test_migrate_course.py
@@ -13,6 +13,7 @@ import httpretty
 from oscar.core.loading import get_model
 import pytz
 
+from ecommerce.core.constants import ISO_8601_FORMAT
 from ecommerce.courses.models import Course
 from ecommerce.extensions.catalogue.management.commands.migrate_course import MigratedCourse
 from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
@@ -21,7 +22,7 @@ from ecommerce.extensions.catalogue.utils import generate_sku
 JSON = 'application/json'
 ACCESS_TOKEN = 'edx'
 EXPIRES = datetime.datetime(year=1985, month=10, day=26, hour=1, minute=20, tzinfo=pytz.utc)
-EXPIRES_STRING = EXPIRES.isoformat()[:-6] + 'Z'
+EXPIRES_STRING = EXPIRES.strftime(ISO_8601_FORMAT)
 
 logger = logging.getLogger(__name__)
 

--- a/ecommerce/extensions/payment/constants.py
+++ b/ecommerce/extensions/payment/constants.py
@@ -1,7 +1,5 @@
 """Payment processor constants."""
 
-ISO_8601_FORMAT = u'%Y-%m-%dT%H:%M:%SZ'
-
 CARD_TYPES = {
     'american_express': {
         'display_name': 'American Express',

--- a/ecommerce/extensions/payment/processors/cybersource.py
+++ b/ecommerce/extensions/payment/processors/cybersource.py
@@ -11,8 +11,9 @@ from suds.client import Client
 from suds.sudsobject import asdict
 from suds.wsse import Security, UsernameToken
 
+from ecommerce.core.constants import ISO_8601_FORMAT
 from ecommerce.extensions.order.constants import PaymentEventTypeName
-from ecommerce.extensions.payment.constants import ISO_8601_FORMAT, CYBERSOURCE_CARD_TYPE_MAP
+from ecommerce.extensions.payment.constants import CYBERSOURCE_CARD_TYPE_MAP
 from ecommerce.extensions.payment.exceptions import (InvalidSignatureError, InvalidCybersourceDecision,
                                                      PartialAuthorizationError)
 from ecommerce.extensions.payment.helpers import sign

--- a/ecommerce/extensions/payment/tests/test_processors.py
+++ b/ecommerce/extensions/payment/tests/test_processors.py
@@ -20,10 +20,10 @@ import paypalrestsdk
 from paypalrestsdk import Payment, Sale
 from paypalrestsdk.resource import Resource
 
+from ecommerce.core.constants import ISO_8601_FORMAT
 from ecommerce.courses.models import Course
 from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
 from ecommerce.extensions.payment import processors
-from ecommerce.extensions.payment.constants import ISO_8601_FORMAT
 from ecommerce.extensions.payment.exceptions import (InvalidSignatureError, InvalidCybersourceDecision,
                                                      PartialAuthorizationError)
 from ecommerce.extensions.payment.models import PaypalWebProfile


### PR DESCRIPTION
This constant is shared across multiple apps, not just payment, so should be in a more centralized location.

XCOM-505

@rlucioni @jimabramson @Nickersoft 

Follow up from #210 
