### PR TITLE
update text and styling for credit payment notification

### DIFF
--- a/ecommerce/extensions/checkout/tests/test_signals.py
+++ b/ecommerce/extensions/checkout/tests/test_signals.py
@@ -39,21 +39,25 @@ class SignalTests(CourseCatalogTestMixin, PartnerMixin, TestCase):
         self.assertEqual(mail.outbox[0].subject, 'Order Receipt')
         self.assertEqual(
             mail.outbox[0].body,
-            '\nReceipt Confirmation for: {course_name}'
-            '\n\nHi {full_name},\n\n'
-            'Thank you for purchasing {credit_hour} credit hours from {provider_name} for {course_name}.'
-            ' The charge below will appear on your next credit or debit card statement with a '
-            'company name of {platform_name}.\n\nYou can see the status the status of your credit request or '
-            'complete the credit request process on your {platform_name} dashboard\nTo browse other '
-            'credit-eligible courses visit the edX website. More courses are added all the time.\n\n'
-            'Thank you and congratulation on your achievement. We hope you enjoy the course!\n\n'
-            'To view receipt please visit the link below'
-            '\n\n{receipt_url}\n\n'
-            '{platform_name} team\n\nThe edX team\n'.format(
-                course_name=order.lines.first().product.title,
+            '\nPayment confirmation for: {course_title}'
+            '\n\nDear {full_name},'
+            '\n\nThank you for purchasing {credit_hours} credit hours from {credit_provider} for {course_title}. '
+            'A charge will appear on your credit or debit card statement with a company name of "{platform_name}".'
+            '\n\nTo receive your course credit, you must also request credit at the {credit_provider} website. '
+            'For a link to request credit from {credit_provider}, or to see the status of your credit request, '
+            'go to your {platform_name} dashboard.'
+            '\n\nTo explore other credit-eligible courses, visit the {platform_name} website. '
+            'We add new courses frequently!'
+            '\n\nTo view your payment information, visit the following website.'
+            '\n{receipt_url}'
+            '\n\nThank you. We hope you enjoyed your course!'
+            '\nThe {platform_name} team'
+            '\n\nYou received this message because you purchased credit hours for {course_title}, '
+            'an {platform_name} course.\n'.format(
+                course_title=order.lines.first().product.title,
                 full_name=user.get_full_name(),
-                credit_hour=2,
-                provider_name='Hogwarts',
+                credit_hours=2,
+                credit_provider='Hogwarts',
                 platform_name=settings.PLATFORM_NAME,
                 receipt_url=get_lms_url('/commerce/checkout/receipt/?basket_id={}'.format(order.basket.id))
             )

--- a/ecommerce/templates/customer/email_base.html
+++ b/ecommerce/templates/customer/email_base.html
@@ -115,17 +115,49 @@
             }
         }
 
+        /* Credit Notification: basic css for credit notifications */
+        .cn-container {
+            font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;
+            width: 600px;
+            font-size: 14px;
+            line-height: 150%;
+            border: 2px solid #eeeeee;
+            margin: 0 auto;
+        }
+        .cn-container .cn-body {
+            padding: 20px;
+        }
+        .cn-img-wrapper {
+            padding: 9px 0;
+        }
+        .cn-img-wrapper .cn-img {
+            float: left;
+            width: 80px;
+        }
+        .cn-content-clear {
+            padding: 0px 18px 18px;
+            border-top: 3px solid #1d9fd9;
+        }
+        .cn-content-clear .cn-footer {
+            border-top-width: 6px;
+        }
+        .cn-content p {
+            padding: 5px 0;
+        }
+        .cn-footer-content p {
+            padding: 5px 0;
+        }
     </style>
 
 </head>
-<body bgcolor="#dddddd" leftmargin="0" topmargin="0" marginwidth="0" marginheight="0">
+<body style="font-family:Arial,'Helvetica Neue',Helvetica,sans-serif;font-size:14px;line-height:150%;margin:auto">
 
 <br>
-<table border="0" width="100%" height="100%" cellpadding="0" cellspacing="0" bgcolor="#dddddd" style="padding-top:5px; padding-bottom: 5px; padding-left:5px; padding-right:5px;">
+<table border="0" width="100%" height="100%" cellpadding="0" cellspacing="0" style="padding: 5px;">
     <tr>
