### PR TITLE
Updated PayPal and requests dependencies

### DIFF
--- a/ecommerce/core/tests/patched_httpretty.py
+++ b/ecommerce/core/tests/patched_httpretty.py
@@ -1,0 +1,40 @@
+# Note (CCB): We must patch httpretty to work around SSL issues.
+# See https://github.com/gabrielfalcao/HTTPretty/issues/242, and remove this once an proper fix is in place.
+
+import httpretty
+from httpretty import HTTPretty as OriginalHTTPretty
+import httpretty.core
+
+try:
+    from requests.packages.urllib3.contrib.pyopenssl import inject_into_urllib3, extract_from_urllib3
+
+    pyopenssl_override = True
+except:  # pylint: disable=bare-except
+    pyopenssl_override = False
+
+
+class PatchedHTTPretty(httpretty.HTTPretty):
+    """ pyopenssl monkey-patches the default ssl_wrap_socket() function in the 'requests' library,
+    but this can stop the HTTPretty socket monkey-patching from working for HTTPS requests.
+
+    Our version extends the base HTTPretty enable() and disable() implementations to undo
+    and redo the pyopenssl monkey-patching, respectively.
+    """
+
+    @classmethod
+    def enable(cls):
+        OriginalHTTPretty.enable()
+        if pyopenssl_override:
+            # Take out the pyopenssl version - use the default implementation
+            extract_from_urllib3()
+
+    @classmethod
+    def disable(cls):
+        OriginalHTTPretty.disable()
+        if pyopenssl_override:
+            # Put the pyopenssl version back in place
+            inject_into_urllib3()
+
+
+httpretty.core.httpretty = PatchedHTTPretty
+httpretty.httpretty = PatchedHTTPretty

--- a/ecommerce/courses/tests/test_views.py
+++ b/ecommerce/courses/tests/test_views.py
@@ -3,7 +3,6 @@ import json
 import httpretty
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from requests import Timeout
 from testfixtures import LogCapture
 
 from ecommerce.settings import get_lms_url
@@ -78,11 +77,11 @@ class CourseAppViewTests(TestCase):
 
         return providers, provider_json
 
-    def mock_credit_api_timeout(self):
-        """ Mock a timeout when calling the Credit API providers endpoint. """
+    def mock_credit_api_error(self):
+        """ Mock an error response when calling the Credit API providers endpoint. """
 
         def callback(request, uri, headers):  # pylint: disable=unused-argument
-            raise Timeout
+            return 500, headers, 'Failure!'
 
         url = get_lms_url('/api/credit/v1/providers/')
         httpretty.register_uri(httpretty.GET, url, body=callback, content_type='application/json')
@@ -133,7 +132,7 @@ class CourseAppViewTests(TestCase):
         user = self.create_user(is_staff=True)
         self.create_access_token(user)
         self.client.login(username=user.username, password=self.password)
-        self.mock_credit_api_timeout()
+        self.mock_credit_api_error()
 
         with LogCapture(LOGGER_NAME) as l:
             response = self.client.get(self.path)

--- a/ecommerce/extensions/payment/tests/test_processors.py
+++ b/ecommerce/extensions/payment/tests/test_processors.py
@@ -12,7 +12,6 @@ import ddt
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
-import httpretty
 import mock
 from oscar.apps.payment.exceptions import TransactionDeclined, UserCancelled, GatewayError
 from oscar.core.loading import get_model
@@ -24,6 +23,7 @@ from testfixtures import LogCapture
 
 from ecommerce.core.constants import ISO_8601_FORMAT
 from ecommerce.core.tests import toggle_switch
+from ecommerce.core.tests.patched_httpretty import httpretty
 from ecommerce.courses.models import Course
 from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
 from ecommerce.extensions.order.constants import PaymentEventTypeName

--- a/ecommerce/extensions/payment/tests/test_transport.py
+++ b/ecommerce/extensions/payment/tests/test_transport.py
@@ -1,9 +1,9 @@
 import uuid
 
-import httpretty
 from suds.transport import Request
 
 from ecommerce.extensions.payment.transport import RequestsTransport
+from ecommerce.core.tests.patched_httpretty import httpretty
 from ecommerce.tests.testcases import TestCase
 
 API_URL = 'https://example.com/api.wsdl'

--- a/ecommerce/extensions/payment/tests/test_views.py
+++ b/ecommerce/extensions/payment/tests/test_views.py
@@ -3,7 +3,6 @@ import ddt
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 from factory.django import mute_signals
-import httpretty
 import mock
 from oscar.apps.order.exceptions import UnableToPlaceOrder
 from oscar.apps.payment.exceptions import PaymentError, UserCancelled, TransactionDeclined
@@ -17,6 +16,7 @@ from ecommerce.extensions.payment.processors.cybersource import Cybersource
 from ecommerce.extensions.payment.processors.paypal import Paypal
 from ecommerce.extensions.payment.tests.mixins import PaymentEventsMixin, CybersourceMixin, PaypalMixin
 from ecommerce.extensions.payment.views import CybersourceNotifyView, PaypalPaymentExecutionView
+from ecommerce.core.tests.patched_httpretty import httpretty
 from ecommerce.tests.testcases import TestCase
 
 Basket = get_model('basket', 'Basket')

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,6 +18,7 @@ edx-ecommerce-worker==0.3.0
 edx-rest-api-client==1.3.0
 jsonfield==1.0.3
 libsass==0.9.2
+ndg-httpsclient==0.4.0
 paypalrestsdk==1.11.5
 premailer==2.9.2
 pycountry==1.18

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@ coverage==4.0.2
 ddt==1.0.0
 django-nose==1.4.2
 edx-ecommerce-api-client==1.1.0
-httpretty==0.8.10
+httpretty==0.8.14
 mock==1.3.0
 mock-django==0.6.9
 nose-ignore-docstring==0.2


### PR DESCRIPTION
These updates ensure we do not encounter issues with the forthcoming PayPal TLS switchover.

ECOM-3835
