### PR TITLE
Add separate requirements file for acceptance testing

### DIFF
--- a/acceptance_tests/pages/coupons.py
+++ b/acceptance_tests/pages/coupons.py
@@ -1,7 +1,8 @@
+import random
+# The string module is not deprecated. This is a bug in Pylint: https://www.logilab.org/ticket/2481.
+import string  # pylint: disable=deprecated-module
+
 from bok_choy.javascript import wait_for_js
-
-from factory.fuzzy import FuzzyText
-
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
@@ -14,7 +15,9 @@ from acceptance_tests.pages.ecommerce import EcommerceAppPage
 def _get_coupon_name(is_discount):
     """ Returns an appropriate coupon name. """
     prefix = 'test-discount-code-' if is_discount else 'test-enrollment-code-'
-    return FuzzyText(length=3, prefix=prefix).fuzz()
+    postfix = ''.join(random.choice(string.ascii_letters) for _ in range(3))
+
+    return prefix + postfix
 
 
 class BasketPage(EcommerceAppPage):

--- a/acceptance_tests/requirements.txt
+++ b/acceptance_tests/requirements.txt
@@ -1,0 +1,8 @@
+# Packages required to run acceptance tests
+bok-choy==0.5.0
+ddt==1.0.1
+django-nose==1.4.2
+edx-rest-api-client==1.5.0
+nose-ignore-docstring==0.2
+requests==2.9.1
+selenium>=2.53.1

--- a/requirements/monitoring/requirements.txt
+++ b/requirements/monitoring/requirements.txt
@@ -10,3 +10,4 @@
 -r ../optional.txt
 -r ../production.txt
 -r ../test.txt
+-r ../../acceptance_tests/requirements.txt


### PR DESCRIPTION
Jenkins nodes don't currently have libffi-dev installed. The solution presented here, a separate requirements file for acceptance tests, isn't ideal because it forces the ecommerce project to duplicate some dependencies listed in other (modular) requirements files. That said, having Jenkins install a bunch of superfluous dependencies isn't ideal either.

Here's the challenge. Say we include the new acceptance.txt as part of test.txt. We then list `requests` in acceptance.txt. Developers can no longer install dependencies using local.txt, since `requests` is now listed twice; it's already listed in base.txt. We don't want to move `requests` out of base.txt because anyone running production.txt won't have it installed, and we don't want to install acceptance testing dependencies in production.

@benpatterson @clintonb @schenedx @jzoldak thoughts?
