### PR TITLE
Quieted noisy logging statement

### DIFF
--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -165,7 +165,7 @@ class EnrollmentFulfillmentModule(BaseFulfillmentModule):
             try:
                 provider = line.product.attr.credit_provider
             except AttributeError:
-                logger.info("Supported Seat Product does not have a credit provider.")
+                logger.debug("Seat [%d] has no credit_provider attribute. Defaulted to None.", line.product.id)
                 provider = None
 
             data = {


### PR DESCRIPTION
The majority of our course seats will not have a credit provier set. This logging statement is only useful when developing for credit locally. It's severity has been appropriately decreased.

ECOM-2477

FYI @rlucioni @jimabramson @peter-fogg @bderusha @cpennington
