### PR TITLE
Code redemption endpoint

### DIFF
--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -1,15 +1,39 @@
+import datetime
+from decimal import Decimal
 import json
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
+from django.http import HttpResponseRedirect
+from django.utils.timezone import now
+from django.utils.translation import ugettext_lazy as _
 import httpretty
-from testfixtures import LogCapture
+from oscar.core.loading import get_class, get_model
+from oscar.test.factories import (OrderFactory, ConditionalOfferFactory, VoucherFactory,
+                                  RangeFactory, BenefitFactory, ProductFactory)
+from oscar.test.utils import RequestFactory
+import pytz
 
+from ecommerce.coupons.views import get_voucher, voucher_is_valid
+from ecommerce.courses.tests.factories import CourseFactory
+from ecommerce.extensions.test.factories import create_coupon
+from ecommerce.settings import get_lms_url
 from ecommerce.tests.testcases import TestCase
+
+Applicator = get_class('offer.utils', 'Applicator')
+Basket = get_model('basket', 'Basket')
+Catalog = get_model('catalogue', 'Catalog')
+Course = get_model('courses', 'Course')
+StockRecord = get_model('partner', 'StockRecord')
+Voucher = get_model('voucher', 'Voucher')
+VoucherApplication = get_model('voucher', 'VoucherApplication')
 
 
 class CouponAppViewTests(TestCase):
     path = reverse('coupons:app', args=[''])
+
+    def setUp(self):
+        super(CouponAppViewTests, self).setUp()
 
     def test_login_required(self):
         """ Users are required to login before accessing the view. """
@@ -29,3 +53,224 @@ class CouponAppViewTests(TestCase):
         self.client.login(username=user.username, password=self.password)
         response = self.client.get(self.path)
         self.assertEqual(response.status_code, 200)
