### PR TITLE
Added API endpoint for course publishing

### DIFF
--- a/ecommerce/courses/publishers.py
+++ b/ecommerce/courses/publishers.py
@@ -45,7 +45,7 @@ class LMSPublisher(object):
 
         if not settings.COMMERCE_API_URL:
             logger.error('COMMERCE_API_URL is not set. Commerce data will not be published!')
-            return
+            return False
 
         modes = [self.serialize_seat_for_commerce_api(seat) for seat in course.seat_products]
         course_id = course.id


### PR DESCRIPTION
This endpoint allows external parties (e.g. devs) to trigger course publishing to LMS.

XCOM-514

@rlucioni @jimabramson @Nickersoft 

Follow-up to #224 
