### PR TITLE
update model 'SiteConfiguration' to change relation with model 'Site'…

### DIFF
--- a/ecommerce/core/migrations/0004_auto_20150915_1023.py
+++ b/ecommerce/core/migrations/0004_auto_20150915_1023.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0003_auto_20150914_1120'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='siteconfiguration',
+            name='site',
+            field=models.OneToOneField(to='sites.Site'),
+        ),
+    ]

--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -12,7 +12,7 @@ class SiteConfiguration(models.Model):
     The multi-tenant implementation has one site per partner.
     """
 
-    site = models.ForeignKey('sites.Site', null=False, blank=False)
+    site = models.OneToOneField('sites.Site', null=False, blank=False)
     partner = models.ForeignKey('partner.Partner', null=False, blank=False)
     lms_url_root = models.URLField(
         verbose_name=_('LMS base url for custom site/microsite'),


### PR DESCRIPTION
… to 'OneToOneField'

ECOM-2233
@awais786 @aamir-khan @ahsan-ul-haq @tasawernawaz 
- Update model `SiteConfiguration` to change relation with model `Site` from `ForeignKey` to `OneToOneField` so that each site can have only one configuration.
- Add migration for app `core` which has modified custom sites model `SiteConfiguration`.

PR to add model  `SiteConfiguration`: https://github.com/edx/ecommerce/pull/334
