### PR TITLE
Converted order API views to viewset

### DIFF
--- a/ecommerce/extensions/api/permissions.py
+++ b/ecommerce/extensions/api/permissions.py
@@ -1,7 +1,7 @@
-from rest_framework.permissions import BasePermission
+from rest_framework import permissions
 
 
-class CanActForUser(BasePermission):
+class CanActForUser(permissions.BasePermission):
     """
     Allows access only if the user has permission to perform operations for the user represented by the username field
     in request.data.
@@ -15,3 +15,13 @@ class CanActForUser(BasePermission):
 
         user = request.user
         return user and (user.is_superuser or user.username == username)
+
+
+class IsStaffOrOwner(permissions.BasePermission):
+    """
+    Permission that allows access to admin users or the owner of an object.
+    The owner is considered the User object represented by obj.user.
+    """
+
+    def has_object_permission(self, request, view, obj):
+        return request.user and (request.user.is_staff or obj.user == request.user)

--- a/ecommerce/extensions/api/v2/urls.py
+++ b/ecommerce/extensions/api/v2/urls.py
@@ -21,20 +21,6 @@ BASKET_URLS = [
     ),
 ]
 
-ORDER_URLS = [
-    url(r'^$', order_views.OrderListView.as_view(), name='list'),
-    url(
-        r'^{number}/$'.format(number=ORDER_NUMBER_PATTERN),
-        order_views.OrderRetrieveView.as_view(),
-        name='retrieve'
-    ),
-    url(
-        r'^{number}/fulfill/$'.format(number=ORDER_NUMBER_PATTERN),
-        order_views.OrderFulfillView.as_view(),
-        name='fulfill'
-    ),
-]
-
 PAYMENT_URLS = [
     url(r'^processors/$', payment_views.PaymentProcessorListView.as_view(),
         name='list_processors'),
@@ -56,7 +42,6 @@ ATOMIC_PUBLICATION_URLS = [
 
 urlpatterns = [
     url(r'^baskets/', include(BASKET_URLS, namespace='baskets')),
-    url(r'^orders/', include(ORDER_URLS, namespace='orders')),
     url(r'^payment/', include(PAYMENT_URLS, namespace='payment')),
     url(r'^refunds/', include(REFUND_URLS, namespace='refunds')),
     url(r'^publication/', include(ATOMIC_PUBLICATION_URLS, namespace='publication')),
@@ -78,5 +63,7 @@ router.register(r'stockrecords', stockrecords_views.StockRecordViewSet, base_nam
 router.register(r'catalogs', catalog_views.CatalogViewSet) \
     .register(r'products', product_views.ProductViewSet, base_name='catalog-product',
               parents_query_lookups=['stockrecords__catalogs'])
+
+router.register(r'orders', order_views.OrderViewSet)
 
 urlpatterns += router.urls


### PR DESCRIPTION
- Using a viewset to clean code
- Allowing staff users to retrieve orders
- Deprecated OrderByBasketRetrieveView