-        <td align="center" valign="top" bgcolor="#dddddd" style="background-color: #dddddd;">
+        <td align="center" valign="top">
             <!-- 600px container (white background) -->
-            <table border="0" width="600" cellpadding="0" cellspacing="0" class="container" bgcolor="#ffffff" style="border-radius: 5px; box-shadow: 0 0 2px #aaaaaa;">
+            <table class="cn-container">
                 {% block body %}
                 {% endblock body %}
                 {% block footer %}

--- a/ecommerce/templates/customer/emails/commtype_credit_receipt_body.html
+++ b/ecommerce/templates/customer/emails/commtype_credit_receipt_body.html
@@ -1,86 +1,97 @@
 {% extends 'customer/email_base.html' %}
 {% load i18n %}
 {% block body %}
-<tr>
-    <td class="container-padding container-pre-header" bgcolor="#ffffff">
-        <table border="0" cellpadding="0" cellspacing="0" class="pre-header-container">
-            <tr>
-                <td align="left" valign="middle" style="font-size:30px; font-style: bold; height: 50px; font-family: Open Sans, Arial, sans-serif;">
-                    <img src="http://gallery.mailchimp.com/1822a33c054dc20e223ca40e2/images/logo_web_edx_studio01aad778f34f.png" height="30" alt="{platform_name} Logo" border="0" hspace="0" vspace="0" class="platform-img">
-                </td>
-                <td align="left" class="email-type" valign="top" style="font-size: 20px; vertical-align: middle; padding-left: 20px; font-family: Open Sans, Arial, sans-serif; color: #127eb1;">
-                    {% trans "Receipt Confirmation" %}
+
+    <tr>
+        <table class="cn-body">
+            <!-- Message header -->
+            <tr align="left" class="cn-img-wrapper">
+                <td colspan="2" align="left" class="cn-img-wrapper cn-full-width" style="font-size: 20px; vertical-align: middle; padding-left: 20px; color: #127eb1;">
+                    <img src="http://gallery.mailchimp.com/1822a33c054dc20e223ca40e2/images/logo_web_edx_studio01aad778f34f.png"
+                        height="30" alt="{platform_name} Logo" border="0" hspace="0" vspace="0"
+                        class="platform-img">
+                    {% trans "Payment Confirmation" %}
                 </td>
             </tr>
-        </table><!--/ end .pre-header-container-->
-    </td>
-</tr>
-<tr>
-    <td class="container-padding container-header" bgcolor="#f3f3f3">
-        <table border="0" cellpadding="0" cellspacing="0" class="columns-container" style="width:100%;">
-          <tr>
-            <td class="force-col" style="padding-right: 20px;" valign="middle">
-                <!-- ### COLUMN 1 - COURSE AND TITLE ### -->
-                <table border="0" cellspacing="0" cellpadding="0" width="280" align="left" class="col-2">
-                    <tr>
-                        <td align="left" valign="top" style="font-size:13px; line-height: 20px; font-family: Open Sans, Arial, sans-serif; color: #aaaaaa;">
-                            <br>
-                            {% trans "Receipt Confirmation for:" %}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td align="left" valign="top" style="line-height: 26px; font-family: Open Sans, Arial, sans-serif; font-style: bold; font-size:24px; color: #002D40;">
-                            {{course_title}}
-                            <br><br>
-                        </td>
-                    </tr>
-                </table>
-            </td>
-            <td class="force-col"  valign="middle">
-                <!-- ### COLUMN 2 - VIEW RECEIPT ### -->
-                <table border="0" cellspacing="0" cellpadding="10" width="100" align="right" class="col-2">
-                    <tr>
-                        <td align="center" valign="middle" style="font-size:13px; font-family: Open Sans, Arial, sans-serif; background-color: #127eb1; border-radius: 5px; box-shadow: 0 2px #002D40;">
-                            <a href="{{receipt_page_url}}" style="color: #ffffff; text-decoration: none;">{% trans "View Receipt" %}</a>
-                        </td>
-                    </tr>
-                </table>
-            </td>
-          </tr>
-        </table><!--/ end .columns-container-->
-    </td>
-</tr>
 
