### PR TITLE
Revert "Upgrade Django to 1.8.10"

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 analytics-python==1.1.0
 celery==3.1.18
-Django==1.8.10
+Django==1.8.9
 django-appconf==0.6
 django-compressor==1.5
 django_extensions==1.5.5


### PR DESCRIPTION
Reverts edx/ecommerce#592

The two fixes contained in Django [1.8.10](https://www.djangoproject.com/weblog/2016/mar/01/security-releases/) are for basic auth and password hashing, parts of Django we don't use in edx/ecommerce. Since 1.8.10 is causing problems for us related to https://code.djangoproject.com/ticket/26308, I am reverting this commit.

@mjfrey @clintonb 
