### PR TITLE
Prevent Celery from removing handlers on the root logger

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -434,6 +434,10 @@ CELERY_IMPORTS = (
     'ecommerce_worker.fulfillment.v1.tasks',
 )
 
+# Prevent Celery from removing handlers on the root logger. Allows setting custom logging handlers.
+# See http://celery.readthedocs.org/en/latest/configuration.html#celeryd-hijack-root-logger.
+CELERYD_HIJACK_ROOT_LOGGER = False
+
 # Execute tasks locally (synchronously) instead of sending them to the queue.
 # See http://celery.readthedocs.org/en/latest/configuration.html#celery-always-eager.
 CELERY_ALWAYS_EAGER = False


### PR DESCRIPTION
Allows use of custom logging handlers. ECOM-2249.

@jimabramson please review.