+
+
+class CouponOfferViewTests(TestCase):
+    offer_url = reverse('coupons:offer')
+
+    def setUp(self):
+        super(CouponOfferViewTests, self).setUp()
+
+    def prepare_voucher(self, range_=None, start_datetime=None, benefit_value=100):
+        """ Create a voucher and add an offer to it that contains a created product. """
+        if range_ is None:
+            product = ProductFactory(title='Test product')
+            range_ = RangeFactory(products=[product, ])
+        else:
+            product = range_.all_products()[0]
+
+        if start_datetime is None:
+            start_datetime = now() - datetime.timedelta(days=1)
+
+        voucher = VoucherFactory(code='COUPONTEST', start_datetime=start_datetime, usage=Voucher.SINGLE_USE)
+        benefit = BenefitFactory(range=range_, value=benefit_value)
+        offer = ConditionalOfferFactory(benefit=benefit)
+        voucher.offers.add(offer)
+        return voucher, product
+
+    def test_get_voucher(self):
+        """ Verify that get_voucher() returns product and voucher. """
+        self.prepare_voucher()
+        voucher, product = get_voucher(code='COUPONTEST')
+        self.assertIsNotNone(voucher)
+        self.assertEqual(voucher.code, 'COUPONTEST')
+        self.assertIsNotNone(product)
+        self.assertEqual(product.title, 'Test product')
+
+    def test_no_product(self):
+        """ Verify that None is returned if there is no product. """
+        voucher = VoucherFactory(code='NOPRODUCT')
+        offer = ConditionalOfferFactory()
+        voucher.offers.add(offer)
+        voucher, product = get_voucher(code='NOPRODUCT')
+        self.assertIsNotNone(voucher)
+        self.assertEqual(voucher.code, 'NOPRODUCT')
+        self.assertIsNone(product)
+
+    def test_get_non_existing_voucher(self):
+        """ Verify that get_voucher() returns None for non-existing voucher. """
+        voucher, product = get_voucher(code='INVALID')
+        self.assertIsNone(voucher)
+        self.assertIsNone(product)
+
+    def test_valid_voucher(self):
+        """ Verify voucher_is_valid() assess that the voucher is valid. """
+        voucher, product = self.prepare_voucher()
+        request = RequestFactory().request()
+        valid, msg = voucher_is_valid(voucher=voucher, product=product, request=request)
+        self.assertTrue(valid)
+        self.assertEquals(msg, '')
+
+    def test_no_voucher(self):
+        """ Verify voucher_is_valid() assess that the voucher is invalid. """
+        valid, msg = voucher_is_valid(voucher=None, product=None, request=None)
+        self.assertFalse(valid)
+        self.assertEqual(msg, _('Coupon does not exist'))
+
+    def test_expired_voucher(self):
+        """ Verify voucher_is_valid() assess that the voucher has expired. """
+        future_datetime = now() + datetime.timedelta(days=10)
+        voucher, product = self.prepare_voucher(start_datetime=future_datetime)
+        valid, msg = voucher_is_valid(voucher=voucher, product=product, request=None)
+        self.assertFalse(valid)
+        self.assertEqual(msg, _('Coupon expired'))
+
+    def test_voucher_unavailable_to_buy(self):
+        """ Verify that False is returned for unavialable products. """
+        request = RequestFactory().request()
+        voucher, product = self.prepare_voucher()
+        product.expires = pytz.utc.localize(datetime.datetime.min)
+        valid, __ = voucher_is_valid(voucher=voucher, product=product, request=request)
+        self.assertFalse(valid)
+
+    def test_used_voucher(self):
+        """ Verify voucher_is_valid() assess that the voucher is unavailable. """
+        voucher, product = self.prepare_voucher()
+        order = OrderFactory()
+        user = self.create_user()
+        VoucherApplication.objects.create(voucher=voucher, user=user, order=order)
+        request = RequestFactory().request()
+        valid, msg = voucher_is_valid(voucher=voucher, product=product, request=request)
+        self.assertFalse(valid)
+        self.assertEqual(msg, _('This coupon has already been used'))
+
+    def test_no_code(self):
+        """ Verify a proper response is returned when no code is supplied. """
+        response = self.client.get(self.offer_url)
+        self.assertEqual(response.context['error'], _('This coupon code is invalid.'))
+
+    def test_invalid_voucher(self):
+        """ Verify a proper response is returned when voucher with provided code does not exist. """
+        url = self.offer_url + '?code={}'.format('DOESNTEXIST')
+        response = self.client.get(url)
+        self.assertEqual(response.context['error'], _('Coupon does not exist'))
+
+    @httpretty.activate
+    def test_course_information_error(self):
+        """ Verify a response is returned when course information is not accessable. """
+        course = CourseFactory()
+        seat = course.create_or_update_seat('verified', True, 50, self.partner)
+        range_ = RangeFactory(products=[seat, ])
+        self.prepare_voucher(range_=range_)
+
+        course_url = get_lms_url('api/courses/v1/courses/{}/'.format(course.id))
+        httpretty.register_uri(httpretty.GET, course_url, status=404, content_type='application/json')
+
+        url = self.offer_url + '?code={}'.format('COUPONTEST')
+        response = self.client.get(url)
+        response_text = (
+            'Could not get course information. '
+            '[Client Error 404: http://127.0.0.1:8000/api/courses/v1/courses/{}/]'
+        ).format(course.id)
+        self.assertEqual(response.context['error'], _(response_text))
+
+    @httpretty.activate
+    def test_proper_code(self):
+        """ Verify that proper information is returned when a valid code is provided. """
+        course = CourseFactory()
+        seat = course.create_or_update_seat('verified', True, 50, self.partner)
+        sr = StockRecord.objects.get(product=seat)
+        catalog = Catalog.objects.create(name='Test catalog', partner=self.partner)
+        catalog.stock_records.add(sr)
+        range_ = RangeFactory(catalog=catalog)
+        self.prepare_voucher(range_=range_)
+
+        course_info = {
+            "media": {
+                "course_image": {
+                    "uri": "/asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.jpg"
+                }
+            },
+            "name": "edX Demonstration Course",
+        }
+        course_info_json = json.dumps(course_info)
+        course_url = get_lms_url('api/courses/v1/courses/{}/'.format(course.id))
+        httpretty.register_uri(httpretty.GET, course_url, body=course_info_json, content_type='application/json')
+
+        url = self.offer_url + '?code={}'.format('COUPONTEST')
+        response = self.client.get(url)
+        self.assertEqual(response.context['course']['name'], _('edX Demonstration Course'))
+        self.assertEqual(response.context['code'], _('COUPONTEST'))
+
+
+class CouponRedeemViewTests(TestCase):
+    redeem_url = reverse('coupons:redeem')
+
+    def setUp(self):
+        super(CouponRedeemViewTests, self).setUp()
+        self.user = self.create_user()
+        self.client.login(username=self.user.username, password=self.password)
+        course = Course.objects.create(id='org/course/run')
+        self.seat = course.create_or_update_seat('verified', True, 50, self.partner)
+
+        self.catalog = Catalog.objects.create(partner=self.partner)
+        self.catalog.stock_records.add(StockRecord.objects.get(product=self.seat))
+
+    def test_login_required(self):
+        """ Users are required to login before accessing the view. """
+        self.client.logout()
+        response = self.client.get(self.redeem_url)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(settings.LOGIN_URL, response.url)
+
+    def test_code_not_provided(self):
+        """ Verify a response message is returned when no code is provided. """
+        response = self.client.get(self.redeem_url)
+        self.assertEqual(response.context['error'], _('Code not provided'))
+
+    def test_invalid_voucher(self):
+        """ Verify a response message is returned when voucher does not exist. """
+        url = self.redeem_url + '?code={}'.format('DOESNTEXIST')
+        response = self.client.get(url)
+        self.assertEqual(response.context['error'], _('Coupon does not exist'))
+
+    def test_basket_not_free(self):
+        """ Verify a response message is returned when the basket is not free. """
+        self.assertEqual(StockRecord.objects.get(product=self.seat).price_excl_tax, Decimal('50.00'))
+        create_coupon(catalog=self.catalog, code='COUPONTEST', benefit_value=0)
+        url = self.redeem_url + '?code={}'.format('COUPONTEST')
+        response = self.client.get(url)
+        self.assertEqual(str(response.context['error']), _('Basket total not $0, current value = $50.00'))
+
+    def test_order_not_completed(self):
+        """ Verify a response message is returned when an order is not completed. """
+        create_coupon(catalog=self.catalog, code='COUPONTEST')
+        self.assertEqual(Voucher.objects.filter(code='COUPONTEST').count(), 1)
+
+        url = self.redeem_url + '?code={}'.format('COUPONTEST')
+        response = self.client.get(url)
+        self.assertEqual(response.context['error'], _('Error when trying to redeem code'))
+
+    @httpretty.activate
+    def test_redirect(self):
+        """ Verify a redirect happens when valid info is provided. """
+        create_coupon(catalog=self.catalog, code='COUPONTEST')
+        self.assertEqual(Voucher.objects.filter(code='COUPONTEST').count(), 1)
+
+        httpretty.register_uri(httpretty.POST, settings.ENROLLMENT_API_URL, status=200)
+        url = self.redeem_url + '?code={}'.format('COUPONTEST')
+        response = self.client.get(url)
+        self.assertIsInstance(response, HttpResponseRedirect)
+
+    @httpretty.activate
+    def test_multiple_vouchers(self):
+        """ Verify a redirect happens when a basket with already existing vouchers is used. """
+        create_coupon(catalog=self.catalog, code='COUPONTEST')
+        self.assertEqual(Voucher.objects.filter(code='COUPONTEST').count(), 1)
+        basket = Basket.get_basket(self.user, self.site)
+        basket.vouchers.add(Voucher.objects.get(code='COUPONTEST'))
+        httpretty.register_uri(httpretty.POST, settings.ENROLLMENT_API_URL, status=200)
+
+        url = self.redeem_url + '?code={}'.format('COUPONTEST')
+        response = self.client.get(url)
+        self.assertIsInstance(response, HttpResponseRedirect)

