### PR TITLE
Improve the acceptance testing experience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ serve:
 clean:
 	find . -name '*.pyc' -delete
 	coverage erase
-	rm -rf assets/ ecommerce/static/build coverage
+	rm -rf assets/ ecommerce/static/build coverage htmlcov
 
 validate_js:
 	rm -rf coverage

--- a/acceptance_tests/config.py
+++ b/acceptance_tests/config.py
@@ -3,44 +3,52 @@ import os
 
 def str2bool(s):
     s = unicode(s)
-    return s.lower() in (u"yes", u"true", u"t", u"1")
+    return s.lower() in (u'yes', u'true', u't', u'1')
 
 
-ACCESS_TOKEN = os.environ.get('ACCESS_TOKEN', 'edx')
-
-# Application configuration
-APP_SERVER_URL = os.environ.get('APP_SERVER_URL', 'http://localhost:8002').strip('/')
-ECOMMERCE_API_SERVER_URL = os.environ.get('ECOMMERCE_API_SERVER_URL', APP_SERVER_URL + '/api/v2').strip('/')
-ECOMMERCE_API_TOKEN = os.environ.get('ECOMMERCE_API_AUTH_TOKEN', ACCESS_TOKEN)
-
-# Amount of time allotted for processing an order. This value is used to match newly-placed orders in testing, and
-# account for processing delays such as load times
-ORDER_PROCESSING_TIME = int(os.environ.get('ORDER_PROCESSING_TIME', 15))
-
-# Test configuration
-ENABLE_LMS_AUTO_AUTH = str2bool(os.environ.get('ENABLE_LMS_AUTO_AUTH', False))
-ENABLE_OAUTH_TESTS = str2bool(os.environ.get('ENABLE_OAUTH_TESTS', True))
-COURSE_ID = os.environ.get('COURSE_ID', 'edX/DemoX/Demo_Course')
+# GENERAL CONFIGURATION
+ACCESS_TOKEN = os.environ.get('ACCESS_TOKEN')
+ENABLE_OAUTH2_TESTS = str2bool(os.environ.get('ENABLE_OAUTH2_TESTS', True))
+HONOR_COURSE_ID = os.environ.get('HONOR_COURSE_ID', 'edX/DemoX/Demo_Course')
 VERIFIED_COURSE_ID = os.environ.get('VERIFIED_COURSE_ID', 'edX/victor101/Victor_s_test_course')
 
-# LMS configuration
-BASIC_AUTH_USERNAME = os.environ.get('BASIC_AUTH_USERNAME')
-BASIC_AUTH_PASSWORD = os.environ.get('BASIC_AUTH_PASSWORD')
-LMS_URL = os.environ.get('LMS_URL').strip('/')
+if ACCESS_TOKEN is None:
+    raise RuntimeError('A valid OAuth2 access token is required to run acceptance tests.')
+# END GENERAL CONFIGURATION
+
+
+# OTTO CONFIGURATION
+try:
+    ECOMMERCE_URL_ROOT = os.environ.get('ECOMMERCE_URL_ROOT').strip('/')
+except AttributeError:
+    raise RuntimeError('You must provide a valid URL root for the E-Commerce Service to run acceptance tests.')
+
+ECOMMERCE_API_URL = os.environ.get('ECOMMERCE_API_URL', ECOMMERCE_URL_ROOT + '/api/v2')
+ECOMMERCE_API_TOKEN = os.environ.get('ECOMMERCE_API_TOKEN', ACCESS_TOKEN)
+PAYPAL_EMAIL = os.environ.get('PAYPAL_EMAIL')
+PAYPAL_PASSWORD = os.environ.get('PAYPAL_PASSWORD')
+# It can be a pain to set up CyberSource for local testing. This flag allows CyberSource
+# tests to be disabled.
+ENABLE_CYBERSOURCE_TESTS = str2bool(os.environ.get('ENABLE_CYBERSOURCE_TESTS', True))
+# END OTTO CONFIGURATION
+
+
+# LMS CONFIGURATION
+try:
+    LMS_URL_ROOT = os.environ.get('LMS_URL_ROOT').strip('/')
+except AttributeError:
+    raise RuntimeError('You must provide a valid URL root for the LMS to run acceptance tests.')
+
 LMS_USERNAME = os.environ.get('LMS_USERNAME')
 LMS_EMAIL = os.environ.get('LMS_EMAIL')
 LMS_PASSWORD = os.environ.get('LMS_PASSWORD')
