### PR TITLE
Basket Update 1 of 3: Add Partner Link

### DIFF
--- a/ecommerce/extensions/basket/migrations/0006_basket_partner.py
+++ b/ecommerce/extensions/basket/migrations/0006_basket_partner.py
@@ -15,6 +15,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='basket',
             name='partner',
-            field=models.ForeignKey(related_name='baskets', blank=True, to='partner.Partner', null=True),
+            field=models.ForeignKey(related_name='baskets', default=None, blank=True, to='partner.Partner', null=True),
         ),
     ]

--- a/ecommerce/extensions/basket/migrations/0006_basket_partner.py
+++ b/ecommerce/extensions/basket/migrations/0006_basket_partner.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('partner', '0008_auto_20150914_1057'),
+        ('basket', '0005_auto_20150709_1205'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='basket',
+            name='partner',
+            field=models.ForeignKey(related_name='baskets', blank=True, to='partner.Partner', null=True),
+        ),
+    ]

--- a/ecommerce/extensions/basket/migrations/0007_auto_20151012_0902.py
+++ b/ecommerce/extensions/basket/migrations/0007_auto_20151012_0902.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('basket', '0006_basket_partner'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='basket',
+            name='partner',
+            field=models.ForeignKey(related_name='baskets', default=1, blank=True, to='partner.Partner', null=True),
+        ),
+    ]

--- a/ecommerce/extensions/basket/models.py
+++ b/ecommerce/extensions/basket/models.py
@@ -1,3 +1,4 @@
+from django.db import models
 from oscar.apps.basket.abstract_models import AbstractBasket
 from oscar.core.loading import get_class
 
@@ -6,6 +7,8 @@ OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
 
 
 class Basket(AbstractBasket):
+    partner = models.ForeignKey('partner.Partner', null=True, blank=True, related_name='baskets')
+
     @property
     def order_number(self):
         return OrderNumberGenerator().order_number(self)

--- a/ecommerce/extensions/basket/models.py
+++ b/ecommerce/extensions/basket/models.py
@@ -1,4 +1,3 @@
-from django.db import models
 from oscar.apps.basket.abstract_models import AbstractBasket
 from oscar.core.loading import get_class
 
@@ -7,8 +6,6 @@ OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
 
 
 class Basket(AbstractBasket):
-    partner = models.ForeignKey('partner.Partner', null=True, blank=True, related_name='baskets')
-
     @property
     def order_number(self):
         return OrderNumberGenerator().order_number(self)

--- a/ecommerce/extensions/basket/models.py
+++ b/ecommerce/extensions/basket/models.py
@@ -1,3 +1,4 @@
+from django.db import models
 from oscar.apps.basket.abstract_models import AbstractBasket
 from oscar.core.loading import get_class
 
@@ -6,6 +7,8 @@ OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
 
 
 class Basket(AbstractBasket):
+    partner = models.ForeignKey('partner.Partner', null=True, blank=True, default=None, related_name='baskets')
+
     @property
     def order_number(self):
         return OrderNumberGenerator().order_number(self)


### PR DESCRIPTION
Adding foreign key from the Basket model pointing to the Partner model. Previously one PR was created with code changes as well. But during load testing issue appear that if migrations are running on large scale db ( 2million baskets) then basket creation throws errors.
OperationalError: (1054, "Unknown column 'basket_basket.partner_id' in 'field list'")

Old PR link.
https://github.com/edx/ecommerce/pull/326
