### PR TITLE
[WIP] Add category to coupon model

### DIFF
--- a/ecommerce/extensions/api/constants.py
+++ b/ecommerce/extensions/api/constants.py
@@ -24,9 +24,10 @@ class APIDictionaryKeys(object):
     QUANTITY = u'quantity'
     SHIPPING_CHARGE = u'shipping_charge'
     SHIPPING_METHOD = u'shipping_method'
+    SKU = u'sku'
     START_DATE = u'start_date'
     STOCK_RECORD_IDS = u'stock_record_ids'
-    SKU = u'sku'
+    SUB_CATEGORY = u'sub_category'
     TITLE = u'title'
     VOUCHER_TYPE = u'voucher_type'
 

--- a/ecommerce/extensions/api/constants.py
+++ b/ecommerce/extensions/api/constants.py
@@ -9,6 +9,7 @@ class APIDictionaryKeys(object):
     CHECKOUT = u'checkout'
     CLIENT_USERNAME = u'client_username'
     CODE = u'code'
+    CATEGORY = u'category'
     COUPON_ID = u'coupon_id'
     END_DATE = u'end_date'
     ORDER = u'order'

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -391,9 +391,9 @@ class CategorySerializer(serializers.ModelSerializer):
     child = serializers.SerializerMethodField()
 
     def get_child(self, obj):
-        desc = obj.get_children()
-        if desc:
-            serializer = CategorySerializer(desc, many=True)
+        child = obj.get_children()
+        if child:
+            serializer = CategorySerializer(child, many=True)
             return serializer.data
         return None
 

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -392,10 +392,8 @@ class CategorySerializer(serializers.ModelSerializer):
 
     def get_child(self, obj):
         child = obj.get_children()
-        if child:
-            serializer = CategorySerializer(child, many=True)
-            return serializer.data
-        return None
+        serializer = CategorySerializer(child, many=True)
+        return serializer.data
 
     class Meta(object):
         model = Category

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -408,6 +408,7 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
     client = serializers.SerializerMethodField()
     vouchers = serializers.SerializerMethodField()
     category = serializers.SerializerMethodField()
+    sub_category = serializers.SerializerMethodField()
 
     def get_coupon_type(self, obj):
         voucher = obj.attr.coupon_vouchers.vouchers.first()
@@ -437,9 +438,18 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
 
     def get_category(self, obj):
         category = ProductCategory.objects.get(product=obj).category
+        if category.depth == 3:
+            category = category.get_ancestors().last()
+        serializer = CategorySerializer(category)
+        return serializer.data
+
+    def get_sub_category(self, obj):
+        category = ProductCategory.objects.get(product=obj).category
+        if category.depth != 3:
+            return None
         serializer = CategorySerializer(category)
         return serializer.data
 
     class Meta(object):
         model = Product
-        fields = ('id', 'title', 'coupon_type', 'last_edited', 'seats', 'client', 'price', 'vouchers', 'category')
+        fields = ('id', 'title', 'coupon_type', 'last_edited', 'seats', 'client', 'price', 'vouchers', 'category', 'sub_category')

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -21,6 +21,7 @@ Basket = get_model('basket', 'Basket')
 Benefit = get_model('offer', 'Benefit')
 BillingAddress = get_model('order', 'BillingAddress')
 Catalog = get_model('catalogue', 'Catalog')
+Category = get_model('catalogue', 'Category')
 Line = get_model('order', 'Line')
 Order = get_model('order', 'Order')
 Product = get_model('catalogue', 'Product')
@@ -422,3 +423,9 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
     class Meta(object):
         model = Product
         fields = ('id', 'title', 'coupon_type', 'last_edited', 'seats', 'client', 'price', 'vouchers',)
+
+
+class CategorySerializer(serializers.ModelSerializer):
+
+    class Meta(object):
+        model = Category

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -388,9 +388,18 @@ class VoucherSerializer(serializers.ModelSerializer):
 
 
 class CategorySerializer(serializers.ModelSerializer):
+    child = serializers.SerializerMethodField()
+
+    def get_child(self, obj):
+        desc = obj.get_children()
+        if desc:
+            serializer = CategorySerializer(desc, many=True)
+            return serializer.data
+        return None
 
     class Meta(object):
         model = Category
+        fields = ('id', 'name', 'slug', 'description', 'path', 'depth', 'numchild', 'image', 'child')
 
 
 class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -452,4 +452,8 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
 
     class Meta(object):
         model = Product
-        fields = ('id', 'title', 'coupon_type', 'last_edited', 'seats', 'client', 'price', 'vouchers', 'category', 'sub_category')
+        fields = (
+            'id', 'title', 'coupon_type', 'last_edited',
+            'seats', 'client', 'price', 'vouchers',
+            'category', 'sub_category'
+        )

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -27,6 +27,7 @@ Order = get_model('order', 'Order')
 Product = get_model('catalogue', 'Product')
 Partner = get_model('partner', 'Partner')
 ProductAttributeValue = get_model('catalogue', 'ProductAttributeValue')
