### PR TITLE
Optionally include marketing site during acceptance testing

### DIFF
--- a/acceptance_tests/config.py
+++ b/acceptance_tests/config.py
@@ -10,7 +10,8 @@ def str2bool(s):
 ACCESS_TOKEN = os.environ.get('ACCESS_TOKEN')
 ENABLE_OAUTH2_TESTS = str2bool(os.environ.get('ENABLE_OAUTH2_TESTS', True))
 HONOR_COURSE_ID = os.environ.get('HONOR_COURSE_ID', 'edX/DemoX/Demo_Course')
-VERIFIED_COURSE_ID = os.environ.get('VERIFIED_COURSE_ID', 'edX/victor101/Victor_s_test_course')
+VERIFIED_COURSE_ID = os.environ.get('VERIFIED_COURSE_ID', 'course-v1:BerkeleyX+ColWri.3.6x+3T2015')
+PROFESSIONAL_COURSE_ID = os.environ.get('PROFESSIONAL_COURSE_ID', 'course-v1:UBCx+Marketing5501x+2T2015')
 
 if ACCESS_TOKEN is None:
     raise RuntimeError('A valid OAuth2 access token is required to run acceptance tests.')
@@ -32,6 +33,23 @@ PAYPAL_PASSWORD = os.environ.get('PAYPAL_PASSWORD')
 # tests to be disabled.
 ENABLE_CYBERSOURCE_TESTS = str2bool(os.environ.get('ENABLE_CYBERSOURCE_TESTS', True))
 # END OTTO CONFIGURATION
+
+
+# MARKETING CONFIGURATION
+ENABLE_MARKETING_SITE = str2bool(os.environ.get('ENABLE_MARKETING_SITE', False))
+
+MARKETING_URL_ROOT = os.environ.get('MARKETING_URL_ROOT').strip('/')
+
+# These must correspond to the course IDs provided for each enrollment mode.
+VERIFIED_COURSE_SLUG = os.environ.get(
+    'VERIFIED_COURSE_SLUG',
+    'dracula-stoker-berkeleyx-book-club-uc-berkeleyx-colwri3-6x'
+)
+PROFESSIONAL_COURSE_SLUG = os.environ.get(
+    'PROFESSIONAL_COURSE_SLUG',
+    'marketing-non-marketers-ubcx-marketing5501x'
+)
+# END MARKETING CONFIGURATION
 
 
 # LMS CONFIGURATION

--- a/acceptance_tests/pages.py
+++ b/acceptance_tests/pages.py
@@ -6,7 +6,9 @@ from bok_choy.promise import EmptyPromise
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.support.select import Select
 
-from acceptance_tests.config import BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD, ECOMMERCE_URL_ROOT, LMS_URL_ROOT
+from acceptance_tests.config import (
+    BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD, ECOMMERCE_URL_ROOT, MARKETING_URL_ROOT, LMS_URL_ROOT
+)
 
 
 class EcommerceAppPage(PageObject):  # pylint: disable=abstract-method
@@ -28,6 +30,28 @@ class DashboardHomePage(EcommerceAppPage):
 
     def is_browser_on_page(self):
         return self.browser.title.startswith('Dashboard | Oscar')
+
+
+class MarketingCourseAboutPage(PageObject):
+    def is_browser_on_page(self):
+        return self.q(css='.js-enroll-btn').visible
+
+    def _build_url(self, path):
+        url = '{}/{}'.format(MARKETING_URL_ROOT, path)
+
+        if BASIC_AUTH_USERNAME and BASIC_AUTH_PASSWORD:
+            url = url.replace('://', '://{}:{}@'.format(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD))
+
+        return url
+
+    @property
+    def url(self):
+        path = 'course/{}'.format(urllib.quote_plus(self.slug))
+        return self._build_url(path)
+
+    def __init__(self, browser, slug):
+        super(MarketingCourseAboutPage, self).__init__(browser)
+        self.slug = slug
 
 
 class LMSPage(PageObject):  # pylint: disable=abstract-method

--- a/acceptance_tests/test_profed_enrollment.py
+++ b/acceptance_tests/test_profed_enrollment.py
@@ -1,26 +1,32 @@
-from unittest import skip
-
 from bok_choy.web_app_test import WebAppTest
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 
+from acceptance_tests.config import PROFESSIONAL_COURSE_ID, ENABLE_MARKETING_SITE, PROFESSIONAL_COURSE_SLUG
 from acceptance_tests.mixins import LogistrationMixin, EnrollmentApiMixin
-from acceptance_tests.pages import LMSCourseModePage
+from acceptance_tests.pages import LMSCourseModePage, MarketingCourseAboutPage
 
 
-@skip('Prof. Ed. tests should be run on an as-needed basis.')
 class ProfessionalEducationEnrollmentTests(EnrollmentApiMixin, LogistrationMixin, WebAppTest):
     def test_payment_required(self):
