### PR TITLE
Add a wait to PayPal acceptance test to allow checkout form to load

### DIFF
--- a/acceptance_tests/test_payment.py
+++ b/acceptance_tests/test_payment.py
@@ -179,7 +179,8 @@ class VerifiedCertificatePaymentTests(UnenrollmentMixin, EcommerceApiMixin, Enro
         self.browser.find_element_by_css_selector('input#login_password').send_keys(PAYPAL_PASSWORD)
         self.browser.find_element_by_css_selector('input#submitLogin').click()
 
-        # Checkout
+        # Wait for the checkout form to load, then submit it.
+        WebDriverWait(self.browser, 10).until(EC.presence_of_element_located((By.ID, 'continue')))
         self.browser.find_element_by_css_selector('input#continue').click()
 
     def test_paypal(self):


### PR DESCRIPTION
This test sometimes tries to submit the checkout form before it has been able to load, causing the test to fail. This change ensures that the page has loaded before the test tries to submit payment.

@clintonb @ronaldmulero @edx/ecommerce 
