### PR TITLE
Running migrations for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ install:
     - pip install coveralls
     - make requirements.js
 script:
+    - make migrate -e DJANGO_SETTINGS_MODULE="ecommerce.settings.test"
     - make static -e DJANGO_SETTINGS_MODULE="ecommerce.settings.test"
     - make validate
 branches:


### PR DESCRIPTION
We run migrations to ensure no migrations are missing, and they work on fresh installs.
