### PR TITLE
Updated clean_static make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ clean:
 	rm -rf coverage htmlcov
 
 clean_static:
-	rm -rf assets/ ecommerce/static/build
+	rm -rf assets/* ecommerce/static/build/*
 
 validate_js:
 	rm -rf coverage


### PR DESCRIPTION
The contents of the static directories are deleted, but the parent directories are retained. This avoids issues with Django being unable to find ecommerce/static/build after running `make clean_static`.
