### PR TITLE
Use heartbeats and disable connection pooling to prevent broker connection loss

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -428,6 +428,18 @@ LANGUAGE_COOKIE_NAME = 'ecommerce_language'
 # configured for the ecommerce worker!
 BROKER_URL = None
 
+# Disable connection pooling. Connections may be severed by load balancers.
+# This forces the application to connect explicitly to the broker each time
+# rather than assume a long-lived connection.
+BROKER_POOL_LIMIT = 0
+BROKER_CONNECTION_TIMEOUT = 1
+
+# Use heartbeats to prevent broker connection loss. When the broker
+# is behind a load balancer, the load balancer may timeout Celery's
+# connection to the broker, causing messages to be lost.
+BROKER_HEARTBEAT = 10.0
+BROKER_HEARTBEAT_CHECKRATE = 2
+
 # A sequence of modules to import when the worker starts.
 # See http://celery.readthedocs.org/en/latest/configuration.html#celery-imports.
 CELERY_IMPORTS = (


### PR DESCRIPTION
When the broker is behind a load balancer, the load balancer may timeout Celery's connection to the broker, causing messages to be lost. Since we currently run with RabbitMQ behind a load balancer in production, these changes are necessary to prevent messages from being dropped.

@jimabramson, please review. I've verified with @maxrothman's help that these changes work as expected, preventing messages from being dropped on the floor when Rabbit is behind an ELB.
