### PR TITLE
Updated copyright line in base email template

### DIFF
--- a/ecommerce/templates/customer/email_base.html
+++ b/ecommerce/templates/customer/email_base.html
@@ -174,7 +174,8 @@
                                 <tr>
                                     <td align="left" valign="top" style="font-size: 10px; color: #767676; font-style: italic;">
                                         <br>
-                                        {% blocktrans %}Copyright © 2015 {{platform_name}}, All Rights. Reserved.{% endblocktrans %}
+                                        {% now 'Y' as year %}
+                                        {% blocktrans %}Copyright © {{ year }} {{ platform_name }}. All rights reserved.{% endblocktrans %}
                                     </td>
                                 </tr>
                                 <tr>


### PR DESCRIPTION
- Replaced hard-coded year so we no longer need to update this (or translations) annually
- Corrected punctuation
