### PR TITLE
Rework coupon order and invoice record.

### DIFF
--- a/ecommerce/core/admin.py
+++ b/ecommerce/core/admin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.utils.translation import ugettext_lazy as _
 
-from ecommerce.core.models import SiteConfiguration, User
+from ecommerce.core.models import BusinessClient, SiteConfiguration, User
 
 
 class SiteConfigurationAdmin(admin.ModelAdmin):
@@ -20,6 +20,10 @@ class EcommerceUserAdmin(UserAdmin):
         (_('Important dates'), {'fields': ('last_login', 'date_joined')}),
     )
 
+
+@admin.register(BusinessClient)
+class BusinessClientAdmin(admin.ModelAdmin):
+    pass
 
 admin.site.register(SiteConfiguration, SiteConfigurationAdmin)
 admin.site.register(User, EcommerceUserAdmin)

--- a/ecommerce/core/migrations/0012_businessclient.py
+++ b/ecommerce/core/migrations/0012_businessclient.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0011_siteconfiguration_oauth_settings'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='BusinessClient',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(unique=True, max_length=255, verbose_name='Name')),
+            ],
+        ),
+    ]

--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -69,5 +69,13 @@ class User(AbstractUser):
 
 
 class Client(User):
-    """The model for the business client."""
     pass
+
+
+class BusinessClient(models.Model):
+    """The model for the business client."""
+
+    name = models.CharField(_('Name'), unique=True, max_length=255, blank=False, null=False)
+
+    def __str__(self):
+        return self.name

--- a/ecommerce/core/tests/test_models.py
+++ b/ecommerce/core/tests/test_models.py
@@ -1,4 +1,4 @@
-from ecommerce.core.models import User
+from ecommerce.core.models import BusinessClient, User
 from ecommerce.tests.testcases import TestCase
 
 
@@ -38,3 +38,10 @@ class UserTests(TestCase):
 
         user = self.create_user(full_name=full_name, first_name=first_name, last_name=last_name)
         self.assertEquals(user.get_full_name(), full_name)
+
+
+class BusinessClientTests(TestCase):
+
+    def test_str(self):
+        client = BusinessClient.objects.create(name='TestClient')
+        self.assertEquals(str(client), 'TestClient')

--- a/ecommerce/extensions/payment/processors/invoice.py
+++ b/ecommerce/extensions/payment/processors/invoice.py
@@ -18,7 +18,7 @@ class InvoicePayment(BasePaymentProcessor):
 
     NAME = u'invoice'
 
