### PR TITLE
XCOM-501: Advanced search on order/refund list views now displays correctly

### DIFF
--- a/ecommerce/templates/oscar/dashboard/orders/order_list.html
+++ b/ecommerce/templates/oscar/dashboard/orders/order_list.html
@@ -64,21 +64,27 @@
             <a data-toggle="modal" href="#SearchModal">{% trans "Advanced Search" %}</a>
         </form>
 
-        <div class="modal hide fade" id="SearchModal">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal">&times;</button>
-                <h3>{% trans "Advanced Search" %}</h3>
+        <div class="modal fade" id="SearchModal">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal">&times;</button>
+                        <h3>{% trans "Advanced Search" %}</h3>
+                    </div>
+                    <form action="" method="get" class="form-horizontal">
+                        <div class="modal-body">
+                            <div class="container-fluid">
+                                {% csrf_token %}
+                                {% include "partials/form_fields.html" with form=form %}
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <a href="#" class="btn btn-default" data-dismiss="modal">{% trans "Close" %}</a>
+                            <button type="submit" class="btn btn-primary" data-loading-text="{% trans 'Searching...' %}">{% trans "Search" %}</button>
+                        </div>
+                    </form>
+                </div>
             </div>
-            <form action="" method="get" class="form-horizontal">
-                <div class="modal-body">
-                  {% csrf_token %}
-                  {% include "partials/form_fields.html" with form=form %}
-                </div>
-                <div class="modal-footer">
-                    <a href="#" class="btn" data-dismiss="modal">{% trans "Close" %}</a>
-                    <button type="submit" class="btn btn-primary">{% trans "Search" %}</button>
-                </div>
-            </form>
         </div>
     </div>
 

--- a/ecommerce/templates/oscar/dashboard/refunds/refund_list.html
+++ b/ecommerce/templates/oscar/dashboard/refunds/refund_list.html
@@ -66,18 +66,26 @@
         <a data-toggle="modal" href="#SearchModal">{% trans "Advanced Search" %}</a>
     </form>
 
-    <div class="modal hide fade" id="SearchModal">
-        <div class="modal-header">
-            <button type="button" class="close" data-dismiss="modal">&times;</button>
-            <h3>{% trans "Advanced Search" %}</h3>
-        </div>
-        <form action="" method="get" class="form-horizontal">
-            <div class="modal-body">{% include "partials/form_fields.html" with form=form %}</div>
-            <div class="modal-footer">
-                <a href="#" class="btn" data-dismiss="modal">{% trans "Close" %}</a>
-                <button type="submit" class="btn btn-primary">{% trans "Search" %}</button>
+    <div class="modal fade" id="SearchModal">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal">&times;</button>
+                    <h3>{% trans "Advanced Search" %}</h3>
+                </div>
+                <form action="" method="get" class="form-horizontal">
+                    <div class="modal-body">
+                        <div class="container-fluid">
+                            {% include "partials/form_fields.html" with form=form %}
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <a href="#" class="btn" data-dismiss="modal">{% trans "Close" %}</a>
+                        <button type="submit" class="btn btn-primary">{% trans "Search" %}</button>
+                    </div>
+                </form>
             </div>
-        </form>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
Due to some unnecessary Bootstrap classes, advanced search modals in Oscar's order/refund list views were not displaying when "Advanced Search" was clicked. These classes were removed and the DOM was updated to reflect the Bootstrap 3 standard.

@rlucioni @clintonb @jimabramson 
