### PR TITLE
Include 'jquery-cookie' to fix JS errors in basket page.

### DIFF
--- a/ecommerce/static/js/pages/basket_page.js
+++ b/ecommerce/static/js/pages/basket_page.js
@@ -6,7 +6,8 @@ define([
         'jquery',
         'underscore',
         'underscore.string',
-        'utils/utils'
+        'utils/utils',
+        'jquery-cookie'
     ],
     function ($,
               _,


### PR DESCRIPTION
Need to include query-cookie to fit JS error on the basket page.
