### PR TITLE
mark strings in javascript files for translation

### DIFF
--- a/ecommerce/static/js/pages/course_create_page.js
+++ b/ecommerce/static/js/pages/course_create_page.js
@@ -9,7 +9,7 @@ define([
         'use strict';
 
         return Page.extend({
-            title: 'Create New Course',
+            title: gettext('Create New Course'),
 
             initialize: function () {
                 this.model = new Course({});

--- a/ecommerce/static/js/pages/course_list_page.js
+++ b/ecommerce/static/js/pages/course_list_page.js
@@ -9,7 +9,7 @@ define([
         'use strict';
 
         return Page.extend({
-            title: 'Courses',
+            title: gettext('Courses'),
 
             initialize: function () {
                 this.collection = new CourseCollection();

--- a/ecommerce/static/js/views/payment_button_view.js
+++ b/ecommerce/static/js/views/payment_button_view.js
@@ -85,7 +85,7 @@ define([
             },
 
             handleCreateOrderError: function (xhr) {
-                var errorMsg = 'An error has occurred. Please try again.';
+                var errorMsg = gettext('An error has occurred. Please try again.');
 
                 if (xhr.status === 400) {
                     errorMsg = xhr.responseText;

--- a/ecommerce/static/vendor-extensions/oscar/js/order_list.js
+++ b/ecommerce/static/vendor-extensions/oscar/js/order_list.js
@@ -1,7 +1,8 @@
 $(document).ready(function () {
     var retryFulfillment = function (e) {
         var $btn = $(e.target),
-            order_number = $btn.data('order-number');
+            order_number = $btn.data('order-number'),
+            message = '';
 
         // Disable button
         e.preventDefault();
@@ -15,10 +16,19 @@ $(document).ready(function () {
             headers: {'X-CSRFToken': $.cookie('ecommerce_csrftoken')}
         }).success(function (data) {
             $('tr[data-order-number=' + order_number + '] .order-status').text(data.status);
-            addMessage('alert-success', 'icon-check-sign', 'Order ' + order_number + ' has been fulfilled.');
+
+            message = interpolate(
+                gettext('Order %(order_number)s has been fulfilled.'), {order_number: order_number}, true
+            );
+            addMessage('alert-success', 'icon-check-sign', message);
             $btn.remove();
         }).fail(function (jqXHR, textStatus, errorThrown) {
-            addMessage('alert-error', 'icon-exclamation-sign', 'Failed to fulfill order ' + order_number + ': ' + errorThrown);
+            message = interpolate(
+                gettext('Failed to fulfill order %(order_number)s: %(error)s'),
+                {order_number: order_number, error: errorThrown},
+                true
+            );
+            addMessage('alert-error', 'icon-exclamation-sign', message);
 
             // Re-enable the button
             $btn.click(retryFulfillment);

--- a/ecommerce/static/vendor-extensions/oscar/js/refund_list.js
+++ b/ecommerce/static/vendor-extensions/oscar/js/refund_list.js
@@ -3,7 +3,8 @@ $(document).ready(function () {
     var processRefund = function (e) {
         var $btn = $(e.target),
             refund_id = $btn.data('refund-id'),
-            decision = $btn.data('decision');
+            decision = $btn.data('decision'),
+            message = '';
 
         // Disable button
         e.preventDefault();
@@ -18,19 +19,28 @@ $(document).ready(function () {
             headers: {'X-CSRFToken': $.cookie('ecommerce_csrftoken')}
         }).success(function (data) {
             $('tr[data-refund-id=' + refund_id + '] .refund-status').text(data.status);
-            addMessage('alert-success', 'icon-check-sign', 'Refund #' + refund_id + ' has been processed.');
+
+            message = interpolate(
+                gettext('Refund #%(refund_id)s has been processed.'), {refund_id: refund_id}, true
+            );
+            addMessage('alert-success', 'icon-check-sign', message);
             $('tr[data-refund-id=' + refund_id + '] [data-action=process-refund]').remove();
         }).fail(function (jqXHR, textStatus, errorThrown) {
             // NOTE (RFL): For an MVP, changing the displayed refund state on any error may be viable.
             // Ideally, the displayed refund state would only change if the refund were to enter an
             // error state. This would be easiest if the processing endpoint returned 200 and a serialized
             // refund, even when the refund has entered an error state during processing.
-            $('tr[data-refund-id=' + refund_id + '] .refund-status').text('Error');
+            $('tr[data-refund-id=' + refund_id + '] .refund-status').text(gettext('Error'));
 
+            message = interpolate(
+                gettext('Failed to process refund #%(refund_id)s: %(error)s. Please try again, or contact the E-Commerce Development Team.'),
+                {refund_id: refund_id, error: errorThrown},
+                true
+            );
             addMessage(
                 'alert-error',
                 'icon-exclamation-sign',
-                'Failed to process refund #' + refund_id + ': ' + errorThrown + '. Please try again, or contact the E-Commerce Development Team.'
+                message
             );
         }).always(function () {
             // Re-enable the button

--- a/ecommerce/templates/oscar/dashboard/index.html
+++ b/ecommerce/templates/oscar/dashboard/index.html
@@ -9,6 +9,13 @@
     <meta http-equiv="refresh" content="300">
 {% endblock %}
 
+{% block extrascripts %}
+  {{ block.super }}
+
+  {# Translation support for JavaScript strings. #}
+  <script type="text/javascript" src="{% url 'django.views.i18n.javascript_catalog' %}"></script>
+{% endblock extrascripts %}
+
 {% block breadcrumbs %}
 {% endblock %}
 

--- a/ecommerce/templates/oscar/dashboard/orders/order_detail.html
+++ b/ecommerce/templates/oscar/dashboard/orders/order_detail.html
@@ -8,6 +8,13 @@
   {% blocktrans with number=order.number %}Order {{ number }}{% endblocktrans %} | {{ block.super }}
 {% endblock %}
 
+{% block extrascripts %}
+  {{ block.super }}
+
+  {# Translation support for JavaScript strings. #}
+  <script type="text/javascript" src="{% url 'django.views.i18n.javascript_catalog' %}"></script>
+{% endblock extrascripts %}
+
 {% block breadcrumbs %}
     <ul class="breadcrumb">
         <li>

--- a/ecommerce/templates/oscar/dashboard/orders/order_list.html
+++ b/ecommerce/templates/oscar/dashboard/orders/order_list.html
@@ -14,6 +14,9 @@
 {% block extrascripts %}
   {{ block.super }}
 
+  {# Translation support for JavaScript strings. #}
+  <script type="text/javascript" src="{% url 'django.views.i18n.javascript_catalog' %}"></script>
+
   {% compress js %}
       <script src="{% static "bower_components/jquery-cookie/jquery.cookie.js" %}" type="text/javascript"></script>
       <script src="{% static "vendor-extensions/oscar/js/add_message.js" %}" type="text/javascript"></script>

--- a/ecommerce/templates/oscar/dashboard/refunds/refund_detail.html
+++ b/ecommerce/templates/oscar/dashboard/refunds/refund_detail.html
@@ -13,6 +13,9 @@
 {% block extrascripts %}
     {{ block.super }}
 
+    {# Translation support for JavaScript strings. #}
+    <script type="text/javascript" src="{% url 'django.views.i18n.javascript_catalog' %}"></script>
+
     {% compress js %}
     <script src="{% static "bower_components/jquery-cookie/jquery.cookie.js" %}" type="text/javascript"></script>
     <script src="{% static 'vendor-extensions/oscar/js/add_message.js' %}" type="text/javascript"></script>

--- a/ecommerce/templates/oscar/dashboard/refunds/refund_list.html
+++ b/ecommerce/templates/oscar/dashboard/refunds/refund_list.html
@@ -14,6 +14,8 @@
 {% block extrascripts %}
     {{ block.super }}
 
+    {# Translation support for JavaScript strings. #}
+    <script type="text/javascript" src="{% url 'django.views.i18n.javascript_catalog' %}"></script>
 
     {% compress js %}
     <script src="{% static "bower_components/jquery-cookie/jquery.cookie.js" %}" type="text/javascript"></script>

--- a/ecommerce/templates/oscar/dashboard/users/detail.html
+++ b/ecommerce/templates/oscar/dashboard/users/detail.html
@@ -7,6 +7,13 @@
 
 {% block title %}{{ customer.username }} | {{ block.super }}{% endblock %}
 
+{% block extrascripts %}
+    {{ block.super }}
+
+    {# Translation support for JavaScript strings. #}
+    <script type="text/javascript" src="{% url 'django.views.i18n.javascript_catalog' %}"></script>
+{% endblock extrascripts %}
+
 {% block breadcrumbs %}
     <ul class="breadcrumb">
         <li>


### PR DESCRIPTION
XCOM-343
@awais786 @aamir-khan @ahsan-ul-haq @tasawernawaz 
- Verify that all strings presented to the user via JavaScript are marked for translation.
- Include django javascript translation catalog `jsi18n` file in templates which extend from `'dashboard/layout.html'` instead of local `'edx/base.html'` (which already have this file).
