### PR TITLE
Default JWT_LEEWAY to 1 second

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -305,6 +305,7 @@ JWT_AUTH = {
     'JWT_SECRET_KEY': None,
     'JWT_ALGORITHM': 'HS256',
     'JWT_VERIFY_EXPIRATION': True,
+    'JWT_LEEWAY': 1,
     'JWT_DECODE_HANDLER': 'ecommerce.extensions.api.handlers.jwt_decode_handler',
     # This setting is not one of DRF-JWT's defaults.
     'JWT_ISSUERS': (),


### PR DESCRIPTION
Allows ecommerce to tolerate slight clock skew. Companion to https://github.com/edx/configuration/pull/2892. The base JWT_AUTH dictionary modified here is [overwritten](https://github.com/edx/ecommerce/blob/master/ecommerce/settings/production.py#L48) in production.py. This change makes the setting an application default.

@jimabramson 