-<!-- Message Body -->
-<tr>
-    <td class="container-padding container-body" bgcolor="#ffffff" align="left">
-        <br>
-        <!--/message HTML content -->
-        <p>{% blocktrans %}Hi {{full_name}},{% endblocktrans %}</p>
-        <br>
-        <p>{% blocktrans with credit_hours=credit_hours credit_provider=credit_provider course_title=course_title platform_name=platform_name %}Thank you for purchasing {{credit_hours}} credit hours from {{credit_provider}} for {{course_title}}. The charge below will appear on your next credit or debit card statement with a company name of {{platform_name}}.{% endblocktrans %}</p>
-        <br>
-        <p>{% blocktrans %}You can see the status the status of your credit request or complete the credit request process on your {{platform_name}} dashboard{% endblocktrans %}</p>
-        <p>{% blocktrans %}To browse other credit-eligible courses visit the {{platform_name}} website. More courses are added all the time.{% endblocktrans %}</p>
-        <br>
-        <p>{% trans "Thank you and congratulation on your achievement. We hope you enjoy the course!" %}</p>
-        <p>{% blocktrans %}{{platform_name}} team{% endblocktrans %}</p>
-        <!--/message HTML content -->
-        <br><br>
-    </td>
-</tr>
+            <tr>
+                <td class="cn-content-clear" colspan="2"></td>
+            </tr>
 
-<tr>
-    <td class="footer-padding container-footer" align="left">
-        <!--footer content -->
-        <br>
-        <p>{% blocktrans with course_title=course_title platform_name=platform_name %}You are receiving this email because you purchased a seat in the {{platform_name}} course {{course_title}}.{% endblocktrans %}</p>
-        <br>
-        <!--/ end footer content -->
-    </td>
-</tr>
-<!--/100% wrapper-->
-<br>
-<br>
+            <!-- Message sub-header -->
+            <tr class="force-col" valign="middle" style="background-color: #f3f3f3;">
+                <td style="padding: 20px;">
+                    <table border="0" cellspacing="0" cellpadding="0" width="280" align="left" class="col-2">
+                        <tr>
+                            <td align="left" valign="top" style="font-size:13px; line-height: 20px; color: #aaaaaa;">
+                                {% trans "Payment confirmation for:" %}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td align="left" valign="top" style="line-height: 26px; font-size:24px; color: #002D40;">
+                                {{ course_title }}
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+                <td style="padding: 20px;">
+                    <table border="0" cellspacing="0" cellpadding="10" width="100" align="right" class="col-2">
+                        <tr>
+                            <td align="center" valign="middle"
+                                style="font-size:13px; background-color: #127eb1; border-radius: 5px; box-shadow: 0 2px #002D40;">
+                                <a href="{{ receipt_page_url }}" style="color: #ffffff; text-decoration: none;">
+                                    {% trans "View Payment Information" %}
+                                </a>
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            <tr>
+
+            <!-- Message Body -->
+            <tr class="cn-content cn-full-width">
+                <td colspan="2">
+                    <p>
+                        {% blocktrans %}Dear {{full_name}},{% endblocktrans %}
+                    </p>
+
+                    <p>
+                        {% blocktrans with credit_hours=credit_hours credit_provider=credit_provider course_title=course_title platform_name=platform_name %}
+                            Thank you for purchasing {{credit_hours}} credit hours from {{credit_provider}} for {{course_title}}. A charge will appear on your credit or debit card statement with a company name of "{{platform_name}}".
+                        {% endblocktrans %}
+                    </p>
+
+                    <p>
+                        {% blocktrans %}To receive your course credit, you must also request credit at the {{credit_provider}} website. For a link to request credit from {{credit_provider}}, or to see the status of your credit request, go to your {{platform_name}} dashboard.{% endblocktrans %}
+                    </p>
+
+                    <p>
+                        {% blocktrans %}To explore other credit-eligible courses, visit the {{platform_name}} website. We add new courses frequently!{% endblocktrans %}
+                    </p>
+
+                    <p>{% trans "Thank you. We hope you enjoyed your course!" %}</p>
+                    <p>{% blocktrans %}The {{platform_name}} team{% endblocktrans %}</p>
+                </td>
+            </tr>
+
+            <tr>
+                <td class="cn-content-clear cn-footer" colspan="2"></td>
+            </tr>
+
+            <!-- Footer content -->
+            <tr class="cn-full-width">
+                <td class="cn-footer-content" colspan="2">
+                    <p>
+                        {% blocktrans with course_title=course_title platform_name=platform_name %}
+                            You received this message because you purchased credit hours for {{course_title}}, an {{platform_name}} course.
+                        {% endblocktrans %}
+                    </p>
+                </td>
+            </tr>
+
+            <!-- Empty base footer -->
+            {% block footer %}{% endblock footer %}
+        </table>
+    </tr>
+
 {% endblock body %}
