### PR TITLE
Only create honor or audit seats, not both.

### DIFF
--- a/ecommerce/static/js/models/course_model.js
+++ b/ecommerce/static/js/models/course_model.js
@@ -300,6 +300,8 @@ define([
                     honorMode,
                     honorSeatClass,
                     honorSeat,
+                    products,
+                    auditSeat,
                     data = {
                         id: this.get('id'),
                         name: this.get('name'),
@@ -314,7 +316,12 @@ define([
                         /*jshint newcap: false */
                         honorSeat = new honorSeatClass({course: this});
                         /*jshint newcap: true */
-                        this.get('products').add(honorSeat);
+
+                        products = this.get('products');
+                        auditSeat = products.where({certificate_type: null});
+
+                        products.remove(auditSeat);
+                        products.add(honorSeat);
                     }
                 }
 

--- a/ecommerce/static/js/test/specs/models/course_model_spec.js
+++ b/ecommerce/static/js/test/specs/models/course_model_spec.js
@@ -5,6 +5,8 @@ define([
         'collections/product_collection',
         'models/course_model',
         'models/course_seats/professional_seat',
+        'models/course_seats/audit_seat',
+        'models/course_seats/honor_seat',
         'jquery-cookie'
     ],
     function ($,
@@ -12,7 +14,9 @@ define([
               _,
               ProductCollection,
               Course,
-              ProfessionalSeat) {
+              ProfessionalSeat,
+              AuditSeat,
+              HonorSeat) {
         'use strict';
 
         var model,
@@ -278,20 +282,32 @@ define([
                 });
 
                 describe('when honor_mode true', function() {
-                    it('adds an honor seat', function() {
-                        model.set('products', [auditSeat]);
+                    it('adds an honor seat and removes the audit seat', function() {
+                        var seats;
+
+                        model.set('products', []);
+                        model.get('products').push(new AuditSeat({}));
                         model.set('honor_mode', true);
                         model.save();
-                        expect(model.get('products').length).toEqual(2);
+
+                        seats = model.seats();
+                        expect(seats.length).toEqual(1);
+                        expect(seats[0].attributes.certificate_type).toEqual('honor');
                     });
                 });
 
                 describe('when honor_mode false', function() {
-                    it('does not add an honor seat', function() {
-                        model.set('products', [auditSeat]);
+                    it('does not add an honor seat and leaves the audit seat', function() {
+                        var seats;
+
+                        model.set('products', []);
+                        model.get('products').push(new AuditSeat({}));
                         model.set('honor_mode', false);
                         model.save();
-                        expect(model.get('products').length).toEqual(1);
+
+                        seats = model.seats();
+                        expect(seats.length).toEqual(1);
+                        expect(seats[0].attributes.certificate_type).toBeNull();
                     });
                 });
             });
@@ -381,14 +397,17 @@ define([
                 describe('with seats', function () {
                     it('sets honor_mode to true', function () {
                         model.set('honor_mode', null);
-                        model.set('products', [auditSeat, honorSeat]);
+                        model.set('products', []);
+                        model.get('products').push(new AuditSeat({}));
+                        model.get('products').push(new HonorSeat({}));
                         model.honorModeInit();
                         expect(model.get('honor_mode')).toBeTruthy();
                     });
 
                     it('sets honor_mode to false', function () {
                         model.set('honor_mode', null);
-                        model.set('products', [auditSeat]);
+                        model.set('products', []);
+                        model.get('products').push(new AuditSeat({}));
                         model.honorModeInit();
                         expect(model.get('honor_mode')).toBeFalsy();
                     });


### PR DESCRIPTION
Audit is the default seat, however if a PM adds the honor seat back in we need to remove the audit seat.

This is a short term fix so that we are not creating both seats.  There will be a follow on fix that includes visual changes to help PMs configure courses in both the new (audit) and old (honor) way. 

@peter-fogg @rlucioni please review
