### PR TITLE
Fixed admin page

### DIFF
--- a/ecommerce/extensions/basket/models.py
+++ b/ecommerce/extensions/basket/models.py
@@ -14,6 +14,13 @@ class Basket(AbstractBasket):
     def order_number(self):
         return OrderNumberGenerator().order_number(self)
 
+    def __unicode__(self):
+        return _(u"{id} - {status} basket (owner: {owner}, lines: {num_lines})").format(
+            id=self.id,
+            status=self.status,
+            owner=self.owner,
+            num_lines=self.num_lines)
+
 
 # noinspection PyUnresolvedReferences
 from oscar.apps.basket.models import *  # noqa pylint: disable=wildcard-import,unused-wildcard-import

--- a/ecommerce/extensions/basket/tests/test_models.py
+++ b/ecommerce/extensions/basket/tests/test_models.py
@@ -2,7 +2,6 @@ from django.test import TestCase
 from oscar.core.loading import get_class
 from oscar.test import factories
 
-
 OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
 
 
@@ -15,3 +14,13 @@ class BasketTests(TestCase):
         """Verify that an instance of Basket can generate its own order number."""
         expected = OrderNumberGenerator().order_number(self.basket)
         self.assertEqual(self.basket.order_number, expected)
+
+    def test_unicode(self):
+        """ Verify the __unicode__ method returns the correct value. """
+        expected = u"{id} - {status} basket (owner: {owner}, lines: {num_lines})".format(
+            id=self.basket.id,
+            status=self.basket.status,
+            owner=self.basket.owner,
+            num_lines=self.basket.num_lines)
+
+        self.assertEqual(unicode(self.basket), expected)

--- a/ecommerce/extensions/order/admin.py
+++ b/ecommerce/extensions/order/admin.py
@@ -1,1 +1,11 @@
-import oscar.apps.order.admin  # pragma: no cover pylint: disable=unused-import
+from oscar.apps.order.admin import *  # noqa pylint: disable=wildcard-import,unused-wildcard-import
+
+Order = get_model('order', 'Order')
+
+
+class OrderAdminExtended(OrderAdmin):
+    readonly_fields = ('basket',) + OrderAdmin.readonly_fields
+
+
+admin.site.unregister(Order)
+admin.site.register(Order, OrderAdminExtended)

--- a/ecommerce/extensions/payment/admin.py
+++ b/ecommerce/extensions/payment/admin.py
@@ -2,7 +2,6 @@ from pprint import pformat
 
 from django.contrib import admin
 from django.utils.html import format_html
-from django.utils.translation import ugettext_lazy as _
 from oscar.core.loading import get_model
 
 PaymentProcessorResponse = get_model('payment', 'PaymentProcessorResponse')
@@ -11,14 +10,9 @@ PaymentProcessorResponse = get_model('payment', 'PaymentProcessorResponse')
 class PaymentProcessorResponseAdmin(admin.ModelAdmin):
     list_filter = ('processor_name',)
     search_fields = ('id', 'processor_name', 'transaction_id',)
-    list_display = ('id', 'processor_name', 'transaction_id', 'basket_display_value', 'created')
-    fields = ('processor_name', 'transaction_id', 'basket_display_value', 'formatted_response')
-    readonly_fields = ('processor_name', 'transaction_id', 'basket_display_value', 'formatted_response')
-
-    def basket_display_value(self, obj):
-        return '{} - {}'.format(obj.basket.id, obj.basket)
-
-    basket_display_value.short_description = _('Basket')
+    list_display = ('id', 'processor_name', 'transaction_id', 'basket', 'created')
+    fields = ('processor_name', 'transaction_id', 'basket', 'formatted_response')
+    readonly_fields = ('processor_name', 'transaction_id', 'basket', 'formatted_response')
 
     def formatted_response(self, obj):
         pretty_response = pformat(obj.response)


### PR DESCRIPTION
- Overrode Basket model's Unicode method to include basket ID
- Payment processor response detail page now loads without issue
- Order detail page loads more efficiently without loading all baskets

ECOM-2732
