### PR TITLE
[SOL-1636] Refactor get_voucher_from_code

### DIFF
--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -172,6 +172,16 @@ class CouponOfferViewTests(CourseCatalogTestMixin, LmsApiMockMixin, TestCase):
         response = self.client.get(url)
         self.assertEqual(response.context['error'], _('Coupon does not exist'))
 
+    def test_expired_voucher(self):
+        """ Verify proper response is returned for expired vouchers. """
+        start_datetime = now() - datetime.timedelta(days=20)
+        end_datetime = now() - datetime.timedelta(days=10)
+        prepare_voucher(code='EXPIRED', start_datetime=start_datetime, end_datetime=end_datetime)
+
+        url = self.path + '?code={}'.format('EXPIRED')
+        response = self.client.get(url)
+        self.assertEqual(response.context['error'], _('This coupon code has expired.'))
+
     def test_no_product(self):
         """ Verify an error is returned for voucher with no product. """
         no_product_range = RangeFactory()

--- a/ecommerce/extensions/test/factories.py
+++ b/ecommerce/extensions/test/factories.py
@@ -53,8 +53,10 @@ def prepare_voucher(code='COUPONTEST', _range=None, start_datetime=None, end_dat
     if _range is None:
         product = ProductFactory(title='Test product')
         _range = RangeFactory(products=[product, ])
-    else:
+    elif _range.num_products() > 0:
         product = _range.all_products()[0]
+    else:
+        product = ProductFactory(title='Test product')
 
     if start_datetime is None:
         start_datetime = now() - datetime.timedelta(days=1)


### PR DESCRIPTION
When no voucher exists for given code and when no products are associated with the voucher, raise exceptions instead of returning None.

This is a fix for: https://openedx.atlassian.net/browse/SOL-1636
