### PR TITLE
Add new Basket summary view that can handle Coupons.

### DIFF
--- a/ecommerce/core/context_processors.py
+++ b/ecommerce/core/context_processors.py
@@ -3,5 +3,6 @@ from django.conf import settings
 
 def core(_request):
     return {
+        'support_url': settings.SUPPORT_URL,
         'platform_name': settings.PLATFORM_NAME
     }

--- a/ecommerce/core/tests/test_context_processors.py
+++ b/ecommerce/core/tests/test_context_processors.py
@@ -4,10 +4,11 @@ from ecommerce.core.context_processors import core
 from ecommerce.tests.testcases import TestCase
 
 PLATFORM_NAME = 'Test Platform'
+SUPPORT_URL = 'example.com'
 
 
 class CoreContextProcessorTests(TestCase):
-    @override_settings(PLATFORM_NAME=PLATFORM_NAME)
+    @override_settings(PLATFORM_NAME=PLATFORM_NAME, SUPPORT_URL=SUPPORT_URL)
     def test_core(self):
         request = RequestFactory().get('/')
-        self.assertDictEqual(core(request), {'platform_name': PLATFORM_NAME})
+        self.assertDictEqual(core(request), {'platform_name': PLATFORM_NAME, 'support_url': SUPPORT_URL})

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 import logging
 
 from django.contrib.auth.decorators import login_required
+from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_lazy as _
@@ -16,6 +17,7 @@ from ecommerce.core.views import StaffOnlyMixin
 from ecommerce.extensions.api import data as data_api
 from ecommerce.extensions.api.constants import APIConstants as AC
 from ecommerce.extensions.api.data import get_lms_footer
+from ecommerce.extensions.basket.utils import prepare_basket
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
 from ecommerce.extensions.fulfillment.status import ORDER
 from ecommerce.settings import get_lms_url
@@ -29,9 +31,9 @@ StockRecord = get_model('partner', 'StockRecord')
 Voucher = get_model('voucher', 'Voucher')
 
 
