### PR TITLE
Adding missing waffle switch.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,8 @@ switches exist:
 | ENABLE_NOTIFICATIONS           | Enable email notification for the different task generated e.g. course    |
 |                                | purchase.                                                                 |
 +--------------------------------+---------------------------------------------------------------------------+
+| PAYPAL_RETRY_ATTEMPTS          | Enable retry mechanism for failed PayPal payment executions.              |
++--------------------------------+---------------------------------------------------------------------------+
 
 .. _Waffle: https://waffle.readthedocs.org/
 


### PR DESCRIPTION
Use a Waffle switch "PAYPAL_RETRY_ATTEMPTS" to gate Retry PayPal payment execution.
Related PR. 
https://github.com/edx/ecommerce/pull/318
