### PR TITLE
Add discount to line items

### DIFF
--- a/ecommerce/extensions/payment/processors/paypal.py
+++ b/ecommerce/extensions/payment/processors/paypal.py
@@ -93,7 +93,7 @@ class Paypal(BasePaymentProcessor):
                             'quantity': line.quantity,
                             # PayPal requires that item names be at most 127 characters long.
                             'name': middle_truncate(line.product.title, 127),
-                            'price': unicode(line.price_incl_tax),
+                            'price': unicode(line.line_price_incl_tax_incl_discounts),
                             'currency': line.stockrecord.price_currency,
                         }
                         for line in basket.all_lines()


### PR DESCRIPTION
Use line.line_price_incl_tax_incl_discounts so PayPal knows the proper price.