-HTTPS_RECEIPT_PAGE = str2bool(os.environ.get('HTTPS_RECEIPT_PAGE', True))
-
-if ENABLE_OAUTH_TESTS and not (LMS_URL and LMS_USERNAME and LMS_PASSWORD):
-    raise Exception('LMS settings must be set in order to test OAuth.')
-
-# Enrollment API configuration
-ENROLLMENT_API_URL = os.environ.get('ENROLLMENT_API_URL')
-if not ENROLLMENT_API_URL:
-    ENROLLMENT_API_URL = '{}/api/enrollment/v1'.format(LMS_URL)
-
+LMS_AUTO_AUTH = str2bool(os.environ.get('LMS_AUTO_AUTH', False))
+LMS_HTTPS = str2bool(os.environ.get('LMS_HTTPS', True))
+ENROLLMENT_API_URL = os.environ.get('ENROLLMENT_API_URL', LMS_URL_ROOT + '/api/enrollment/v1')
 ENROLLMENT_API_TOKEN = os.environ.get('ENROLLMENT_API_TOKEN', ACCESS_TOKEN)
+BASIC_AUTH_USERNAME = os.environ.get('BASIC_AUTH_USERNAME')
+BASIC_AUTH_PASSWORD = os.environ.get('BASIC_AUTH_PASSWORD')
 
-PAYPAL_EMAIL = os.environ.get('PAYPAL_EMAIL', None)
-PAYPAL_PASSWORD = os.environ.get('PAYPAL_PASSWORD', None)
+if ENABLE_OAUTH2_TESTS and not (LMS_URL_ROOT and LMS_USERNAME and LMS_PASSWORD):
+    raise RuntimeError('Configuring LMS settings is required to run OAuth2 tests.')
+# END LMS CONFIGURATION

--- a/acceptance_tests/mixins.py
+++ b/acceptance_tests/mixins.py
@@ -5,8 +5,8 @@ from ecommerce_api_client.client import EcommerceApiClient
 import requests
 
 from acceptance_tests.api import EnrollmentApiClient
-from acceptance_tests.config import (ENABLE_LMS_AUTO_AUTH, APP_SERVER_URL, LMS_PASSWORD, LMS_EMAIL, LMS_URL,
-                                     BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD, ECOMMERCE_API_SERVER_URL,
+from acceptance_tests.config import (LMS_AUTO_AUTH, ECOMMERCE_URL_ROOT, LMS_PASSWORD, LMS_EMAIL, LMS_URL_ROOT,
+                                     BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD, ECOMMERCE_API_URL,
                                      LMS_USERNAME, ECOMMERCE_API_TOKEN)
 from acceptance_tests.pages import LMSLoginPage, LMSDashboardPage, LMSRegistrationPage
 
@@ -17,7 +17,7 @@ class LmsUserMixin(object):
     password = 'edx'
 
     def get_lms_user(self):
-        if ENABLE_LMS_AUTO_AUTH:
+        if LMS_AUTO_AUTH:
             return self.create_lms_user()
 
         return LMS_USERNAME, LMS_PASSWORD, LMS_EMAIL
@@ -32,7 +32,11 @@ class LmsUserMixin(object):
         username, email, password = self.generate_user_credentials(username_prefix='auto_auth_')
 
         url = '{host}/auto_auth?no_login=true&username={username}&password={password}&email={email}'.format(
-            host=LMS_URL, username=username, password=password, email=email)
+            host=LMS_URL_ROOT,
+            username=username,
+            password=password,
+            email=email
+        )
         auth = None
 
         if BASIC_AUTH_USERNAME and BASIC_AUTH_PASSWORD:
@@ -73,7 +77,7 @@ class LogistrationMixin(LmsUserMixin):
 
 class LogoutMixin(object):
     def logout(self):
-        url = '{}/accounts/logout/'.format(APP_SERVER_URL)
+        url = '{}/accounts/logout/'.format(ECOMMERCE_URL_ROOT)
         self.browser.get(url)
 
 
@@ -104,7 +108,7 @@ class EnrollmentApiMixin(object):
 class EcommerceApiMixin(object):
     @property
     def ecommerce_api_client(self):
