### PR TITLE
[SOL-1640] Change 'Add to basket' link from basket:single-item to basket:summary

### DIFF
--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -251,10 +251,8 @@ class CouponRedeemViewTests(TestCase):
     def test_basket_redirect_discount_code(self):
         """ Verify the view redirects to the basket single-item view when a discount code is provided. """
         create_coupon(catalog=self.catalog, code=COUPON_CODE, benefit_value=5)
-        sku = StockRecord.objects.get(product=self.seat).partner_sku
-        test_server_url = self.get_full_url(path=reverse('basket:single-item'))
-        expected_url = '{url}?sku={sku}&code={code}'.format(url=test_server_url, sku=sku, code=COUPON_CODE)
-        self.assert_redemption_page_redirects(expected_url, 303)
+        expected_url = self.get_full_url(path=reverse('basket:summary'))
+        self.assert_redemption_page_redirects(expected_url)
 
     @httpretty.activate
     def test_basket_redirect_enrollment_code(self):

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -196,14 +196,7 @@ class CouponRedeemView(EdxOrderPlacementMixin, View):
                 order_total=order_metadata[AC.KEYS.ORDER_TOTAL],
             )
         else:
-            partner = request.site.siteconfiguration.partner
-            sku = StockRecord.objects.get(product=product, partner=partner).partner_sku
-            url = '{url}?sku={sku}&code={code}'.format(
-                url=reverse('basket:single-item'),
-                sku=sku,
-                code=code
-            )
-            return HttpResponseRedirect(url)
+            return HttpResponseRedirect(reverse('basket:summary'))
 
         if order.status is ORDER.COMPLETE:
             return HttpResponseRedirect(get_lms_url(''))


### PR DESCRIPTION
`prepare_basket` was called twice, once in `CouponRedeemView` once in `BasketSingleItemView` and caused the product to be added twice. Since the `BasketSingleItemView` view does the same checks that are already done in `CouponRedeemView` there is no need to route through that view and therefore it's been rerouted to the summary page.

Maybe even change the redeem links to point to the basket single-item view in the first place?

@marjev @mjfrey 
