### PR TITLE
wait longer for alert modal in acceptance test

### DIFF
--- a/ecommerce/extensions/dashboard/orders/tests.py
+++ b/ecommerce/extensions/dashboard/orders/tests.py
@@ -77,7 +77,7 @@ class OrderListViewTests(OrderViewTestsMixin, RefundTestMixin, LiveServerTestCas
         button.click()
 
         # Wait for the AJAX call to finish and display an alert
-        WebDriverWait(self.selenium, 0.1).until(lambda d: d.find_element_by_css_selector('#messages .alert'))
+        WebDriverWait(self.selenium, 0.5).until(lambda d: d.find_element_by_css_selector('#messages .alert'))
 
     def assertAlertDisplayed(self, alert_class, text):
         """ Verifies that the most recent alert has the given class and message. """


### PR DESCRIPTION
`ecommerce.extensions.dashboard.orders.tests.OrderListViewTests.test_retry_fulfillment` fails consistently on my local system without a longer wait.   i don't have the same problem with any other tests.

@rlucioni any objections?
