### PR TITLE
avoid exception when `paypal_profile list` has no results

### DIFF
--- a/ecommerce/extensions/payment/management/commands/paypal_profile.py
+++ b/ecommerce/extensions/payment/management/commands/paypal_profile.py
@@ -106,7 +106,13 @@ class Command(BaseCommand):
     def handle_list(self, args):  # pylint: disable=unused-argument
         """Wrapper for paypalrestsdk List operation."""
         profiles = WebProfile.all()
-        self.print_json([profile.to_dict() for profile in profiles])
+        result = []
+        try:
+            result = [profile.to_dict() for profile in profiles]
+        except KeyError:
+            # weird internal paypal sdk behavior; it means the result was empty.
+            pass
+        self.print_json(result)
 
     def handle_create(self, args):
         """Wrapper for paypalrestsdk Create operation."""


### PR DESCRIPTION
not bothering with a deep investigation of the internal paypal sdk behavior here; the frequency of this use case is extremely low.

@rlucioni FYI
