### PR TITLE
E0d/upgrade gevent

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,2 +1,2 @@
 # Optional packages
-newrelic==2.56.0.42
+newrelic==2.58.1.44

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -5,5 +5,5 @@ django-ses==0.7.0
 MySQL-python==1.2.5
 PyYAML==3.11
 gunicorn==19.2.1
-gevent==1.0.1
+gevent==1.0.2
 nodeenv==0.13.6


### PR DESCRIPTION
@clintonb @jibsheet 

There's a bug with gevent 1.0.1 and python 2.7.10  I've verified that upgrading fixes the immediate issue

Change log is here:

https://github.com/gevent/gevent/blob/1.0.2/changelog.rst#release-102-may-23-2015

Error is:

```
Traceback (most recent call last):
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/edx/app/ecommerce/ecommerce/ecommerce/core/views.py", line 54, in health
    response = requests.get(settings.LMS_HEARTBEAT_URL, timeout=1)
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/requests/api.py", line 69, in get
    return request('get', url, params=params, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/newrelic-2.56.0.42/newrelic/api/external_trace.py", line 103, in dynamic_wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/requests/api.py", line 50, in request
    response = session.request(method=method, url=url, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/requests/sessions.py", line 468, in request
    resp = self.send(prep, **send_kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/newrelic-2.56.0.42/newrelic/api/external_trace.py", line 103, in dynamic_wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/requests/sessions.py", line 576, in send
    r = adapter.send(request, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/requests/adapters.py", line 370, in send
    timeout=timeout
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py", line 559, in urlopen
    body=body, headers=headers)
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py", line 345, in _make_request
    self._validate_conn(conn)
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py", line 782, in _validate_conn
    conn.connect()
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/newrelic-2.56.0.42/newrelic/hooks/external_httplib.py", line 9, in httplib_connect_wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/requests/packages/urllib3/connection.py", line 250, in connect
    ssl_version=resolved_ssl_version)
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/requests/packages/urllib3/util/ssl_.py", line 285, in ssl_wrap_socket
    return context.wrap_socket(sock, server_hostname=server_hostname)
  File "/usr/lib/python2.7/ssl.py", line 352, in wrap_socket
    _context=self)
TypeError: __init__() got an unexpected keyword argument 'server_hostname'
```
