### PR TITLE
Remove multi-use coupon usage limitation

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -55,7 +55,7 @@ class CouponViewSetTest(CouponMixin, CourseCatalogTestMixin, TestCase):
             'code': '',
             'quantity': 2,
             'start_date': '2015-1-1',
-            'voucher_type': Voucher.MULTI_USE,
+            'voucher_type': Voucher.ONCE_PER_CUSTOMER,
             'categories': [self.category],
             'note': None,
         }
@@ -117,7 +117,7 @@ class CouponViewSetTest(CouponMixin, CourseCatalogTestMixin, TestCase):
         self.assertEqual(Product.objects.filter(product_class=self.product_class).count(), 1)
         self.assertEqual(StockRecord.objects.filter(product=coupon_append).count(), 1)
         self.assertEqual(coupon_append.attr.coupon_vouchers.vouchers.count(), 7)
-        self.assertEqual(coupon_append.attr.coupon_vouchers.vouchers.filter(usage=Voucher.MULTI_USE).count(), 2)
+        self.assertEqual(coupon_append.attr.coupon_vouchers.vouchers.filter(usage=Voucher.ONCE_PER_CUSTOMER).count(), 2)
 
     def test_custom_code_string(self):
         """Test creating a coupon with custom voucher code."""
@@ -347,6 +347,15 @@ class CouponViewSetFunctionalTest(CouponMixin, CourseCatalogTestMixin, Throttlin
         self.assertEqual(new_coupon.attr.coupon_vouchers.vouchers.last().start_datetime.year, 2030)
         self.assertEqual(new_coupon.attr.coupon_vouchers.vouchers.first().end_datetime.year, 2035)
         self.assertEqual(new_coupon.attr.coupon_vouchers.vouchers.last().end_datetime.year, 2035)
+
+    def test_exception_for_multi_use_voucher_type(self):
+        """Test that an exception is raised for multi-use voucher types."""
+        self.data.update({
+            'voucher_type': Voucher.MULTI_USE,
+        })
+
+        with self.assertRaises(NotImplementedError):
+            self.client.post(COUPONS_LINK, data=self.data, format='json')
 
 
 class CouponCategoriesListViewTests(TestCase):

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -85,6 +85,10 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
             client, __ = BusinessClient.objects.get_or_create(name=client_username)
             note = request.data.get('note', None)
 
+            # We currently do not support multi-use voucher types.
+            if voucher_type == Voucher.MULTI_USE:
+                raise NotImplementedError('Multi-use voucher types are not supported')
+
             stock_records_string = ' '.join(str(id) for id in stock_record_ids)
 
             coupon_catalog, __ = get_or_create_catalog(

--- a/ecommerce/extensions/voucher/tests/test_utils.py
+++ b/ecommerce/extensions/voucher/tests/test_utils.py
@@ -79,7 +79,7 @@ class UtilTests(CouponMixin, CourseCatalogTestMixin, LmsApiMockMixin, TestCase):
             name="Discount code",
             quantity=1,
             start_datetime=datetime.date(2015, 10, 1),
-            voucher_type=Voucher.MULTI_USE,
+            voucher_type=Voucher.SINGLE_USE,
             code=VOUCHER_CODE
         )
 
@@ -92,7 +92,7 @@ class UtilTests(CouponMixin, CourseCatalogTestMixin, LmsApiMockMixin, TestCase):
             name="Enrollment code",
             quantity=1,
             start_datetime=datetime.date.today() - datetime.timedelta(1),
-            voucher_type=Voucher.MULTI_USE
+            voucher_type=Voucher.SINGLE_USE
         )
 
     def use_voucher(self, voucher, users):

--- a/ecommerce/static/js/test/mock_data/coupons.js
+++ b/ecommerce/static/js/test/mock_data/coupons.js
@@ -34,7 +34,7 @@ define([], function(){
         'name': 'Test Discount Code',
         'code': 'TST1234',
         'redeem_url': 'http://localhost:8002/coupons/offer/?code=TST1234',
-        'usage': 'Multi-use',
+        'usage': 'Single use',
         'start_datetime': '2015-01-01T00:00:00Z',
         'end_datetime': '3500-01-01T00:00:00Z',
         'num_basket_additions': 0,

--- a/ecommerce/static/js/test/specs/views/coupon_detail_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/coupon_detail_view_spec.js
@@ -104,9 +104,6 @@ define([
 
             it('should get usage limitation from voucher data', function () {
                 expect(view.usageLimitation(enrollmentCodeVoucher)).toBe('Can be used once by one customer');
-                expect(view.usageLimitation(percentageDiscountCodeVoucher)).toBe(
-                    'Can be used multiple times by multiple customers'
-                );
                 expect(view.usageLimitation(valueDiscountCodeVoucher)).toBe('Can only be used once per customer');
 
                 valueDiscountCodeVoucher.usage = '';

--- a/ecommerce/static/js/test/specs/views/coupon_edit_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/coupon_edit_view_spec.js
@@ -36,7 +36,7 @@ define([
                     expect(view.$el.find('[name=code_type]').val()).toEqual('enrollment');
                     expect(view.$el.find('[name=start_date]').val()).toEqual(startDate);
                     expect(view.$el.find('[name=end_date]').val()).toEqual(endDate);
-                    expect(voucherType.children().length).toBe(3);
+                    expect(voucherType.children().length).toBe(2);
                     expect(voucherType.val()).toEqual(model.get('voucher_type'));
                     expect(view.$el.find('[name=quantity]').val()).toEqual(model.get('quantity').toString());
                     expect(view.$el.find('[name=client_username]').val()).toEqual(model.get('client'));
@@ -61,7 +61,7 @@ define([
                     expect(view.$el.find('[name=code_type]').val()).toEqual('discount');
                     expect(view.$el.find('[name=start_date]').val()).toEqual(startDate);
                     expect(view.$el.find('[name=end_date]').val()).toEqual(endDate);
-                    expect(voucherType.children().length).toBe(3);
+                    expect(voucherType.children().length).toBe(2);
                     expect(voucherType.val()).toEqual(model.get('voucher_type'));
                     expect(view.$el.find('[name=quantity]').val()).toEqual(model.get('quantity').toString());
                     expect(view.$el.find('[name=client_username]').val()).toEqual(model.get('client'));

--- a/ecommerce/static/js/views/coupon_detail_view.js
+++ b/ecommerce/static/js/views/coupon_detail_view.js
@@ -70,8 +70,6 @@ define([
             usageLimitation: function(voucher) {
                 if (voucher.usage === 'Single use') {
                     return gettext('Can be used once by one customer');
-                } else if (voucher.usage === 'Multi-use') {
-                    return gettext('Can be used multiple times by multiple customers');
                 } else if (voucher.usage === 'Once per customer') {
                     return gettext('Can only be used once per customer');
                 }

--- a/ecommerce/static/js/views/coupon_form_view.js
+++ b/ecommerce/static/js/views/coupon_form_view.js
@@ -56,10 +56,6 @@ define([
                 {
                     value: 'Once per customer',
                     label: gettext('Can be used once by multiple customers')
-                },
-                {
-                    value: 'Multi-use',
-                    label: gettext('Can be used multiple times by multiple customers'),
                 }
             ],
 


### PR DESCRIPTION
We currently are not supporting multi-use voucher types and this PR removes that option from the `Usage Limitations` dropdown.

@mjfrey 
