### PR TITLE
add model 'SiteConfiguration' and django admin for custom sites

### DIFF
--- a/ecommerce/core/admin.py
+++ b/ecommerce/core/admin.py
@@ -2,7 +2,12 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.utils.translation import ugettext_lazy as _
 
-from ecommerce.core.models import User
+from ecommerce.core.models import SiteConfiguration, User
+
+
+class SiteConfigurationAdmin(admin.ModelAdmin):
+    list_display = ('site', 'partner', 'lms_url_root', 'theme_scss_path', 'payment_processors')
+    search_fields = ['site__name']
 
 
 class EcommerceUserAdmin(UserAdmin):
@@ -16,4 +21,5 @@ class EcommerceUserAdmin(UserAdmin):
     )
 
 
+admin.site.register(SiteConfiguration, SiteConfigurationAdmin)
 admin.site.register(User, EcommerceUserAdmin)

--- a/ecommerce/core/migrations/0003_auto_20150914_1120.py
+++ b/ecommerce/core/migrations/0003_auto_20150914_1120.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('partner', '0007_auto_20150914_0841'),
+        ('sites', '0001_initial'),
+        ('core', '0002_auto_20150826_1455'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SiteConfiguration',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('lms_url_root', models.URLField(help_text="Root URL of this site's LMS (e.g. https://courses.stage.edx.org)", verbose_name='LMS base url for custom site/microsite')),
+                ('theme_scss_path', models.CharField(help_text='Path to scss files of the custom site theme', max_length=255, verbose_name='Path to custom site theme')),
+                ('payment_processors', models.CharField(help_text="Comma-separated list of processor names: 'cybersource,paypal'", max_length=255, verbose_name='Payment processors')),
+                ('partner', models.ForeignKey(to='partner.Partner')),
+                ('site', models.ForeignKey(to='sites.Site')),
+            ],
+        ),
+        migrations.AlterUniqueTogether(
+            name='siteconfiguration',
+            unique_together=set([('site', 'partner')]),
+        ),
+    ]

--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -1,7 +1,42 @@
 from django.contrib.auth.models import AbstractUser
-from jsonfield.fields import JSONField
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
+from jsonfield.fields import JSONField
+
+
+class SiteConfiguration(models.Model):
+    """Custom Site model for custom sites/microsites.
+
+    This model will enable the basic theming and payment processor
+    configuration for each custom site.
+    The multi-tenant implementation has one site per partner.
+    """
+
+    site = models.ForeignKey('sites.Site', null=False, blank=False)
+    partner = models.ForeignKey('partner.Partner', null=False, blank=False)
+    lms_url_root = models.URLField(
+        verbose_name=_('LMS base url for custom site/microsite'),
+        help_text=_("Root URL of this site's LMS (e.g. https://courses.stage.edx.org)"),
+        null=False,
+        blank=False
+    )
+    theme_scss_path = models.CharField(
+        verbose_name=_('Path to custom site theme'),
+        help_text=_('Path to scss files of the custom site theme'),
+        max_length=255,
+        null=False,
+        blank=False
+    )
+    payment_processors = models.CharField(
+        verbose_name=_('Payment processors'),
+        help_text=_("Comma-separated list of processor names: 'cybersource,paypal'"),
+        max_length=255,
+        null=False,
+        blank=False
+    )
+
+    class Meta(object):
+        unique_together = ('site', 'partner')
 
 
 class User(AbstractUser):


### PR DESCRIPTION
ECOM-2233
@awais786 @aamir-khan @ahsan-ul-haq @tasawernawaz 
- Add model `SiteConfiguration` which extends [Django “sites” framework](https://docs.djangoproject.com/en/1.8/ref/contrib/sites/).
- Add foreign key to model `Partner` for multi-tenant implementation with one site per partner.
- Add migration for app `core` which has new custom sites model `SiteConfiguration`.
- Add django admin for model `SiteConfiguration` in app `core` admin.
