### PR TITLE
Removed migration hack for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,14 +50,14 @@ validate_js:
 
 validate_python: clean
 	python manage.py compress --settings=ecommerce.settings.test -v0
-	DISABLE_MIGRATIONS=True coverage run --branch --source=ecommerce ./manage.py test ecommerce \
+	REUSE_DB=1 coverage run --branch --source=ecommerce ./manage.py test ecommerce \
 	--settings=ecommerce.settings.test --with-ignore-docstrings --logging-level=DEBUG
 	coverage report
 	make quality
 
 fast_validate_python: clean
 	python manage.py compress --settings=ecommerce.settings.test -v0
-	DISABLE_MIGRATIONS=True DISABLE_ACCEPTANCE_TESTS=True ./manage.py test ecommerce \
+	REUSE_DB=1 DISABLE_ACCEPTANCE_TESTS=True ./manage.py test ecommerce \
 	--settings=ecommerce.settings.test --processes=4 --with-ignore-docstrings --logging-level=DEBUG
 	make quality
 

--- a/ecommerce/extensions/order/migrations/0003_auto_20150224_1520.py
+++ b/ecommerce/extensions/order/migrations/0003_auto_20150224_1520.py
@@ -13,8 +13,7 @@ def create_shipping_event(apps, schema_editor):
     """
     # Create all our Product Types.
     ShippingEventType = apps.get_model("order", "ShippingEventType")
-    shipped_event = ShippingEventType(code="shipped", name="Shipped")
-    shipped_event.save()
+    ShippingEventType.objects.create(code="shipped", name="Shipped")
 
 
 class Migration(migrations.Migration):

--- a/ecommerce/extensions/order/tests/test_processing.py
+++ b/ecommerce/extensions/order/tests/test_processing.py
@@ -15,7 +15,7 @@ class EventHandlerTests(TestCase):
 
     def setUp(self):
         super(EventHandlerTests, self).setUp()
-        self.shipping_event_type = ShippingEventType.objects.create(name=SHIPPING_EVENT_NAME)
+        self.shipping_event_type, __ = ShippingEventType.objects.get_or_create(name=SHIPPING_EVENT_NAME)
         self.order = factories.create_order()
 
     def test_create_shipping_event_all_lines_complete(self):

--- a/ecommerce/settings/test.py
+++ b/ecommerce/settings/test.py
@@ -13,34 +13,6 @@ INSTALLED_APPS += (
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
 LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel='DEBUG')
-
-
-class DisableMigrations(object):
-    """Override method calls on the MIGRATION_MODULES dictionary.
-
-    If the `makemigrations` command has not been run for an app, the
-    `migrate` command treats that app as unmigrated, creating tables
-    directly from the models just like the now-defunct `syncdb` command
-    used to do. These overrides are used to force Django to treat apps
-    in this project as unmigrated.
-
-    Django 1.8 features the `--keepdb` flag for exactly this purpose,
-    but we don't have that luxury in 1.7.
-
-    For more context, see http://goo.gl/Fr4qyE.
-    """
-
-    def __contains__(self, item):
-        """Make it appear as if all apps are contained in the dictionary."""
-        return True
-
-    def __getitem__(self, item):
-        """Force Django to look for migrations in a nonexistent package."""
-        return 'notmigrations'
-
-
-if str(os.environ.get('DISABLE_MIGRATIONS')) == 'True':
-    MIGRATION_MODULES = DisableMigrations()
 # END TEST SETTINGS
 
 


### PR DESCRIPTION
Prior to Django 1.8 we had a hack in place to prevent migrations from being run for tests. While this decreases test run times, it also prevents us from testing our migrations and ensuring all model changes have associated migrations. This has bitten us in the past and even resulted in an outage. We can live with the extra test time if it means greater protection from outages.

Closes #308

@rlucioni @jimabramson 
