### PR TITLE
Split up product view tests to avoid a segfault.

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_products.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_products.py
@@ -19,11 +19,10 @@ ProductClass = get_model('catalogue', 'ProductClass')
 Voucher = get_model('voucher', 'Voucher')
 
 
-class ProductViewSetTests(ProductSerializerMixin, CourseCatalogTestMixin, TestCase):
-    maxDiff = None
+class ProductViewSetBase(ProductSerializerMixin, CourseCatalogTestMixin, TestCase):
 
     def setUp(self):
-        super(ProductViewSetTests, self).setUp()
+        super(ProductViewSetBase, self).setUp()
         self.user = self.create_user(is_staff=True)
         self.client.login(username=self.user.username, password=self.password)
         self.course = Course.objects.create(id='edX/DemoX/Demo_Course', name='Test Course')
@@ -31,6 +30,9 @@ class ProductViewSetTests(ProductSerializerMixin, CourseCatalogTestMixin, TestCa
         # TODO Update the expiration date by 2099-12-31
         expires = datetime.datetime(2100, 1, 1, tzinfo=pytz.UTC)
         self.seat = self.course.create_or_update_seat('honor', False, 0, self.partner, expires=expires)
+
+
+class ProductViewSetTests(ProductViewSetBase):
 
     def test_list(self):
         """ Verify a list of products is returned. """
@@ -124,6 +126,9 @@ class ProductViewSetTests(ProductSerializerMixin, CourseCatalogTestMixin, TestCa
             'results': []
         }
         self.assertDictEqual(json.loads(response.content), expected)
+
+
+class ProductViewSetCouponTests(ProductViewSetBase):
 
     def test_coupon_product_details(self):
         """Verify the endpoint returns all coupon information."""


### PR DESCRIPTION
tl;dr ecommerce Python tests were segfaulting due to an issue with nose and SQLite. See https://code.djangoproject.com/ticket/24080 for more details. Splitting the existing tests into two classes works around the problem.

@clintonb Looks like you wrote most of these tests, care to do a quick review?