+ProductCategory = get_model('catalogue', 'ProductCategory')
 Refund = get_model('refund', 'Refund')
 Selector = get_class('partner.strategy', 'Selector')
 StockRecord = get_model('partner', 'StockRecord')
@@ -386,6 +387,12 @@ class VoucherSerializer(serializers.ModelSerializer):
         )
 
 
+class CategorySerializer(serializers.ModelSerializer):
+
+    class Meta(object):
+        model = Category
+
+
 class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
     """ Serializer for Coupons. """
     coupon_type = serializers.SerializerMethodField()
@@ -393,6 +400,7 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
     seats = serializers.SerializerMethodField()
     client = serializers.SerializerMethodField()
     vouchers = serializers.SerializerMethodField()
+    category = serializers.SerializerMethodField()
 
     def get_coupon_type(self, obj):
         voucher = obj.attr.coupon_vouchers.vouchers.first()
@@ -420,12 +428,11 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
         serializer = VoucherSerializer(vouchers, many=True, context={'request': self.context['request']})
         return serializer.data
 
+    def get_category(self, obj):
+        category = ProductCategory.objects.get(product=obj).category
+        serializer = CategorySerializer(category)
+        return serializer.data
+
     class Meta(object):
         model = Product
-        fields = ('id', 'title', 'coupon_type', 'last_edited', 'seats', 'client', 'price', 'vouchers',)
-
-
-class CategorySerializer(serializers.ModelSerializer):
-
-    class Meta(object):
-        model = Category
+        fields = ('id', 'title', 'coupon_type', 'last_edited', 'seats', 'client', 'price', 'vouchers', 'category')

--- a/ecommerce/extensions/api/v2/tests/views/test_categories.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_categories.py
@@ -1,0 +1,52 @@
+from __future__ import unicode_literals
+
+import json
+
+from django.core.urlresolvers import reverse
+from oscar.apps.catalogue.categories import create_from_breadcrumbs
+from oscar.core.loading import get_model
+
+from ecommerce.tests.testcases import TestCase
+
+Category = get_model('catalogue', 'Category')
+
+
+class CategoryViewSetTests(TestCase):
+    """Test the category API endpoint listing."""
+    path = reverse('api:v2:categories-list')
+
+    def setUp(self):
+        super(CategoryViewSetTests, self).setUp()
+        self.user = self.create_user(is_staff=True)
+        self.client.login(username=self.user.username, password=self.password)
+        Category.objects.all().delete()
+
+    def create_and_get_category(self, breadcrumb):
+        """Create a category from breadcrumbs and return the API response for it."""
+        create_from_breadcrumbs(breadcrumb)
+        response = self.client.get(self.path)
+        return json.loads(response.content)['results'][0]
+
+    def test_category_list(self):
+        """Test the reponse data for category."""
+        response_content = self.create_and_get_category('Test')
+        self.assertEqual(response_content['name'], 'Test')
+        self.assertEqual(response_content['path'], '0001')
+        self.assertEqual(response_content['depth'], 1)
+
+    def test_sub_category_list(self):
+        """Test the reponse data for sub-category."""
+        response_content = self.create_and_get_category('Test > Sub-test')
+        self.assertEqual(response_content['name'], 'Test')
+        self.assertEqual(response_content['depth'], 1)
+        self.assertEqual(response_content['child'][0]['name'], 'Sub-test')
+        self.assertEqual(response_content['child'][0]['depth'], 2)
+        self.assertEqual(response_content['child'][0]['path'], '00010001')
+
+    def test_sub_sub_category_list(self):
+        """Test the reponse data for sub-sub-category."""
+        response_content = self.create_and_get_category('Test > Sub-test > Sub-sub-test')
+        category = response_content['child'][0]['child'][0]
+        self.assertEqual(category['name'], 'Sub-sub-test')
+        self.assertEqual(category['depth'], 3)
+        self.assertEqual(category['path'], '000100010001')

--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -21,6 +21,7 @@ Catalog = get_model('catalogue', 'Catalog')
 Course = get_model('courses', 'Course')
 Order = get_model('order', 'Order')
 Product = get_model('catalogue', 'Product')
+ProductCategory = get_model('catalogue', 'ProductCategory')
 ProductClass = get_model('catalogue', 'ProductClass')
 StockRecord = get_model('partner', 'StockRecord')
 Voucher = get_model('voucher', 'Voucher')
@@ -59,7 +60,8 @@ class CouponViewSetTest(TestCase):
             'benefit_value': 100,
             'voucher_type': Voucher.SINGLE_USE,
             'quantity': 1,
-            'price': 100
+            'price': 100,
+            'category': 'Test category'
         }
         request = RequestFactory()
         request.data = data
@@ -86,6 +88,8 @@ class CouponViewSetTest(TestCase):
         self.assertEqual(stock_record.price_excl_tax, 100)
 
         self.assertEqual(coupon.attr.coupon_vouchers.vouchers.count(), 5)
+        category = ProductCategory.objects.get(product=coupon).category
+        self.assertEqual(category.name, 'Test category')
 
     def test_append_to_existing_coupon(self):
         """Test adding additional vouchers to an existing coupon."""
