### PR TITLE
Support migration of legacy audit modes

### DIFF
--- a/ecommerce/courses/publishers.py
+++ b/ecommerce/courses/publishers.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 class LMSPublisher(object):
     def get_seat_expiration(self, seat):
-        if not seat.expires or 'professional' in seat.attr.certificate_type:
+        if not seat.expires or 'professional' in getattr(seat.attr, 'certificate_type', ''):
             return None
 
         return seat.expires.isoformat()

--- a/ecommerce/courses/tests/test_models.py
+++ b/ecommerce/courses/tests/test_models.py
@@ -59,7 +59,7 @@ class CourseTests(CourseCatalogTestMixin, TestCase):
         ('professional', 'professional'),
         ('honor', 'honor'),
         ('no-id-professional', 'professional'),
-        ('audit', 'audit'),
+        ('audit', ''),
         ('unknown', 'unknown'),
     )
     @ddt.unpack
@@ -92,7 +92,7 @@ class CourseTests(CourseCatalogTestMixin, TestCase):
         # pylint: disable=protected-access
         self.assertEqual(seat.title, course._get_course_seat_name(certificate_type, id_verification_required))
         self.assertEqual(seat.get_product_class(), self.seat_product_class)
-        self.assertEqual(seat.attr.certificate_type, certificate_type)
+        self.assertEqual(getattr(seat.attr, 'certificate_type', ''), certificate_type)
         self.assertEqual(seat.attr.course_key, course.id)
         self.assertEqual(seat.attr.id_verification_required, id_verification_required)
         self.assertEqual(seat.stockrecords.first().price_excl_tax, price)

--- a/ecommerce/courses/tests/test_publishers.py
+++ b/ecommerce/courses/tests/test_publishers.py
@@ -98,7 +98,7 @@ class LMSPublisherTests(CourseCatalogTestMixin, TestCase):
     def test_serialize_seat_for_commerce_api(self):
         """ The method should convert a seat to a JSON-serializable dict consumable by the Commerce API. """
         # Grab the verified seat
-        seat = sorted(self.course.seat_products, key=lambda p: p.attr.certificate_type)[1]
+        seat = sorted(self.course.seat_products, key=lambda p: getattr(p.attr, 'certificate_type', ''))[1]
         stock_record = seat.stockrecords.first()
 
         actual = self.publisher.serialize_seat_for_commerce_api(seat)

--- a/ecommerce/courses/tests/test_utils.py
+++ b/ecommerce/courses/tests/test_utils.py
@@ -11,6 +11,7 @@ from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
 class UtilsTests(CourseCatalogTestMixin, TestCase):
     @ddt.unpack
     @ddt.data(
+        ('', False, 'audit'),
         ('honor', True, 'honor'),
         ('honor', False, 'honor'),
         ('verified', True, 'verified'),

--- a/ecommerce/courses/utils.py
+++ b/ecommerce/courses/utils.py
@@ -1,8 +1,10 @@
 def mode_for_seat(seat):
     """ Returns the Enrollment mode for a given seat product. """
-    certificate_type = seat.attr.certificate_type
+    certificate_type = getattr(seat.attr, 'certificate_type', '')
 
     if certificate_type == 'professional' and not seat.attr.id_verification_required:
         return 'no-id-professional'
+    elif certificate_type == '':
+        return 'audit'
 
     return certificate_type

--- a/ecommerce/credit/views.py
+++ b/ecommerce/credit/views.py
@@ -39,7 +39,7 @@ class Checkout(TemplateView):
                 processors_dict[processor] = 'Checkout with {}'.format(processor)
 
         credit_seats = [
-            seat for seat in course.seat_products if seat.attr.certificate_type == self.CREDIT_MODE
+            seat for seat in course.seat_products if getattr(seat.attr, 'certificate_type', '') == self.CREDIT_MODE
         ]
         provider_ids = None
         if credit_seats:

--- a/ecommerce/extensions/catalogue/management/commands/migrate_course.py
+++ b/ecommerce/extensions/catalogue/management/commands/migrate_course.py
@@ -146,9 +146,14 @@ class Command(BaseCommand):
 
                     for seat in course.seat_products:
                         stock_record = seat.stockrecords.first()
-                        data = (seat.attr.certificate_type, seat.attr.id_verification_required,
-                                '{0} {1}'.format(stock_record.price_currency, stock_record.price_excl_tax),
-                                stock_record.partner_sku, seat.slug, seat.expires)
+                        data = (
+                            getattr(seat.attr, 'certificate_type', ''),
+                            seat.attr.id_verification_required,
+                            '{0} {1}'.format(stock_record.price_currency, stock_record.price_excl_tax),
+                            stock_record.partner_sku,
+                            seat.slug,
+                            seat.expires
+                        )
                         msg += '\t{}\n'.format(data)
 
                     logger.info(msg)

--- a/ecommerce/extensions/catalogue/tests/test_migrate_course.py
+++ b/ecommerce/extensions/catalogue/tests/test_migrate_course.py
@@ -18,6 +18,7 @@ from waffle import Switch
 from ecommerce.core.constants import ISO_8601_FORMAT
 from ecommerce.courses.models import Course
 from ecommerce.courses.publishers import LMSPublisher
+from ecommerce.courses.utils import mode_for_seat
 from ecommerce.extensions.catalogue.management.commands.migrate_course import MigratedCourse
 from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
 from ecommerce.extensions.catalogue.utils import generate_sku
@@ -43,7 +44,9 @@ class CourseMigrationTestMixin(CourseCatalogTestMixin):
         'honor': 0,
         'verified': 10,
         'no-id-professional': 100,
-        'professional': 1000
+        'professional': 1000,
+        'audit': 0,
+        'credit': 0,
     }
 
     def _mock_lms_api(self):