--- a/ecommerce/coupons/urls.py
+++ b/ecommerce/coupons/urls.py
@@ -3,5 +3,7 @@ from django.conf.urls import url
 from ecommerce.coupons import views
 
 urlpatterns = [
+    url(r'^offer/$', views.CouponOfferView.as_view(), name='offer'),
+    url(r'^redeem/$', views.CouponRedeemView.as_view(), name='redeem'),
     url(r'^(.*)$', views.CouponAppView.as_view(), name='app'),
 ]

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -1,6 +1,231 @@
-from django.views.generic import TemplateView
+from __future__ import unicode_literals
+import logging
+
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponseRedirect
+from django.utils.decorators import method_decorator
+from django.utils.translation import ugettext_lazy as _
+from django.shortcuts import render
+from django.views.generic import TemplateView, View
+from oscar.core.loading import get_class, get_model
+
+from edx_rest_api_client.client import EdxRestApiClient
+from edx_rest_api_client.exceptions import SlumberHttpBaseException
+
 from ecommerce.core.views import StaffOnlyMixin
+from ecommerce.extensions.api import data as data_api
+from ecommerce.extensions.api.constants import APIConstants as AC
+from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
+from ecommerce.extensions.fulfillment.status import ORDER
+from ecommerce.settings import get_lms_url
+
+
+Applicator = get_class('offer.utils', 'Applicator')
+Basket = get_model('basket', 'Basket')
+logger = logging.getLogger(__name__)
+Selector = get_class('partner.strategy', 'Selector')
+StockRecord = get_model('partner', 'StockRecord')
+Voucher = get_model('voucher', 'Voucher')
+
+
+def get_voucher(code):
+    """
+    Returns a voucher and prodcut for a given code.
+
+    Arguments:
+        code (str): The code of a coupon voucher.
+
+    Returns:
+        voucher (Voucher): The Voucher for the passed code.
+        product (Product): The Product associated with the Voucher.
+    """
+    voucher = None
+    product = None
+    # Check to see if a voucher exists for the code.
+    try:
+        voucher = Voucher.objects.get(code=code)
+    except Voucher.DoesNotExist:
+        logger.exception('Voucher does not exist for code [%s].', code)
+        return voucher, product
+
+    # Just get the first product.
+    products = voucher.offers.all()[0].benefit.range.all_products()
+    if products:
+        product = products[0]
+    return voucher, product
+
+
+def voucher_is_valid(voucher, product, request):
+    """
+    Checks if the voucher is valid.
+
+    Arguments:
+        voucher (Voucher): The Voucher that is checked.
+        product (Product): Product associated with the Voucher.
+        request (Request): WSGI request.
+
+    Returns:
+        bool (bool): True if the voucher is valid, False otherwise.
+        msg (str): Message in case the voucher is invalid.
+    """
+
+    if voucher is None:
+        return False, _('Coupon does not exist')
+
+    if not voucher.is_active():
+        return False, _('Coupon expired')
+
+    avail, msg = voucher.is_available_to_user(request.user)
+    if not avail:
+        voucher_msg = msg.replace('voucher', 'coupon')
+        return False, voucher_msg
+
+    purchase_info = request.strategy.fetch_for_product(product)
+    if not purchase_info.availability.is_available_to_buy:
+        return False, _('Product [{product}] not available for purchase.'.format(product=product))
+
+    return True, ''
 
 
 class CouponAppView(StaffOnlyMixin, TemplateView):
     template_name = 'coupons/coupon_app.html'