-        """ Verify payment is required before enrolling in a professional education course. """
-
-        # Note: Populate this list by querying the course modes/products for prof. ed. course IDs.
-        course_ids = ()
+        """Verify payment is required before enrolling in a professional education course."""
 
         # Sign into LMS
         username, password, email = self.get_lms_user()
         self.login_with_lms(email, password)
 
-        for course_id in course_ids:
-            # Visit the course mode page (where auto-enrollment normally occurs)
-            LMSCourseModePage(self.browser, course_id).visit()
+        if ENABLE_MARKETING_SITE:
+            course_about_page = MarketingCourseAboutPage(self.browser, PROFESSIONAL_COURSE_SLUG)
+            course_about_page.visit()
 
-            # Verify auto-enrollment does NOT occur for the course
-            self.assert_user_not_enrolled(username, course_id)
+            # Click the first enroll button on the page to take the browser to the track selection page,
+            # and allow it to load.
+            course_about_page.q(css='.js-enroll-btn').first.click()
+            WebDriverWait(self.browser, 10).until(EC.presence_of_element_located((By.CLASS_NAME, 'make-payment-step')))
+        else:
+            # Visit the course mode page (where auto-enrollment normally occurs)
+            LMSCourseModePage(self.browser, PROFESSIONAL_COURSE_ID).visit()
+
+        # Verify auto-enrollment does NOT occur for the course.
+        self.assert_user_not_enrolled(username, PROFESSIONAL_COURSE_ID)

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -107,51 +107,36 @@ Environment Variables
 
 Our acceptance tests rely on configuration which can be specified using environment variables.
 
