### PR TITLE
[SOL-1713] Solve Integrity Error on Create Coupon request

### DIFF
--- a/ecommerce/settings/production.py
+++ b/ecommerce/settings/production.py
@@ -1,5 +1,6 @@
 """Production settings and globals."""
 from os import environ
+import psycopg2.extensions
 
 # Normally you should not import ANYTHING from Django directly
 # into your settings, but ImproperlyConfigured is an exception.
@@ -58,3 +59,5 @@ DB_OVERRIDES = dict(
 
 for override, value in DB_OVERRIDES.iteritems():
     DATABASES['default'][override] = value
+
+DATABASES['OPTIONS']['isolation_level'] = psycopg2.extensions.ISOLATION_LEVEL_READ_COMMITTED

--- a/ecommerce/settings/production.py
+++ b/ecommerce/settings/production.py
@@ -1,6 +1,5 @@
 """Production settings and globals."""
 from os import environ
-import psycopg2.extensions
 
 # Normally you should not import ANYTHING from Django directly
 # into your settings, but ImproperlyConfigured is an exception.
@@ -60,4 +59,4 @@ DB_OVERRIDES = dict(
 for override, value in DB_OVERRIDES.iteritems():
     DATABASES['default'][override] = value
 
-DATABASES['OPTIONS']['isolation_level'] = psycopg2.extensions.ISOLATION_LEVEL_READ_COMMITTED
+DATABASES['OPTIONS']['init_command'] = 'SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED'


### PR DESCRIPTION
@mjfrey please review this.

I guess the reason for IntegrityError is explained in Django documentation.
https://docs.djangoproject.com/en/1.9/ref/models/querysets/#django.db.models.query.QuerySet.get_or_create

I don't see another reason for it. There are many unofficial ways to solve this problem like creating our own get_or_create method, but that's not global solution like this is. Let me know what you think.
