### PR TITLE
Revert "Include nodeenv in base requirements"

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,6 @@ djangorestframework-jwt==1.5.0
 edx-auth-backends==0.1.3
 jsonfield==1.0.3
 libsass==0.8.2
-nodeenv==0.13.2
 paypalrestsdk==1.9.0
 pycountry==1.10
 python-dateutil==2.4.2

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -5,3 +5,4 @@ MySQL-python==1.2.5
 PyYAML==3.11
 gunicorn==19.2.1
 gevent==1.0.1
+nodeenv==0.13.2


### PR DESCRIPTION
Reverts edx/ecommerce#221

The correct approach is to install production requirements when bringing up a devstack, not modify the way we organize our requirements. I'll modify the Ansible roles as necessary.

FYI @clintonb 
