### PR TITLE
[SOL-1708] Restrict the basket to one voucher

### DIFF
--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -13,7 +13,9 @@ def prepare_basket(request, product, voucher=None):
     Create or get the basket, add the product, and apply a voucher.
 
     Existing baskets are merged. The specified product will
-    be added to the remaining open basket. The Voucher is applied to the basket.
+    be added to the remaining open basket. If a voucher is passed, all existing
+    ones added to the basket are removed because we allow only one voucher per
+    basket after the Voucher is applied to the basket.
 
     Arguments:
         request (Request): The request object made to the view.
@@ -27,6 +29,8 @@ def prepare_basket(request, product, voucher=None):
     basket.flush()
     basket.add_product(product, 1)
     if voucher:
+        for v in basket.vouchers.all():
+            basket.vouchers.remove(v)
         basket.vouchers.add(voucher)
         Applicator().apply(basket, request.user, request)
         logger.info('Applied Voucher [%s] to basket [%s].', voucher.code, basket.id)


### PR DESCRIPTION
If a user goes to the basket via coupon offer page from multiple links, the coupon vouchers get stacked. We want only one voucher to exist for one basket.
This PR contains code that removes existing vouchers and adds only the last one provided.

@mjfrey 

https://openedx.atlassian.net/browse/SOL-1708
