### PR TITLE
Updated Course Migration and Publishing

### DIFF
--- a/ecommerce/courses/publishers.py
+++ b/ecommerce/courses/publishers.py
@@ -14,6 +14,12 @@ class LMSPublisher(object):
             return 'no-id-professional'
         return seat.attr.certificate_type
 
+    def get_seat_expiration(self, seat):
+        if not seat.expires or 'professional' in seat.attr.certificate_type:
+            return None
+
+        return seat.expires.isoformat()
+
     def serialize_seat_for_commerce_api(self, seat):
         """ Serializes a course seat product to a dict that can be further serialized to JSON. """
         stock_record = seat.stockrecords.first()
@@ -22,7 +28,7 @@ class LMSPublisher(object):
             'currency': stock_record.price_currency,
             'price': int(stock_record.price_excl_tax),
             'sku': stock_record.partner_sku,
-            'expires': seat.expires.isoformat() if seat.expires else None,
+            'expires': self.get_seat_expiration(seat),
         }
 
     def publish(self, course):

--- a/ecommerce/extensions/catalogue/tests/test_migrate_course.py
+++ b/ecommerce/extensions/catalogue/tests/test_migrate_course.py
@@ -177,10 +177,9 @@ class CommandTests(CourseMigrationTestMixin, TestCase):
         self._mock_lms_api()
 
         with mock.patch.object(LMSPublisher, 'publish') as mock_publish:
-            mock_publish.return_value = True
             call_command('migrate_course', self.course_id, access_token=ACCESS_TOKEN, commit=True)
 
-            # Verify that the migrated course was not published back to the LMS
-            self.assertFalse(mock_publish.called)
+            # Verify that the migrated course was published back to the LMS
+            self.assertTrue(mock_publish.called)
 
         self.assert_course_migrated()


### PR DESCRIPTION
- XCOM-514: Course publishing has been decoupled from course saving (to DB).
- XCOM-515: The migration management command once again publishes data (esp. SKU) back to LMS
- When publishing, professional seats NEVER have an expiration date

@rlucioni @jimabramson 