@@ -99,7 +103,8 @@ class CouponViewSetTest(TestCase):
             'code': '',
             'quantity': 2,
             'start_date': datetime.date(2015, 1, 1),
-            'voucher_type': Voucher.MULTI_USE
+            'voucher_type': Voucher.MULTI_USE,
+            'category': 'Test category'
         }
         coupon_append = CouponViewSet().create_coupon_product(
             title='Test coupon',
@@ -123,7 +128,8 @@ class CouponViewSetTest(TestCase):
             'code': 'CUSTOMCODE',
             'quantity': 1,
             'start_date': datetime.date(2015, 1, 1),
-            'voucher_type': Voucher.ONCE_PER_CUSTOMER
+            'voucher_type': Voucher.ONCE_PER_CUSTOMER,
+            'category': 'Test category'
         }
         custom_coupon = CouponViewSet().create_coupon_product(
             title='Custom coupon',
@@ -144,7 +150,8 @@ class CouponViewSetTest(TestCase):
             'code': 'CUSTOMCODE',
             'quantity': 1,
             'start_date': datetime.date(2015, 1, 1),
-            'voucher_type': Voucher.SINGLE_USE
+            'voucher_type': Voucher.SINGLE_USE,
+            'category': 'Test category'
         }
         CouponViewSet().create_coupon_product(
             title='Custom coupon',
@@ -223,7 +230,8 @@ class CouponViewSetFunctionalTest(TestCase):
             'benefit_value': 100,
             'voucher_type': Voucher.SINGLE_USE,
             'quantity': 2,
-            'price': 100
+            'price': 100,
+            'category': 'Test category'
         }
         self.response = self.client.post(COUPONS_LINK, data=self.data, format='json')
 

--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -6,6 +6,7 @@ import json
 from django.core.urlresolvers import reverse
 from django.db.utils import IntegrityError
 from django.test import RequestFactory
+from oscar.apps.catalogue.categories import create_from_breadcrumbs
 from oscar.core.loading import get_model
 
 from ecommerce.core.models import Client
@@ -18,6 +19,7 @@ from ecommerce.tests.testcases import TestCase
 Basket = get_model('basket', 'Basket')
 Benefit = get_model('offer', 'Benefit')
 Catalog = get_model('catalogue', 'Catalog')
+Category = get_model('catalogue', 'Category')
 Course = get_model('courses', 'Course')
 Order = get_model('order', 'Order')
 Product = get_model('catalogue', 'Product')
@@ -218,7 +220,8 @@ class CouponViewSetFunctionalTest(TestCase):
         course_id = 'edx/Demo_Course2/DemoX'
         course = Course.objects.create(id=course_id)
         course.create_or_update_seat('verified', True, 100, self.partner)
-
+        breadcrumb = 'Coupons > Test category'
+        create_from_breadcrumbs(breadcrumb)
         self.data = {
             'title': 'Test coupon',
             'client_username': 'TestX',
@@ -231,7 +234,8 @@ class CouponViewSetFunctionalTest(TestCase):
             'voucher_type': Voucher.SINGLE_USE,
             'quantity': 2,
             'price': 100,
-            'category': 'Test category'
+            'category': 'Test category',
+            'sub_category': ''
         }
         self.response = self.client.post(COUPONS_LINK, data=self.data, format='json')
 

--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -62,7 +62,7 @@ class CouponViewSetTest(CouponMixin, TestCase):
             'voucher_type': Voucher.SINGLE_USE,
             'quantity': 1,
             'price': 100,
-            'category': 'Test category',
+            'category': self.category.id,
             'sub_category': ''
         }
         request = RequestFactory()
@@ -105,7 +105,7 @@ class CouponViewSetTest(CouponMixin, TestCase):
             'quantity': 2,
             'start_date': datetime.date(2015, 1, 1),
             'voucher_type': Voucher.MULTI_USE,
-            'category': 'New category',
+            'category': 9999,
             'sub_category': ''
         }
         with self.assertRaises(Exception):
@@ -127,7 +127,7 @@ class CouponViewSetTest(CouponMixin, TestCase):
             'quantity': 2,
             'start_date': datetime.date(2015, 1, 1),
             'voucher_type': Voucher.MULTI_USE,
