### PR TITLE
Lines should be empty for non-existing baskets.

### DIFF
--- a/ecommerce/extensions/basket/tests/test_views.py
+++ b/ecommerce/extensions/basket/tests/test_views.py
@@ -181,8 +181,15 @@ class BasketSummaryViewTests(LmsApiMockMixin, TestCase):
 
         response = self.client.get(self.path)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['lines']), 1)
         self.assertEqual(response.context['payment_processors'][0].NAME, DummyProcessor.NAME)
         self.assertEqual(json.loads(response.context['footer']), {'footer': 'edX Footer'})
+
+    def test_no_basket_response(self):
+        """ Verify there are no lines in the context for a non-existing basket. """
+        response = self.client.get(self.path)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['lines'], [])
 
     def test_line_item_discount_data(self):
         """ Verify that line item has correct discount data. """

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -63,7 +63,7 @@ class BasketSummaryView(BasketView):
     """
     def get_context_data(self, **kwargs):
         context = super(BasketSummaryView, self).get_context_data(**kwargs)
-        lines = context['line_list']
+        lines = context.get('line_list', [])
         api = EdxRestApiClient(get_lms_url('api/courses/v1/'))
         for line in lines:
             course_id = line.product.course_id


### PR DESCRIPTION
We got this!
![](http://i.telegraph.co.uk/multimedia/archive/01789/pipeline-fire_1789045i.jpg)

In case a user goes to `/basket` without adding anything to the basket `line_list` would not exist in the context. This change adds a default empty list in that case. 
https://openedx.atlassian.net/browse/SOL-1675