-def get_voucher(code):
+def get_voucher_from_code(code):
     """
-    Returns a voucher and prodcut for a given code.
+    Returns a voucher and product for a given code.
 
     Arguments:
         code (str): The code of a coupon voucher.
@@ -100,7 +102,7 @@ class CouponOfferView(TemplateView):
         footer = get_lms_footer()
         code = self.request.GET.get('code', None)
         if code is not None:
-            voucher, product = get_voucher(code=code)
+            voucher, product = get_voucher_from_code(code=code)
             valid_voucher, msg = voucher_is_valid(voucher, product, self.request)
             if valid_voucher:
                 api = EdxRestApiClient(
@@ -165,12 +167,12 @@ class CouponRedeemView(EdxOrderPlacementMixin, View):
         if not code:
             return render(request, template_name, {'error': _('Code not provided')})
 
-        voucher, product = get_voucher(code=code)
+        voucher, product = get_voucher_from_code(code=code)
         valid_voucher, msg = voucher_is_valid(voucher, product, request)
         if not valid_voucher:
             return render(request, template_name, {'error': msg})
 
-        basket = self._prepare_basket(request.site, request.user, product, voucher)
+        basket = prepare_basket(request, product, voucher)
         if basket.total_excl_tax == AC.FREE:
             basket.freeze()
             order_metadata = data_api.get_order_metadata(basket)
@@ -194,54 +196,17 @@ class CouponRedeemView(EdxOrderPlacementMixin, View):
                 order_total=order_metadata[AC.KEYS.ORDER_TOTAL],
             )
         else:
-            return render(
-                request,
-                template_name,
-                {'error': _('Basket total not $0, current value = ${basket_price}'.format(
-                    basket_price=basket.total_excl_tax
-                ))}
+            partner = request.site.siteconfiguration.partner
+            sku = StockRecord.objects.get(product=product, partner=partner).partner_sku
+            url = '{url}?sku={sku}&code={code}'.format(
+                url=reverse('basket:single-item'),
+                sku=sku,
+                code=code
             )
+            return HttpResponseRedirect(url)
 
         if order.status is ORDER.COMPLETE:
             return HttpResponseRedirect(get_lms_url(''))
         else:
             logger.error('Order was not completed [%s]', order.id)
             return render(request, template_name, {'error': _('Error when trying to redeem code')})
-
-    def _prepare_basket(self, site, user, product, voucher):
-        """
-        Prepare the basket, add the product, and apply a voucher.
-
-        Existing baskets are merged and flushed. The specified product will
-        be added to the remaining open basket, and the basket will be frozen.
-        The Voucher is applied to the basket and checked for discounts.
-
-        Arguments:
-            site (Site): The site from which the request came.
-            user (User): User who made the request.
-            product (Product): Product to be added to the basket.
-            voucher (Voucher): Voucher to apply to the basket.
-
-        Returns:
-            basket (Basket): Contains the product to be redeemed and the Voucher applied.
-        """
-        basket = Basket.get_basket(user, site)
-        basket.thaw()
-        # remove all existing vouchers from the basket
-        for v in basket.vouchers.all():
-            basket.vouchers.remove(v)
-        basket.reset_offer_applications()
-        basket.flush()
-        basket.add_product(product, 1)
-        basket.vouchers.add(voucher)
-        Applicator().apply(basket, user, self.request)
-        discounts = basket.offer_applications
-        # Look for discounts from this new voucher
-        for discount in discounts:
-            if discount['voucher'] and discount['voucher'] == voucher:
-                logger.info('Applied Voucher [%s] to basket.', voucher.code)
-                break
-            else:
-                logger.info('Voucher [%s] does not offer a discount.', voucher.code)
-                basket.vouchers.remove(voucher)
-        return basket

--- a/ecommerce/extensions/basket/app.py
+++ b/ecommerce/extensions/basket/app.py
@@ -1,0 +1,23 @@
+from django.conf.urls import url
+from django.contrib.auth.decorators import login_required
+from oscar.apps.basket import app
+from oscar.core.loading import get_class
+
+
+class BasketApplication(app.BasketApplication):
+    single_item_view = get_class('basket.views', 'BasketSingleItemView')
+    summary_view = get_class('basket.views', 'BasketSummaryView')
+
+    def get_urls(self):
+        urls = [
+            url(r'^$', self.summary_view.as_view(), name='summary'),
+            url(r'^add/(?P<pk>\d+)/$', self.add_view.as_view(), name='add'),
+            url(r'^vouchers/add/$', self.add_voucher_view.as_view(), name='vouchers-add'),
+            url(r'^vouchers/(?P<pk>\d+)/remove/$', self.remove_voucher_view.as_view(), name='vouchers-remove'),
+            url(r'^saved/$', login_required(self.saved_view.as_view()), name='saved'),
+            url(r'^single-item/$', login_required(self.single_item_view.as_view()), name='single-item'),
+        ]
+        return self.post_process_urls(urls)
+
+
+application = BasketApplication()

--- a/ecommerce/extensions/basket/tests/test_utils.py
+++ b/ecommerce/extensions/basket/tests/test_utils.py
@@ -1,0 +1,72 @@
+import ddt
+
+from django.test import RequestFactory
+from oscar.core.loading import get_model
+from oscar.test.factories import ProductFactory, RangeFactory
+
+from ecommerce.extensions.basket.utils import get_certificate_type_display_value, prepare_basket
+from ecommerce.extensions.partner.models import StockRecord
+from ecommerce.extensions.test.factories import prepare_voucher
+from ecommerce.tests.factories import SiteConfigurationFactory
+from ecommerce.tests.testcases import TestCase
+
+Benefit = get_model('offer', 'Benefit')
+Basket = get_model('basket', 'Basket')
+
+
+@ddt.ddt
+class BasketUtilsTests(TestCase):
+    """ Tests for basket utility functions. """
+
+    def setUp(self):
+        super(BasketUtilsTests, self).setUp()
+        self.request = RequestFactory()
+        self.request.user = self.create_user()
+        site_configuration = SiteConfigurationFactory(partner__name='Tester')
+        self.request.site = site_configuration.site
+
+    def test_prepare_basket_with_voucher(self):
+        """ Verify a basket is returned and contains a voucher and the voucher is applied. """
+        # Prepare a product with price of 100 and a voucher with 10% discount for that product.
+        product = ProductFactory(stockrecords__price_excl_tax=100)
+        new_range = RangeFactory(products=[product, ])
+        voucher, product = prepare_voucher(_range=new_range, benefit_value=10)
+
+        stock_record = StockRecord.objects.get(product=product)
+        self.assertEqual(stock_record.price_excl_tax, 100.00)
+
+        basket = prepare_basket(self.request, product, voucher)
+        self.assertIsNotNone(basket)
+        self.assertEqual(basket.status, Basket.FROZEN)
+        self.assertEqual(basket.lines.count(), 1)
+        self.assertEqual(basket.lines.first().product, product)
+        self.assertEqual(basket.vouchers.count(), 1)
+        self.assertIsNotNone(basket.applied_offers())
+        self.assertEqual(basket.total_discount, 10.00)
+        self.assertEqual(basket.total_excl_tax, 90.00)
+
+    def test_prepare_basket_without_voucher(self):
+        """ Verify a basket is returned and does not contain a voucher. """
+        product = ProductFactory()
+        basket = prepare_basket(self.request, product)
+        self.assertIsNotNone(basket)
+        self.assertEqual(basket.status, Basket.FROZEN)
+        self.assertEqual(basket.lines.count(), 1)
+        self.assertEqual(basket.lines.first().product, product)
+        self.assertFalse(basket.vouchers.all())
+        self.assertFalse(basket.applied_offers())
+
+    @ddt.data(
+        ('honor', 'Honor'),
+        ('verified', 'Verified'),
+        ('professional', 'Professional'),
+        ('audit', 'Audit')
+    )
+    @ddt.unpack
+    def test_cert_display(self, cert_type, cert_display):
+        """ Verify certificate display types. """
+        self.assertEqual(get_certificate_type_display_value(cert_type), cert_display)
+
+    def test_cert_display_assertion(self):
+        """ Verify assertion for invalid cert type """
+        self.assertRaises(ValueError, lambda: get_certificate_type_display_value('junk'))

--- a/ecommerce/extensions/basket/tests/test_views.py
+++ b/ecommerce/extensions/basket/tests/test_views.py
@@ -1,0 +1,196 @@
+import datetime
+import hashlib
+import json
+
+import ddt
+from django.conf import settings
+from django.core.cache import cache
+from django.core.urlresolvers import reverse
+from django.test import override_settings
+import httpretty
+from oscar.core.loading import get_class, get_model
+from oscar.test import newfactories as factories
+import pytz
+from requests.exceptions import ConnectionError, Timeout
+from slumber.exceptions import SlumberBaseException
+from testfixtures import LogCapture
+
+from ecommerce.core.tests import toggle_switch
+from ecommerce.courses.tests.factories import CourseFactory
+from ecommerce.extensions.payment.tests.processors import DummyProcessor
+from ecommerce.extensions.test.factories import create_coupon, prepare_voucher
+from ecommerce.settings import get_lms_url
+from ecommerce.tests.factories import StockRecordFactory
+from ecommerce.tests.mixins import LmsApiMockMixin
+from ecommerce.tests.testcases import TestCase
+
+Applicator = get_class('offer.utils', 'Applicator')
+Basket = get_model('basket', 'Basket')
+Benefit = get_model('offer', 'Benefit')
+Catalog = get_model('catalogue', 'Catalog')
+Selector = get_class('partner.strategy', 'Selector')
+StockRecord = get_model('partner', 'StockRecord')
+
+COUPON_CODE = 'COUPONTEST'
+
+
+class BasketSingleItemViewTests(LmsApiMockMixin, TestCase):
+    """ BasketSingleItemView view tests. """
+    path = reverse('basket:single-item')
+
+    def setUp(self):
+        super(BasketSingleItemViewTests, self).setUp()
+        self.user = self.create_user()
+        self.client.login(username=self.user.username, password=self.password)
+
+        product = factories.ProductFactory()
+        self.stock_record = StockRecordFactory(product=product, partner=self.partner)
+        self.catalog = Catalog.objects.create(partner=self.partner)
+        self.catalog.stock_records.add(self.stock_record)
+
+    def test_login_required(self):
+        """ The view should redirect to login page if the user is not logged in. """
+        self.client.logout()
+        response = self.client.get(self.path)
+        testserver_login_url = self.get_full_url(reverse('login'))
+        expected_url = '{path}?next={basket_path}'.format(path=testserver_login_url, basket_path=self.path)
+        self.assertRedirects(response, expected_url, target_status_code=302)
+
+    def test_missing_sku(self):
+        """ The view should return HTTP 400 if no SKU is provided. """
+        response = self.client.get(self.path)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.content, 'No SKU provided.')
+
+    def test_missing_product(self):
+        """ The view should return HTTP 400 if SKU has no associated product. """
+        sku = 'NONEXISTING'
+        expected_content = 'SKU [{}] does not exist.'.format(sku)
+        url = '{path}?sku={sku}'.format(path=self.path, sku=sku)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.content, expected_content)
+
+    def test_unavailable_product(self):
+        """ The view should return HTTP 400 if the product is not available for purchase. """
+        product = self.stock_record.product
+        product.expires = pytz.utc.localize(datetime.datetime.min)
+        product.save()
+        self.assertFalse(Selector().strategy().fetch_for_product(product).availability.is_available_to_buy)
+
+        expected_content = 'Product [{}] not available to buy.'.format(product.title)
+        url = '{path}?sku={sku}'.format(path=self.path, sku=self.stock_record.partner_sku)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.content, expected_content)
+
+    @httpretty.activate
+    def test_redirect_to_basket_summary(self):
+        """
+        Verify the view redirects to the basket summary page, and that the user's basket is prepared for checkout.
+        """
+        create_coupon(catalog=self.catalog, code=COUPON_CODE, benefit_value=5)
+
+        self.mock_footer_api_response()
+        self.mock_course_api_response()
+        url = '{path}?sku={sku}&code={code}'.format(path=self.path, sku=self.stock_record.partner_sku,
+                                                    code=COUPON_CODE)
+        response = self.client.get(url)
+        expected_url = self.get_full_url(reverse('basket:summary'))
+        self.assertRedirects(response, expected_url, status_code=303)
+
+        basket = Basket.objects.get(owner=self.user, site=self.site)
+        self.assertEqual(basket.status, Basket.FROZEN)
+        self.assertEqual(basket.lines.count(), 1)
+        self.assertTrue(basket.contains_a_voucher)
+        self.assertEqual(basket.lines.first().product, self.stock_record.product)
+
+
+@httpretty.activate
+@ddt.ddt
+@override_settings(PAYMENT_PROCESSORS=['ecommerce.extensions.payment.tests.processors.DummyProcessor'])
+class BasketSummaryViewTests(LmsApiMockMixin, TestCase):
+    """ BasketSummaryView basket view tests. """
+    path = reverse('basket:summary')
+
+    def setUp(self):
+        super(BasketSummaryViewTests, self).setUp()
+        self.user = self.create_user()
+        self.client.login(username=self.user.username, password=self.password)
+        self.course = CourseFactory(name='BasketSummaryTest')
+        toggle_switch(settings.PAYMENT_PROCESSOR_SWITCH_PREFIX + DummyProcessor.NAME, True)
+
+    def mock_course_api_error(self, error):
+        def callback(request, uri, headers):  # pylint: disable=unused-argument
+            raise error
+        course_url = get_lms_url('api/courses/v1/courses/{}/'.format(self.course))
+        httpretty.register_uri(httpretty.GET, course_url, body=callback, content_type='application/json')
+
+    @ddt.data(ConnectionError, SlumberBaseException, Timeout)
+    def test_course_api_failure(self, error):
+        """ Verify a connection error and timeout are logged when they happen. """
+        self.mock_footer_api_response()
+        seat = self.course.create_or_update_seat('verified', True, 50, self.partner)
+        basket = factories.BasketFactory(owner=self.user)
+        basket.add_product(seat, 1)
+        self.assertEqual(basket.lines.count(), 1)
+
+        logger_name = 'ecommerce.extensions.basket.views'
+        self.mock_course_api_error(error)
+
+        with LogCapture(logger_name) as l:
+            response = self.client.get(self.path)
+            self.assertEqual(response.status_code, 200)
+            l.check(
+                (
+                    logger_name, 'ERROR',
+                    u'Failed to retrieve data from Course API for course [{}].'.format(self.course.id)
+                )
+            )
+
+    @ddt.data(
+        (Benefit.PERCENTAGE, 100, 100, False),
+        (Benefit.PERCENTAGE, 50, 50, True),
+        (Benefit.FIXED_PRICE, 50, 10, True)
+    )
+    @ddt.unpack
+    def test_response_success(self, benefit_type, benefit_value, expected_value, is_discounted):
+        """ Verify a successful response is returned. """
+        seat = self.course.create_or_update_seat('verified', True, 500, self.partner)
+        basket = factories.BasketFactory(owner=self.user)
+        basket.add_product(seat, 1)
+
+        _range = factories.RangeFactory(products=[seat, ])
+        voucher, __ = prepare_voucher(_range=_range, benefit_type=benefit_type, benefit_value=benefit_value)
+        basket.vouchers.add(voucher)
+        Applicator().apply(basket)
+
+        self.assertEqual(basket.lines.count(), 1)
+        self.mock_course_api_response(self.course)
+        self.mock_footer_api_response()
+
+        response = self.client.get(self.path)
+        self.assertEqual(response.context['lines'][0].discount_percentage, expected_value)
+        self.assertEqual(response.context['lines'][0].is_discounted, is_discounted)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['payment_processors'][0].NAME, DummyProcessor.NAME)
+        self.assertEqual(json.loads(response.context['footer']), {'footer': 'edX Footer'})
+
+    def test_cached_course(self):
+        """ Verify that the course info is cached. """
+        seat = self.course.create_or_update_seat('verified', True, 50, self.partner)
+        basket = factories.BasketFactory(owner=self.user)
+        basket.add_product(seat, 1)
+        self.assertEqual(basket.lines.count(), 1)
+        self.mock_course_api_response(self.course)
+        self.mock_footer_api_response()
+
+        cache_key = 'courses_api_detail_{}'.format(self.course.id)
+        cache_hash = hashlib.md5(cache_key).hexdigest()
+        cached_course_before = cache.get(cache_hash)
+        self.assertIsNone(cached_course_before)
+
+        response = self.client.get(self.path)
+        self.assertEqual(response.status_code, 200)
+        cached_course_after = cache.get(cache_hash)
+        self.assertEqual(cached_course_after['name'], self.course.name)

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -1,0 +1,48 @@
+import logging
+
+from django.utils.translation import ugettext_lazy as _
+from oscar.core.loading import get_class, get_model
+
+Applicator = get_class('offer.utils', 'Applicator')
+Basket = get_model('basket', 'Basket')
+logger = logging.getLogger(__name__)
+
+
+def prepare_basket(request, product, voucher=None):
+    """
+    Create or get the basket, add the product, and apply a voucher.
+
+    Existing baskets are merged. The specified product will
+    be added to the remaining open basket. The Voucher is applied to the basket.
+
+    Arguments:
+        request (Request): The request object made to the view.
+        product (Product): Product to be added to the basket.
+        voucher (Voucher): Voucher to apply to the basket.
+
+    Returns:
+        basket (Basket): Contains the product to be redeemed and the Voucher applied.
+    """
+    basket = Basket.get_basket(request.user, request.site)
+    basket.add_product(product, 1)
+    if voucher:
+        basket.vouchers.add(voucher)
+        Applicator().apply(basket, request.user, request)
+        logger.info('Applied Voucher [%s] to basket [%s].', voucher.code, basket.id)
+    basket.freeze()
+
+    return basket
+
+
+def get_certificate_type_display_value(certificate_type):
+    display_values = {
+        'audit': _('Audit'),
+        'verified': _('Verified'),
+        'professional': _('Professional'),
+        'honor': _('Honor')
+    }
+
+    if certificate_type not in display_values:
+        raise ValueError('Certificate Type [%s] not found.', certificate_type)
+
+    return display_values[certificate_type]

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -1,0 +1,114 @@
+from __future__ import unicode_literals
+import hashlib
+import logging
+
+from django.conf import settings
+from django.http import HttpResponseBadRequest, HttpResponseRedirect
+from django.core.cache import cache
+from django.core.urlresolvers import reverse
+from django.utils.translation import ugettext_lazy as _
+from requests.exceptions import ConnectionError, Timeout
+from oscar.apps.basket.views import *  # pylint: disable=wildcard-import, unused-wildcard-import
+from edx_rest_api_client.client import EdxRestApiClient
+from slumber.exceptions import SlumberBaseException
+
+from ecommerce.coupons.views import get_voucher_from_code
+from ecommerce.extensions.api.data import get_lms_footer
+from ecommerce.extensions.basket.utils import get_certificate_type_display_value, prepare_basket
+from ecommerce.extensions.payment.helpers import get_processor_class
+from ecommerce.extensions.partner.shortcuts import get_partner_for_site
+from ecommerce.settings import get_lms_url
+
+Benefit = get_model('offer', 'Benefit')
+logger = logging.getLogger(__name__)
+StockRecord = get_model('partner', 'StockRecord')
+
+
+class BasketSingleItemView(View):
+    """
+    View that adds a single product to a user's basket.
+    An additional coupon code can be supplied so the offer is applied to the basket.
+    """
+    def get(self, request):
+        partner = get_partner_for_site(request)
+
+        sku = request.GET.get('sku', None)
+        code = request.GET.get('code', None)
+
+        if not sku:
+            return HttpResponseBadRequest(_('No SKU provided.'))
+
+        if code:
+            voucher, __ = get_voucher_from_code(code=code)
+        else:
+            voucher = None
+
+        try:
+            product = StockRecord.objects.get(partner=partner, partner_sku=sku).product
+        except StockRecord.DoesNotExist:
+            return HttpResponseBadRequest(_('SKU [{sku}] does not exist.'.format(sku=sku)))
+
+        purchase_info = request.strategy.fetch_for_product(product)
+        if not purchase_info.availability.is_available_to_buy:
+            return HttpResponseBadRequest(_('Product [{product}] not available to buy.'.format(product=product.title)))
+
+        prepare_basket(request, product, voucher)
+        return HttpResponseRedirect(reverse('basket:summary'), status=303)
+
+
+class BasketSummaryView(BasketView):
+    """
+    Display basket contents and checkout/payment options.
+    """
+    def get_context_data(self, **kwargs):
+        context = super(BasketSummaryView, self).get_context_data(**kwargs)
+        lines = self.request.basket.lines.all()
+        api = EdxRestApiClient(get_lms_url('api/courses/v1/'))
+        for line in lines:
+            course_id = line.product.course_id
+
+            # Get each course type so we can display to the user at checkout.
+            try:
+                line.certificate_type = get_certificate_type_display_value(line.product.attr.certificate_type)
+            except ValueError:
+                line.certificate_type = None
+
+            cache_key = 'courses_api_detail_{}'.format(course_id)
+            cache_hash = hashlib.md5(cache_key).hexdigest()
+            try:
+                course = cache.get(cache_hash)
+                if not course:
+                    course = api.courses(course_id).get()
+                    course['image_url'] = get_lms_url(course['media']['course_image']['uri'])
+                    cache.set(cache_hash, course, settings.COURSES_API_CACHE_TIMEOUT)
+                line.course = course
+            except (ConnectionError, SlumberBaseException, Timeout):
+                logger.exception('Failed to retrieve data from Course API for course [%s].', course_id)
+
+            applied_offers = self.request.basket.applied_offers()
+            benefit = applied_offers.values()[0].benefit if applied_offers else None
+            if benefit:
+                if benefit.type == Benefit.PERCENTAGE:
+                    line.discount_percentage = benefit.value
+                    line.is_discounted = True if benefit.value < 100 else False
+                else:
+                    line.is_discounted = True
+                    discount_percentage = float(benefit.value / line.unit_price_excl_tax) * 100.0
+                    line.discount_percentage = 100.0 if discount_percentage > 100 else discount_percentage
+            else:
+                line.is_discounted = False
+                line.discount_percentage = 0
+
+        context.update({
+            'payment_processors': self.get_payment_processors(),
+            'homepage_url': get_lms_url(''),
+            'footer': get_lms_footer(),
+            'lines': lines,
+        })
+        return context
+
+    def get_payment_processors(self):
+        """ Retrieve the list of active payment processors. """
+        # TODO Retrieve this information from SiteConfiguration
+        processors = (get_processor_class(path) for path in settings.PAYMENT_PROCESSORS)
+        return [processor for processor in processors if processor.is_enabled()]

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -222,6 +222,9 @@ ENROLLMENT_API_URL = None
 COMMERCE_API_TIMEOUT = 7
 COMMERCE_API_URL = None
 
+# Cache course info from course API.
+COURSES_API_CACHE_TIMEOUT = 3600  # Value is in seconds
+
 # PROVIDER DATA PROCESSING
 PROVIDER_DATA_PROCESSING_TIMEOUT = 15  # Value is in seconds.
 CREDIT_PROVIDER_CACHE_TIMEOUT = 600
@@ -474,3 +477,6 @@ CELERY_ALWAYS_EAGER = False
 
 PLATFORM_NAME = 'Your Platform Name Here'
 THEME_SCSS = 'sass/themes/default.scss'
+
+# Link to the support site
+SUPPORT_URL = 'SET-ME-PLEASE'

--- a/ecommerce/tests/factories.py
+++ b/ecommerce/tests/factories.py
@@ -1,6 +1,7 @@
 from django.contrib.sites.models import Site
 import factory
 from oscar.core.loading import get_model
+from oscar.test.factories import ProductFactory, StockRecordFactory as OscarStockRecordFactory
 
 from ecommerce.core.models import SiteConfiguration
 
@@ -24,3 +25,8 @@ class SiteConfigurationFactory(factory.DjangoModelFactory):
 
     site = factory.SubFactory(SiteFactory)
     partner = factory.SubFactory(PartnerFactory)
+
+
+class StockRecordFactory(OscarStockRecordFactory):
+    product = factory.SubFactory(ProductFactory)
+    price_currency = 'USD'


### PR DESCRIPTION
Add a new basket view in otto that displays the product as well as any offers applied.  

The intent of this is to replace the current LMS payment page.

The PR implements the following:
Basket summary view 
Single item api endpoint (adds a single item to a basket, and optionally accepts a coupon code)
coupon tests that use the new api
