### PR TITLE
Fixed for duplicate payment ID received from Paypal.

### DIFF
--- a/ecommerce/extensions/payment/processors/paypal.py
+++ b/ecommerce/extensions/payment/processors/paypal.py
@@ -47,6 +47,7 @@ class Paypal(BasePaymentProcessor):
         configuration = self.configuration
         self.receipt_url = configuration['receipt_url']
         self.cancel_url = configuration['cancel_url']
+        self.error_url = configuration['error_url']
 
         # Number of times payment execution is retried after failure.
         self.retry_attempts = configuration.get('retry_attempts', 1)

--- a/ecommerce/settings/_oscar.py
+++ b/ecommerce/settings/_oscar.py
@@ -115,6 +115,7 @@ PAYMENT_PROCESSOR_CONFIG = {
         'client_secret': None,
         'receipt_url': None,
         'cancel_url': None,
+        'error_url': None,
     },
 }
 # END PAYMENT PROCESSING

--- a/ecommerce/settings/devstack.py
+++ b/ecommerce/settings/devstack.py
@@ -39,6 +39,7 @@ PAYMENT_PROCESSOR_CONFIG = {
         'client_secret': 'fake-client-secret',
         'receipt_url': get_lms_url('/commerce/checkout/receipt/'),
         'cancel_url': get_lms_url('/commerce/checkout/cancel/'),
+        'error_url': get_lms_url('/commerce/checkout/error/'),
     },
 }
 # END PAYMENT PROCESSING

--- a/ecommerce/settings/local.py
+++ b/ecommerce/settings/local.py
@@ -122,6 +122,7 @@ PAYMENT_PROCESSOR_CONFIG = {
         'client_secret': 'fake-client-secret',
         'receipt_url': get_lms_url('/commerce/checkout/receipt/'),
         'cancel_url': get_lms_url('/commerce/checkout/cancel/'),
+        'error_url': get_lms_url('/commerce/checkout/error/'),
     },
 }
 # END PAYMENT PROCESSING

--- a/ecommerce/settings/test.py
+++ b/ecommerce/settings/test.py
@@ -99,6 +99,7 @@ PAYMENT_PROCESSOR_CONFIG = {
         'client_secret': 'fake-client-secret',
         'receipt_url': get_lms_url('/commerce/checkout/receipt/'),
         'cancel_url': get_lms_url('/commerce/checkout/cancel/'),
+        'error_url': get_lms_url('/commerce/checkout/error/'),
     },
 }
 # END PAYMENT PROCESSING


### PR DESCRIPTION
Paypal sometime sends duplicate payment ID, which cause error while getting basket or order. An exception will be logged when duplicate ID returned and user will be redirected to checkout error page served at `/commerce/checkout/error/`.

This PR depends upon this [PR](https://github.com/edx/edx-platform/pull/10502).

Please review this @awais786 @afeef @ahsan-ul-haq @zubair-arbi 
