### PR TITLE
Avoid product slug collisions

### DIFF
--- a/ecommerce/courses/models.py
+++ b/ecommerce/courses/models.py
@@ -2,9 +2,9 @@ from __future__ import unicode_literals
 import logging
 
 from django.db import models, transaction
-from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _
 from oscar.core.loading import get_model
+from oscar.core.utils import slugify
 from simple_history.models import HistoricalRecords
 
 from ecommerce.courses.publishers import LMSPublisher
@@ -35,7 +35,7 @@ class Course(models.Model):
 
     def _create_parent_seat(self):
         """ Create the parent seat product if it does not already exist. """
-        slug = 'parent-cs-{}'.format(slugify(unicode(self.id)))
+        slug = 'parent-cs-{}'.format(slugify(self.id))
         defaults = {
             'is_discountable': True,
             'structure': Product.PARENT,

--- a/ecommerce/courses/tests/test_models.py
+++ b/ecommerce/courses/tests/test_models.py
@@ -133,6 +133,20 @@ class CourseTests(CourseCatalogTestMixin, TestCase):
             seat, course, certificate_type, id_verification_required, price, credit_provider, credit_hours=credit_hours
         )
 
+    def test_slug_generation(self):
+        """Verify that product slug collisions due to stripped characters are avoided."""
+        dotted_course = Course.objects.create(id='a/...course.../id')
+        regular_course = Course.objects.create(id='a/course/id')
+
+        certificate_type = 'honor'
+        id_verification_required = False
+        price = 0
+        dotted_course.create_or_update_seat(certificate_type, id_verification_required, price)
+        regular_course.create_or_update_seat(certificate_type, id_verification_required, price)
+
+        child_products = Product.objects.filter(slug__istartswith='child-cs')
+        self.assertEqual(len(child_products), 2)
+
     def test_type(self):
         """ Verify the property returns a type value corresponding to the available products. """
         course = Course.objects.create(id='a/b/c', name='Test Course')

--- a/ecommerce/extensions/refund/tests/factories.py
+++ b/ecommerce/extensions/refund/tests/factories.py
@@ -1,9 +1,9 @@
 from decimal import Decimal
 
 from django.conf import settings
-from django.utils.text import slugify
 import factory
 from oscar.core.loading import get_model
+from oscar.core.utils import slugify
 from oscar.test import factories
 from oscar.test.newfactories import UserFactory
 

--- a/ecommerce/settings/_oscar.py
+++ b/ecommerce/settings/_oscar.py
@@ -152,6 +152,7 @@ OSCAR_REFUND_LINE_STATUS_PIPELINE = {
 }
 # END REFUND PROCESSING
 
+
 # DASHBOARD NAVIGATION MENU
 OSCAR_DASHBOARD_NAVIGATION = [
     {
@@ -228,6 +229,15 @@ OSCAR_DASHBOARD_NAVIGATION = [
     },
 ]
 # END DASHBOARD NAVIGATION MENU
+
+
+# SLUG SETTINGS
+# Mapping applied before slug generation. Use to replace characters which would normally be stripped.
+OSCAR_SLUG_MAP = {
+    '.': '_',
+}
+# END SLUG SETTINGS
+
 
 # Default timeout for Enrollment API calls
 ENROLLMENT_FULFILLMENT_TIMEOUT = 7


### PR DESCRIPTION
Avoids product slug collisions by retaining information about periods during slug generation. Periods would normally be stripped entirely. XCOM-562.

@jimabramson @clintonb 
