### PR TITLE
Update acceptance tests to select country during LMS registration

### DIFF
--- a/acceptance_tests/mixins.py
+++ b/acceptance_tests/mixins.py
@@ -23,7 +23,7 @@ class LmsUserMixin(object):
         return LMS_USERNAME, LMS_PASSWORD, LMS_EMAIL
 
     def generate_user_credentials(self, username_prefix):
-        username = username_prefix + uuid.uuid4().hex[0:20]
+        username = username_prefix + uuid.uuid4().hex[0:10]
         password = self.password
         email = '{}@example.com'.format(username)
         return username, email, password

--- a/acceptance_tests/pages.py
+++ b/acceptance_tests/pages.py
@@ -3,6 +3,7 @@ import urllib
 
 from bok_choy.page_object import PageObject
 from bok_choy.promise import EmptyPromise
+from selenium.webdriver.support.select import Select
 
 from acceptance_tests.config import BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD, APP_SERVER_URL, LMS_URL
 
@@ -83,6 +84,10 @@ class LMSRegistrationPage(LMSPage):
         self.q(css='input#register-name').fill(name)
         self.q(css='input#register-email').fill(email)
         self.q(css='input#register-password').fill(password)
+
+        select = Select(self.browser.find_element_by_css_selector('select#register-country'))
+        select.select_by_value('US')
+
         self.q(css='input#register-honor_code').click()
         self.q(css='button.register-button').click()
 


### PR DESCRIPTION
With this fix in place, acceptance tests run successfully against stage. The username being created by the `LmsUserMixin` was too long and truncated by Otto, causing later API calls to Otto checking for the user's order/enrollment status to fail.

@jimabramson and @clintonb, FYI.
