### PR TITLE
Building all branches on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,5 @@ script:
     - make static
     - make validate_python
     - make validate_js
-branches:
-    only:
-        - master
 after_success:
     - codecov


### PR DESCRIPTION
There is no good reason to disable builds on non-master branches. Also, doing so allows developers to get build feedback without opening a PR.