-+---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
-| Variable                  | Purpose                                                                  | Required? | Default Value                        |
-+===========================+==========================================================================+===========+======================================+
-| ACCESS\_TOKEN             | OAuth2 access token used to authenticate requests                        | Yes       | N/A                                  |
-+---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
-| ENABLE\_OAUTH2\_TESTS     | Whether to run tests verifying that the LMS can be used to sign into Otto| No        | True                                 |
-+---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
-| HONOR\_COURSE\_ID         | The ID of a Free (Honor) course                                          | No        | 'edX/DemoX/Demo_Course'              |
-+---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
-| VERIFIED\_COURSE\_ID      | The ID of a Verified course                                              | No        | 'edX/victor101/Victor_s_test_course' |
-+---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
-| ECOMMERCE\_URL\_ROOT      | URL root for the E-Commerce Service                                      | Yes       | N/A                                  |
-+---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
-| ECOMMERCE\_API\_URL       | URL for the E-Commerce API, used to initialize an API client             | No        | ECOMMERCE\_URL\_ROOT + '/api/v2'     |
-+---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
-| ECOMMERCE\_API\_TOKEN     | Token used to authenticate against the E-Commerce API                    | No        | ACCESS\_TOKEN                        |
-+---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
-| MAX\_COMPLETION\_RETRIES  | Number of times to retry checking for an order's completion              | No        | 3                                    |
-+---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
-| PAYPAL\_EMAIL             | Email address used to sign into PayPal during payment                    | Yes       | N/A                                  |
-+---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
-| PAYPAL\_PASSWORD          | Password used to sign into PayPal during payment                         | Yes       | N/A                                  |
-+---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
-| ENABLE\_CYBERSOURCE\_TESTS| Whether to run tests verifying the CyberSource payment flow              | No        | True                                 |
-+---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
-| LMS\_URL\_ROOT            | URL root for the LMS                                                     | Yes       | N/A                                  |
-+---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
-| LMS\_USERNAME             | Username belonging to an LMS user to use during testing                  | Yes       | N/A                                  |
-+---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
-| LMS\_EMAIL                | Email address used to sign into the LMS                                  | Yes       | N/A                                  |
-+---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
-| LMS\_PASSWORD             | Password used to sign into the LMS                                       | Yes       | N/A                                  |
-+---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
-| LMS\_AUTO\_AUTH           | Whether auto-auth is enabled on the LMS                                  | No        | False                                |
-+---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
-| LMS\_HTTPS                | Whether HTTPS is enabled on the LMS                                      | No        | True                                 |
-+---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
-| ENROLLMENT\_API\_URL      | URL for the LMS Enrollment API                                           | No        | LMS\_URL\_ROOT + '/api/enrollment/v1'|
-+---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
-| ENROLLMENT\_API\_TOKEN    | Token used to authenticate against the Enrollment API                    | No        | ACCESS\_TOKEN                        |
-+---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
-| BASIC\_AUTH\_USERNAME     | Username used to bypass HTTP basic auth on the LMS                       | No        | N/A                                  |
-+---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
-| BASIC\_AUTH\_PASSWORD     | Password used to bypass HTTP basic auth on the LMS                       | No        | N/A                                  |
-+---------------------------+--------------------------------------------------------------------------+-----------+--------------------------------------+
+======================== ========================================================================= ========= ============================================================
+Variable                 Description                                                               Required? Default Value
+======================== ========================================================================= ========= ============================================================
+ACCESS_TOKEN             OAuth2 access token used to authenticate requests                         Yes       N/A
+ENABLE_OAUTH2_TESTS      Whether to run tests verifying that the LMS can be used to sign into Otto No        True
+HONOR_COURSE_ID          The ID of a Free (Honor) course                                           No        'edX/DemoX/Demo_Course'
+VERIFIED_COURSE_ID       The ID of a Verified course                                               No        'course-v1:BerkeleyX+ColWri.3.6x+3T2015'
+PROFESSIONAL_COURSE_ID   The ID of a Professional Education course                                 No        'course-v1:UBCx+Marketing5501x+2T2015'
+ECOMMERCE_URL_ROOT       URL root for the E-Commerce Service                                       Yes       N/A
+ECOMMERCE_API_URL        URL for the E-Commerce API, used to initialize an API client              No        ECOMMERCE_URL_ROOT + '/api/v2'
+ECOMMERCE_API_TOKEN      Token used to authenticate against the E-Commerce API                     No        ACCESS_TOKEN
+MAX_COMPLETION_RETRIES   Number of times to retry checking for an order's completion               No        3
+PAYPAL_EMAIL             Email address used to sign into PayPal during payment                     Yes       N/A
+PAYPAL_PASSWORD          Password used to sign into PayPal during payment                          Yes       N/A
+ENABLE_CYBERSOURCE_TESTS Whether to run tests verifying the CyberSource payment flow               No        True
+ENABLE_MARKETING_SITE    Whether to visit the marketing site during testing                        No        False
+MARKETING_URL_ROOT       URL root for the marketing site                                           No        None
+VERIFIED_COURSE_SLUG     Drupal slug corresponding to the provided verified course ID              No        'dracula-stoker-berkeleyx-book-club-uc-berkeleyx-colwri3-6x'
+PROFESSIONAL_COURSE_SLUG Drupal slug corresponding to the provided professional course ID          No        'marketing-non-marketers-ubcx-marketing5501x'
+LMS_URL_ROOT             URL root for the LMS                                                      Yes       N/A
+LMS_USERNAME             Username belonging to an LMS user to use during testing                   Yes       N/A
+LMS_EMAIL                Email address used to sign into the LMS                                   Yes       N/A
+LMS_PASSWORD             Password used to sign into the LMS                                        Yes       N/A
+LMS_AUTO_AUTH            Whether auto-auth is enabled on the LMS                                   No        False
+LMS_HTTPS                Whether HTTPS is enabled on the LMS                                       No        True
+ENROLLMENT_API_URL       URL for the LMS Enrollment API                                            No        LMS_URL_ROOT + '/api/enrollment/v1'
+ENROLLMENT_API_TOKEN     Token used to authenticate against the Enrollment API                     No        ACCESS_TOKEN
+BASIC_AUTH_USERNAME      Username used to bypass HTTP basic auth on the LMS                        No        N/A
+BASIC_AUTH_PASSWORD      Password used to bypass HTTP basic auth on the LMS                        No        N/A
+======================== ========================================================================= ========= ============================================================
 
 Running Acceptance Tests
 ************************
@@ -167,5 +152,3 @@ As discussed above, the acceptance tests rely on configuration which can be spec
 When running against a production-like staging environment, you might run::
 
     $ ECOMMERCE_URL_ROOT="https://ecommerce.stage.edx.org" LMS_URL_ROOT="https://courses.stage.edx.org" LMS_USERNAME="<username>" LMS_EMAIL="<email address>" LMS_PASSWORD="<password>" ACCESS_TOKEN="<access token>" LMS_HTTPS="True" LMS_AUTO_AUTH="False" PAYPAL_EMAIL="<email address>" PAYPAL_PASSWORD="<password>" BASIC_AUTH_USERNAME="<username>" BASIC_AUTH_PASSWORD="<password>" HONOR_COURSE_ID="<course ID>" VERIFIED_COURSE_ID="<course ID>" make accept
-
-


### PR DESCRIPTION
Extends existing acceptance tests, providing more complete coverage of the marketing site and the LMS Commerce API. Also removes skips on professional education tests.

@clintonb, please review. FYI @ronaldmulero.
