### PR TITLE
Logging JWT authentication errors

### DIFF
--- a/ecommerce/extensions/api/authentication.py
+++ b/ecommerce/extensions/api/authentication.py
@@ -43,6 +43,15 @@ class JwtAuthentication(JSONWebTokenAuthentication):
         200
     """
 
+    def authenticate(self, request):
+        try:
+            return super(JwtAuthentication, self).authenticate(request)
+        except Exception as ex:
+            # Errors in production do not need to be logged (as they may be noisy),
+            # but debug logging can help quickly resolve issues during development.
+            logger.debug(ex)
+            raise
+
     def authenticate_credentials(self, payload):
         """Get or create an active user with the username contained in the payload."""
         username = payload.get('username')


### PR DESCRIPTION
JWT authentication errors get squashed by DRF. Logging these errors during development will help quickly identify configuration issues and other potential causes of the errors.

ECOM-2477

FYI @rlucioni @jimabramson @peter-fogg @bderusha @cpennington 
