### PR TITLE
Allow disabling payment processors.

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_payments.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_payments.py
@@ -1,8 +1,10 @@
 import json
 
+from django.conf import settings
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
 from django.test import override_settings
+from waffle.models import Switch
 
 from ecommerce.extensions.payment.tests.processors import DummyProcessor, AnotherDummyProcessor
 from ecommerce.tests.testcases import TestCase
@@ -13,9 +15,16 @@ class PaymentProcessorListViewTests(TestCase):
 
     def setUp(self):
         self.token = self.generate_jwt_token_header(self.create_user())
-
+        self.toggle_payment_processor('dummy', True)
+        self.toggle_payment_processor('another-dummy', True)
         # Clear the view cache
         cache.clear()
+
+    def toggle_payment_processor(self, processor, active):
+        """Set the given payment processor's Waffle switch."""
+        switch, __ = Switch.objects.get_or_create(name=settings.PAYMENT_PROCESSOR_SWITCH_PREFIX + processor)
+        switch.active = active
+        switch.save()
 
     def assert_processor_list_matches(self, expected):
         """ DRY helper. """
@@ -40,3 +49,19 @@ class PaymentProcessorListViewTests(TestCase):
     def test_get_many(self):
         """Ensure multiple processors in settings are handled correctly."""
         self.assert_processor_list_matches([DummyProcessor.NAME, AnotherDummyProcessor.NAME])
+
+    @override_settings(PAYMENT_PROCESSORS=[
+        'ecommerce.extensions.payment.tests.processors.DummyProcessor',
+    ])
+    def test_processor_disabled(self):
+        self.toggle_payment_processor('dummy', False)
+        self.assert_processor_list_matches([])
+
+    @override_settings(PAYMENT_PROCESSORS=[
+        'ecommerce.extensions.payment.tests.processors.DummyProcessor',
+        'ecommerce.extensions.payment.tests.processors.AnotherDummyProcessor',
+    ])
+    def test_waffle_switches_clear_cache(self):
+        self.assert_processor_list_matches([DummyProcessor.NAME, AnotherDummyProcessor.NAME])
+        self.toggle_payment_processor('dummy', False)
+        self.assert_processor_list_matches([AnotherDummyProcessor.NAME])

--- a/ecommerce/extensions/api/v2/urls.py
+++ b/ecommerce/extensions/api/v2/urls.py
@@ -1,5 +1,4 @@
 from django.conf.urls import url, include
-from django.views.decorators.cache import cache_page
 from rest_framework_extensions.routers import ExtendedSimpleRouter
 
 from ecommerce.core.constants import COURSE_ID_PATTERN
@@ -37,7 +36,7 @@ ORDER_URLS = [
 ]
 
 PAYMENT_URLS = [
-    url(r'^processors/$', cache_page(60 * 30)(payment_views.PaymentProcessorListView.as_view()),
+    url(r'^processors/$', payment_views.PaymentProcessorListView.as_view(),
         name='list_processors'),
 ]
 

--- a/ecommerce/extensions/api/v2/views/payments.py
+++ b/ecommerce/extensions/api/v2/views/payments.py
@@ -2,9 +2,14 @@
 from django.conf import settings
 from rest_framework import generics
 from rest_framework.permissions import IsAuthenticated
+from rest_framework_extensions.cache.decorators import cache_response
 
 from ecommerce.extensions.api import serializers
 from ecommerce.extensions.payment.helpers import get_processor_class
+
+
+PAYMENT_PROCESSOR_CACHE_KEY = 'PAYMENT_PROCESSOR_LIST'
+PAYMENT_PROCESSOR_CACHE_TIMEOUT = 60 * 30
 
 
 class PaymentProcessorListView(generics.ListAPIView):
@@ -13,6 +18,15 @@ class PaymentProcessorListView(generics.ListAPIView):
     permission_classes = (IsAuthenticated,)
     serializer_class = serializers.PaymentProcessorSerializer
 
+    @cache_response(
+        PAYMENT_PROCESSOR_CACHE_TIMEOUT,
+        key_func=lambda *args, **kwargs: PAYMENT_PROCESSOR_CACHE_KEY,
+        cache_errors=False,
+    )
+    def get(self, request):
+        return super(PaymentProcessorListView, self).get(request)
+
     def get_queryset(self):
         """Fetch the list of payment processor classes based on Django settings."""
-        return [get_processor_class(path) for path in settings.PAYMENT_PROCESSORS]
+        processors = (get_processor_class(path) for path in settings.PAYMENT_PROCESSORS)
+        return [processor for processor in processors if processor.is_enabled()]

--- a/ecommerce/extensions/payment/config.py
+++ b/ecommerce/extensions/payment/config.py
@@ -15,3 +15,7 @@ class PaymentConfig(config.PaymentConfig):
                 'client_id': paypal_configuration['client_id'],
                 'client_secret': paypal_configuration['client_secret']
             })
