### PR TITLE
[SOL-1628] "N" times use coupon code

### DIFF
--- a/ecommerce/courses/tests/factories.py
+++ b/ecommerce/courses/tests/factories.py
@@ -10,5 +10,5 @@ class CourseFactory(factory.DjangoModelFactory):
     class Meta(object):
         model = Course
 
-    id = FuzzyText(prefix='course-id-')
+    id = FuzzyText(prefix='course-v1:test-org+course+')
     name = FuzzyText(prefix='course-name-')

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -86,6 +86,10 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
             categories = Category.objects.filter(id__in=request.data['category_ids'])
             client, __ = BusinessClient.objects.get_or_create(name=client_username)
             note = request.data.get('note', None)
+            max_uses = request.data.get('max_uses', None)
+
+            if max_uses:
+                max_uses = int(max_uses)
 
             # We currently do not support multi-use voucher types.
             if voucher_type == Voucher.MULTI_USE:
@@ -123,6 +127,7 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
                 'voucher_type': voucher_type,
                 'categories': categories,
                 'note': note,
+                'max_uses': max_uses,
             }
 
             coupon_product = self.create_coupon_product(title, price, data)
@@ -152,6 +157,7 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
                 - voucher_type (str)
                 - categories (list of Category objects)
                 - note (str)
+                - max_uses (int)
 
         Returns:
             A coupon product object.
@@ -185,7 +191,9 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
                 code=data['code'] or None,
                 quantity=int(data['quantity']),
                 start_datetime=data['start_date'],
-                voucher_type=data['voucher_type']
+                voucher_type=data['voucher_type'],
+                max_uses=data['max_uses'],
+                coupon_id=coupon_product.id
             )
         except IntegrityError as ex:
             logger.exception('Failed to create vouchers for [%s] coupon.', coupon_product.title)

--- a/ecommerce/extensions/test/factories.py
+++ b/ecommerce/extensions/test/factories.py
@@ -48,7 +48,7 @@ def create_order(number=None, basket=None, user=None, shipping_address=None,  # 
 
 
 def prepare_voucher(code='COUPONTEST', _range=None, start_datetime=None, end_datetime=None, benefit_value=100,
-                    benefit_type=Benefit.PERCENTAGE):
+                    benefit_type=Benefit.PERCENTAGE, usage=Voucher.SINGLE_USE, max_usage=None):
     """ Helper function to create a voucher and add an offer to it that contains a product. """
     if _range is None:
         product = ProductFactory(title='Test product')
@@ -65,9 +65,12 @@ def prepare_voucher(code='COUPONTEST', _range=None, start_datetime=None, end_dat
         end_datetime = now() + datetime.timedelta(days=10)
 
     voucher = VoucherFactory(code=code, start_datetime=start_datetime, end_datetime=end_datetime,
-                             usage=Voucher.SINGLE_USE)
+                             usage=usage)
     benefit = BenefitFactory(type=benefit_type, range=_range, value=benefit_value)
     condition = ConditionFactory(value=1, range=_range)
-    offer = ConditionalOfferFactory(benefit=benefit, condition=condition)
+    if max_usage:
+        offer = ConditionalOfferFactory(benefit=benefit, condition=condition, max_global_applications=max_usage)
+    else:
+        offer = ConditionalOfferFactory(benefit=benefit, condition=condition)
     voucher.offers.add(offer)
     return voucher, product

--- a/ecommerce/static/js/models/coupon_model.js
+++ b/ecommerce/static/js/models/coupon_model.js
@@ -144,6 +144,7 @@ define([
                 data.price = this.get('price');
                 data.category_ids = [ this.get('category') ];
                 data.note = this.get('note');
+                data.max_usage = this.get('max_usage');
 
                 // Enrollment code always gives 100% discount
                 switch (this.get('coupon_type')) {

--- a/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
@@ -144,13 +144,17 @@ define([
                 it('should show the code field only for multi-use vouchers', function () {
                     view.$el.find('[name=voucher_type]').val('Single use').trigger('change');
                     expect(visible('[name=code]')).toBe(false);
-                    view.$el.find('[name=voucher_type]').val('Multi-use').trigger('change');
-                    expect(visible('[name=code]')).toBe(true);
                     view.$el.find('[name=voucher_type]').val('Once per customer').trigger('change');
                     expect(visible('[name=code]')).toBe(true);
                 });
-            });
 
+                it('should show the usage number field only for multi-use vouchers', function () {
+                    view.$el.find('[name=voucher_type]').val('Single use').trigger('change');
+                    expect(visible('[name=max_uses]')).toBe(false);
+                    view.$el.find('[name=voucher_type]').val('Once per customer').trigger('change');
+                    expect(visible('[name=max_uses]')).toBe(true);
+                });
+            });
         });
     }
 );

