### PR TITLE
Updated ecommerce-worker

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,4 @@
 analytics-python==1.1.0
-celery==3.1.18
 Django==1.8.9
 django-appconf==0.6
 django-compressor==1.5
@@ -14,7 +13,7 @@ djangorestframework==3.2.3
 djangorestframework-jwt==1.7.2
 drf-extensions==0.2.8
 edx-auth-backends==0.1.3
-edx-ecommerce-worker==0.3.0
+edx-ecommerce-worker==0.3.3
 edx-rest-api-client==1.5.0
 jsonfield==1.0.3
 libsass==0.9.2


### PR DESCRIPTION
- Updated to latest version of lib
- Removed unnecessary celery requirement

ECOM-3860
