### PR TITLE
WAIT-LMS: Updated CreditCourse creation

### DIFF
--- a/ecommerce/courses/tests/factories.py
+++ b/ecommerce/courses/tests/factories.py
@@ -1,4 +1,7 @@
+from __future__ import unicode_literals
+
 import factory
+from factory.fuzzy import FuzzyText
 
 from ecommerce.courses.models import Course
 
@@ -6,3 +9,6 @@ from ecommerce.courses.models import Course
 class CourseFactory(factory.DjangoModelFactory):
     class Meta(object):
         model = Course
+
+    id = FuzzyText(prefix='course-id-')
+    name = FuzzyText(prefix='course-name-')

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,6 +13,7 @@ djangorestframework-jwt==1.7.2
 drf-extensions==0.2.8
 edx-auth-backends==0.1.3
 edx-ecommerce-worker==0.2.0
+edx-rest-api-client==1.2.1
 jsonfield==1.0.3
 libsass==0.8.2
 paypalrestsdk==1.9.0


### PR DESCRIPTION
The credit endpoint has been updated to use PUT to create new CreditCourse objects. The publisher has been updated to use this method, greatly simplifying the code necessary to create these objects.

ECOM-2524