-            'category': 'Test category',
+            'category': self.category.id,
             'sub_category': 'Test sub-category'
         }
         coupon = CouponViewSet().create_coupon_product(
@@ -152,7 +152,7 @@ class CouponViewSetTest(CouponMixin, TestCase):
             'quantity': 2,
             'start_date': datetime.date(2015, 1, 1),
             'voucher_type': Voucher.MULTI_USE,
-            'category': 'Test category',
+            'category': self.category.id,
             'sub_category': ''
         }
         coupon_append = CouponViewSet().create_coupon_product(
@@ -178,7 +178,7 @@ class CouponViewSetTest(CouponMixin, TestCase):
             'quantity': 1,
             'start_date': datetime.date(2015, 1, 1),
             'voucher_type': Voucher.ONCE_PER_CUSTOMER,
-            'category': 'Test category',
+            'category': self.category.id,
             'sub_category': ''
         }
         custom_coupon = CouponViewSet().create_coupon_product(
@@ -201,7 +201,7 @@ class CouponViewSetTest(CouponMixin, TestCase):
             'quantity': 1,
             'start_date': datetime.date(2015, 1, 1),
             'voucher_type': Voucher.SINGLE_USE,
-            'category': 'Test category',
+            'category': self.category.id,
             'sub_category': ''
         }
         CouponViewSet().create_coupon_product(
@@ -281,7 +281,7 @@ class CouponViewSetFunctionalTest(CouponMixin, TestCase):
             'voucher_type': Voucher.SINGLE_USE,
             'quantity': 2,
             'price': 100,
-            'category': 'Test category',
+            'category': self.category.id,
             'sub_category': 'Test sub-category'
         }
         self.response = self.client.post(COUPONS_LINK, data=self.data, format='json')
@@ -326,7 +326,8 @@ class CouponViewSetFunctionalTest(CouponMixin, TestCase):
         response_data = json.loads(response.content)
         coupon_data = response_data['results'][0]
         self.assertEqual(coupon_data['title'], 'Test coupon')
-        self.assertEqual(coupon_data['category']['name'], 'Test sub-category')
+        self.assertEqual(coupon_data['category']['name'], 'Test category')
+        self.assertEqual(coupon_data['sub_category']['name'], 'Test sub-category')
         self.assertEqual(coupon_data['coupon_type'], 'Enrollment code')
         self.assertIsNotNone(coupon_data['last_edited'][0])
         self.assertEqual(coupon_data['seats'][0]['attribute_values'][0]['value'], 'verified')

--- a/ecommerce/extensions/api/v2/tests/views/test_products.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_products.py
@@ -9,7 +9,7 @@ import pytz
 from ecommerce.courses.models import Course
 from ecommerce.extensions.api.v2.tests.views import JSON_CONTENT_TYPE, ProductSerializerMixin
 from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
-from ecommerce.extensions.test.factories import create_coupon
+from ecommerce.tests.mixins import CouponMixin
 from ecommerce.tests.testcases import TestCase
 
 Benefit = get_model('offer', 'Benefit')
@@ -125,15 +125,23 @@ class ProductViewSetTests(ProductSerializerMixin, CourseCatalogTestMixin, TestCa
         }
         self.assertDictEqual(json.loads(response.content), expected)
 
+
+class ProductViewSetCouponTests(CouponMixin, TestCase):
+
+    def setUp(self):
+        super(ProductViewSetCouponTests, self).setUp()
+        self.user = self.create_user(is_staff=True)
+        self.client.login(username=self.user.username, password=self.password)
+
     def test_coupon_product_details(self):
         """Verify the endpoint returns all coupon information."""
-        coupon = create_coupon()
+        coupon = self.create_coupon()
         url = reverse('api:v2:product-detail', kwargs={'pk': coupon.id})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
         response_data = json.loads(response.content)
-        self.assertEqual(response_data['id'], 3)
+        self.assertEqual(response_data['id'], 1)
         self.assertEqual(response_data['title'], 'Test coupon')
         self.assertEqual(response_data['price'], '100.00')
         self.assertEqual(response_data['attribute_values'][0]['name'], 'Coupon vouchers')
