### PR TITLE
Creating new migration with setting default value to 1

### DIFF
--- a/ecommerce/extensions/basket/migrations/0007_auto_20151013_1209.py
+++ b/ecommerce/extensions/basket/migrations/0007_auto_20151013_1209.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('basket', '0006_basket_partner'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='basket',
+            name='partner',
+            field=models.ForeignKey(related_name='baskets', default=1, to='partner.Partner'),
+        ),
+    ]

--- a/ecommerce/extensions/basket/models.py
+++ b/ecommerce/extensions/basket/models.py
@@ -1,3 +1,4 @@
+from django.db import models
 from oscar.apps.basket.abstract_models import AbstractBasket
 from oscar.core.loading import get_class
 
@@ -6,6 +7,8 @@ OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
 
 
 class Basket(AbstractBasket):
+    partner = models.ForeignKey('partner.Partner', default=1, null=False, blank=False, related_name='baskets')
+
     @property
     def order_number(self):
         return OrderNumberGenerator().order_number(self)


### PR DESCRIPTION
This is the 2nd phase of migration and follows previous work https://github.com/edx/ecommerce/pull/326 to add `partner` to model `basket`.
- Set the `default` to value `1` and also set `null=False`.

_**Note:** This need to rebase with master after the previous work https://github.com/edx/ecommerce/pull/326 is merged._
