### PR TITLE
Add coupon attribute to audit log

### DIFF
--- a/ecommerce/extensions/checkout/mixins.py
+++ b/ecommerce/extensions/checkout/mixins.py
@@ -101,7 +101,8 @@ class EdxOrderPlacementMixin(OrderPlacementMixin):
             basket_id=order.basket.id,
             currency=order.currency,
             order_number=order.number,
-            user_id=order.user.id
+            user_id=order.user.id,
+            contains_coupon=order.contains_coupon
         )
 
         if waffle.sample_is_active('async_order_fulfillment'):

--- a/ecommerce/extensions/checkout/tests/test_mixins.py
+++ b/ecommerce/extensions/checkout/tests/test_mixins.py
@@ -103,9 +103,11 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, RefundTestMixin, Te
                 (
                     LOGGER_NAME,
                     'INFO',
-                    'order_placed: amount="{}", basket_id="{}", currency="{}", order_number="{}", user_id="{}"'.format(
+                    'order_placed: amount="{}", basket_id="{}", contains_coupon="{}", currency="{}",'
+                    ' order_number="{}", user_id="{}"'.format(
                         self.order.total_excl_tax,
                         self.order.basket.id,
+                        self.order.contains_coupon,
                         self.order.currency,
                         self.order.number,
                         self.order.user.id

--- a/ecommerce/extensions/order/models.py
+++ b/ecommerce/extensions/order/models.py
@@ -15,6 +15,12 @@ class Order(AbstractOrder):
         """Returns a boolean indicating if order can be fulfilled."""
         return self.status in (ORDER.OPEN, ORDER.FULFILLMENT_ERROR)
 
+    @property
+    def contains_coupon(self):
+        """ Return a boolean if the order contains a Coupon. """
+        return any(line.product.get_product_class().name == 'Coupon' for line in
+                   self.basket.all_lines())
+
 
 class PaymentEvent(AbstractPaymentEvent):
     processor_name = models.CharField(_("Payment Processor"), max_length=32, blank=True, null=True)

--- a/ecommerce/extensions/order/tests/test_models.py
+++ b/ecommerce/extensions/order/tests/test_models.py
@@ -27,3 +27,14 @@ class OrderTests(TestCase):
         self.order.status = status
         self.order.save()
         self.assertFalse(self.order.is_fulfillable)
+
+    def test_contains_coupon(self):
+        self.assertFalse(self.order.contains_coupon)
+
+        product_class = u'Coupon'
+        product = factories.create_product(product_class=product_class)
+        basket = factories.create_basket(empty=True)
+        factories.create_stockrecord(product, num_in_stock=1)
+        basket.add_product(product)
+        order = factories.create_order(basket=basket)
+        self.assertTrue(order.contains_coupon)


### PR DESCRIPTION
Add an attribute to the audit log for determining if the order was for a Coupon.  This allows us to modify alerts and filter out such orders.

@vkaracic @rlucioni Please take a look.