+
+
+class CouponOfferView(TemplateView):
+    template_name = 'coupons/offer.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(CouponOfferView, self).get_context_data(**kwargs)
+
+        code = self.request.GET.get('code', None)
+        if code is not None:
+            voucher, product = get_voucher(code=code)
+            valid_voucher, msg = voucher_is_valid(voucher, product, self.request)
+            if valid_voucher:
+                api = EdxRestApiClient(
+                    get_lms_url('api/courses/v1/'),
+                )
+                try:
+                    course = api.courses(product.course_id).get()
+                except SlumberHttpBaseException as e:
+                    logger.exception('Could not get course information. [%s]', e)
+                    return {
+                        'error': _('Could not get course information. [{error}]'.format(error=e))
+                    }
+
+                course['image_url'] = get_lms_url(course['media']['course_image']['uri'])
+                stock_records = voucher.offers.first().benefit.range.catalog.stock_records.first()
+                context.update({
+                    'course': course,
+                    'code': code,
+                    'price': stock_records.price_excl_tax,
+                    'verified': (product.attr.certificate_type is 'verified')
+                })
+                return context
+            return {
+                'error': msg
+            }
+        return {
+            'error': _('This coupon code is invalid.')
+        }
+
+    def get(self, request, *args, **kwargs):
+        """Get method for coupon redemption page."""
+        return super(CouponOfferView, self).get(request, *args, **kwargs)
+
+
+class CouponRedeemView(EdxOrderPlacementMixin, View):
+
+    @method_decorator(login_required)
+    def get(self, request):
+        """
+        Looks up the passed code and adds the matching product to a basket,
+        then applies the voucher and if the basket total is FREE places the order and
+        enrolls the user in the course.
+        """
+        template_name = 'coupons/offer.html'
+        code = request.GET.get('code', None)
+
+        if not code:
+            return render(request, template_name, {'error': _('Code not provided')})
+
+        voucher, product = get_voucher(code=code)
+        valid_voucher, msg = voucher_is_valid(voucher, product, request)
+        if not valid_voucher:
+            return render(request, template_name, {'error': msg})
+
+        basket = self._prepare_basket(request.site, request.user, product, voucher)
+        if basket.total_excl_tax == AC.FREE:
+            basket.freeze()
+            order_metadata = data_api.get_order_metadata(basket)
+
+            logger.info(
+                u"Preparing to place order [%s] for the contents of basket [%d]",
+                order_metadata[AC.KEYS.ORDER_NUMBER],
+                basket.id,
+            )
+
+            # Place an order. If order placement succeeds, the order is committed
+            # to the database so that it can be fulfilled asynchronously.
+            order = self.handle_order_placement(
+                order_number=order_metadata[AC.KEYS.ORDER_NUMBER],
+                user=basket.owner,
+                basket=basket,
+                shipping_address=None,
+                shipping_method=order_metadata[AC.KEYS.SHIPPING_METHOD],
+                shipping_charge=order_metadata[AC.KEYS.SHIPPING_CHARGE],
+                billing_address=None,
+                order_total=order_metadata[AC.KEYS.ORDER_TOTAL],
+            )
+        else:
+            return render(
+                request,
+                template_name,
+                {'error': _('Basket total not $0, current value = ${basket_price}'.format(
+                    basket_price=basket.total_excl_tax
+                ))}
+            )
+
+        if order.status is ORDER.COMPLETE:
+            return HttpResponseRedirect(get_lms_url(''))
+        else:
+            logger.error('Order was not completed [%s]', order.id)
+            return render(request, template_name, {'error': _('Error when trying to redeem code')})
+
+    def _prepare_basket(self, site, user, product, voucher):
+        """
+        Prepare the basket, add the product, and apply a voucher.
+
+        Existing baskets are merged and flushed. The specified product will
+        be added to the remaining open basket, and the basket will be frozen.
+        The Voucher is applied to the basket and checked for discounts.
+
+        Arguments:
+            site (Site): The site from which the request came.
+            user (User): User who made the request.
+            product (Product): Product to be added to the basket.
+            voucher (Voucher): Voucher to apply to the basket.
+
+        Returns:
+            basket (Basket): Contains the product to be redeemed and the Voucher applied.
+        """
+        basket = Basket.get_basket(user, site)
+        basket.thaw()
+        # remove all existing vouchers from the basket
+        for v in basket.vouchers.all():
+            basket.vouchers.remove(v)
+        basket.reset_offer_applications()
+        basket.flush()
+        basket.add_product(product, 1)
+        basket.vouchers.add(voucher)
+        Applicator().apply(basket, user, self.request)
+        discounts = basket.offer_applications
+        # Look for discounts from this new voucher
+        for discount in discounts:
+            if discount['voucher'] and discount['voucher'] == voucher:
+                logger.info('Applied Voucher [%s] to basket.', voucher.code)
+                break
+            else:
+                logger.info('Voucher [%s] does not offer a discount.', voucher.code)
+                basket.vouchers.remove(voucher)
+        return basket

