### PR TITLE
Remove message after course type selection

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ Afeef Janjua <janjua.afeef@gmail.com>
 Michael Frey <mfrey@edx.org>
 Marko Jevtic <mjevtic@edx.org>
 Vedran Karačić <vedran@edx.org>
+Awais Jibran <awaisdar001@gmail.com>

--- a/ecommerce/static/js/test/specs/views/course_create_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/course_create_view_spec.js
@@ -25,6 +25,15 @@ define([
                 expect(view.$el.find('.alert').length).toBe(1);
                 expect(view.$el.find('.alert').html()).toBe(errorHTML);
             });
+            it('select a course type message is removed', function () {
+                expect(view.$el.find('.course-types input[type=radio]:checked').length).toEqual(0);
+                expect(view.$el.find('.course-seat.empty').hasClass('hidden')).toBe(false);
+                expect(view.$el.find('.course-types input[type=radio]').length).toEqual(4);
+
+                view.model.set('type', 'credit');
+                expect(view.$el.find('.course-types input[type=radio]:checked').length).toEqual(1);
+                expect(view.$el.find('.course-seat.empty').hasClass('hidden')).toBe(true);
+            });
 
         });
     }

--- a/ecommerce/static/js/views/course_form_view.js
+++ b/ecommerce/static/js/views/course_form_view.js
@@ -290,6 +290,7 @@ define([
                                     view = new viewClass({model: seats[0]});
                                 }
 
+                                this.$el.find('.course-seat.empty').addClass('hidden');
                                 /*jshint newcap: true */
                                 view.render();
 


### PR DESCRIPTION
[ECOM-3150 - CAT "select a course type" remains after selected](https://openedx.atlassian.net/browse/ECOM-3150)
## Issue

The "select a course type" message remains on the page after the course type has been selected.
## Acceptance Criteria

VERIFY that the "select a course type" message is removed upon selection of a course type.
