### PR TITLE
Use a Waffle Sample to control async order fulfillment

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -1,12 +1,12 @@
 Feature Toggling
 ================
 
-All new features/functionality should be released behind a feature gate. This allows us to easily disable features
-in the event that an issue is discovered in production. This project uses the
-`Waffle <http://waffle.readthedocs.org/en/latest/>`_ library for feature gating.
+All new features/functionality should be released behind a feature gate. This allows us to release
+new features in a controlled manner and easily disable features in the event that an issue is discovered
+in production. This project uses the `Waffle <http://waffle.readthedocs.org/en/latest/>`_ library
+for feature gating.
 
-Waffle supports three types of feature gates (listed below). We typically use flags and switches since samples are
-random and not ideal for our needs.
+Waffle supports three types of feature gates, listed below.
 
     Flag
         Enable a feature for specific users, groups, users meeting certain criteria (e.g. authenticated or staff),
@@ -22,28 +22,21 @@ random and not ideal for our needs.
 For information on creating or updating features, refer to the
 `Waffle documentation <http://waffle.readthedocs.org/en/latest/>`_.
 
-Available Switches
-------------------
+Available Feature Gates
+-----------------------
 
-Switches can be managed via the Django admin. The following switches exist:
+Waffle-based feature gates can be managed via the Django admin. The following feature gates exist:
 
-+--------------------------------+---------------------------------------------------------------------------+
-| Name                           | Functionality                                                             |
-+================================+=======================+===================================================+
-| user_enrollments_on_dashboard  | Display a user's current enrollments on the dashboard user detail page    |
-+--------------------------------+---------------------------------------------------------------------------+
-| publish_course_modes_to_lms    | Publish prices and SKUs to the LMS after every course modification        |
-+--------------------------------+---------------------------------------------------------------------------+
-| async_order_fulfillment        | Fulfill orders asynchronously                                             |
-+--------------------------------+---------------------------------------------------------------------------+
-| ENABLE_CREDIT_APP              | Enable the credit checkout page, from which students can purchase credit  |
-|                                | courses                                                                   |
-+--------------------------------+---------------------------------------------------------------------------+
-| ENABLE_NOTIFICATIONS           | Enable email notifications for a variety of user actions (e.g., order     |
-|                                | placed)                                                                   |
-+--------------------------------+---------------------------------------------------------------------------+
-| PAYPAL_RETRY_ATTEMPTS          | Enable retry mechanism for failed PayPal payment executions               |
-+--------------------------------+---------------------------------------------------------------------------+
+============================= ====== ===============================================================================
+Name                          Type   Purpose
+============================= ====== ===============================================================================
+user_enrollments_on_dashboard Switch Display a user's current enrollments on the dashboard user detail page
+publish_course_modes_to_lms   Switch Publish prices and SKUs to the LMS after every course modification
+async_order_fulfillment       Sample Determines what percentage of orders are fulfilled asynchronously.
+ENABLE_CREDIT_APP             Switch Enable the credit checkout page, from which students can purchase credit course
+ENABLE_NOTIFICATIONS          Switch Enable email notifications for a variety of user actions (e.g., order placed)
+PAYPAL_RETRY_ATTEMPTS         Switch Enable retry mechanism for failed PayPal payment executions
+============================= ====== ===============================================================================
 
 Toggling Payment Processors
 ---------------------------

--- a/ecommerce/core/migrations/0010_add_async_sample.py
+++ b/ecommerce/core/migrations/0010_add_async_sample.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def create_sample(apps, schema_editor):
+    """
+    Create the async_order_fulfillment sample if it does not already exist, and
+    delete the existing switch with the same name.
+    """
+    Sample = apps.get_model('waffle', 'Sample')
+    Sample.objects.get_or_create(
+        name='async_order_fulfillment',
+        defaults={
+            'percent': 0.0,
+            'note': 'Determines what percentage of orders are fulfilled asynchronously.',
+        }
+    )
+
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.filter(name='async_order_fulfillment').delete()
+
+
+def delete_sample(apps, schema_editor):
+    """
+    Delete the async_order_fulfillment sample, and create the old switch with
+    the same name.
+    """
+    Sample = apps.get_model('waffle', 'Sample')
+    Sample.objects.filter(name='async_order_fulfillment').delete()
+
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.get_or_create(name='async_order_fulfillment', defaults={'active': False})
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('core', '0009_service_user_privileges'),
+        ('waffle', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_sample, delete_sample),
+    ]

--- a/ecommerce/extensions/checkout/mixins.py
+++ b/ecommerce/extensions/checkout/mixins.py
@@ -98,7 +98,7 @@ class EdxOrderPlacementMixin(OrderPlacementMixin):
             user_id=order.user.id
         )
 
-        if waffle.switch_is_active('async_order_fulfillment'):
+        if waffle.sample_is_active('async_order_fulfillment'):
             # Always commit transactions before sending tasks depending on state from the current transaction!
             # There's potential for a race condition here if the task starts executing before the active
             # transaction has been committed; the necessary order doesn't exist in the database yet.

--- a/ecommerce/settings/test.py
+++ b/ecommerce/settings/test.py
@@ -105,6 +105,12 @@ PAYMENT_PROCESSOR_CONFIG = {
 # END PAYMENT PROCESSING
 
 
+# CELERY
+# Run tasks in-process, without sending them to the queue (i.e., synchronously).
+CELERY_ALWAYS_EAGER = True
+# END CELERY
+
+
 # Use production settings for asset compression so that asset compilation can be tested on the CI server.
 COMPRESS_ENABLED = True
 COMPRESS_OFFLINE = True


### PR DESCRIPTION
Allows more controlled, careful release and use of this feature.

@clintonb, as we discussed. If you have a moment to review, I'd appreciate it. If not, let me know and I'll ping someone else.
