### PR TITLE
ECOM-2239: Added the models for catalog and catalogStockRecords models

### DIFF
--- a/ecommerce/extensions/catalogue/migrations/0010_catalog.py
+++ b/ecommerce/extensions/catalogue/migrations/0010_catalog.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('partner', '0008_auto_20150914_1057'),
+        ('catalogue', '0009_credit_hours_attr'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Catalog',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=255)),
+                ('partner', models.ForeignKey(related_name='catalogs', to='partner.Partner')),
+                ('stock_records', models.ManyToManyField(to='partner.StockRecord', blank=True)),
+            ],
+        ),
+    ]

--- a/ecommerce/extensions/catalogue/models.py
+++ b/ecommerce/extensions/catalogue/models.py
@@ -15,5 +15,19 @@ class Product(AbstractProduct):
 class ProductAttributeValue(AbstractProductAttributeValue):
     history = HistoricalRecords()
 
+
+class Catalog(models.Model):
+    name = models.CharField(max_length=255)
+    partner = models.ForeignKey('partner.Partner', related_name='catalogs')
+    stock_records = models.ManyToManyField('partner.StockRecord', blank=True)
+
+    def __unicode__(self):
+        return u'{id}: {partner_code}-{catalog_name}'.format(
+            id=self.id,
+            partner_code=self.partner.short_code,
+            catalog_name=self.name
+        )
+
+
 # noinspection PyUnresolvedReferences
 from oscar.apps.catalogue.models import *  # noqa pylint: disable=wildcard-import,unused-wildcard-import

--- a/ecommerce/extensions/partner/admin.py
+++ b/ecommerce/extensions/partner/admin.py
@@ -1,5 +1,10 @@
+from django.utils.translation import ugettext_lazy as _
 from oscar.apps.partner.admin import *  # noqa pylint: disable=wildcard-import,unused-wildcard-import
+from oscar.core.loading import get_class
 from simple_history.admin import SimpleHistoryAdmin
+
+
+Catalog = get_class('ecommerce.extensions.catalogue.models', 'Catalog')
 
 
 class StockRecordAdminExtended(SimpleHistoryAdmin):
@@ -7,5 +12,43 @@ class StockRecordAdminExtended(SimpleHistoryAdmin):
     list_filter = ('partner',)
 
 
+class CatalogAdmin(admin.ModelAdmin):
+
+    list_display = ('name', 'partner')
+    search_fields = ('name', 'partner__name')
+    list_filter = ('partner',)
+
+    def render_change_form(self, request, context, *args, **kwargs):
+        if 'partner' in context['adminform'].form.fields:
+            context['adminform'].form.fields['partner'].help_text = _(
+                u"Click 'Save and Continue Editing' to add stock records"
+            )
+        return super(CatalogAdmin, self).render_change_form(request, context, args, kwargs)
+
+    def get_readonly_fields(self, request, obj=None):
+        readonly_fields = list(self.readonly_fields)
+        if obj:
+            readonly_fields.extend(['partner'])
+        return readonly_fields
+
+    def formfield_for_manytomany(self, db_field, request=None, **kwargs):
+        catalog_obj = self.get_object_updated(request, Catalog)
+        if db_field.name == 'stock_records':
+            if catalog_obj:
+                kwargs['queryset'] = StockRecord.objects.filter(partner=catalog_obj.partner)
+            else:
+                # Assigning None to queryset raises the error.
+                # To assign it an empty queryset just filter with id=None
+                kwargs['queryset'] = StockRecord.objects.none()
+
+        return super(CatalogAdmin, self).formfield_for_foreignkey(db_field, request, **kwargs)
+
+    def get_object_updated(self, request, model):
+        object_id = request.META['PATH_INFO'].strip('/').split('/')[-1]
+        if object_id and object_id != 'add':
+            return model.objects.get(pk=object_id)
+
+
 admin.site.unregister(StockRecord)
 admin.site.register(StockRecord, StockRecordAdminExtended)
+admin.site.register(Catalog, CatalogAdmin)


### PR DESCRIPTION
- Added the `Catalog` model
- Enable creating the `Catalog` though django admin

@awais786 @zubair-arbi @ahsan-ul-haq @tasawernawaz Please review this PR.
