### PR TITLE
Updated link to django-oscar

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ edX E-Commerce Service  |Travis|_ |Codecov|_
 .. |Codecov| image:: http://codecov.io/github/edx/ecommerce/coverage.svg?branch=master
 .. _Codecov: http://codecov.io/github/edx/ecommerce?branch=master
 
-This repository contains the edX E-Commerce Service, which relies heavily on `django-oscar <https://github.com/edx/django-oscar>`_, as well as all frontend and backend code used to manage edX's product catalog and handle orders for those products.
+This repository contains the edX E-Commerce Service, which relies heavily on `django-oscar <https://django-oscar.readthedocs.org/en/latest/>`_, as well as all frontend and backend code used to manage edX's product catalog and handle orders for those products.
 
 Prerequisites
 -------------


### PR DESCRIPTION
@rlucioni added updated link to django-oscar. Was previously pointing a repo that no longer exists.