@@ -59,8 +62,8 @@ class CourseMigrationTestMixin(CourseCatalogTestMixin):
         # Mock Enrollment API
         body = {
             'course_id': self.course_id,
-            'course_modes': [{'slug': seat_type, 'min_price': price, 'expiration_datetime': EXPIRES_STRING} for
-                             seat_type, price in self.prices.iteritems()]
+            'course_modes': [{'slug': mode, 'min_price': price, 'expiration_datetime': EXPIRES_STRING} for
+                             mode, price in self.prices.iteritems()]
         }
         httpretty.register_uri(httpretty.GET, self.enrollment_api_url, body=json.dumps(body), content_type=JSON)
 
@@ -75,12 +78,15 @@ class CourseMigrationTestMixin(CourseCatalogTestMixin):
         """ Verify the given seat is configured correctly. """
         certificate_type = Course.certificate_type_for_mode(mode)
 
-        expected_title = 'Seat in A Tést Côurse with {} certificate'.format(certificate_type)
-        if seat.attr.id_verification_required:
-            expected_title += u' (and ID verification)'
+        expected_title = 'Seat in A Tést Côurse'
+        if certificate_type != '':
+            expected_title += ' with {} certificate'.format(certificate_type)
+
+            if seat.attr.id_verification_required:
+                expected_title += u' (and ID verification)'
 
         self.assertEqual(seat.title, expected_title)
-        self.assertEqual(seat.attr.certificate_type, certificate_type)
+        self.assertEqual(getattr(seat.attr, 'certificate_type', ''), certificate_type)
         self.assertEqual(seat.expires, EXPIRES)
         self.assertEqual(seat.attr.course_key, self.course_id)
         self.assertEqual(seat.attr.id_verification_required, Course.is_mode_verified(mode))
@@ -89,18 +95,20 @@ class CourseMigrationTestMixin(CourseCatalogTestMixin):
         """ Verify the course was migrated and saved to the database. """
         course = Course.objects.get(id=self.course_id)
         seats = course.seat_products
-        self.assertEqual(len(seats), 4)
+
+        # Verify that all modes are migrated.
+        self.assertEqual(len(seats), len(self.prices))
+
         parent = course.products.get(structure=Product.PARENT)
         self.assertEqual(list(parent.categories.all()), [self.category])
+
         for seat in seats:
-            seat_type = seat.attr.certificate_type
-            if seat_type == 'professional' and not seat.attr.id_verification_required:
-                seat_type = 'no-id-professional'
-            logger.info('Validating objects for %s certificate type...', seat_type)
+            mode = mode_for_seat(seat)
+            logger.info('Validating objects for [%s] mode...', mode)
 
             stock_record = self.partner.stockrecords.get(product=seat)
-            self.assert_seat_valid(seat, seat_type)
-            self.assert_stock_record_valid(stock_record, seat, self.prices[seat_type])
+            self.assert_seat_valid(seat, mode)
+            self.assert_stock_record_valid(stock_record, seat, self.prices[mode])
 
     def assert_lms_api_headers(self, request):
         self.assertEqual(request.headers['Accept'], JSON)
@@ -140,11 +148,10 @@ class MigratedCourseTests(CourseMigrationTestMixin, TestCase):
         self.assertEqual(course.verification_deadline, EXPIRES)
 
         for seat in course.seat_products:
