### PR TITLE
Fix credit checkout page for courses with an audit mode.

### DIFF
--- a/ecommerce/credit/tests/test_views.py
+++ b/ecommerce/credit/tests/test_views.py
@@ -209,6 +209,24 @@ class CheckoutPageTest(CourseCatalogTestMixin, TestCase, JwtMixin):
         self._assert_success_checkout_page()
 
     @httpretty.activate
+    def test_get_checkout_page_with_audit_seats(self):
+        """ Verify the page loads with the proper context, if all Credit API
+        calls return successfully.
+        """
+        # Create the credit seat
+        self.course.create_or_update_seat(
+            'credit', True, self.price, self.partner, self.provider, credit_hours=self.credit_hours
+        )
+
+        # Create the audit seat
+        self.course.create_or_update_seat('', False, 0, self.partner)
+
+        self._mock_eligibility_api(body=self.eligibilities)
+        self._mock_providers_api(body=self.provider_data)
+
+        self._assert_success_checkout_page()
+
+    @httpretty.activate
     def test_get_without_credit_seat(self):
         """ Verify an error is shown if the Credit API returns an empty list
         of providers.

--- a/ecommerce/credit/views.py
+++ b/ecommerce/credit/views.py
@@ -43,9 +43,13 @@ class Checkout(TemplateView):
             }
 
         partner = get_partner_for_site(self.request)
-        credit_seats = [seat for seat in course.seat_products if
-                        seat.attr.certificate_type == self.CREDIT_MODE and seat.stockrecords.filter(
-                            partner=partner).exists()]
+        # Audit seats do not have a `certificate_type` attribute, so
+        # we use getattr to avoid an exception.
+        credit_seats = [
+            seat for seat in course.seat_products
+            if getattr(seat.attr, 'certificate_type', None) == self.CREDIT_MODE and
+            seat.stockrecords.filter(partner=partner).exists()
+        ]
 
         if not credit_seats:
             return {


### PR DESCRIPTION
# ECOM-3166

Fixes the credit checkout page for courses which have an audit seat.
