### PR TITLE
Don't freeze a basket in the preparation step

### DIFF
--- a/ecommerce/extensions/basket/tests/test_utils.py
+++ b/ecommerce/extensions/basket/tests/test_utils.py
@@ -37,7 +37,7 @@ class BasketUtilsTests(TestCase):
 
         basket = prepare_basket(self.request, product, voucher)
         self.assertIsNotNone(basket)
-        self.assertEqual(basket.status, Basket.FROZEN)
+        self.assertEqual(basket.status, Basket.OPEN)
         self.assertEqual(basket.lines.count(), 1)
         self.assertEqual(basket.lines.first().product, product)
         self.assertEqual(basket.vouchers.count(), 1)
@@ -50,7 +50,7 @@ class BasketUtilsTests(TestCase):
         product = ProductFactory()
         basket = prepare_basket(self.request, product)
         self.assertIsNotNone(basket)
-        self.assertEqual(basket.status, Basket.FROZEN)
+        self.assertEqual(basket.status, Basket.OPEN)
         self.assertEqual(basket.lines.count(), 1)
         self.assertEqual(basket.lines.first().product, product)
         self.assertFalse(basket.vouchers.all())

--- a/ecommerce/extensions/basket/tests/test_views.py
+++ b/ecommerce/extensions/basket/tests/test_views.py
@@ -43,7 +43,9 @@ class BasketSingleItemViewTests(LmsApiMockMixin, TestCase):
         self.user = self.create_user()
         self.client.login(username=self.user.username, password=self.password)
 
-        product = factories.ProductFactory()
+        course = CourseFactory()
+        course.create_or_update_seat('verified', True, 50, self.partner)
+        product = course.create_or_update_seat('verified', False, 0, self.partner)
         self.stock_record = StockRecordFactory(product=product, partner=self.partner)
         self.catalog = Catalog.objects.create(partner=self.partner)
         self.catalog.stock_records.add(self.stock_record)
@@ -100,7 +102,7 @@ class BasketSingleItemViewTests(LmsApiMockMixin, TestCase):
         self.assertRedirects(response, expected_url, status_code=303)
 
         basket = Basket.objects.get(owner=self.user, site=self.site)
-        self.assertEqual(basket.status, Basket.FROZEN)
+        self.assertEqual(basket.status, Basket.OPEN)
         self.assertEqual(basket.lines.count(), 1)
         self.assertTrue(basket.contains_a_voucher)
         self.assertEqual(basket.lines.first().product, self.stock_record.product)

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -29,7 +29,6 @@ def prepare_basket(request, product, voucher=None):
         basket.vouchers.add(voucher)
         Applicator().apply(basket, request.user, request)
         logger.info('Applied Voucher [%s] to basket [%s].', voucher.code, basket.id)
-    basket.freeze()
 
     return basket
 


### PR DESCRIPTION
The basket shouldn't be frozen while it's still being prepared, but rather on the checkout step:
https://github.com/edx/ecommerce/blob/master/ecommerce/extensions/api/v2/views/checkout.py#L37
