### PR TITLE
Updated checkout page, now each provider can have their own fulfillment instructions.

### DIFF
--- a/ecommerce/credit/tests/test_views.py
+++ b/ecommerce/credit/tests/test_views.py
@@ -158,6 +158,11 @@ class CheckoutPageTest(CourseCatalogTestMixin, TestCase, JwtMixin):
             'Congratulations! You are eligible to purchase academic course credit for this course.'
         )
 
+        self.assertContains(
+            response,
+            self.provider_data[0]['fulfillment_instructions']
+        )
+
     def test_course_not_found(self):
         """ The view should return HTTP 404 if the course cannot be found. """
         path = reverse('credit:checkout', args=['course/not/found'])

--- a/ecommerce/extensions/analytics/models.py
+++ b/ecommerce/extensions/analytics/models.py
@@ -1,1 +1,1 @@
-from oscar.apps.analytics.models import *  # pragma: no cover pylint: disable=wildcard-import
+from oscar.apps.analytics.models import *  # pragma: no cover pylint: disable=wildcard-import,unused-wildcard-import

--- a/ecommerce/extensions/offer/models.py
+++ b/ecommerce/extensions/offer/models.py
@@ -10,9 +10,9 @@ class Range(AbstractRange):
         if self.catalog:
             return (
                 product.id in self.catalog.stock_records.values_list('product', flat=True) or
-                super(Range, self).contains_product(product)
+                super(Range, self).contains_product(product)  # pylint: disable=bad-super-call
             )
-        return super(Range, self).contains_product(product)
+        return super(Range, self).contains_product(product)  # pylint: disable=bad-super-call
 
     contains = contains_product
 
@@ -22,7 +22,7 @@ class Range(AbstractRange):
     def all_products(self):
         if self.catalog:
             catalog_products = [record.product for record in self.catalog.stock_records.all()]
-            return catalog_products + list(super(Range, self).all_products())
-        return super(Range, self).all_products()
+            return catalog_products + list(super(Range, self).all_products())  # pylint: disable=bad-super-call
+        return super(Range, self).all_products()  # pylint: disable=bad-super-call
 
 from oscar.apps.offer.models import *  # noqa pylint: disable=wildcard-import,unused-wildcard-import,wrong-import-position

--- a/ecommerce/templates/edx/credit/_provider_detail.html
+++ b/ecommerce/templates/edx/credit/_provider_detail.html
@@ -29,39 +29,7 @@
             </button>
 
             <div class="collapse" id="fulfillment-instructions-{{ provider.id|lower }}">
-                <p>
-                    {% blocktrans with display_name=provider.display_name %}
-                        You can purchase credit through {{ display_name }} for this course for up to one year
-                        after the course end date. You can use the credit at {{ display_name }} or transfer the
-                        credit to another institution that accepts the credit.
-                    {% endblocktrans %}
-                </p>
-
-                <p>{% trans "To purchase course credit:" %}</p>
-
-                <ol>
-                    <li>
-                        {% trans "On this page, select a checkout option." %}
-                    </li>
-                    <li>{% trans "On the payment page, enter your payment information." %}</li>
-                    <li>
-                        {% blocktrans with display_name=provider.display_name %}
-                            When your payment is complete, follow the link to the {{ display_name }} website.
-                        {% endblocktrans %}
-                    </li>
-                    <li>
-                        {% blocktrans with display_name=provider.display_name %}
-                            On the {{ display_name }} website, enter all required information to request your course
-                            credit.
-                        {% endblocktrans %}
-                    </li>
-                </ol>
-                <p>
-                    {% blocktrans with display_name=provider.display_name %}
-                        After {{ display_name }} approves your credit, you can request an official transcript from
-                        {{ display_name }}.
-                    {% endblocktrans %}
-                </p>
+                {{ provider.fulfillment_instructions|safe }}
             </div>
         </div>
         <div class="col-sm-2 col-xs-2 hidden-xs">


### PR DESCRIPTION
[ECOM-2934](https://openedx.atlassian.net/browse/ECOM-2934)

Now each credit provider can have their own fulfillment instructions (which now includes a paragraph that was previously not parameterized)
## Screenshots:
- Collapsed
  <img width="366" alt="screen shot 2016-03-17 at 3 21 24 pm" src="https://cloud.githubusercontent.com/assets/2851134/13843186/fd227ba6-ec53-11e5-9e78-2bb76c174b0d.png">
- Expanded
  <img width="364" alt="screen shot 2016-03-17 at 3 19 37 pm" src="https://cloud.githubusercontent.com/assets/2851134/13843152/cebe448e-ec53-11e5-8f30-84396c41cb1f.png">

@zubair-arbi @tasawernawaz @awais786 Please review this.
