### PR TITLE
Added optional nesting of course products

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -123,8 +123,16 @@ class RefundSerializer(serializers.ModelSerializer):
 
 class CourseSerializer(serializers.HyperlinkedModelSerializer):
     id = serializers.RegexField(COURSE_ID_REGEX, max_length=255)
+    products = ProductSerializer(many=True)
     products_url = serializers.SerializerMethodField()
     last_edited = serializers.SerializerMethodField()
+
+    def __init__(self, *args, **kwargs):
+        super(CourseSerializer, self).__init__(*args, **kwargs)
+
+        include_products = kwargs['context'].pop('include_products', False)
+        if not include_products:
+            self.fields.pop('products', None)
 
     def get_last_edited(self, obj):
         return obj.history.latest().history_date.strftime(ISO_8601_FORMAT)
@@ -135,8 +143,8 @@ class CourseSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta(object):
         model = Course
-        fields = ('id', 'url', 'name', 'verification_deadline', 'type', 'products_url', 'last_edited')
-        read_only_fields = ('type',)
+        fields = ('id', 'url', 'name', 'verification_deadline', 'type', 'products_url', 'last_edited', 'products')
+        read_only_fields = ('type', 'products')
         extra_kwargs = {
             'url': {'view_name': COURSE_DETAIL_VIEW}
         }

--- a/ecommerce/extensions/api/v2/tests/views/__init__.py
+++ b/ecommerce/extensions/api/v2/tests/views/__init__.py
@@ -1,11 +1,15 @@
+from django.core.urlresolvers import reverse
 from django.test import RequestFactory
+from oscar.core.loading import get_class
 from oscar.test import factories
 from oscar.test.newfactories import ProductAttributeValueFactory
 
+from ecommerce.core.constants import ISO_8601_FORMAT
 from ecommerce.extensions.api.serializers import OrderSerializer
 from ecommerce.tests.mixins import UserMixin, ThrottlingMixin
 
 JSON_CONTENT_TYPE = 'application/json'
+Selector = get_class('partner.strategy', 'Selector')
 
 
 class OrderDetailViewTestMixin(ThrottlingMixin, UserMixin):
@@ -42,3 +46,26 @@ class TestServerUrlMixin(object):
     def get_full_url(self, path):
         """ Returns a complete URL with the given path. """
         return 'http://testserver' + path
+
+
+class ProductSerializerMixin(TestServerUrlMixin):
+    def serialize_product(self, product):
+        """ Serializes a Product to a Python dict. """
+        attribute_values = [{'name': av.attribute.name, 'value': av.value} for av in product.attribute_values.all()]
+        data = {
+            'id': product.id,
+            'url': self.get_full_url(reverse('api:v2:product-detail', kwargs={'pk': product.id})),
+            'structure': product.structure,
+            'product_class': unicode(product.get_product_class()),
+            'title': product.title,
+            'expires': product.expires.strftime(ISO_8601_FORMAT) if product.expires else None,
+            'attribute_values': attribute_values
+        }
+
+        info = Selector().strategy().fetch_for_product(product)
+        data.update({
+            'is_available_to_buy': info.availability.is_available_to_buy,
+            'price': "{0:.2f}".format(info.price.excl_tax) if info.availability.is_available_to_buy else None
+        })
+
+        return data

--- a/ecommerce/extensions/api/v2/views.py
+++ b/ecommerce/extensions/api/v2/views.py
@@ -500,6 +500,11 @@ class CourseViewSet(NonDestroyableModelViewSet):
     serializer_class = serializers.CourseSerializer
     permission_classes = (IsAuthenticated, IsAdminUser,)
 
+    def get_serializer_context(self):
+        context = super(CourseViewSet, self).get_serializer_context()
+        context['include_products'] = bool(self.request.GET.get('include_products', False))
+        return context
+
     @detail_route(methods=['post'])
     def publish(self, request, pk=None):  # pylint: disable=unused-argument
         """ Publish the course to LMS. """


### PR DESCRIPTION
 API clients can request that a course's products be nested with the course by setting the include_products querystring parameter to "true".

XCOM-309

@jimabramson @rlucioni @Nickersoft 
