### PR TITLE
Call gulp from NODE_BIN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,9 @@ clean:
 
 validate_js:
 	rm -rf coverage
-	gulp test
-	gulp lint
-	gulp jscs
+	$(NODE_BIN)/gulp test
+	$(NODE_BIN)/gulp lint
+	$(NODE_BIN)/gulp jscs
 
 validate_python: clean
 	python manage.py compress --settings=ecommerce.settings.test -v0


### PR DESCRIPTION
Prevents assumptions from being made about a developer's $PATH.

FYI @clintonb @Nickersoft @jimabramson 