--- a/ecommerce/extensions/test/factories.py
+++ b/ecommerce/extensions/test/factories.py
@@ -46,20 +46,23 @@ def create_order(number=None, basket=None, user=None, shipping_address=None,  # 
     return order
 
 
-def create_coupon(title='Test coupon', price=100, partner=None, catalog=None):
+def create_coupon(title='Test coupon', price=100, partner=None, catalog=None, code='', benefit_value=100):
     """Helper method for creating a coupon."""
     if partner is None:
         partner = PartnerFactory(name='Tester')
     if catalog is None:
         catalog = Catalog.objects.create(partner=partner)
+    quantity = 5
+    if code is not '':
+        quantity = 1
     data = {
         'partner': partner,
         'benefit_type': Benefit.PERCENTAGE,
-        'benefit_value': 100,
+        'benefit_value': benefit_value,
         'catalog': catalog,
         'end_date': datetime.date(2020, 1, 1),
-        'code': '',
-        'quantity': 5,
+        'code': code,
+        'quantity': quantity,
         'start_date': datetime.date(2015, 1, 1),
         'voucher_type': Voucher.SINGLE_USE
     }

--- a/ecommerce/static/sass/base/main.scss
+++ b/ecommerce/static/sass/base/main.scss
@@ -31,3 +31,4 @@
 @import '../views/credit';
 @import '../views/course_admin';
 @import '../views/coupon_admin';
+@import '../views/coupon_offer';

--- a/ecommerce/static/sass/views/_coupon_offer.scss
+++ b/ecommerce/static/sass/views/_coupon_offer.scss
@@ -1,0 +1,79 @@
+#offer {
+
+    .message-error {
+        border-top: 4px solid #B20610;
+        h3 {
+            font-weight: bold;
+            margin-bottom: 10px;
+        }
+    }
+
+    .container {
+        padding-top: spacing-vertical(small);
+        padding-bottom: spacing-vertical(small);
+    }
+
+    .course-price {
+        strong {
+            color: #25B85A;
+        }
+        .course-price {
+            color: #9EB1B9;
+            font-weight: bold;
+        }
+        s {
+            // replace the default line-through
+            text-decoration: none;
+            position: relative;
+            &:after {
+                content:"";
+                position: absolute;
+                bottom: 0;
+                left: 0;
+                border-top: 2px solid #B20610;
+                height: 50%;
+                width: 100%;
+            }
+        }
+    }
+
+    .total-price {
+        color: #065683;
+    }
+
+    .depth {
+        padding: 1.25rem 1.25rem;
+    }
+
+    .depth-2 {
+        background: #fcfcfc;
+        box-shadow: 0 1px 2px 1px rgba(167, 164, 164, 0.25);
+    }
+
+    .depth--3 {
+        background: #34383a;
+        .copy {
+            color: #e7e6e6;
+            @include container-fixed;
+
+            @media (min-width: $screen-sm-min) {
+              width: $container-sm;
+            }
+            @media (min-width: $screen-md-min) {
+              width: $container-md;
+            }
+            @media (min-width: $screen-lg-min) {
+              width: $container-lg;
+            }
+        }
+    }
+
+    .note {
+        border: 1px solid  #D2D0D0;
+        border-radius: 0;
+        margin-top: 1.25rem;
+        background: none;
+        color: #6B6969;
+    }
+
+}