--- a/ecommerce/static/js/views/coupon_form_view.js
+++ b/ecommerce/static/js/views/coupon_form_view.js
@@ -149,6 +149,9 @@ define([
                 },
                 'input[name=note]': {
                     observe: 'note'
+                },
+                'input[name=max_uses]': {
+                    observe: 'max_uses'
                 }
             },
 
@@ -180,6 +183,7 @@ define([
             },
 
             toggleFields: function () {
+                var hiddenClass = 'hidden';
                 var couponType = this.model.get('coupon_type'),
                     voucherType = this.model.get('voucher_type'),
                     formGroup = function (sel) {
@@ -187,27 +191,34 @@ define([
                     }.bind(this);
 
                 if (couponType === 'discount') {
-                    formGroup('[name=benefit_value]').removeClass('hidden');
+                    formGroup('[name=benefit_value]').removeClass(hiddenClass);
                 } else {
                     // enrollment
-                    formGroup('[name=benefit_value]').addClass('hidden');
+                    formGroup('[name=benefit_value]').addClass(hiddenClass);
                 }
 
                 // When creating a discount show the CODE field for both (they are both multi-use)
                 //     - Multiple times by multiple customers
                 //     - Once per customer
                 if (couponType === 'discount' && voucherType !== 'Single use') {
-                    formGroup('[name=code]').removeClass('hidden');
+                    formGroup('[name=code]').removeClass(hiddenClass);
                 } else {
-                    formGroup('[name=code]').addClass('hidden');
+                    formGroup('[name=code]').addClass(hiddenClass);
+                }
+
+                // When creating a Once by multiple customers code show the usage number field.
+                if (voucherType !== 'Single use') {
+                    formGroup('[name=max_uses]').removeClass(hiddenClass);
+                } else {
+                    formGroup('[name=max_uses]').addClass(hiddenClass);
                 }
 
                 // The only time we allow for a generation of multiple codes is
                 // when they are of type single use.
                 if (voucherType === 'Single use') {
-                    formGroup('[name=quantity]').removeClass('hidden');
+                    formGroup('[name=quantity]').removeClass(hiddenClass);
                 } else {
-                    formGroup('[name=quantity]').addClass('hidden');
+                    formGroup('[name=quantity]').addClass(hiddenClass);
                 }
             },
 
@@ -289,6 +300,7 @@ define([
                 this.$el.find('select[name=seat_type]').attr('disabled', true);
                 this.$el.find('select[name=category]').attr('disabled', true);
                 this.$el.find('input[name=note]').attr('disabled', true);
+                this.$el.find('input[name=max_uses]').attr('disabled', true);
             },
 
             getSeatData: function () {

--- a/ecommerce/static/templates/coupon_form.html
+++ b/ecommerce/static/templates/coupon_form.html
@@ -56,6 +56,12 @@
         </div>
 
         <div class="form-group">
+            <label for="max_uses"><%= gettext('Maximum Number of Uses') %></label>
+            <input type="number" step="1" class="form-control" name="max_uses" value="1" min="1">
+            <p class="help-block"></p>
+        </div>
+
+        <div class="form-group">
             <label for="benefit_value"><%= gettext('Discount Value') %> *</label>
             <div class="input-group">
                 <div class="benefit-addon input-group-addon"></div>

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,6 +16,7 @@ drf-extensions==0.2.8
 edx-auth-backends==0.2.0
 edx-django-sites-extensions==1.0.0
 edx-ecommerce-worker==0.3.3
+edx-opaque-keys==0.3.1
 edx-rest-api-client==1.5.0
 jsonfield==1.0.3
 libsass==0.9.2


### PR DESCRIPTION
This PR adds an ability to create coupons with a set usage number for `ONCE_PER_CUSTOMER` limitation type vouchers. 
A new field appears on the coupon creation form when the user selects `ONCE_PER_CUSTOMER` which sets the `max_global_applications` for the offer. Also new columns are added to the coupon report which adds new information about the usage count and order.

UI screenshot:
![screenshot from 2016-04-04 09-00-22](https://cloud.githubusercontent.com/assets/2808092/14240247/97428544-fa43-11e5-962a-0ada658a5829.png)

Example coupon report document:
https://drive.google.com/a/edx.org/file/d/0ByBQUYJ4LMyAMWlQWWpWSWozQTg/view?usp=sharing

https://openedx.atlassian.net/browse/SOL-1628