-

--- a/ecommerce/templates/customer/emails/commtype_credit_receipt_body.txt
+++ b/ecommerce/templates/customer/emails/commtype_credit_receipt_body.txt
@@ -1,19 +1,18 @@
 {% load i18n %}
-{% trans "Receipt Confirmation for: " %}{{course_title}}
+{% trans "Payment confirmation for: " %}{{course_title}}
 
-{% blocktrans %}Hi {{full_name}},{% endblocktrans %}
+{% blocktrans %}Dear {{full_name}},{% endblocktrans %}
 
-{% blocktrans with credit_hours=credit_hours credit_provider=credit_provider course_title=course_title platform_name=platform_name %}Thank you for purchasing {{credit_hours}} credit hours from {{credit_provider}} for {{course_title}}. The charge below will appear on your next credit or debit card statement with a company name of {{platform_name}}.{% endblocktrans %}
+{% blocktrans with credit_hours=credit_hours credit_provider=credit_provider course_title=course_title platform_name=platform_name %}Thank you for purchasing {{credit_hours}} credit hours from {{credit_provider}} for {{course_title}}. A charge will appear on your credit or debit card statement with a company name of "{{platform_name}}".{% endblocktrans %}
 
-{% blocktrans %}You can see the status the status of your credit request or complete the credit request process on your {{platform_name}} dashboard{% endblocktrans %}
-{% blocktrans %}To browse other credit-eligible courses visit the edX website. More courses are added all the time.{% endblocktrans %}
+{% blocktrans %}To receive your course credit, you must also request credit at the {{credit_provider}} website. For a link to request credit from {{credit_provider}}, or to see the status of your credit request, go to your {{platform_name}} dashboard.{% endblocktrans %}
 
-{% trans "Thank you and congratulation on your achievement. We hope you enjoy the course!" %}
+{% blocktrans %}To explore other credit-eligible courses, visit the {{platform_name}} website. We add new courses frequently!{% endblocktrans %}
 
-{% trans "To view receipt please visit the link below" %}
-
+{% trans "To view your payment information, visit the following website." %}
 {{receipt_page_url}}
 
-{% blocktrans %}{{platform_name}} team{% endblocktrans %}
+{% trans "Thank you. We hope you enjoyed your course!" %}
+{% blocktrans %}The {{platform_name}} team{% endblocktrans %}
 
-{% trans "The edX team" %}
+{% blocktrans with course_title=course_title platform_name=platform_name %}You received this message because you purchased credit hours for {{course_title}}, an {{platform_name}} course.{% endblocktrans %}


### PR DESCRIPTION
ECOM-2340
@awais786 @aamir-khan @ahsan-ul-haq @tasawernawaz 
- Update `HTML` version of credit receipt notification styling consistent with `LMS` credit notifications
- Update notification text for both `Plain Text` and `HTML` versions

**HTML Version**
<img width="485" alt="screen shot 2015-10-06 at 9 45 36 pm" src="https://cloud.githubusercontent.com/assets/5072991/10315533/531fcca8-6c74-11e5-8841-efb3a8802e94.png">

**Plain Text Version**
<img width="557" alt="screen shot 2015-10-06 at 9 47 10 pm" src="https://cloud.githubusercontent.com/assets/5072991/10315541/5f6e9d68-6c74-11e5-9f7a-42f0833ea546.png">