--- a/ecommerce/templates/coupons/_offer_error.html
+++ b/ecommerce/templates/coupons/_offer_error.html
@@ -1,0 +1,8 @@
+{% load i18n %}
+
+<div class="container">
+    <div class="depth depth-2 message-error">
+        <h3>{{ error }}</h3>
+        {% trans "If you need assistance, contact edX support." %}
+    </div>
+</div>

--- a/ecommerce/templates/coupons/_offer_success.html
+++ b/ecommerce/templates/coupons/_offer_success.html
@@ -1,0 +1,47 @@
+{% load i18n %}
+
+<div class="depth depth--3">
+    <div class="copy copy-meta">
+        {% trans "Enrollment code applied to course price. To redeem the enrollment code, enroll in the course." %}
+    </div>
+</div>
+<div class="container">
+    <h5>{% trans "Enroll and pursue a verified certificate in the following course." %}</h5>
+    <div class="row">
+        <div class="col-md-2">
+            <img class="img-responsive" src="{{course.image_url}}" alt="" />
+        </div>
+        <div class="col-md-8">
+            <h3>{{ course.name }} - {{ course.org }}</h3>
+            <p>
+                {{ course.short_description }}
+            </p>
+        </div>
+        <div class="col-md-2 text-right course-price">
+            <s class="course-price">${{ price }}</s>
+            <strong>{% trans "FREE" %}</strong>
+        </div>
+    </div>
+    <hr>
+    <div class="text-right">
+        <p>
+            <b class="total-price">{% trans "Total: $0" %}</b>
+        </p>
+        <a href="{% url 'coupons:redeem' %}?code={{ code }}" class="btn btn-primary">{% trans "Enroll and Redeem Code" %}</a>
+    </div>
+
+    {% if verified %}
+    <div class="alert alert-info note">
+        <span class="fa fa-exclamation-circle" aria-hidden="true"></span>
+        <b>{% trans "Note:" %}</b>
+        {% trans "You must verify your identity using a webcam and a government-issued photo ID before the course ends." %}
+    </div>
+    {% endif %}
+
+    <div>
+        <b>{% trans "Questions?" %}</b>
+        <p>
+            {% trans "Read our FAQs for answers to common questions about our certificates." %}
+        </p>
+    </div>
+</div>

