### PR TITLE
Coupon UI fixes

### DIFF
--- a/ecommerce/static/js/collections/coupon_collection.js
+++ b/ecommerce/static/js/collections/coupon_collection.js
@@ -12,14 +12,7 @@ define([
 
         return PaginatedCollection.extend({
             model: CouponModel,
-            url: '/api/v2/products/',
-            fetch: function (options) {
-                options = options || {};
-                _.defaults(options.data || (options.data = {}), {
-                    product_class__name: 'Coupon'
-                });
-                return PaginatedCollection.prototype.fetch.call(this, options);
-            }
+            url: '/api/v2/coupons/'
         });
     }
 );

--- a/ecommerce/static/js/test/specs/collections/coupon_collection_spec.js
+++ b/ecommerce/static/js/test/specs/collections/coupon_collection_spec.js
@@ -11,7 +11,7 @@ define([
                 results: [
                     {
                         id: 4,
-                        url: 'http://localhost:8002/api/v2/products/4/',
+                        url: 'http://localhost:8002/api/v2/coupons/4/',
                         structure: 'standalone',
                         product_class: 'Coupon',
                         title: 'Coupon',
@@ -53,27 +53,13 @@ define([
             describe('parse', function () {
                 it('should fetch the next page of results', function () {
                     spyOn(collection, 'fetch').and.returnValue(null);
-                    response.next = '/api/v2/products/?page=2';
+                    response.next = '/api/v2/coupons/?page=2';
 
                     collection.parse(response);
                     expect(collection.url).toEqual(response.next);
                     expect(collection.fetch).toHaveBeenCalledWith({remove: false});
                 });
 
-            });
-
-            describe('fetch', function () {
-                it('should call correct url', function () {
-                    var args;
-                    spyOn($, 'ajax');
-                    collection.fetch({
-                      dummyOption: 'dummy', data: {arg: 'arg'}
-                    });
-                    args = $.ajax.calls.argsFor(0);
-                    expect(args[0].data).toEqual({
-                        arg: 'arg', product_class__name: 'Coupon'
-                    });
-                });
             });
         });
     }

--- a/ecommerce/templates/coupons/coupon_app.html
+++ b/ecommerce/templates/coupons/coupon_app.html
@@ -64,7 +64,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-xs-12 text-right">
-                    <em>{% blocktrans %}{{ platform_name }} Coupon Administration Tool{% endblocktrans %}</em>
+                    <em>{% blocktrans %}Coupon Administration Tool{% endblocktrans %}</em>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Depends on #476
- collection url is again /api/v2/coupons/
- remove "Your Platform Name Here" from footer (SOL-1540)
- ~~default value for category~~
