### PR TITLE
Turn off startup validation for core app because it is breaking migrations

### DIFF
--- a/ecommerce/core/config.py
+++ b/ecommerce/core/config.py
@@ -27,6 +27,10 @@ class CoreAppConfig(AppConfig):
             # Here we're are consciously violating Django's warning about not interacting with DB in AppConfig.ready
             # We know what we're doing, have considered a couple of other approaches and discussed it in great length:
             # https://github.com/edx/ecommerce/pull/630#discussion-diff-58026881
-            validate_configuration()
+            # TODO: This was causing an issue with running migrations from scratch
+            # on a sandbox. We need to fix this before uncommenting.
+            # http://jenkins.edx.org:8080/job/ansible-provision/6495/console
+            # validate_configuration()
+            pass
         except OperationalError:
             log.exception(self.OPERATIONAL_ERROR_MESSAGE)

--- a/ecommerce/core/tests/test_config.py
+++ b/ecommerce/core/tests/test_config.py
@@ -1,32 +1,33 @@
 """ Tests for CoreAppConfig """
-import mock
-from django.db import OperationalError
-from django.test import SimpleTestCase
+# import mock
+# from django.db import OperationalError
+# from django.test import SimpleTestCase
+#
+# from ecommerce import core
+#
+# from ecommerce.core.config import CoreAppConfig
 
-from ecommerce import core
 
-from ecommerce.core.config import CoreAppConfig
-
-
-class TestAppConfig(SimpleTestCase):
-    """ Test suite for CoreAppConfig class """
-    def test_ready_validates_configuration(self):
-        """ Tests that method `ready` invokes `models.validate_configuration` method"""
-        config = CoreAppConfig('core', core)
-
-        with mock.patch('ecommerce.core.models.validate_configuration') as patched_validate:
-            config.ready()
-
-            self.assertTrue(patched_validate.called)
-
-    def test_ready_validate_suppresses_operational_error(self):
-        """ Tests that django.db.OperationalError is suppressed and logged in `ready` method """
-        config = CoreAppConfig('core', core)
-
-        with mock.patch('ecommerce.core.models.validate_configuration') as patched_validate:
-            with mock.patch('ecommerce.core.config.log') as patched_log:
-                patched_validate.side_effect = OperationalError
-                config.ready()
-
-                self.assertTrue(patched_validate.called)
-                patched_log.exception.assert_called_once_with(config.OPERATIONAL_ERROR_MESSAGE)
+# TODO: Uncomment these tests when app startup validation is reintroduced, see core/config.py
+# class TestAppConfig(SimpleTestCase):
+#     """ Test suite for CoreAppConfig class """
+#     def test_ready_validates_configuration(self):
+#         """ Tests that method `ready` invokes `models.validate_configuration` method"""
+#         config = CoreAppConfig('core', core)
+#
+#         with mock.patch('ecommerce.core.models.validate_configuration') as patched_validate:
+#             config.ready()
+#
+#             self.assertTrue(patched_validate.called)
+#
+#     def test_ready_validate_suppresses_operational_error(self):
+#         """ Tests that django.db.OperationalError is suppressed and logged in `ready` method """
+#         config = CoreAppConfig('core', core)
+#
+#         with mock.patch('ecommerce.core.models.validate_configuration') as patched_validate:
+#             with mock.patch('ecommerce.core.config.log') as patched_log:
+#                 patched_validate.side_effect = OperationalError
+#                 config.ready()
+#
+#                 self.assertTrue(patched_validate.called)
+#                 patched_log.exception.assert_called_once_with(config.OPERATIONAL_ERROR_MESSAGE)


### PR DESCRIPTION
Sandbox provisioning is broken due to the startup validation introduced in https://github.com/edx/ecommerce/pull/630.

http://jenkins.edx.org:8080/job/ansible-provision/6495/console

@e-kolpakov @clintonb @mjfrey @maxrothman 