--- a/ecommerce/templates/coupons/offer.html
+++ b/ecommerce/templates/coupons/offer.html
@@ -1,0 +1,15 @@
+{% extends 'edx/base.html' %}
+{% load i18n %}
+{% load staticfiles %}
+
+{% block title %}{% trans "Redeem" %}{% endblock %}
+
+{% block content %}
+    <div id="offer">
+        {% if error %}
+            {% include "coupons/_offer_error.html" %}
+        {% else%}
+            {% include "coupons/_offer_success.html" %}
+        {% endif %}
+    </div>
+{% endblock %}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ djangorestframework-jwt==1.7.2
 drf-extensions==0.2.8
 edx-auth-backends==0.1.3
 edx-ecommerce-worker==0.3.0
-edx-rest-api-client==1.2.1
+edx-rest-api-client==1.3.0
 jsonfield==1.0.3
 libsass==0.9.2
 paypalrestsdk==1.11.4


### PR DESCRIPTION
https://openedx.atlassian.net/browse/SOL-1419

Code offer and redemption views.
Offer (`/coupons/offer/?code=<code>`) displays the information about the coupon, which course is it for and how much of a discount does it provide (currently only enrollment codes are created, discount codes are in the future milestones). 
Redeem (`/coupons/redeem/?code=<code>`) checks the validity of the code. If it's valid enrolls and redirects user to his dashboard, if not displays an error message.

We need to update the edx rest api client to 1.3.0 to enable unauthorized clients to access course information. When an unregistered user checks the coupon offer the course information needs to be displayed to him.

OFFER:

Valid coupon voucher:
![screenshot from 2016-01-08 15 16 23](https://cloud.githubusercontent.com/assets/2808092/12199823/5a994e28-b61b-11e5-8b41-c4d8084a217d.png)

Invalid coupon voucher:
![screenshot from 2016-01-11 15-36-34](https://cloud.githubusercontent.com/assets/2808092/12236614/2b7d5da2-b87b-11e5-9632-1c231b7dff47.png)

No coupon voucher:
![screenshot from 2016-01-08 15 17 06](https://cloud.githubusercontent.com/assets/2808092/12199845/7a4eb1ea-b61b-11e5-850e-0e289efe8931.png)

REDEEM:

Invalid coupon voucher:
![screenshot from 2016-01-11 15-38-22](https://cloud.githubusercontent.com/assets/2808092/12236634/49041384-b87b-11e5-954a-3165f73df016.png)

Used coupon voucher:
![screenshot from 2016-01-11 15-49-15](https://cloud.githubusercontent.com/assets/2808092/12236647/5625c670-b87b-11e5-99e8-51e080155e77.png)
