### PR TITLE
Updated baskets order endpoint

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/__init__.py
+++ b/ecommerce/extensions/api/v2/tests/views/__init__.py
@@ -1,11 +1,11 @@
 from django.core.urlresolvers import reverse
 from django.test import RequestFactory
 from oscar.core.loading import get_class, get_model
-from oscar.test import factories
 from oscar.test.newfactories import ProductAttributeValueFactory
 
 from ecommerce.core.constants import ISO_8601_FORMAT
 from ecommerce.extensions.api.serializers import OrderSerializer
+from ecommerce.extensions.test import factories
 from ecommerce.tests.mixins import UserMixin, ThrottlingMixin
 
 JSON_CONTENT_TYPE = 'application/json'

--- a/ecommerce/extensions/api/v2/urls.py
+++ b/ecommerce/extensions/api/v2/urls.py
@@ -17,7 +17,7 @@ BASKET_URLS = [
     url(r'^$', basket_views.BasketCreateView.as_view(), name='create'),
     url(
         r'^{basket_id}/order/$'.format(basket_id=BASKET_ID_PATTERN),
-        order_views.OrderByBasketRetrieveView.as_view(),
+        basket_views.OrderByBasketRetrieveView.as_view(),
         name='retrieve_order'
     ),
 ]

--- a/ecommerce/extensions/api/v2/views/orders.py
+++ b/ecommerce/extensions/api/v2/views/orders.py
@@ -10,7 +10,6 @@ from ecommerce.extensions.api import serializers
 from ecommerce.extensions.api.constants import APIConstants as AC
 from ecommerce.extensions.api.throttles import ServiceUserThrottle
 
-
 logger = logging.getLogger(__name__)
 
 Order = get_model('order', 'Order')
@@ -79,15 +78,6 @@ class OrderRetrieveView(generics.RetrieveAPIView):
         This ensures we do not allow one user to view the data of another user.
         """
         return self.request.user.orders
-
-
-class OrderByBasketRetrieveView(OrderRetrieveView):
-    """Allow the viewing of Orders by Basket.
-
-    Works exactly the same as OrderRetrieveView, except that orders are looked
-    up via the id of the related basket.
-    """
-    lookup_field = 'basket_id'
 
 
 class OrderFulfillView(generics.UpdateAPIView):

--- a/ecommerce/extensions/order/utils.py
+++ b/ecommerce/extensions/order/utils.py
@@ -1,4 +1,5 @@
 """Order Utility Classes. """
+from __future__ import unicode_literals
 from django.conf import settings
 
 
@@ -11,21 +12,20 @@ class OrderNumberGenerator(object):
     OFFSET = 100000
 
     def order_number(self, basket):
-        """Create an order number with a configured prefix.
+        return self.order_number_from_basket_id(basket.id)
 
-        Creates a unique order number with a configured prefix.
+    def order_number_from_basket_id(self, basket_id):
+        """
+        Return an order number for a given basket ID.
 
         Arguments:
-            basket (Basket): Used to construct the order ID.
+            basket_id (int): Basket identifier.
 
         Returns:
-            str: Representation of the order 'number' with a configured prefix.
-
+            string: Order number.
         """
-        order_id = basket.id + self.OFFSET
-        order_number = u'{prefix}-{order_id}'.format(prefix=settings.ORDER_NUMBER_PREFIX, order_id=order_id)
-
-        return order_number
+        order_id = int(basket_id) + self.OFFSET
+        return u'{prefix}-{order_id}'.format(prefix=settings.ORDER_NUMBER_PREFIX, order_id=order_id)
 
     def basket_id(self, order_number):
         """Inverse of order number generation.

--- a/ecommerce/extensions/test/factories.py
+++ b/ecommerce/extensions/test/factories.py
@@ -1,0 +1,40 @@
+from oscar.test.factories import *  # pylint:disable=wildcard-import,unused-wildcard-import
+
+OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
+
+
+def create_order(number=None, basket=None, user=None, shipping_address=None,  # pylint:disable=function-redefined
+                 shipping_method=None, billing_address=None, total=None, **kwargs):
+    """
+    Helper method for creating an order for testing
+    """
+    if not basket:
+        basket = Basket.objects.create()
+        basket.strategy = strategy.Default()
+        product = create_product()
+        create_stockrecord(
+            product, num_in_stock=10, price_excl_tax=D('10.00'))
+        basket.add_product(product)
+    if not basket.id:
+        basket.save()
+    if shipping_method is None:
+        shipping_method = Free()
+    shipping_charge = shipping_method.calculate(basket)
+    if total is None:
+        total = OrderTotalCalculator().calculate(basket, shipping_charge)
+
+    # Ensure we use our own OrderNumberGenerator instead of Oscar's default.
+    number = number or OrderNumberGenerator().order_number(basket)
+
+    order = OrderCreator().place_order(
+        order_number=number,
+        user=user,
+        basket=basket,
+        shipping_address=shipping_address,
+        shipping_method=shipping_method,
+        shipping_charge=shipping_charge,
+        billing_address=billing_address,
+        total=total,
+        **kwargs)
+    basket.set_as_submitted()
+    return order


### PR DESCRIPTION
The /baskets/:id/order/ endpoint now retrieves orders based on the order number instead of the order's foreign key to the basket. This allows orders to be retrieved even if the basket has been deleted.

ECOM-2654
