### PR TITLE
Disable course configuration in CAT after enrollment start.

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -293,7 +293,12 @@ class AtomicPublicationSerializer(serializers.Serializer):  # pylint: disable=ab
                         credit_hours=credit_hours,
                     )
 
-                resp_message = course.publish_to_lms(access_token=self.access_token)
+                # Publish the course. If the course is new (i.e.,
+                # `created == True`), ensure that the course has not
+                # started enrollment yet in order to avoid allowing
+                # inconsistencies in course modes between Otto and the
+                # LMS.
+                resp_message = course.publish_to_lms(access_token=self.access_token, check_enrollment_start=created)
                 published = (resp_message is None)
 
                 if published:


### PR DESCRIPTION
# [ECOM-3254](https://openedx.atlassian.net/browse/ECOM-3254)

In order to avoid inconsistencies between LMS and CAT, this queries the enrollment API before publishing course modes and saving the course to Otto.

Note that this will require the changes in https://github.com/edx/edx-platform/pull/11053 to be deployed, since our Slumber-based API client adds a trailing slash to URLs.

@rlucioni @bderusha, can you review?