-    def handle_processor_response(self, response, basket=None):
+    def handle_processor_response(self, response, order=None, business_client=None):  # pylint: disable=arguments-differ
         """
         Since this is an Invoice just record the transaction.
 
@@ -34,7 +34,7 @@ class InvoicePayment(BasePaymentProcessor):
         event = PaymentEvent(event_type=event_type, processor_name=self.NAME)
 
         # Create an Invoice.
-        Invoice.objects.create(basket=basket)
+        Invoice.objects.create(order=order, business_client=business_client)
 
         return source, event
 

--- a/ecommerce/extensions/payment/tests/test_processors.py
+++ b/ecommerce/extensions/payment/tests/test_processors.py
@@ -656,7 +656,9 @@ class InvoiceTests(PaymentProcessorTestCaseMixin, TestCase):
     def test_handle_processor_response(self):
         """ Verify the processor creates the appropriate PaymentEvent and Source objects. """
 
-        source, payment_event = self.processor_class().handle_processor_response({}, basket=self.basket)
+        order = factories.OrderFactory()
+
+        source, payment_event = self.processor_class().handle_processor_response({}, order)
 
         # Validate PaymentEvent
         self.assertEqual(payment_event.event_type.name, PaymentEventTypeName.PAID)

--- a/ecommerce/invoice/admin.py
+++ b/ecommerce/invoice/admin.py
@@ -6,5 +6,4 @@ from ecommerce.invoice.models import Invoice
 
 @admin.register(Invoice)
 class InvoiceAdmin(SimpleHistoryAdmin):
-    list_fields = ('order', 'client')
-    raw_id_fields = ('basket',)
+    pass

--- a/ecommerce/invoice/migrations/0002_auto_20160324_1919.py
+++ b/ecommerce/invoice/migrations/0002_auto_20160324_1919.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('order', '0009_auto_20150709_1205'),
+        ('core', '0012_businessclient'),
+        ('invoice', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='historicalinvoice',
+            name='business_client',
+            field=models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.DO_NOTHING, db_constraint=False, blank=True, to='core.BusinessClient', null=True),
+        ),
+        migrations.AddField(
+            model_name='historicalinvoice',
+            name='order',
+            field=models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.DO_NOTHING, db_constraint=False, blank=True, to='order.Order', null=True),
+        ),
+        migrations.AddField(
+            model_name='invoice',
+            name='business_client',
+            field=models.ForeignKey(to='core.BusinessClient', null=True),
+        ),
+        migrations.AddField(
+            model_name='invoice',
+            name='order',
+            field=models.ForeignKey(to='order.Order', null=True),
+        ),
+        migrations.AlterField(
+            model_name='invoice',
+            name='basket',
+            field=models.ForeignKey(blank=True, to='basket.Basket', null=True),
+        ),
+    ]

--- a/ecommerce/invoice/models.py
+++ b/ecommerce/invoice/models.py
@@ -10,20 +10,22 @@ class Invoice(TimeStampedModel):
         (NOT_PAID, _('Not Paid')),
         (PAID, _('Paid')),
     )
-    basket = models.ForeignKey('basket.Basket', null=False, blank=False)
+    basket = models.ForeignKey('basket.Basket', null=True, blank=True)
+    order = models.ForeignKey('order.Order', null=True, blank=False)
+    business_client = models.ForeignKey('core.BusinessClient', null=True, blank=False)
     state = models.CharField(max_length=255, default=NOT_PAID, choices=state_choices)
 
     history = HistoricalRecords()
 
     def __str__(self):
-        return 'Invoice {id} for order number {order}'.format(id=self.id, order=self.basket.order.number)
+        return 'Invoice {id} for order number {order}'.format(id=self.id, order=self.order.number)
 
     @property
     def total(self):
         """Total amount paid for this Invoice"""
-        return self.basket.order.total_incl_tax
+        return self.order.total_incl_tax
 
     @property
     def client(self):
         """Client for this invoice"""
-        return self.basket.order.user
+        return self.business_client

--- a/ecommerce/invoice/tests.py
+++ b/ecommerce/invoice/tests.py
@@ -11,7 +11,7 @@ class InvoiceTests(TestCase):
         self.basket.owner = factories.UserFactory()
         self.basket.order = factories.OrderFactory()
         self.basket.save()
-        self.invoice = Invoice.objects.create(basket=self.basket, state='Paid')
+        self.invoice = Invoice.objects.create(order=self.basket.order, state='Paid')
 
     def test_string(self):
         """Test to check to Invoice string matches what is expected"""
@@ -20,7 +20,7 @@ class InvoiceTests(TestCase):
 
     def test_order(self):
         """Test to check invoice order"""
-        self.assertEqual(self.basket.order, self.invoice.basket.order)
+        self.assertEqual(self.basket.order, self.invoice.order)
 
     def test_client(self):
         """Test to check invoice client"""


### PR DESCRIPTION
This PR re-works the way we record orders for Coupons and Invoices.

Changes include:
- Create new InvoiceClient model
- Added InvoiceClient to the Django admin
- Add following FKs to Invoice model
  - Order
  - InvoiceClient
- Added Invoices the the Django admin
- Updated Coupon API
  - request.user for order
  - Create Invoice using Order and InvoiceClient
- Update Invoice Payment Processor to user Order and InvoiceClient
- Updated tests