-            certificate_type = seat.attr.certificate_type
-            if certificate_type == 'professional' and not seat.attr.id_verification_required:
-                certificate_type = 'no-id-professional'
-            logger.info('Validating objects for %s certificate type...', certificate_type)
-            self.assert_stock_record_valid(seat.stockrecords.first(), seat, Decimal(self.prices[certificate_type]))
+            mode = mode_for_seat(seat)
+            logger.info('Validating objects for [%s] mode...', mode)
+
+            self.assert_stock_record_valid(seat.stockrecords.first(), seat, Decimal(self.prices[mode]))
 
     @httpretty.activate
     def test_course_name_missing(self):

--- a/ecommerce/extensions/catalogue/utils.py
+++ b/ecommerce/extensions/catalogue/utils.py
@@ -9,9 +9,12 @@ def generate_sku(product):
     """
     # Note: This currently supports seats. In the future, this should
     # be updated to accommodate other product classes.
-    _hash = u' '.join((product.attr.certificate_type.lower(),
-                       product.attr.course_key.lower(),
-                       unicode(product.attr.id_verification_required)))
+    _hash = u' '.join((
+        getattr(product.attr, 'certificate_type', '').lower(),
+        product.attr.course_key.lower(),
+        unicode(product.attr.id_verification_required)
+    ))
     _hash = md5(_hash)
     _hash = _hash.hexdigest()[-7:]
+
     return _hash.upper()

--- a/ecommerce/extensions/checkout/signals.py
+++ b/ecommerce/extensions/checkout/signals.py
@@ -3,6 +3,7 @@ import waffle
 from django.dispatch import receiver
 from oscar.core.loading import get_class
 
+from ecommerce.courses.utils import mode_for_seat
 from ecommerce.extensions.analytics.utils import is_segment_configured, parse_tracking_context, log_exceptions
 from ecommerce.notifications.notifications import send_notification
 
@@ -33,7 +34,7 @@ def track_completed_order(sender, order=None, **kwargs):  # pylint: disable=unus
                     # SKU. Marketing is aware that this approach will not scale once we start selling
                     # products other than courses, and will need to change in the future.
                     'id': line.partner_sku,
-                    'sku': line.product.attr.certificate_type,
+                    'sku': mode_for_seat(line.product),
                     'name': line.product.title,
                     'price': str(line.line_price_excl_tax),
                     'quantity': line.quantity,

--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -228,12 +228,12 @@ class EnrollmentFulfillmentModule(BaseFulfillmentModule):
         try:
             logger.info('Attempting to revoke fulfillment of Line [%d]...', line.id)
 
-            certificate_type = line.product.attr.certificate_type
+            mode = mode_for_seat(line.product)
             course_key = line.product.attr.course_key
             data = {
                 'user': line.order.user.username,
                 'is_active': False,
-                'mode': certificate_type,
+                'mode': mode,
                 'course_details': {
                     'course_id': course_key,
                 },
@@ -248,7 +248,7 @@ class EnrollmentFulfillmentModule(BaseFulfillmentModule):
                     order_number=line.order.number,
                     product_class=line.product.get_product_class().name,
                     course_id=course_key,
-                    certificate_type=certificate_type,
+                    certificate_type=getattr(line.product.attr, 'certificate_type', ''),
                     user_id=line.order.user.id
                 )
 

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -143,7 +143,7 @@ class EnrollmentFulfillmentModuleTests(EnrollmentFulfillmentTestMixin, TestCase)
                     'INFO',
                     'line_revoked: certificate_type="{}", course_id="{}", order_line_id="{}", order_number="{}", '
                     'product_class="{}", user_id="{}"'.format(
-                        line.product.attr.certificate_type,
+                        getattr(line.product.attr, 'certificate_type', ''),
                         line.product.attr.course_key,
                         line.id,
                         line.order.number,

--- a/ecommerce/extensions/payment/processors/cybersource.py
+++ b/ecommerce/extensions/payment/processors/cybersource.py
@@ -98,7 +98,7 @@ class Cybersource(BasePaymentProcessor):
         single_seat = self.get_single_seat(basket)
         if single_seat:
             parameters[u'merchant_defined_data1'] = single_seat.attr.course_key
-            parameters[u'merchant_defined_data2'] = single_seat.attr.certificate_type
+            parameters[u'merchant_defined_data2'] = getattr(single_seat.attr, 'certificate_type', '')
 
         # Sign all fields
         signed_field_names = parameters.keys()

--- a/ecommerce/extensions/refund/signals.py
+++ b/ecommerce/extensions/refund/signals.py
@@ -1,6 +1,7 @@
 import analytics
 from django.dispatch import receiver, Signal
 
+from ecommerce.courses.utils import mode_for_seat
 from ecommerce.extensions.analytics.utils import is_segment_configured, parse_tracking_context, log_exceptions
 
 
@@ -34,7 +35,7 @@ def track_completed_refund(sender, refund=None, **kwargs):  # pylint: disable=un
                     # SKU. Marketing is aware that this approach will not scale once we start selling
                     # products other than courses, and will need to change in the future.
                     'id': line.order_line.partner_sku,
-                    'sku': line.order_line.product.attr.certificate_type,
+                    'sku': mode_for_seat(line.order_line.product),
                     'name': line.order_line.product.title,
                     'price': str(line.line_credit_excl_tax),
                     'quantity': -1 * line.quantity,

--- a/ecommerce/extensions/refund/tests/factories.py
+++ b/ecommerce/extensions/refund/tests/factories.py
@@ -7,7 +7,9 @@ from oscar.core.loading import get_model
 from oscar.test import factories
 from oscar.test.newfactories import UserFactory
 
+from ecommerce.courses.models import Course
 from ecommerce.extensions.refund.status import REFUND, REFUND_LINE
+
 
 Category = get_model("catalogue", "Category")
 Partner = get_model('partner', 'Partner')
@@ -87,14 +89,21 @@ class CourseFactory(object):
     def add_mode(self, name, price, id_verification_required=False):
         parent_product = self._get_parent_seat_product()
 
-        title = u'{mode_name} Seat in {course_name}'.format(mode_name=name, course_name=self.course_name)
-        slug = slugify(u'{course_name}-seat-{mode_name}'.format(course_name=self.course_name, mode_name=name))
+        certificate_type = Course.certificate_type_for_mode(name)
+        title = u'{certificate_type} Seat in {course_name}'.format(
+            certificate_type=certificate_type,
+            course_name=self.course_name
+        )
+        slug = slugify(u'{course_name}-seat-{certificate_type}'.format(
+            course_name=self.course_name,
+            certificate_type=certificate_type
+        ))
         child_product, created = Product.objects.get_or_create(parent=parent_product, title=title, slug=slug,
                                                                structure='child')
 
         if created:
             child_product.attr.course_key = self.course_id
-            child_product.attr.certificate_type = name
+            child_product.attr.certificate_type = certificate_type
             child_product.attr.id_verification_required = id_verification_required
             child_product.save()
 

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -12,6 +12,7 @@ from mock import patch
 from oscar.test import factories
 from oscar.core.loading import get_model, get_class
 
+from ecommerce.courses.utils import mode_for_seat
 from ecommerce.extensions.api.constants import APIConstants as AC
 from ecommerce.extensions.fulfillment.mixins import FulfillmentMixin
 
@@ -201,7 +202,7 @@ class BusinessIntelligenceMixin(object):
                 self.assertEqual(line.product.title, tracked_product['name'])
                 self.assertEqual(str(line.line_price_excl_tax), tracked_product['price'])
                 self.assertEqual(line.quantity, tracked_product['quantity'])
-                self.assertEqual(line.product.attr.certificate_type, tracked_product['sku'])
+                self.assertEqual(mode_for_seat(line.product), tracked_product['sku'])
                 self.assertEqual(line.product.get_product_class().name, tracked_product['category'])
         elif model_name == 'Refund':
             self.assertEqual(event_payload['total'], '-{}'.format(total))
@@ -212,7 +213,7 @@ class BusinessIntelligenceMixin(object):
                 self.assertEqual(line.order_line.product.title, tracked_product['name'])
                 self.assertEqual(str(line.line_credit_excl_tax), tracked_product['price'])
                 self.assertEqual(-1 * line.quantity, tracked_product['quantity'])
-                self.assertEqual(line.order_line.product.attr.certificate_type, tracked_product['sku'])
+                self.assertEqual(mode_for_seat(line.order_line.product), tracked_product['sku'])
                 self.assertEqual(line.order_line.product.get_product_class().name, tracked_product['category'])
         else:
             # Payload validation is currently limited to order and refund events


### PR DESCRIPTION
If a ProductAttribute is saved with a value of None or the empty string, the ProductAttribute is deleted ([reference](https://github.com/django-oscar/django-oscar/blob/master/src/oscar/apps/catalogue/abstract_models.py#L870-L871)). As a consequence, Seats derived from a migrated "audit" mode do not have a certificate_type attribute. XCOM-541.

@clintonb @jimabramson 
