### PR TITLE
Actually check that httpretty is enabled when attempting to register URIs

### DIFF
--- a/ecommerce/courses/tests/test_publishers.py
+++ b/ecommerce/courses/tests/test_publishers.py
@@ -34,7 +34,7 @@ class LMSPublisherTests(CourseCatalogTestMixin, TestCase):
         )
 
     def _mock_commerce_api(self, status, body=None):
-        self.assertTrue(httpretty.is_enabled, 'httpretty must be enabled to mock Commerce API calls.')
+        self.assertTrue(httpretty.is_enabled(), 'httpretty must be enabled to mock Commerce API calls.')
 
         body = body or {}
         url = '{}/courses/{}/'.format(settings.COMMERCE_API_URL.rstrip('/'), self.course.id)
@@ -42,7 +42,7 @@ class LMSPublisherTests(CourseCatalogTestMixin, TestCase):
                                content_type=JSON)
 
     def mock_creditcourse_endpoint(self, course_id, status, body=None):
-        self.assertTrue(httpretty.is_enabled, 'httpretty must be enabled to mock Credit API calls.')
+        self.assertTrue(httpretty.is_enabled(), 'httpretty must be enabled to mock Credit API calls.')
 
         url = get_lms_url('/api/credit/v1/courses/{}/'.format(course_id))
         httpretty.register_uri(
@@ -225,6 +225,7 @@ class LMSPublisherTests(CourseCatalogTestMixin, TestCase):
         self.assertEqual(actual, expected)
         self.assert_creditcourse_endpoint_called()
 
+    @httpretty.activate
     @mock.patch('requests.get', mock.Mock(side_effect=Exception))
     def test_credit_publication_uncaught_exception(self):
         """ Verify the endpoint fails appropriately when the Credit API fails unexpectedly. """

--- a/ecommerce/extensions/catalogue/tests/test_migrate_course.py
+++ b/ecommerce/extensions/catalogue/tests/test_migrate_course.py
@@ -55,7 +55,7 @@ class CourseMigrationTestMixin(CourseCatalogTestMixin):
     }
 
     def _mock_lms_apis(self):
-        self.assertTrue(httpretty.is_enabled, 'httpretty must be enabled to mock LMS API calls.')
+        self.assertTrue(httpretty.is_enabled(), 'httpretty must be enabled to mock LMS API calls.')
 
         # Mock Commerce API
         body = {

--- a/ecommerce/extensions/dashboard/users/tests/test_views.py
+++ b/ecommerce/extensions/dashboard/users/tests/test_views.py
@@ -25,7 +25,7 @@ class UserDetailViewTests(DashboardViewTestMixin, TestCase):
         self.data = [{'course_id': 'a/b/c'}]
 
     def mock_enrollment_api(self, status=200):
-        self.assertTrue(httpretty.is_enabled)
+        self.assertTrue(httpretty.is_enabled())
         httpretty.register_uri(httpretty.GET, settings.ENROLLMENT_API_URL, status=status,
                                body=json.dumps(self.data),
                                content_type='application/json')


### PR DESCRIPTION
Drive-by bug fix. I stumbled across this while looking for something else.

`httpretty.is_enabled` returns a bound method which will always evaluate as truthy. Actually calling that method allows the assertion to work as expected and exposed a bug in the tests, too.

@clintonb FYI @edx/ecommerce 
