### PR TITLE
Properly wrapping tests

### DIFF
--- a/ecommerce/static/js/test/specs/collections/course_collection_spec.js
+++ b/ecommerce/static/js/test/specs/collections/course_collection_spec.js
@@ -25,18 +25,20 @@ define([
             collection = new CourseCollection();
         });
 
-        describe('parse', function () {
-            it('should return the results list in the response', function () {
-                expect(collection.parse(response)).toEqual(response.results);
-            });
+        describe('Course collection', function () {
+            describe('parse', function () {
+                it('should return the results list in the response', function () {
+                    expect(collection.parse(response)).toEqual(response.results);
+                });
 
-            it('should fetch the next page of results', function () {
-                spyOn(collection, 'fetch').and.returnValue(null);
-                response.next = '/api/v2/courses/?page=2';
+                it('should fetch the next page of results', function () {
+                    spyOn(collection, 'fetch').and.returnValue(null);
+                    response.next = '/api/v2/courses/?page=2';
 
-                collection.parse(response);
-                expect(collection.url).toEqual(response.next);
-                expect(collection.fetch).toHaveBeenCalledWith({remove: false});
+                    collection.parse(response);
+                    expect(collection.url).toEqual(response.next);
+                    expect(collection.fetch).toHaveBeenCalledWith({remove: false});
+                });
             });
         });
     }

--- a/ecommerce/static/js/test/specs/models/course_seats/course_seat_spec.js
+++ b/ecommerce/static/js/test/specs/models/course_seats/course_seat_spec.js
@@ -36,80 +36,82 @@ define([
             model = CourseSeat.findOrCreate(data, {parse: true});
         });
 
-        describe('getSeatType', function () {
-            it('should return a seat type corresponding to the certificate type', function () {
-                var mappings = {
-                    'credit': 'credit',
-                    'honor': 'honor',
-                    'no-id-professional': 'professional',
-                    'professional': 'professional',
-                    'verified': 'verified'
-                };
+        describe('Course seat model', function () {
+            describe('getSeatType', function () {
+                it('should return a seat type corresponding to the certificate type', function () {
+                    var mappings = {
+                        'credit': 'credit',
+                        'honor': 'honor',
+                        'no-id-professional': 'professional',
+                        'professional': 'professional',
+                        'verified': 'verified'
+                    };
 
-                _.each(mappings, function (seatType, certificateType) {
-                    model.set('certificate_type', certificateType);
-                    expect(model.getSeatType()).toEqual(seatType);
+                    _.each(mappings, function (seatType, certificateType) {
+                        model.set('certificate_type', certificateType);
+                        expect(model.getSeatType()).toEqual(seatType);
+                    });
+                });
+
+                it('should return audit for empty certificate types', function () {
+                    var certificate_types = ['', null];
+
+                    _.each(certificate_types, function (certificateType) {
+                        model.set('certificate_type', certificateType);
+                        expect(model.getSeatType()).toEqual('audit');
+                    });
                 });
             });
 
-            it('should return audit for empty certificate types', function () {
-                var certificate_types = ['', null];
+            describe('getSeatTypeDisplayName', function () {
+                it('should return a value corresponding to the certificate type', function () {
+                    var mappings = {
+                        'credit': 'Credit',
+                        'honor': 'Honor',
+                        'no-id-professional': 'Professional',
+                        'professional': 'Professional',
+                        'verified': 'Verified'
+                    };
 
-                _.each(certificate_types, function (certificateType) {
-                    model.set('certificate_type', certificateType);
-                    expect(model.getSeatType()).toEqual('audit');
+                    _.each(mappings, function (seatType, certificateType) {
+                        model.set('certificate_type', certificateType);
+                        expect(model.getSeatTypeDisplayName()).toEqual(seatType);
+                    });
                 });
-            });
-        });
 
-        describe('getSeatTypeDisplayName', function () {
-            it('should return a value corresponding to the certificate type', function () {
-                var mappings = {
-                    'credit': 'Credit',
-                    'honor': 'Honor',
-                    'no-id-professional': 'Professional',
-                    'professional': 'Professional',
-                    'verified': 'Verified'
-                };
+                it('should return Audit for empty certificate types', function () {
+                    var certificate_types = ['', null];
 
-                _.each(mappings, function (seatType, certificateType) {
-                    model.set('certificate_type', certificateType);
-                    expect(model.getSeatTypeDisplayName()).toEqual(seatType);
-                });
-            });
-
-            it('should return Audit for empty certificate types', function () {
-                var certificate_types = ['', null];
-
-                _.each(certificate_types, function (certificateType) {
-                    model.set('certificate_type', certificateType);
-                    expect(model.getSeatTypeDisplayName()).toEqual('Audit');
-                });
-            });
-        });
-
-        describe('getCertificateDisplayName', function () {
-            it('should return a value corresponding to the certificate type', function () {
-                var mappings = {
-                    'credit': 'Verified Certificate',
-                    'honor': 'Honor Certificate',
-                    'no-id-professional': 'Professional Certificate',
-                    'professional': 'Professional Certificate',
-                    'verified': 'Verified Certificate'
-                };
-
-                _.each(mappings, function (seatType, certificateType) {
-                    model.set('certificate_type', certificateType);
-                    expect(model.getCertificateDisplayName()).toEqual(seatType);
+                    _.each(certificate_types, function (certificateType) {
+                        model.set('certificate_type', certificateType);
+                        expect(model.getSeatTypeDisplayName()).toEqual('Audit');
+                    });
                 });
             });
 
-            it('should return (No Certificate) for empty certificate types', function () {
-                var certificate_types = ['', null];
+            describe('getCertificateDisplayName', function () {
+                it('should return a value corresponding to the certificate type', function () {
+                    var mappings = {
+                        'credit': 'Verified Certificate',
+                        'honor': 'Honor Certificate',
+                        'no-id-professional': 'Professional Certificate',
+                        'professional': 'Professional Certificate',
+                        'verified': 'Verified Certificate'
+                    };
 
-                _.each(certificate_types, function (certificateType) {
-                    model.set('certificate_type', certificateType);
-                    expect(model.getCertificateDisplayName()).toEqual('(No Certificate)');
+                    _.each(mappings, function (seatType, certificateType) {
+                        model.set('certificate_type', certificateType);
+                        expect(model.getCertificateDisplayName()).toEqual(seatType);
+                    });
+                });
+
+                it('should return (No Certificate) for empty certificate types', function () {
+                    var certificate_types = ['', null];
+
+                    _.each(certificate_types, function (certificateType) {
+                        model.set('certificate_type', certificateType);
+                        expect(model.getCertificateDisplayName()).toEqual('(No Certificate)');
+                    });
                 });
             });
         });

--- a/ecommerce/static/js/test/specs/models/product_model_spec.js
+++ b/ecommerce/static/js/test/specs/models/product_model_spec.js
@@ -36,40 +36,42 @@ define([
             model = Product.findOrCreate(data, {parse: true});
         });
 
-        // NOTE (CCB): There is a bug preventing this from being called 'toJSON'.
-        // See https://github.com/karma-runner/karma/issues/1534.
-        describe('#toJSON', function () {
-            it('should not modify expires if expires is empty', function () {
-                var json,
-                    values = [null, ''];
+        describe('Product model', function () {
+            // NOTE (CCB): There is a bug preventing this from being called 'toJSON'.
+            // See https://github.com/karma-runner/karma/issues/1534.
+            describe('#toJSON', function () {
+                it('should not modify expires if expires is empty', function () {
+                    var json,
+                        values = [null, ''];
 
-                _.each(values, function (value) {
-                    model.set('expires', value);
-                    json = model.toJSON();
-                    expect(json.expires).toEqual(value);
+                    _.each(values, function (value) {
+                        model.set('expires', value);
+                        json = model.toJSON();
+                        expect(json.expires).toEqual(value);
+                    });
                 });
-            });
 
-            it('should add a timezone to expires if expires is not empty', function () {
-                var json,
-                    deadline = '2015-01-01T00:00:00';
+                it('should add a timezone to expires if expires is not empty', function () {
+                    var json,
+                        deadline = '2015-01-01T00:00:00';
 
-                model.set('expires', deadline);
-                json = model.toJSON();
+                    model.set('expires', deadline);
+                    json = model.toJSON();
 
-                expect(json.expires).toEqual(deadline + '+00:00');
-            });
+                    expect(json.expires).toEqual(deadline + '+00:00');
+                });
 
-            it('should re-nest the un-nested attributes', function () {
-                var json = model.toJSON();
+                it('should re-nest the un-nested attributes', function () {
+                    var json = model.toJSON();
 
-                // Sanity check
-                expect(model.get('certificate_type')).toEqual('verified');
-                expect(model.get('course_key')).toEqual('edX/DemoX/Demo_Course');
-                expect(model.get('id_verification_required')).toEqual(true);
+                    // Sanity check
+                    expect(model.get('certificate_type')).toEqual('verified');
+                    expect(model.get('course_key')).toEqual('edX/DemoX/Demo_Course');
+                    expect(model.get('id_verification_required')).toEqual(true);
 
-                // Very the attributes have been re-nested
-                expect(json.attribute_values).toEqual(data.attribute_values);
+                    // Very the attributes have been re-nested
+                    expect(json.attribute_values).toEqual(data.attribute_values);
+                });
             });
         });
     }

--- a/ecommerce/static/js/test/specs/utils/course_utils_spec.js
+++ b/ecommerce/static/js/test/specs/utils/course_utils_spec.js
@@ -16,28 +16,30 @@ define([
               VerifiedSeat) {
         'use strict';
 
-        describe('getCourseSeatModel', function () {
-            it('should return the CourseSeat child class corresponding to a seat type', function () {
-                expect(CourseUtils.getCourseSeatModel('audit')).toEqual(AuditSeat);
-                expect(CourseUtils.getCourseSeatModel('honor')).toEqual(HonorSeat);
-                expect(CourseUtils.getCourseSeatModel('professional')).toEqual(ProfessionalSeat);
-                expect(CourseUtils.getCourseSeatModel('verified')).toEqual(VerifiedSeat);
+        describe('CourseUtils', function () {
+            describe('getCourseSeatModel', function () {
+                it('should return the CourseSeat child class corresponding to a seat type', function () {
+                    expect(CourseUtils.getCourseSeatModel('audit')).toEqual(AuditSeat);
+                    expect(CourseUtils.getCourseSeatModel('honor')).toEqual(HonorSeat);
+                    expect(CourseUtils.getCourseSeatModel('professional')).toEqual(ProfessionalSeat);
+                    expect(CourseUtils.getCourseSeatModel('verified')).toEqual(VerifiedSeat);
+                });
+
+                it('should return CourseSeat if the seat type is unknown', function () {
+                    expect(CourseUtils.getCourseSeatModel(null)).toEqual(CourseSeat);
+                });
             });
 
-            it('should return CourseSeat if the seat type is unknown', function () {
-                expect(CourseUtils.getCourseSeatModel(null)).toEqual(CourseSeat);
-            });
-        });
+            describe('orderSeatTypesForDisplay', function () {
+                it('should return a list ordered seat types', function () {
+                    var data = [
+                        ['audit', 'professional', 'credit'],
+                        ['audit', 'honor', 'verified', 'professional', 'credit']
+                    ];
 
-        describe('orderSeatTypesForDisplay', function () {
-            it('should return a list ordered seat types', function () {
-                var data = [
-                    ['audit', 'professional', 'credit'],
-                    ['audit', 'honor', 'verified', 'professional', 'credit']
-                ];
-
-                _.each(data, function (expected) {
-                    expect(CourseUtils.orderSeatTypesForDisplay(_.shuffle(expected))).toEqual(expected);
+                    _.each(data, function (expected) {
+                        expect(CourseUtils.orderSeatTypesForDisplay(_.shuffle(expected))).toEqual(expected);
+                    });
                 });
             });
         });

--- a/ecommerce/static/js/test/specs/utils/utils_spec.js
+++ b/ecommerce/static/js/test/specs/utils/utils_spec.js
@@ -4,29 +4,31 @@ define([
     function (Utils) {
         'use strict';
 
-        describe('stripTimezone', function () {
-            it('should return the input value if the input is empty', function () {
-                expect(Utils.stripTimezone('')).toEqual('');
-                expect(Utils.stripTimezone(null)).toBeNull();
-                expect(Utils.stripTimezone(undefined)).toBeUndefined();
+        describe('Utils', function () {
+            describe('stripTimezone', function () {
+                it('should return the input value if the input is empty', function () {
+                    expect(Utils.stripTimezone('')).toEqual('');
+                    expect(Utils.stripTimezone(null)).toBeNull();
+                    expect(Utils.stripTimezone(undefined)).toBeUndefined();
+                });
+
+                it('should return the datetime without the timezone component', function () {
+                    var dt = '2015-01-01T00:00:00';
+                    expect(Utils.stripTimezone(dt + 'Z')).toEqual(dt);
+                });
             });
 
-            it('should return the datetime without the timezone component', function () {
-                var dt = '2015-01-01T00:00:00';
-                expect(Utils.stripTimezone(dt + 'Z')).toEqual(dt);
-            });
-        });
+            describe('restoreTimezone', function () {
+                it('should return the input value if the input is empty', function () {
+                    expect(Utils.restoreTimezone('')).toEqual('');
+                    expect(Utils.restoreTimezone(null)).toBeNull();
+                    expect(Utils.restoreTimezone(undefined)).toBeUndefined();
+                });
 
-        describe('restoreTimezone', function () {
-            it('should return the input value if the input is empty', function () {
-                expect(Utils.restoreTimezone('')).toEqual('');
-                expect(Utils.restoreTimezone(null)).toBeNull();
-                expect(Utils.restoreTimezone(undefined)).toBeUndefined();
-            });
-
-            it('should return the datetime with the timezone component', function () {
-                var dt = '2015-01-01T00:00:00';
-                expect(Utils.restoreTimezone(dt)).toEqual(dt + '+00:00');
+                it('should return the datetime with the timezone component', function () {
+                    var dt = '2015-01-01T00:00:00';
+                    expect(Utils.restoreTimezone(dt)).toEqual(dt + '+00:00');
+                });
             });
         });
     }

--- a/ecommerce/static/js/test/specs/views/course_seat_form_fields/course_seat_form_field_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/course_seat_form_fields/course_seat_form_field_view_spec.js
@@ -13,10 +13,12 @@ define([
             view = new CourseSeatFormFieldView({model: model});
         });
 
-        describe('cleanIdVerificationRequired', function () {
-            it('should always return a boolean', function () {
-                expect(view.cleanIdVerificationRequired('false')).toEqual(false);
-                expect(view.cleanIdVerificationRequired('true')).toEqual(true);
+        describe('course seat form field view', function () {
+            describe('cleanIdVerificationRequired', function () {
+                it('should always return a boolean', function () {
+                    expect(view.cleanIdVerificationRequired('false')).toEqual(false);
+                    expect(view.cleanIdVerificationRequired('true')).toEqual(true);
+                });
             });
         });
     }

--- a/ecommerce/static/js/test/specs/views/course_seat_form_fields/professional_course_seat_form_field_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/course_seat_form_fields/professional_course_seat_form_field_view_spec.js
@@ -13,22 +13,25 @@ define([
             view = new CourseSeatFormFieldView({model: model}).render();
         });
 
-        describe('getFieldValue', function () {
-            it('should return a boolean if the name is id_verification_required', function () {
-                // NOTE (CCB): Ideally _.each should be used here to loop over an array of Boolean values.
-                // However, the tests fail when that implementation is used, hence the repeated code.
-                model.set('id_verification_required', false);
-                expect(model.get('id_verification_required')).toEqual(false);
-                expect(view.getFieldValue('id_verification_required')).toEqual(false);
+        describe('professional course seat form field view', function () {
+            describe('getFieldValue', function () {
+                it('should return a boolean if the name is id_verification_required', function () {
+                    // NOTE (CCB): Ideally _.each should be used here to loop over an array of Boolean values.
+                    // However, the tests fail when that implementation is used, hence the repeated code.
+                    model.set('id_verification_required', false);
+                    expect(model.get('id_verification_required')).toEqual(false);
+                    expect(view.getFieldValue('id_verification_required')).toEqual(false);
 
-                model.set('id_verification_required', true);
-                expect(model.get('id_verification_required')).toEqual(true);
-                expect(view.getFieldValue('id_verification_required')).toEqual(true);
-            });
+                    model.set('id_verification_required', true);
+                    expect(model.get('id_verification_required')).toEqual(true);
+                    expect(view.getFieldValue('id_verification_required')).toEqual(true);
+                });
 
-            // NOTE (CCB): This test is flaky (hence it being skipped). Occasionally, calls to the parent class fail.
-            xit('should always return professional if the name is certificate_type', function () {
-                expect(view.getFieldValue('certificate_type')).toEqual('professional');
+                // NOTE (CCB): This test is flaky (hence it being skipped).
+                // Occasionally, calls to the parent class fail.
+                xit('should always return professional if the name is certificate_type', function () {
+                    expect(view.getFieldValue('certificate_type')).toEqual('professional');
+                });
             });
         });
     }

--- a/ecommerce/static/js/test/specs/views/course_seat_form_fields/verified_seat_form_field_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/course_seat_form_fields/verified_seat_form_field_view_spec.js
@@ -13,16 +13,18 @@ define([
             view = new VerifiedCourseSeatFormFieldView({model: model}).render();
         });
 
-        describe('getData', function () {
-            it('should return the data from the DOM/model', function () {
-                var data = {
-                    certificate_type: 'verified',
-                    id_verification_required: 'true',
-                    price: '100',
-                    expires: ''
-                };
+        describe('verified course seat form field view', function () {
+            describe('getData', function () {
+                it('should return the data from the DOM/model', function () {
+                    var data = {
+                        certificate_type: 'verified',
+                        id_verification_required: 'true',
+                        price: '100',
+                        expires: ''
+                    };
 
-                expect(view.getData()).toEqual(data);
+                    expect(view.getData()).toEqual(data);
+                });
             });
         });
     }


### PR DESCRIPTION
Updated offending tests with a describe block representing the object being tested (e.g. course model). This will result in a proper grouping of specs when Jasmine displays the results.

FYI @rlucioni @jimabramson 
