### PR TITLE
Caching Node and Bower Dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,11 @@ sudo: false
 
 # Cache the pip directory. "cache: pip" doesn't work due to install override. See https://github.com/travis-ci/travis-ci/issues/3239.
 cache:
-  directories:
+  - bundler
+  - directories:
     - $HOME/.cache/pip
+    - node_modules
+    - ecommerce/static/bower_components
 addons:
     apt:
         packages:


### PR DESCRIPTION
This should cut Travis CI build times by at least a minute.

FYI @jimabramson @rlucioni @Nickersoft 