@@ -141,7 +149,7 @@ class ProductViewSetTests(ProductSerializerMixin, CourseCatalogTestMixin, TestCa
 
     def test_coupon_voucher_serializer(self):
         """Verify that the vouchers of a coupon are properly serialized."""
-        coupon = create_coupon()
+        coupon = self.create_coupon()
         url = reverse('api:v2:product-detail', kwargs={'pk': coupon.id})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -155,12 +163,12 @@ class ProductViewSetTests(ProductSerializerMixin, CourseCatalogTestMixin, TestCa
 
     def test_product_filtering(self):
         """Verify products are filtered."""
-        create_coupon()
+        self.create_coupon()
         url = reverse('api:v2:product-list')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         response_data = json.loads(response.content)
-        self.assertEqual(response_data['count'], 3)
+        self.assertEqual(response_data['count'], 1)
 
         filtered_url = '{}?product_class=CoUpOn'.format(url)
         response = self.client.get(filtered_url)

--- a/ecommerce/extensions/api/v2/urls.py
+++ b/ecommerce/extensions/api/v2/urls.py
@@ -6,9 +6,8 @@ from ecommerce.extensions.api.v2.views import (baskets as basket_views, payments
                                                orders as order_views, refunds as refund_views,
                                                products as product_views, courses as course_views,
                                                publication as publication_views, partners as partner_views,
-                                               catalog as catalog_views,
-                                               stockrecords as stockrecords_views,
-                                               coupons as coupon_views)
+                                               catalog as catalog_views, stockrecords as stockrecords_views,
+                                               coupons as coupon_views, categories as category_views)
 from ecommerce.extensions.voucher.views import CouponReportCSVView
 
 ORDER_NUMBER_PATTERN = r'(?P<number>[-\w]+)'
@@ -73,5 +72,5 @@ router.register(r'catalogs', catalog_views.CatalogViewSet) \
 
 router.register(r'coupons', coupon_views.CouponViewSet, base_name='coupons')
 router.register(r'orders', order_views.OrderViewSet)
-
+router.register(r'categories', category_views.CategoryViewSet)
 urlpatterns += router.urls

--- a/ecommerce/extensions/api/v2/urls.py
+++ b/ecommerce/extensions/api/v2/urls.py
@@ -72,5 +72,5 @@ router.register(r'catalogs', catalog_views.CatalogViewSet) \
 
 router.register(r'coupons', coupon_views.CouponViewSet, base_name='coupons')
 router.register(r'orders', order_views.OrderViewSet)
-router.register(r'categories', category_views.CategoryViewSet)
+router.register(r'categories', category_views.CategoryViewSet, base_name='categories')
 urlpatterns += router.urls

--- a/ecommerce/extensions/api/v2/views/categories.py
+++ b/ecommerce/extensions/api/v2/views/categories.py
@@ -1,6 +1,7 @@
 """HTTP endpoints for interacting with categories."""
+import django_filters
 from oscar.core.loading import get_model
-from rest_framework import viewsets
+from rest_framework import filters, viewsets
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
 
 from ecommerce.extensions.api import serializers
@@ -9,7 +10,19 @@ from ecommerce.extensions.api import serializers
 Category = get_model('catalogue', 'Category')
 
 
+class CategoryFilter(django_filters.FilterSet):
+    """Filter for categories via query string parameters."""
+    depth = django_filters.NumberFilter(name='depth', lookup_type='exact')
+    path = django_filters.CharFilter(name='path', lookup_type='startswith')
+
+    class Meta(object):
+        model = Category
+        fields = ('depth', 'path')
+
+
 class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Category.objects.all()
     serializer_class = serializers.CategorySerializer
+    filter_backends = (filters.DjangoFilterBackend,)
+    filter_class = CategoryFilter
     permission_classes = (IsAuthenticated, IsAdminUser,)

--- a/ecommerce/extensions/api/v2/views/categories.py
+++ b/ecommerce/extensions/api/v2/views/categories.py
@@ -21,7 +21,7 @@ class CategoryFilter(django_filters.FilterSet):
 
 
 class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
-    queryset = Category.objects.all()
+    queryset = Category.objects.filter(depth=1)
     serializer_class = serializers.CategorySerializer
     filter_backends = (filters.DjangoFilterBackend,)
     filter_class = CategoryFilter

--- a/ecommerce/extensions/api/v2/views/categories.py
+++ b/ecommerce/extensions/api/v2/views/categories.py
@@ -1,0 +1,15 @@
+"""HTTP endpoints for interacting with categories."""
+from oscar.core.loading import get_model
+from rest_framework import viewsets
+from rest_framework.permissions import IsAuthenticated, IsAdminUser
+
+from ecommerce.extensions.api import serializers
+
+
+Category = get_model('catalogue', 'Category')
+
+
+class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Category.objects.all()
+    serializer_class = serializers.CategorySerializer
+    permission_classes = (IsAuthenticated, IsAdminUser,)

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -176,7 +176,8 @@ class CouponViewSet(EdxOrderPlacementMixin, NonDestroyableModelViewSet):
 
         coupon_vouchers = CouponVouchers.objects.get(coupon=coupon_product)
 
-        category_name = data['category']
+        category = data['category']
+        category_name = Category.objects.get(id=category).name
         coupon_product.attr.coupon_vouchers = coupon_vouchers
 
         coupons_category = Category.objects.get(name='Coupons')
@@ -186,7 +187,6 @@ class CouponViewSet(EdxOrderPlacementMixin, NonDestroyableModelViewSet):
         ).filter(
             depth__lt=3
         ).values_list('name', flat=True)
-
         if category_name not in existing_categories:
             raise Exception('Invalid category')
 

--- a/ecommerce/extensions/catalogue/migrations/0013_coupon_product_class.py
+++ b/ecommerce/extensions/catalogue/migrations/0013_coupon_product_class.py
@@ -26,7 +26,7 @@ def create_product_class(apps, schema_editor):
         type='entity',
         required=False
     )
