### PR TITLE
Default value of oauth_settings should be an empty dict, not a str

### DIFF
--- a/ecommerce/core/migrations/0011_siteconfiguration_oauth_settings.py
+++ b/ecommerce/core/migrations/0011_siteconfiguration_oauth_settings.py
@@ -15,6 +15,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='siteconfiguration',
             name='oauth_settings',
-            field=jsonfield.fields.JSONField(default=b'{}', help_text='JSON string containing OAuth backend settings.', verbose_name='OAuth settings'),
+            field=jsonfield.fields.JSONField(default={}, help_text='JSON string containing OAuth backend settings.', verbose_name='OAuth settings'),
         ),
     ]


### PR DESCRIPTION
This fixes a problem with rolling out the multitenancy work to stage/production, allowing us to fall back on configured Django settings until we have a change to update the oauth_settings field of the SiteConfiguration with the appropriate values.

@mjfrey @clintonb 
