### PR TITLE
Text improvement on credit checkout page

### DIFF
--- a/ecommerce/static/templates/credit_provider_details.html
+++ b/ecommerce/static/templates/credit_provider_details.html
@@ -8,6 +8,21 @@
         <%= gettext( "How does credit work?" ) %>
     </button>
     <div class="collapse" id="fulfillment-instructions">
-        <%= fulfillment_instructions %>
+        <p>
+            <!-- Translators: 'institution' is the name of credit provider, such as 'State University'. -->
+            <%= interpolate(gettext("You can purchase credit through %(institution)s for this course for up to one year after the course end date. You can use the credit at %(institution)s or transfer the credit to another institution that accepts the credit."),
+            {institution: display_name},
+            true) %>
+        </p>
+
+        <!-- Translators: List of instructions to get credit from the credit provider institution. 'Checkout' and 'Checkout with PayPal' are payment button texts. -->
+        <p><%= gettext("To purchase course credit:") %></p>
+        <ol>
+            <li><%= gettext("On this page, select either <b>Checkout</b> or <b>Checkout with PayPal</b>.") %></li>
+            <li><%= gettext("On the payment page, enter your payment information.") %></li>
+            <li><%= interpolate(gettext("When your payment is complete, follow the link to the %(institution)s website."), {institution: display_name}, true) %></li>
+            <li><%= interpolate(gettext("On the %(institution)s website, enter all required information to request your course credit."), {institution: display_name}, true) %></li>
+        </ol>
+        <p><%= interpolate(gettext("After %(institution)s approves your credit, you can request an official transcript from %(institution)s"), {institution: display_name}, true) %>.</p>
     </div>
 </div>

--- a/ecommerce/templates/edx/credit/checkout.html
+++ b/ecommerce/templates/edx/credit/checkout.html
@@ -79,7 +79,7 @@
 
                 <div class="col-md-4">
                     <div class="advantages">
-                        <strong>{% trans "You deserved it." %}</strong>
+                        <strong>{% trans "You deserve it." %}</strong>
 
                         <p>
                             {% trans "The hard work is over - you passed the course! Now get the credit you deserve to start or complete a degree." %}


### PR DESCRIPTION
ECOM-2339

@awais786 @ahsan-ul-haq @aamir-khan @tasawernawaz 
Update credit instructions for link `How does credit work?` on credit checkout page.
<img width="1125" alt="screen shot 2015-10-01 at 12 52 10 pm" src="https://cloud.githubusercontent.com/assets/5072991/10215525/9fa5ae04-683b-11e5-88c8-e04e97e3575a.png">
