### PR TITLE
Make acceptance tests compatible with async fulfillment

### DIFF
--- a/acceptance_tests/README.rst
+++ b/acceptance_tests/README.rst
@@ -81,6 +81,8 @@ Our acceptance tests rely on configuration which can be specified using environm
 +---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
 | ECOMMERCE\_API\_TOKEN     | Token used to authenticate against the E-Commerce API                    | No        | ACCESS\_TOKEN                        |
 +---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
+| MAX\_COMPLETION\_RETRIES  | Number of times to retry checking for an order's completion              | No        | 3                                    |
++---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
 | PAYPAL\_EMAIL             | Email address used to sign into PayPal during payment                    | Yes       | N/A                                  |
 +---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
 | PAYPAL\_PASSWORD          | Password used to sign into PayPal during payment                         | Yes       | N/A                                  |

--- a/acceptance_tests/config.py
+++ b/acceptance_tests/config.py
@@ -25,6 +25,7 @@ except AttributeError:
 
 ECOMMERCE_API_URL = os.environ.get('ECOMMERCE_API_URL', ECOMMERCE_URL_ROOT + '/api/v2')
 ECOMMERCE_API_TOKEN = os.environ.get('ECOMMERCE_API_TOKEN', ACCESS_TOKEN)
+MAX_COMPLETION_RETRIES = int(os.environ.get('MAX_COMPLETION_RETRIES', 3))
 PAYPAL_EMAIL = os.environ.get('PAYPAL_EMAIL')
 PAYPAL_PASSWORD = os.environ.get('PAYPAL_PASSWORD')
 # It can be a pain to set up CyberSource for local testing. This flag allows CyberSource


### PR DESCRIPTION
Acceptance tests check a configurable number of times for an order's completion before failing. Review https://github.com/edx/ecommerce/pull/359 first. ECOM-2248.

@clintonb @jimabramson @bderusha @peter-fogg 
