### PR TITLE
Add indexes to all TimeStampedModels to match their default ordering

### DIFF
--- a/ecommerce/extensions/refund/migrations/0002_auto_20151211_1417.py
+++ b/ecommerce/extensions/refund/migrations/0002_auto_20151211_1417.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('refund', '0001_squashed_0002_auto_20150515_2220'),
+    ]
+
+    operations = [
+        migrations.AlterIndexTogether(
+            name='refund',
+            index_together=set([('modified', 'created')]),
+        ),
+        migrations.AlterIndexTogether(
+            name='refundline',
+            index_together=set([('modified', 'created')]),
+        ),
+    ]

--- a/ecommerce/extensions/refund/models.py
+++ b/ecommerce/extensions/refund/models.py
@@ -58,6 +58,10 @@ class StatusMixin(object):
 
 class Refund(StatusMixin, TimeStampedModel):
     """Main refund model, used to represent the state of a refund."""
+
+    class Meta(TimeStampedModel.Meta):
+        index_together = ["modified", "created"]
+
     order = models.ForeignKey('order.Order', related_name='refunds', verbose_name=_('Order'))
     user = models.ForeignKey('core.User', related_name='refunds', verbose_name=_('User'))
     total_credit_excl_tax = models.DecimalField(_('Total Credit (excl. tax)'), decimal_places=2, max_digits=12)
@@ -211,6 +215,10 @@ class Refund(StatusMixin, TimeStampedModel):
 
 class RefundLine(StatusMixin, TimeStampedModel):
     """A refund line, used to represent the state of a single item as part of a larger Refund."""
+
+    class Meta(TimeStampedModel.Meta):
+        index_together = ["modified", "created"]
+
     refund = models.ForeignKey('refund.Refund', related_name='lines', verbose_name=_('Refund'))
     order_line = models.ForeignKey('order.Line', related_name='refund_lines', verbose_name=_('Order Line'))
     line_credit_excl_tax = models.DecimalField(_('Line Credit (excl. tax)'), decimal_places=2, max_digits=12)

--- a/ecommerce/invoice/models.py
+++ b/ecommerce/invoice/models.py
@@ -15,6 +15,9 @@ class Invoice(TimeStampedModel):
 
     history = HistoricalRecords()
 
+    class Meta(TimeStampedModel.Meta):
+        index_together = ["modified", "created"]
+
     def __str__(self):
         return 'Invoice {id} for order number {order}'.format(id=self.id, order=self.basket.order.number)
 


### PR DESCRIPTION
TimeStampedModels have a default ordering of ('-modified', '-created').
In the django admin, this causes a full table scan. Indexing these
columns together will speed up those views.

Reference:
  https://github.com/django-extensions/django-extensions/blob/master/django_extensions/db/models.py#L29
