### PR TITLE
Update Course model to allow creation of multiple credit seats

### DIFF
--- a/ecommerce/courses/models.py
+++ b/ecommerce/courses/models.py
@@ -138,8 +138,24 @@ class Course(models.Model):
             attribute_values__value_boolean=id_verification_required
         )
 
+        if credit_provider is None:
+            # Yields a match if attribute names do not include 'credit_provider'.
+            credit_provider_query = ~Q(attributes__name='credit_provider')
+        else:
+            # Yields a match if attribute with name 'credit_provider' matches provided value.
+            credit_provider_query = Q(
+                attributes__name='credit_provider',
+                attribute_values__value_text=credit_provider
+            )
+
         try:
-            seat = self.seat_products.filter(certificate_type_query).get(id_verification_required_query)
+            seat = self.seat_products.filter(
+                certificate_type_query
+            ).filter(
+                id_verification_required_query
+            ).get(
+                credit_provider_query
+            )
 
             logger.info(
                 'Retrieved course seat child product with certificate type [%s] for [%s] from database.',

--- a/ecommerce/extensions/catalogue/tests/test_utils.py
+++ b/ecommerce/extensions/catalogue/tests/test_utils.py
@@ -15,7 +15,8 @@ class UtilsTests(CourseCatalogTestMixin, TestCase):
         certificate_type = 'honor'
         product = course.create_or_update_seat(certificate_type, False, 0)
 
-        _hash = md5(u'{} {} {}'.format(certificate_type, course_id, 'False')).hexdigest()[-7:]
+        _hash = u'{} {} {} {}'.format(certificate_type, course_id, 'False', '')
+        _hash = md5(_hash.lower()).hexdigest()[-7:]
         expected = _hash.upper()
         actual = generate_sku(product)
         self.assertEqual(actual, expected)

--- a/ecommerce/extensions/catalogue/utils.py
+++ b/ecommerce/extensions/catalogue/utils.py
@@ -10,11 +10,12 @@ def generate_sku(product):
     # Note: This currently supports seats. In the future, this should
     # be updated to accommodate other product classes.
     _hash = u' '.join((
-        getattr(product.attr, 'certificate_type', '').lower(),
-        product.attr.course_key.lower(),
-        unicode(product.attr.id_verification_required)
+        getattr(product.attr, 'certificate_type', ''),
+        product.attr.course_key,
+        unicode(product.attr.id_verification_required),
+        getattr(product.attr, 'credit_provider', '')
     ))
-    _hash = md5(_hash)
+    _hash = md5(_hash.lower())
     _hash = _hash.hexdigest()[-7:]
 
     return _hash.upper()


### PR DESCRIPTION
Courses may have multiple credit seats associated with them. To make this possible, the query used to locate existing seats has been extended to include credit provider in the query. Our SKU generation utility has also been modified to include the credit provider in the hash. XCOM-574.

@clintonb @jimabramson, please review when able.