-    # Create a category for course seats
+    # Create a category for coupons
     Category.objects.create(
         description='All Coupons',
         slug='coupons',

--- a/ecommerce/extensions/catalogue/migrations/0015_default_categories.py
+++ b/ecommerce/extensions/catalogue/migrations/0015_default_categories.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from oscar.apps.catalogue.categories import create_from_breadcrumbs
+from oscar.core.loading import get_model
+
+Category = get_model("catalogue", "Category")
+
+
+def create_default_categories(apps, schema_editor):
+    """Create default coupon categories."""
+    categories = (
+        'Coupons > NewCoursePromo',
+        'Coupons > BulkEnrollment',
+        'Coupons > CustomerService',
+        'Coupons > Marketing-Other',
+        'Coupons > PaidCohort',
+        'Coupons > ConnectEd',
+        'Coupons > Services-Other',
+        'Coupons > FinancialAssistance',
+        'Coupons > Support-Other',
+    )
+    for breadcrumbs in categories:
+        create_from_breadcrumbs(breadcrumbs)
+
+
+def remove_default_categories(apps, schema_editor):
+    """Remove default coupon categories."""
+    default_categories = [
+        'NewCoursePromo', 'BulkEnrollment', 'CustomerService', 'Marketing-Other',
+        'PaidCohort', 'ConnectEd', 'Services-Other', 'FinancialAssistance', 'Support-Other'
+    ]
+    for category in default_categories:
+        Category.objects.get(name=category).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('catalogue', '0001_initial'),
+        ('catalogue', '0014_alter_couponvouchers_attribute')
+    ]
+    operations = [
+        migrations.RunPython(create_default_categories, remove_default_categories)
+    ]

--- a/ecommerce/extensions/catalogue/tests/test_coupons.py
+++ b/ecommerce/extensions/catalogue/tests/test_coupons.py
@@ -21,11 +21,11 @@ class CouponProductTest(TestCase):
         voucher = VoucherFactory(code='MYVOUCHER')
         voucherList = CouponVouchers.objects.create(coupon=coupon_product)
         voucherList.vouchers.add(voucher)
-        coupon_product.attr.coupon_voucher = voucherList
+        coupon_product.attr.coupon_vouchers = voucherList
 
         # clean() is an Oscar validation method for products
         self.assertIsNone(coupon_product.clean())
         self.assertIsInstance(coupon_product, Product)
         self.assertEqual(coupon_product.title, 'Test product')
-        self.assertEqual(coupon_product.attr.coupon_voucher.vouchers.count(), 1)
-        self.assertEqual(coupon_product.attr.coupon_voucher.vouchers.first().code, 'MYVOUCHER')
+        self.assertEqual(coupon_product.attr.coupon_vouchers.vouchers.count(), 1)
+        self.assertEqual(coupon_product.attr.coupon_vouchers.vouchers.first().code, 'MYVOUCHER')

--- a/ecommerce/extensions/catalogue/tests/test_utils.py
+++ b/ecommerce/extensions/catalogue/tests/test_utils.py
@@ -6,7 +6,7 @@ from oscar.core.loading import get_model
 
 from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
 from ecommerce.extensions.catalogue.utils import generate_sku, get_or_create_catalog, generate_coupon_slug
-from ecommerce.extensions.test.factories import create_coupon
+from ecommerce.tests.mixins import CouponMixin
 from ecommerce.tests.testcases import TestCase
 
 Benefit = get_model('offer', 'Benefit')
@@ -83,7 +83,7 @@ class UtilsTests(CourseCatalogTestMixin, TestCase):
         self.assertEqual(actual, expected)
 
 
-class CouponUtilsTests(TestCase):
+class CouponUtilsTests(CouponMixin, TestCase):
 
     def setUp(self):
         super(CouponUtilsTests, self).setUp()
@@ -92,7 +92,7 @@ class CouponUtilsTests(TestCase):
 
     def test_generate_sku_for_coupon(self):
         """Verify the method generates a SKU for a coupon."""
