### PR TITLE
Avoid unnecessary lambda in acceptance tests

### DIFF
--- a/acceptance_tests/pages/lms.py
+++ b/acceptance_tests/pages/lms.py
@@ -21,7 +21,7 @@ class LMSPage(PageObject):  # pylint: disable=abstract-method
         return url
 
     def _is_browser_on_lms_dashboard(self):
-        return lambda: self.browser.title.startswith('Dashboard')
+        return self.browser.title.startswith('Dashboard')
 
 
 class LMSLoginPage(LMSPage):
@@ -43,7 +43,7 @@ class LMSLoginPage(LMSPage):
         self.q(css='button.login-button').click()
 
         # Wait for LMS to redirect to the dashboard
-        EmptyPromise(self._is_browser_on_lms_dashboard(), "LMS login redirected to dashboard").fulfill()
+        EmptyPromise(self._is_browser_on_lms_dashboard, "LMS login redirected to dashboard").fulfill()
 
 
 class LMSRegistrationPage(LMSPage):
@@ -75,7 +75,7 @@ class LMSRegistrationPage(LMSPage):
         self.q(css='button.register-button').click()
 
         # Wait for LMS to redirect to the dashboard
-        EmptyPromise(self._is_browser_on_lms_dashboard(), "LMS login redirected to dashboard").fulfill()
+        EmptyPromise(self._is_browser_on_lms_dashboard, "LMS login redirected to dashboard").fulfill()
 
 
 class LMSCourseModePage(LMSPage):


### PR DESCRIPTION
`EmptyPromise` must be initialized with a callable, but that doesn't require use of a lambda. @clintonb @schenedx 