-        return EcommerceApiClient(ECOMMERCE_API_SERVER_URL, oauth_access_token=ECOMMERCE_API_TOKEN)
+        return EcommerceApiClient(ECOMMERCE_API_URL, oauth_access_token=ECOMMERCE_API_TOKEN)
 
     def assert_order_created_and_completed(self):
         orders = self.ecommerce_api_client.orders.get()['results']

--- a/acceptance_tests/pages.py
+++ b/acceptance_tests/pages.py
@@ -3,9 +3,10 @@ import urllib
 
 from bok_choy.page_object import PageObject
 from bok_choy.promise import EmptyPromise
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.support.select import Select
 
-from acceptance_tests.config import BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD, APP_SERVER_URL, LMS_URL
+from acceptance_tests.config import BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD, ECOMMERCE_URL_ROOT, LMS_URL_ROOT
 
 
 class EcommerceAppPage(PageObject):  # pylint: disable=abstract-method
@@ -18,8 +19,8 @@ class EcommerceAppPage(PageObject):  # pylint: disable=abstract-method
     def __init__(self, browser, path=None):
         super(EcommerceAppPage, self).__init__(browser)
         path = path or self.path
-        self.server_url = APP_SERVER_URL
-        self.page_url = '{0}/{1}'.format(self.server_url, path)
+        self.server_url = ECOMMERCE_URL_ROOT
+        self.page_url = '{}/{}'.format(self.server_url, path)
 
 
 class DashboardHomePage(EcommerceAppPage):
@@ -33,10 +34,10 @@ class LMSPage(PageObject):  # pylint: disable=abstract-method
     __metaclass__ = abc.ABCMeta
 
     def _build_url(self, path):
-        url = '{0}/{1}'.format(LMS_URL, path)
+        url = '{}/{}'.format(LMS_URL_ROOT, path)
 
         if BASIC_AUTH_USERNAME and BASIC_AUTH_PASSWORD:
-            url = url.replace('://', '://{0}:{1}@'.format(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD))
+            url = url.replace('://', '://{}:{}@'.format(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD))
 
         return url
 
@@ -50,7 +51,7 @@ class LMSLoginPage(LMSPage):
 
         if course_id:
             params = {'enrollment_action': 'enroll', 'course_id': course_id}
-            url = '{0}?{1}'.format(url, urllib.urlencode(params))
+            url = '{}?{}'.format(url, urllib.urlencode(params))
 
         return url
 
@@ -72,7 +73,7 @@ class LMSRegistrationPage(LMSPage):
 
         if course_id:
             params = {'enrollment_action': 'enroll', 'course_id': course_id}
-            url = '{0}?{1}'.format(url, urllib.urlencode(params))
+            url = '{}?{}'.format(url, urllib.urlencode(params))
 
         return url
 
@@ -85,8 +86,11 @@ class LMSRegistrationPage(LMSPage):
         self.q(css='input#register-email').fill(email)
         self.q(css='input#register-password').fill(password)
 
-        select = Select(self.browser.find_element_by_css_selector('select#register-country'))
-        select.select_by_value('US')
+        try:
+            select = Select(self.browser.find_element_by_css_selector('select#register-country'))
+            select.select_by_value('US')
+        except NoSuchElementException:
+            pass
 
         self.q(css='input#register-honor_code').click()
         self.q(css='button.register-button').click()

--- a/acceptance_tests/test_auth.py
+++ b/acceptance_tests/test_auth.py
@@ -2,12 +2,12 @@ from unittest import skipUnless
 
 from bok_choy.web_app_test import WebAppTest
 
-from acceptance_tests.config import ENABLE_OAUTH_TESTS
+from acceptance_tests.config import ENABLE_OAUTH2_TESTS
 from acceptance_tests.mixins import LogistrationMixin
 from acceptance_tests.pages import DashboardHomePage
 
 
