### PR TITLE
Update outdated slugs for existing products

### DIFF
--- a/ecommerce/courses/models.py
+++ b/ecommerce/courses/models.py
@@ -139,6 +139,8 @@ class Course(models.Model):
 
         try:
             seat = Product.objects.get(slug__in=slugs)
+            seat.slug = slug
+
             logger.info(
                 'Retrieved course seat child product with certificate type [%s] for [%s] from database.',
                 certificate_type,


### PR DESCRIPTION
Our previous method of slug generation did not account for ID verification. This change allows us to correct the structure of existing slugs during migration.

@clintonb and/or @jimabramson, please review. We may want to deploy this change prior to the migration, but it shouldn't be a blocker. In order to update old slugs post-migration, we can re-migrate only the products with outdated slugs.
