### PR TITLE
[SOL-1644] Enrollment button for the basket

### DIFF
--- a/ecommerce/extensions/api/v2/views/baskets.py
+++ b/ecommerce/extensions/api/v2/views/baskets.py
@@ -230,26 +230,7 @@ class BasketCreateView(EdxOrderPlacementMixin, generics.CreateAPIView):
         response_data = self._generate_basic_response(basket)
 
         if basket.total_excl_tax == AC.FREE:
-            order_metadata = data_api.get_order_metadata(basket)
-
-            logger.info(
-                'Preparing to place order [%s] for the contents of basket [%d]',
-                order_metadata[AC.KEYS.ORDER_NUMBER],
-                basket.id,
-            )
-
-            # Place an order. If order placement succeeds, the order is committed
-            # to the database so that it can be fulfilled asynchronously.
-            order = self.handle_order_placement(
-                order_number=order_metadata[AC.KEYS.ORDER_NUMBER],
-                user=basket.owner,
-                basket=basket,
-                shipping_address=None,
-                shipping_method=order_metadata[AC.KEYS.SHIPPING_METHOD],
-                shipping_charge=order_metadata[AC.KEYS.SHIPPING_CHARGE],
-                billing_address=None,
-                order_total=order_metadata[AC.KEYS.ORDER_TOTAL],
-            )
+            order = self.place_free_order(basket)
 
             # Note: Our order serializer could be used here, but in an effort to pare down the information
             # returned by this endpoint, simply returning the order number will suffice for now.

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -138,8 +138,6 @@ class CouponViewSet(EdxOrderPlacementMixin, NonDestroyableModelViewSet):
         Raises:
             IntegrityError: An error occured when create_vouchers method returns
                             an IntegrityError exception
