### PR TITLE
Add footer to enroll landing page

### DIFF
--- a/ecommerce/templates/coupons/offer.html
+++ b/ecommerce/templates/coupons/offer.html
@@ -13,3 +13,15 @@
         {% endif %}
     </div>
 {% endblock %}
+
+{% block footer %}
+    <footer class="footer">
+        <div class="container">
+            <div class="row">
+                <div class="col-xs-12 text-right">
+                    <em>{% blocktrans %}Enroll Landing Page{% endblocktrans %}</em>
+                </div>
+            </div>
+        </div>
+    </footer>
+{% endblock footer %}


### PR DESCRIPTION
@mjfrey Here it is, footer for Enroll Landing Page. Not sure what should be the content there so I just added `Enroll Landing Page`, since other pages have custom text too. Perhaps you have some idea?