-@skipUnless(ENABLE_OAUTH_TESTS, 'OAuth tests are not enabled.')
+@skipUnless(ENABLE_OAUTH2_TESTS, 'OAuth2 tests are not enabled.')
 class OAuth2FlowTests(LogistrationMixin, WebAppTest):
     def setUp(self):
         """

--- a/acceptance_tests/test_login_enrollment.py
+++ b/acceptance_tests/test_login_enrollment.py
@@ -1,25 +1,36 @@
 from bok_choy.web_app_test import WebAppTest
 
-from acceptance_tests.config import COURSE_ID
+from acceptance_tests.config import HONOR_COURSE_ID
 from acceptance_tests.mixins import LogistrationMixin, EcommerceApiMixin, EnrollmentApiMixin, UnenrollmentMixin
 
 
 class LoginEnrollmentTests(UnenrollmentMixin, EcommerceApiMixin, EnrollmentApiMixin, LogistrationMixin, WebAppTest):
     def setUp(self):
         super(LoginEnrollmentTests, self).setUp()
-        self.course_id = COURSE_ID
+        self.course_id = HONOR_COURSE_ID
         self.username, self.password, self.email = self.get_lms_user()
 
     def test_honor_enrollment_and_login(self):
-        """ Verifies that a user can login and enroll in a course via the login page. """
+        """Verify that a user can enroll in a course while logging in.
 
+        Also verifies that the login page redirects the user to their dashboard
+        following enrollment. At the time of writing, the login page only redirects
+        to the dashboard when the user has enrolled in an honor-only course. Otherwise,
+        the user is redirected to a track selection or payment interstitial.
+        """
         # Login and enroll via LMS
         self.login_with_lms(self.email, self.password, self.course_id)
         self.assert_order_created_and_completed()
         self.assert_user_enrolled(self.username, self.course_id)
 
     def test_honor_enrollment_and_registration(self):
-        """ Verifies that a user can register and enroll in a course via the login page. """
+        """Verify that a user can enroll in a course while registering.
+
+        Also verifies that the registration page redirects the user to their dashboard
+        following enrollment. At the time of writing, the registration page only redirects
+        to the dashboard when the user has enrolled in an honor-only course. Otherwise,
+        the user is redirected to a track selection or payment interstitial.
+        """
         username, __, __ = self.register_via_ui(self.course_id)
         self.assert_order_created_and_completed()
         self.assert_user_enrolled(username, self.course_id)

--- a/acceptance_tests/test_payment.py
+++ b/acceptance_tests/test_payment.py
@@ -1,3 +1,5 @@
+from unittest import skipUnless
+
 from bok_choy.web_app_test import WebAppTest
 import ddt
 from selenium.common.exceptions import NoSuchElementException, TimeoutException
@@ -6,7 +8,9 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.select import Select
 from selenium.webdriver.support.ui import WebDriverWait
 
-from acceptance_tests.config import VERIFIED_COURSE_ID, HTTPS_RECEIPT_PAGE, PAYPAL_PASSWORD, PAYPAL_EMAIL
+from acceptance_tests.config import (
+    VERIFIED_COURSE_ID, LMS_HTTPS, PAYPAL_PASSWORD, PAYPAL_EMAIL, ENABLE_CYBERSOURCE_TESTS
+)
 from acceptance_tests.mixins import LogistrationMixin, EnrollmentApiMixin, EcommerceApiMixin, UnenrollmentMixin
 from acceptance_tests.pages import LMSCourseModePage
 
@@ -57,7 +61,7 @@ class VerifiedCertificatePaymentTests(UnenrollmentMixin, EcommerceApiMixin, Enro
         If we are testing locally with a non-HTTPS LMS instance, a security alert may appear when transitioning to
         secure pages. This method dismisses them.
         """
-        if not HTTPS_RECEIPT_PAGE:
+        if not LMS_HTTPS:
             try:
                 WebDriverWait(self.browser, 2).until(EC.alert_is_present())
                 self.browser.switch_to_alert().accept()
@@ -110,6 +114,7 @@ class VerifiedCertificatePaymentTests(UnenrollmentMixin, EcommerceApiMixin, Enro
 
         self._dismiss_alert()
 
+    @skipUnless(ENABLE_CYBERSOURCE_TESTS, 'CyberSource tests are not enabled.')
     @ddt.data(
         {
             'country': 'US',


### PR DESCRIPTION
I got fed up with the state of our acceptance tests while trying to see if asynchronous order fulfillment had broken them. This PR cleans up and updates our acceptance testing documentation, gives environment variables better names, fixes an issue preventing LMS registration and enrollment from being tested locally, and makes testing of the CyberSource payment flow optional. Prelude to ECOM-2248.

@clintonb @jimabramson @bderusha @peter-fogg 
