### PR TITLE
Adding new strategy for admin users.

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -70,8 +70,9 @@ class ProductSerializer(serializers.HyperlinkedModelSerializer):
         return None
 
     def _get_info(self, product):
-        info = Selector().strategy().fetch_for_product(product)
-        return info
+        return Selector().strategy(
+            request=self.context.get('request')
+        ).fetch_for_product(product)
 
     def get_is_available_to_buy(self, product):
         info = self._get_info(product)


### PR DESCRIPTION
CAT displays $0 prices for expired products.
To fix this issue I have add new seat-policy-mixin class for admin and also new admin strategy. 
During serilazation assign the admin strategy if user is staff.