-        coupon = create_coupon(partner=self.partner, catalog=self.catalog)
+        coupon = self.create_coupon(partner=self.partner, catalog=self.catalog)
         _hash = ' '.join((
             unicode(coupon.id),
             unicode(self.catalog.id),

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -19,8 +19,8 @@ from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
 from ecommerce.extensions.fulfillment.modules import CouponFulfillmentModule, EnrollmentFulfillmentModule
 from ecommerce.extensions.fulfillment.status import LINE
 from ecommerce.extensions.fulfillment.tests.mixins import FulfillmentTestMixin
-from ecommerce.extensions.test.factories import create_coupon
 from ecommerce.extensions.voucher.utils import create_vouchers
+from ecommerce.tests.mixins import CouponMixin
 from ecommerce.tests.testcases import TestCase
 
 JSON = 'application/json'
@@ -394,12 +394,12 @@ class EnrollmentFulfillmentModuleTests(CourseCatalogTestMixin, FulfillmentTestMi
         self.assertEqual(seat_basket.total_excl_tax, 0.00)
 
 
-class CouponFulfillmentModuleTest(FulfillmentTestMixin, TestCase):
+class CouponFulfillmentModuleTest(CouponMixin, FulfillmentTestMixin, TestCase):
     """ Test coupon fulfillment. """
 
     def setUp(self):
         super(CouponFulfillmentModuleTest, self).setUp()
-        coupon = create_coupon()
+        coupon = self.create_coupon()
         user = UserFactory()
         basket = BasketFactory()
         basket.add_product(coupon, 1)

--- a/ecommerce/extensions/test/factories.py
+++ b/ecommerce/extensions/test/factories.py
@@ -1,12 +1,5 @@
 from oscar.test.factories import *  # pylint:disable=wildcard-import,unused-wildcard-import
 
-from ecommerce.extensions.api.v2.views.coupons import CouponViewSet
-from ecommerce.tests.factories import PartnerFactory
-
-Benefit = get_model('offer', 'Benefit')
-Catalog = get_model('catalogue', 'Catalog')
-Voucher = get_model('voucher', 'Voucher')
-
 OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
 
 
@@ -45,42 +38,3 @@ def create_order(number=None, basket=None, user=None, shipping_address=None,  # 
         **kwargs)
     basket.set_as_submitted()
     return order
-
-
-def create_coupon(
-        title='Test coupon',
-        price=100,
-        partner=None,
-        catalog=None,
-        code='',
-        benefit_value=100,
-        sub_category=''
-    ):
-    """Helper method for creating a coupon."""
-    if partner is None:
-        partner = PartnerFactory(name='Tester')
-    if catalog is None:
-        catalog = Catalog.objects.create(partner=partner)
-    quantity = 5
-    if code is not '':
-        quantity = 1
-    data = {
-        'partner': partner,
-        'benefit_type': Benefit.PERCENTAGE,
-        'benefit_value': benefit_value,
-        'catalog': catalog,
-        'end_date': datetime.date(2020, 1, 1),
-        'code': code,
-        'quantity': quantity,
-        'start_date': datetime.date(2015, 1, 1),
-        'voucher_type': Voucher.SINGLE_USE,
-        'category': 'Test category',
-        'sub_category': sub_category
-    }
-
-    coupon = CouponViewSet().create_coupon_product(
-        title=title,
-        price=price,
-        data=data
-    )
-    return coupon

--- a/ecommerce/extensions/test/factories.py
+++ b/ecommerce/extensions/test/factories.py
@@ -64,7 +64,8 @@ def create_coupon(title='Test coupon', price=100, partner=None, catalog=None, co
         'code': code,
         'quantity': quantity,
         'start_date': datetime.date(2015, 1, 1),
-        'voucher_type': Voucher.SINGLE_USE
+        'voucher_type': Voucher.SINGLE_USE,
+        'category': 'Test category'
     }
 
     coupon = CouponViewSet().create_coupon_product(

--- a/ecommerce/extensions/test/factories.py
+++ b/ecommerce/extensions/test/factories.py
@@ -1,4 +1,5 @@
 from oscar.test.factories import *  # pylint:disable=wildcard-import,unused-wildcard-import
+
 from ecommerce.extensions.api.v2.views.coupons import CouponViewSet
 from ecommerce.tests.factories import PartnerFactory
 
@@ -46,7 +47,15 @@ def create_order(number=None, basket=None, user=None, shipping_address=None,  # 
     return order
 
 
-def create_coupon(title='Test coupon', price=100, partner=None, catalog=None, code='', benefit_value=100):
+def create_coupon(
+        title='Test coupon',
+        price=100,
+        partner=None,
+        catalog=None,
+        code='',
+        benefit_value=100,
+        sub_category=''
+    ):
     """Helper method for creating a coupon."""
     if partner is None:
         partner = PartnerFactory(name='Tester')
@@ -65,7 +74,8 @@ def create_coupon(title='Test coupon', price=100, partner=None, catalog=None, co
         'quantity': quantity,
         'start_date': datetime.date(2015, 1, 1),
         'voucher_type': Voucher.SINGLE_USE,
-        'category': 'Test category'
+        'category': 'Test category',
+        'sub_category': sub_category
     }
 
     coupon = CouponViewSet().create_coupon_product(

--- a/ecommerce/extensions/voucher/tests/test_views.py
+++ b/ecommerce/extensions/voucher/tests/test_views.py
@@ -1,25 +1,25 @@
 from django.test import RequestFactory
 from oscar.core.loading import get_model
 
-from ecommerce.extensions.test.factories import create_coupon
 from ecommerce.extensions.voucher.views import CouponReportCSVView
 from ecommerce.tests.factories import PartnerFactory
+from ecommerce.tests.mixins import CouponMixin
 from ecommerce.tests.testcases import TestCase
 
 Catalog = get_model('catalogue', 'Catalog')
 
 
-class CouponReportCSVViewTest(TestCase):
+class CouponReportCSVViewTest(CouponMixin, TestCase):
     """Unit tests for getting coupon report."""
 
     def setUp(self):
         super(CouponReportCSVViewTest, self).setUp()
         partner1 = PartnerFactory(name='Tester1')
         catalog1 = Catalog.objects.create(name="Test catalog 1", partner=partner1)
-        self.coupon1 = create_coupon(partner=partner1, catalog=catalog1)
+        self.coupon1 = self.create_coupon(partner=partner1, catalog=catalog1)
         partner2 = PartnerFactory(name='Tester2')
         catalog2 = Catalog.objects.create(name="Test catalog 2", partner=partner2)
-        self.coupon2 = create_coupon(partner=partner2, catalog=catalog2)
+        self.coupon2 = self.create_coupon(partner=partner2, catalog=catalog2)
 
     def request_specific_voucher_report(self, coupon_id):
         request = RequestFactory()

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Broadly-useful mixins for use in automated tests."""
+import datetime
 from decimal import Decimal
 import json
 
@@ -10,21 +11,27 @@ from django.core.cache import cache
 from django.core.urlresolvers import reverse
 import jwt
 from mock import patch
+from oscar.apps.catalogue.categories import create_from_breadcrumbs
 from oscar.core.loading import get_model, get_class
 from oscar.test import factories
 from social.apps.django_app.default.models import UserSocialAuth
 
 from ecommerce.courses.utils import mode_for_seat
 from ecommerce.extensions.api.constants import APIConstants as AC
+from ecommerce.extensions.api.v2.views.coupons import CouponViewSet
 from ecommerce.extensions.fulfillment.signals import SHIPPING_EVENT_NAME
-from ecommerce.tests.factories import SiteConfigurationFactory
+from ecommerce.tests.factories import PartnerFactory, SiteConfigurationFactory
+
 
 Basket = get_model('basket', 'Basket')
+Benefit = get_model('offer', 'Benefit')
+Catalog = get_model('catalogue', 'Catalog')
 Selector = get_class('partner.strategy', 'Selector')
 ShippingEventType = get_model('order', 'ShippingEventType')
 Order = get_model('order', 'Order')
 Partner = get_model('partner', 'Partner')
 User = get_user_model()
+Voucher = get_model('voucher', 'Voucher')
 
 
 class UserMixin(object):
@@ -258,3 +265,50 @@ class TestServerUrlMixin(object):
         """ Returns a complete URL with the given path. """
         site = site or self.site
         return 'http://{domain}{path}'.format(domain=site.domain, path=path)
+
+
+class CouponMixin(object):
+
+    def setUp(self):
+        super(CouponMixin, self).setUp()
+        breadcrumb = 'Coupons > Test category'
+        create_from_breadcrumbs(breadcrumb)
+
+    def create_coupon(
+            self,
+            title='Test coupon',
+            price=100,
+            partner=None,
+            catalog=None,
+            code='',
+            benefit_value=100,
+            sub_category=''):
+        """Helper method for creating a coupon."""
+
+        if partner is None:
+            partner = PartnerFactory(name='Tester')
+        if catalog is None:
+            catalog = Catalog.objects.create(partner=partner)
+        quantity = 5
+        if code is not '':
+            quantity = 1
+        data = {
+            'partner': partner,
+            'benefit_type': Benefit.PERCENTAGE,
+            'benefit_value': benefit_value,
+            'catalog': catalog,
+            'end_date': datetime.date(2020, 1, 1),
+            'code': code,
+            'quantity': quantity,
+            'start_date': datetime.date(2015, 1, 1),
+            'voucher_type': Voucher.SINGLE_USE,
+            'category': 'Test category',
+            'sub_category': sub_category
+        }
+
+        coupon = CouponViewSet().create_coupon_product(
+            title=title,
+            price=price,
+            data=data
+        )
+        return coupon

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -268,7 +268,7 @@ class TestServerUrlMixin(object):
 
 
 class CouponMixin(object):
-    """Mixing for preparing data for coupons and creating coupons."""
+    """Mixin for preparing data for coupons and creating coupons."""
     def setUp(self):
         super(CouponMixin, self).setUp()
         breadcrumb = 'Coupons > Test category'

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -268,7 +268,7 @@ class TestServerUrlMixin(object):
 
 
 class CouponMixin(object):
-
+    """Mixing for preparing data for coupons and creating coupons."""
     def setUp(self):
         super(CouponMixin, self).setUp()
         breadcrumb = 'Coupons > Test category'

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -271,8 +271,7 @@ class CouponMixin(object):
     """Mixin for preparing data for coupons and creating coupons."""
     def setUp(self):
         super(CouponMixin, self).setUp()
-        breadcrumb = 'Coupons > Test category'
-        create_from_breadcrumbs(breadcrumb)
+        self.category = create_from_breadcrumbs('Coupons > Test category')
 
     def create_coupon(
             self,
@@ -302,7 +301,7 @@ class CouponMixin(object):
             'quantity': quantity,
             'start_date': datetime.date(2015, 1, 1),
             'voucher_type': Voucher.SINGLE_USE,
-            'category': 'Test category',
+            'category': self.category.id,
             'sub_category': sub_category
         }
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/SOL-1539

Coupons should have their categories, "support", "student aid" etc.

In this PR:
- new `CouponMixin` test mixin. Contains `create_coupon()` method to create coupons, and creates a default `Test category` category. All instances of `create_coupon()` replaced by the mixin
- new `CategoryViewSet`. A read-only view set that lists out all the categories and supports filtering with `depth` to distinguish categories from sub-categories and `path` to make retrieving sub-categories of a specific category easier
- new `CategorySerializer`. Currently the depth=1 categories are displayed on the first level and all the sub-categories are nested inside.

```
- category1
    child: [
        sub-category1
            child: []
        sub-category2
            child: []
    ]
- category2
    child: []
```
- new migration that inserts all the default categories for coupons
- update to `CouponsViewSet` to handle categories and sub-categories
- new tests and updates to existing ones to test the new functionalities
