### PR TITLE
Use a raw ID field for Products in the Stock Record admin.

### DIFF
--- a/ecommerce/extensions/partner/admin.py
+++ b/ecommerce/extensions/partner/admin.py
@@ -10,6 +10,7 @@ Catalog = get_class('ecommerce.extensions.catalogue.models', 'Catalog')
 class StockRecordAdminExtended(SimpleHistoryAdmin):
     list_display = ('product', 'partner', 'partner_sku', 'price_excl_tax', 'cost_price', 'num_in_stock')
     list_filter = ('partner',)
+    raw_id_fields = ('product',)
 
 
 class CatalogAdmin(admin.ModelAdmin):


### PR DESCRIPTION
The dropdown list on prod is far too large to be useful for stock records. We can always get a raw ID from the admin page for the corresponding product or from querying the read replica, so it's far more user friendly to type the ID in directly.
