### PR TITLE
Test Speed Improvements

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -7,6 +7,13 @@ To run the unit test suite followed by quality checks, run:
 
     $ make validate
 
+The unit tests run database migrations by default. These migrations can take up to two minutes to run. Most local development
+won't require migrations. You can save time by disabling migrations when running tests locally with the command below:
+
+.. code-block:: bash
+
+    $ DISABLE_MIGRATIONS=1 make validate
+
 Code quality validation can be performed independently with:
 
 .. code-block:: bash

--- a/ecommerce/extensions/refund/migrations/0001_squashed_0002_auto_20150515_2220.py
+++ b/ecommerce/extensions/refund/migrations/0001_squashed_0002_auto_20150515_2220.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+import ecommerce.extensions.refund.models
+import oscar.core.utils
+import django.utils.timezone
+from django.conf import settings
+import django_extensions.db.fields
+
+
+class Migration(migrations.Migration):
+
+    replaces = [(b'refund', '0001_initial'), (b'refund', '0002_auto_20150515_2220')]
+
+    dependencies = [
+        ('order', '0008_delete_order_payment_processor'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='HistoricalRefund',
+            fields=[
+                ('id', models.IntegerField(verbose_name='ID', db_index=True, auto_created=True, blank=True)),
+                ('created', django_extensions.db.fields.CreationDateTimeField(default=django.utils.timezone.now, verbose_name='created', editable=False, blank=True)),
+                ('modified', django_extensions.db.fields.ModificationDateTimeField(default=django.utils.timezone.now, verbose_name='modified', editable=False, blank=True)),
+                ('total_credit_excl_tax', models.DecimalField(verbose_name='Total Credit (excl. tax)', max_digits=12, decimal_places=2)),
+                ('currency', models.CharField(default=oscar.core.utils.get_default_currency, max_length=12, verbose_name='Currency')),
+                ('status', models.CharField(max_length=255, verbose_name='Status')),
+                ('history_id', models.AutoField(serialize=False, primary_key=True)),
+                ('history_date', models.DateTimeField()),
+                ('history_type', models.CharField(max_length=1, choices=[('+', 'Created'), ('~', 'Changed'), ('-', 'Deleted')])),
+                ('history_user', models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL, null=True)),
+                ('order', models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.DO_NOTHING, db_constraint=False, blank=True, to='order.Order', null=True)),
+                ('user', models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.DO_NOTHING, db_constraint=False, blank=True, to=settings.AUTH_USER_MODEL, null=True)),
+            ],
+            options={
+                'ordering': ('-history_date', '-history_id'),
+                'get_latest_by': 'history_date',
+                'verbose_name': 'historical refund',
+            },
+        ),
+        migrations.CreateModel(
+            name='HistoricalRefundLine',
+            fields=[
+                ('id', models.IntegerField(verbose_name='ID', db_index=True, auto_created=True, blank=True)),
+                ('created', django_extensions.db.fields.CreationDateTimeField(default=django.utils.timezone.now, verbose_name='created', editable=False, blank=True)),
+                ('modified', django_extensions.db.fields.ModificationDateTimeField(default=django.utils.timezone.now, verbose_name='modified', editable=False, blank=True)),
+                ('line_credit_excl_tax', models.DecimalField(verbose_name='Line Credit (excl. tax)', max_digits=12, decimal_places=2)),
+                ('quantity', models.PositiveIntegerField(default=1, verbose_name='Quantity')),
+                ('status', models.CharField(max_length=255, verbose_name='Status')),
+                ('history_id', models.AutoField(serialize=False, primary_key=True)),
+                ('history_date', models.DateTimeField()),
+                ('history_type', models.CharField(max_length=1, choices=[('+', 'Created'), ('~', 'Changed'), ('-', 'Deleted')])),
+                ('history_user', models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL, null=True)),
+                ('order_line', models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.DO_NOTHING, db_constraint=False, blank=True, to='order.Line', null=True)),
+            ],
+            options={
+                'ordering': ('-history_date', '-history_id'),
+                'get_latest_by': 'history_date',
+                'verbose_name': 'historical refund line',
+            },
+        ),
+        migrations.CreateModel(
+            name='Refund',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('created', django_extensions.db.fields.CreationDateTimeField(default=django.utils.timezone.now, verbose_name='created', editable=False, blank=True)),
+                ('modified', django_extensions.db.fields.ModificationDateTimeField(default=django.utils.timezone.now, verbose_name='modified', editable=False, blank=True)),
+                ('total_credit_excl_tax', models.DecimalField(verbose_name='Total Credit (excl. tax)', max_digits=12, decimal_places=2)),
+                ('currency', models.CharField(default=oscar.core.utils.get_default_currency, max_length=12, verbose_name='Currency')),
+                ('status', models.CharField(max_length=255, verbose_name='Status')),
+                ('order', models.ForeignKey(related_name='refunds', verbose_name='Order', to='order.Order')),
+                ('user', models.ForeignKey(related_name='refunds', verbose_name='User', to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                'ordering': ('-modified', '-created'),
+                'abstract': False,
+                'get_latest_by': 'modified',
+            },
+            bases=(ecommerce.extensions.refund.models.StatusMixin, models.Model),
+        ),
+        migrations.CreateModel(
+            name='RefundLine',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('created', django_extensions.db.fields.CreationDateTimeField(default=django.utils.timezone.now, verbose_name='created', editable=False, blank=True)),
+                ('modified', django_extensions.db.fields.ModificationDateTimeField(default=django.utils.timezone.now, verbose_name='modified', editable=False, blank=True)),
+                ('line_credit_excl_tax', models.DecimalField(verbose_name='Line Credit (excl. tax)', max_digits=12, decimal_places=2)),
+                ('quantity', models.PositiveIntegerField(default=1, verbose_name='Quantity')),
+                ('status', models.CharField(max_length=255, verbose_name='Status')),
+                ('order_line', models.ForeignKey(related_name='refund_lines', verbose_name='Order Line', to='order.Line')),
+                ('refund', models.ForeignKey(related_name='lines', verbose_name='Refund', to='refund.Refund')),
+            ],
+            options={
+                'ordering': ('-modified', '-created'),
+                'abstract': False,
+                'get_latest_by': 'modified',
+            },
+            bases=(ecommerce.extensions.refund.models.StatusMixin, models.Model),
+        ),
+        migrations.AddField(
+            model_name='historicalrefundline',
+            name='refund',
+            field=models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.DO_NOTHING, db_constraint=False, blank=True, to='refund.Refund', null=True),
+        ),
+    ]

--- a/ecommerce/settings/test.py
+++ b/ecommerce/settings/test.py
@@ -13,6 +13,19 @@ INSTALLED_APPS += (
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
 LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel='DEBUG')
+
+if os.getenv('DISABLE_MIGRATIONS'):
+
+    class DisableMigrations(object):
+
+        def __contains__(self, item):
+            return True
+
+        def __getitem__(self, item):
+            return "notmigrations"
+
+
+    MIGRATION_MODULES = DisableMigrations()
 # END TEST SETTINGS
 
 
@@ -53,6 +66,10 @@ JWT_AUTH.update({
     'JWT_SECRET_KEY': 'insecure-secret-key',
     'JWT_ISSUERS': ('test-issuer',),
 })
+
+PASSWORD_HASHERS = (
+    'django.contrib.auth.hashers.MD5PasswordHasher',
+)
 # END AUTHENTICATION
 
 


### PR DESCRIPTION
- Squashed refund migrations
- Added support for disabling migrations when testing

Migrations require up to two minutes to run. This drastically slows down development. The option to disable migrations when testing has been restored. Django 1.9 (https://github.com/django/django/commit/5aa55038ca9ac44b440b56d1fc4e79c876e51393) should speed up migrations.

Note that migrations are still being run on Travis.