-            ValidationError: An error occured clean() validation method returns
-                             a ValidationError exception
         """
         coupon_slug = generate_coupon_slug(title=title, catalog=data['catalog'], partner=data['partner'])
 

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 from decimal import Decimal
 import hashlib
 import logging
@@ -92,6 +93,7 @@ class BasketSummaryView(BasketView):
                 line.discount_percentage = 0
 
         context.update({
+            'free_basket': context['order_total'].incl_tax == 0,
             'payment_processors': self.get_payment_processors(),
             'homepage_url': get_lms_url(''),
             'footer': get_lms_footer(),

--- a/ecommerce/extensions/checkout/app.py
+++ b/ecommerce/extensions/checkout/app.py
@@ -1,0 +1,45 @@
+from django.conf.urls import url
+from oscar.apps.checkout import app
+from oscar.core.loading import get_class
+
+
+class CheckoutApplication(app.CheckoutApplication):
+    free_checkout = get_class('checkout.views', 'FreeCheckoutView')
+
+    def get_urls(self):
+        urls = [
+            url(r'^free-checkout/$', self.free_checkout.as_view(), name='free-checkout'),
+
+            url(r'^$', self.index_view.as_view(), name='index'),
+
+            # Shipping/user address views
+            url(r'shipping-address/$',
+                self.shipping_address_view.as_view(), name='shipping-address'),
+            url(r'user-address/edit/(?P<pk>\d+)/$',
+                self.user_address_update_view.as_view(),
+                name='user-address-update'),
+            url(r'user-address/delete/(?P<pk>\d+)/$',
+                self.user_address_delete_view.as_view(),
+                name='user-address-delete'),
+
+            # Shipping method views
+            url(r'shipping-method/$',
+                self.shipping_method_view.as_view(), name='shipping-method'),
+
+            # Payment views
+            url(r'payment-method/$',
+                self.payment_method_view.as_view(), name='payment-method'),
+            url(r'payment-details/$',
+                self.payment_details_view.as_view(), name='payment-details'),
+
+            # Preview and thankyou
+            url(r'preview/$',
+                self.payment_details_view.as_view(preview=True),
+                name='preview'),
+            url(r'thank-you/$', self.thankyou_view.as_view(),
+                name='thank-you'),
+        ]
+        return self.post_process_urls(urls)
+
+
+application = CheckoutApplication()

--- a/ecommerce/extensions/checkout/exceptions.py
+++ b/ecommerce/extensions/checkout/exceptions.py
@@ -1,0 +1,3 @@
+class BasketNotFreeError(Exception):
+    """ Error for when the basket is not free. """
+    pass

--- a/ecommerce/extensions/checkout/tests/test_views.py
+++ b/ecommerce/extensions/checkout/tests/test_views.py
@@ -1,0 +1,56 @@
+from decimal import Decimal
+
+from django.core.urlresolvers import reverse
+from django.conf import settings
+import httpretty
+from oscar.core.loading import get_model
+from oscar.test import newfactories as factories
+
+from ecommerce.extensions.checkout.exceptions import BasketNotFreeError
+from ecommerce.tests.testcases import TestCase
+from ecommerce.settings import get_lms_url
+
+Order = get_model('order', 'Order')
+
+
+class FreeCheckoutViewTests(TestCase):
+    """ FreeCheckoutView view tests. """
+    path = reverse('checkout:free-checkout')
+
+    def setUp(self):
+        super(FreeCheckoutViewTests, self).setUp()
+        self.user = self.create_user()
+        self.client.login(username=self.user.username, password=self.password)
+
+    def prepare_basket(self, price):
+        """ Helper function that creates a basket and adds a product with set price to it. """
+        basket = factories.BasketFactory(owner=self.user, site=self.site)
+        basket.add_product(factories.ProductFactory(stockrecords__price_excl_tax=price), 1)
+        self.assertEqual(basket.lines.count(), 1)
+        self.assertEqual(basket.total_incl_tax, Decimal(price))
+
+    def test_empty_basket(self):
+        """ Verify redirect to basket summary in case of empty basket. """
+        response = self.client.get(self.path)
+        expected_url = self.get_full_url(reverse('basket:summary'))
+        self.assertRedirects(response, expected_url)
+
+    def test_non_free_basket(self):
+        """ Verify an exception is raised when the URL is being accessed to with a non-free basket. """
+        self.prepare_basket(10)
+
+        with self.assertRaises(BasketNotFreeError):
+            self.client.get(self.path)
+
+    @httpretty.activate
+    def test_successful_redirect(self):
+        """ Verify redirect to the receipt page. """
+        self.prepare_basket(0)
+        self.assertEqual(Order.objects.count(), 0)
+        receipt_page = get_lms_url(settings.RECEIPT_PAGE_PATH)
+
+        response = self.client.get(self.path)
+        self.assertEqual(Order.objects.count(), 1)
+
+        expected_url = '{}?orderNum={}'.format(receipt_page, Order.objects.first().number)
+        self.assertRedirects(response, expected_url, fetch_redirect_response=False)

--- a/ecommerce/extensions/checkout/views.py
+++ b/ecommerce/extensions/checkout/views.py
@@ -1,0 +1,54 @@
+""" Checkout related views. """
+from __future__ import unicode_literals
+
+from decimal import Decimal
+import logging
+
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from django.core.urlresolvers import reverse
+from django.utils.decorators import method_decorator
+from django.views.generic import RedirectView
+from oscar.apps.checkout.views import *  # pylint: disable=wildcard-import, unused-wildcard-import
+from oscar.core.loading import get_class, get_model
+
+from ecommerce.extensions.checkout.exceptions import BasketNotFreeError
+from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
+from ecommerce.settings import get_lms_url
+
+Applicator = get_class('offer.utils', 'Applicator')
+Basket = get_model('basket', 'Basket')
+logger = logging.getLogger(__name__)
+
+
+class FreeCheckoutView(EdxOrderPlacementMixin, RedirectView):
+    """ View to handle free checkouts.
+
+    Retrieves the user's basket and checks to see if the basket is free in which case
+    the user is redirected to the receipt page. Otherwise the user is redirected back
+    to the basket summary page.
+    """
+
+    permanent = False
+
+    @method_decorator(login_required)
+    def dispatch(self, *args, **kwargs):
+        return super(FreeCheckoutView, self).dispatch(*args, **kwargs)
+
+    def get_redirect_url(self, *args, **kwargs):
+        basket = Basket.get_basket(self.request.user, self.request.site)
+        if not basket.is_empty:
+            # Need to re-apply the voucher to the basket.
+            Applicator().apply(basket, self.request.user, self.request)
+            if basket.total_incl_tax != Decimal(0):
+                raise BasketNotFreeError("Basket is not free.")
+
+            order = self.place_free_order(basket)
+
+            receipt_path = '{}?orderNum={}'.format(settings.RECEIPT_PAGE_PATH, order.number)
+            url = get_lms_url(receipt_path)
+        else:
+            # If a user's basket is empty redirect the user to the basket summary
+            # page which displays the appropriate message for empty baskets.
+            url = reverse('basket:summary')
+        return url

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -482,3 +482,6 @@ THEME_SCSS = 'sass/themes/default.scss'
 
 # Link to the support site
 SUPPORT_URL = 'SET-ME-PLEASE'
+
+# Path to the receipt page
+RECEIPT_PAGE_PATH = '/commerce/checkout/receipt/'

--- a/ecommerce/static/sass/views/_basket.scss
+++ b/ecommerce/static/sass/views/_basket.scss
@@ -125,6 +125,10 @@
             }
         }
 
+        .checkout-button {
+            @include float(right);
+        }
+
         .payment-buttons {
             margin: 0 15px;
 

--- a/ecommerce/templates/oscar/basket/partials/basket_content.html
+++ b/ecommerce/templates/oscar/basket/partials/basket_content.html
@@ -100,6 +100,9 @@
 
         <div class="row">
             <div class="payment-buttons col-sm-4" data-basket-id="{{ basket.id }}">
+                {% if free_basket %}
+                <a href="{% url 'checkout:free-checkout' %}" class="btn btn-success checkout-button">{% trans "Place Order" %}</a>
+                {% else %}
                 {% for processor in payment_processors %}
                     <button class="btn btn-success payment-button" value="{{ processor.NAME|lower }}" id="{{ processor.NAME|lower }}">
                         {% if processor.NAME == 'cybersource' %}
@@ -110,6 +113,7 @@
                         {% endif %}
                     </button>
                 {% endfor %}
+                {% endif %}
             </div>
         </div>
 


### PR DESCRIPTION
When a buyer enters an enrollment code or if the basket for any other reason is free the buyer shouldn't go through the payment processors to enroll but rather directly enroll.

In this PR I'm adding a new checkout view `FreeCheckoutView` which validates the request (user should have an item in the basket and the basket should be free) after which it fulfills the order and redirects the user to the receipt page.

Here I'm overriding Oscar's `CheckoutApplication` to include the `free_checkout` link and I'm not sure if we actually need the rest of the links. 
The `order_metadata` and `handle_order_placement` code is being repeated multiple times across the code base and could be extracted to a method of the `EdxOrderPlacementMixin` mixin class in a future PR.

https://openedx.atlassian.net/browse/SOL-1644
