### PR TITLE
Change benefit type to Absolute

### DIFF
--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -194,7 +194,7 @@ class CouponOfferViewTests(LmsApiMockMixin, TestCase):
     def test_fixed_amount(self, benefit_value, new_price):
         """ Verify a new price is calculated properly with fixed price type benefit. """
         _range = self.prepare_course_information()
-        prepare_voucher(code=COUPON_CODE, _range=_range, benefit_value=benefit_value, benefit_type=Benefit.FIXED_PRICE)
+        prepare_voucher(code=COUPON_CODE, _range=_range, benefit_value=benefit_value, benefit_type=Benefit.FIXED)
         response = self.client.get(self.path_with_code)
         self.assertEqual(response.context['new_price'], new_price)
 

--- a/ecommerce/extensions/basket/tests/test_views.py
+++ b/ecommerce/extensions/basket/tests/test_views.py
@@ -153,7 +153,7 @@ class BasketSummaryViewTests(LmsApiMockMixin, TestCase):
     @ddt.data(
         (Benefit.PERCENTAGE, 100, 100, False),
         (Benefit.PERCENTAGE, 50, 50, True),
-        (Benefit.FIXED_PRICE, 50, 10, True)
+        (Benefit.FIXED, 50, 10, True)
     )
     @ddt.unpack
     def test_response_success(self, benefit_type, benefit_value, expected_value, is_discounted):

--- a/ecommerce/static/templates/coupon_form.html
+++ b/ecommerce/static/templates/coupon_form.html
@@ -59,7 +59,7 @@
             <div class="form-inline benefit-type">
                 <input id="benefit_percent" type="radio" name="benefit_type" value="Percentage">
                 <label for="benefit_percent"><%= gettext('Percent') %></label>
-                <input id="benefit_fixed" type="radio" name="benefit_type" value="Fixed">
+                <input id="benefit_fixed" type="radio" name="benefit_type" value="Absolute">
                 <label for="benefit_fixed"><%= gettext('Fixed ($USD)') %></label>
             </div>
             <p class="help-block"></p>


### PR DESCRIPTION
The value of the `Benefit.FIXED` keyword is `Absolute` and not `Fixed`.
https://github.com/django-oscar/django-oscar/blob/master/src/oscar/apps/offer/abstract_models.py#L390-L396

@marjev @mjfrey 
