### PR TITLE
Remove unnecessary setting from base settings.

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -307,7 +307,6 @@ AUTH_USER_MODEL = 'core.User'
 # See: http://getblimp.github.io/django-rest-framework-jwt/#additional-settings
 JWT_AUTH = {
     'JWT_SECRET_KEY': None,
-    'JWT_ALGORITHM': 'HS256',
     'JWT_VERIFY_EXPIRATION': True,
     'JWT_DECODE_HANDLER': 'ecommerce.extensions.api.handlers.jwt_decode_handler',
 }


### PR DESCRIPTION
djangorestframework-jwt uses HS256 by default for cryptographic signing.

@clintonb @peter-fogg @jimabramson @bderusha 