+
+        # Register signal handlers
+        # noinspection PyUnresolvedReferences
+        import ecommerce.extensions.payment.signals  # pylint: disable=unused-variable

--- a/ecommerce/extensions/payment/migrations/0006_enable_payment_processors.py
+++ b/ecommerce/extensions/payment/migrations/0006_enable_payment_processors.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.db import migrations, models
+
+from ecommerce.extensions.payment.processors.cybersource import Cybersource
+from ecommerce.extensions.payment.processors.paypal import Paypal
+
+
+def enable_payment_processors(apps, schema_editor):
+    """
+    Enable both existing payment processors.
+    """
+    Switch = apps.get_model('waffle', 'Switch')
+    for processor in (Cybersource, Paypal):
+        Switch(name=settings.PAYMENT_PROCESSOR_SWITCH_PREFIX + processor.NAME, active=True).save()
+
+
+def delete_processor_switches(apps, schema_editor):
+    """
+    Remove payment processor switches.
+    """
+    Switch = apps.get_model('waffle', 'Switch')
+    for processor in (Cybersource, Paypal):
+        Switch.objects.get(name=settings.PAYMENT_PROCESSOR_SWITCH_PREFIX + processor.NAME).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('payment', '0005_paypalwebprofile'),
+    ]
+
+    operations = [
+        migrations.RunPython(enable_payment_processors, delete_processor_switches)
+    ]

--- a/ecommerce/extensions/payment/processors/__init__.py
+++ b/ecommerce/extensions/payment/processors/__init__.py
@@ -2,6 +2,8 @@ import abc
 
 from django.conf import settings
 from oscar.core.loading import get_model
+import waffle
+
 
 PaymentProcessorResponse = get_model('payment', 'PaymentProcessorResponse')
 
@@ -87,3 +89,10 @@ class BasePaymentProcessor(object):  # pragma: no cover
             currency (string): currency of the amount to be credited
         """
         raise NotImplementedError
+
+    @classmethod
+    def is_enabled(cls):
+        """
+        Returns True if this payment processor is enabled, and False otherwise.
+        """
+        return waffle.switch_is_active(settings.PAYMENT_PROCESSOR_SWITCH_PREFIX + cls.NAME)

--- a/ecommerce/extensions/payment/signals.py
+++ b/ecommerce/extensions/payment/signals.py
@@ -1,0 +1,27 @@
+import logging
+
+from django.conf import settings
+from django.core.cache import caches
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from waffle.models import Switch
+
+from ecommerce.extensions.api.v2.views.payments import PAYMENT_PROCESSOR_CACHE_KEY
+
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(post_save, sender=Switch)
+def invalidate_processor_cache(*_args, **kwargs):
+    """
+    When Waffle switches for payment processors are toggled, the
+    payment processor list view cache must be invalidated.
+    """
+    switch = kwargs['instance']
+    parts = switch.name.split(settings.PAYMENT_PROCESSOR_SWITCH_PREFIX)
+    if len(parts) == 2:
+        processor = parts[1]
+        logger.info('Switched payment processor [%s] %s.', processor, 'on' if switch.active else 'off')
+        caches['default'].delete(PAYMENT_PROCESSOR_CACHE_KEY)
+        logger.info('Invalidated payment processor cache after toggling [%s].', switch.name)

--- a/ecommerce/settings/_oscar.py
+++ b/ecommerce/settings/_oscar.py
@@ -118,6 +118,8 @@ PAYMENT_PROCESSOR_CONFIG = {
         'error_url': None,
     },
 }
+
+PAYMENT_PROCESSOR_SWITCH_PREFIX = 'payment_processor_active_'
 # END PAYMENT PROCESSING
 
 


### PR DESCRIPTION
# [ECOM-2346](https://openedx.atlassian.net/browse/ECOM-2346)

Adds admin functionality to disable payment processors, preventing them from being returned from the payment processor API endpoint. The corresponding platform changes are in https://github.com/edx/edx-platform/pull/10662.

@rlucioni @clintonb FYI @edx/ecommerce 
