### PR TITLE
Compressing JavaScript with Closure Compiler

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,7 @@ Prerequisites
 * Python 2.7.x (not tested with Python 3.x)
 * `gettext <http://www.gnu.org/software/gettext/>`_
 * `npm <https://www.npmjs.org/>`_
+* `JDK 7+ <http://openjdk.java.net/>`_
 
 Documentation |ReadtheDocs|_
 ----------------------------

--- a/docs/asset_pipeline.rst
+++ b/docs/asset_pipeline.rst
@@ -12,7 +12,11 @@ Both tools should operate seamlessly in a local development environment. When de
 
 When creating new pages that utilize RequireJS dependencies, remember new modules to ``build.js``.
 
-NOTE: The static file directories are setup such that the build output directory of ``r.js`` is read before checking
+NOTE 1: django-compressor uses `Closure Compiler <https://developers.google.com/closure/compiler/>`_ to minify assets.
+Closure Compiler requires `JDK 7+ <http://openjdk.java.net/>`_ to be installed on your system, and the ``java``
+command available on your ``PATH``.
+
+NOTE 2: The static file directories are setup such that the build output directory of ``r.js`` is read before checking
 for assets in ``ecommerce\static\``. If you run ``make static`` or ``r.js`` locally (which you should not need to),
 make sure you delete ``ecommerce/static/build`` or run ``make static`` before continuing with development. If you do not
 all changes made to static files will be ignored.

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -118,6 +118,9 @@ COMPRESS_PRECOMPILERS = (
 )
 
 COMPRESS_CSS_FILTERS = ['compressor.filters.css_default.CssAbsoluteFilter']
+COMPRESS_JS_FILTERS = ['compressor.filters.closure.ClosureCompilerFilter']
+COMPRESS_CLOSURE_COMPILER_BINARY = 'java -jar scripts/closure-compiler.jar'
+COMPRESS_CLOSURE_COMPILER_ARGUMENTS = '--compilation_level ADVANCED --language_in ECMASCRIPT5'
 # END STATIC FILE CONFIGURATION
 
 


### PR DESCRIPTION
Closure Compiler is slower, but results in a 27% decrease in the size (340KB to 246KB) of our JS output.

ECOM-2468
