### PR TITLE
Associating baskets with sites

### DIFF
--- a/ecommerce/extensions/basket/migrations/0006_basket_site.py
+++ b/ecommerce/extensions/basket/migrations/0006_basket_site.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sites', '0001_initial'),
+        ('basket', '0005_auto_20150709_1205'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='basket',
+            name='site',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, default=None, blank=True, to='sites.Site', null=True, verbose_name='Site'),
+        ),
+    ]

--- a/ecommerce/extensions/basket/models.py
+++ b/ecommerce/extensions/basket/models.py
@@ -1,14 +1,19 @@
+from django.db import models
+from django.utils.translation import ugettext_lazy as _
 from oscar.apps.basket.abstract_models import AbstractBasket
 from oscar.core.loading import get_class
-
 
 OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
 
 
 class Basket(AbstractBasket):
+    site = models.ForeignKey('sites.Site', verbose_name=_("Site"), null=True, blank=True, default=None,
+                             on_delete=models.SET_NULL)
+
     @property
     def order_number(self):
         return OrderNumberGenerator().order_number(self)
 
 
+# noinspection PyUnresolvedReferences
 from oscar.apps.basket.models import *  # noqa pylint: disable=wildcard-import,unused-wildcard-import


### PR DESCRIPTION
ECOM-2232

@edx/ecommerce I noticed yesterday, while squashing migrations, that orders already have a foreign key to the `Site` model. This means we can skip adding a foreign key to the `Partner` model since every site links to a partner. I have decided to carry this linkage to the `Basket` model and link it to a site instead of a partner.
