### PR TITLE
Added gate around CyberSource Level II/III fields

### DIFF
--- a/ecommerce/settings/_oscar.py
+++ b/ecommerce/settings/_oscar.py
@@ -110,6 +110,7 @@ PAYMENT_PROCESSOR_CONFIG = {
         'payment_page_url': None,
         'receipt_page_url': None,
         'cancel_page_url': None,
+        'send_level_2_3_details': True,
     },
     'paypal': {
         # 'mode' can be either 'sandbox' or 'live'

--- a/ecommerce/settings/devstack.py
+++ b/ecommerce/settings/devstack.py
@@ -33,6 +33,7 @@ PAYMENT_PROCESSOR_CONFIG = {
         'payment_page_url': 'https://testsecureacceptance.cybersource.com/pay',
         'receipt_page_url': get_lms_url(settings.RECEIPT_PAGE_PATH),
         'cancel_page_url': get_lms_url('/commerce/checkout/cancel/'),
+        'send_level_2_3_details': True,
     },
     'paypal': {
         'mode': 'sandbox',

--- a/ecommerce/settings/local.py
+++ b/ecommerce/settings/local.py
@@ -121,6 +121,7 @@ PAYMENT_PROCESSOR_CONFIG = {
         'payment_page_url': 'https://testsecureacceptance.cybersource.com/pay',
         'receipt_page_url': get_lms_url(settings.RECEIPT_PAGE_PATH),
         'cancel_page_url': get_lms_url('/commerce/checkout/cancel/'),
+        'send_level_2_3_details': True,
     },
     'paypal': {
         'mode': 'sandbox',

--- a/ecommerce/settings/test.py
+++ b/ecommerce/settings/test.py
@@ -94,6 +94,7 @@ PAYMENT_PROCESSOR_CONFIG = {
         'payment_page_url': 'https://replace-me/',
         'receipt_page_url': get_lms_url(settings.RECEIPT_PAGE_PATH),
         'cancel_page_url': get_lms_url('/commerce/checkout/cancel/'),
+        'send_level_2_3_details': True,
     },
     'paypal': {
         'mode': 'sandbox',


### PR DESCRIPTION
Not all CyberSource payment processors support this data. This flag ensures open source users have the option of disabling this functionality.

ECOM-3960
