### PR TITLE
Fixing default value of SiteConfiguration.oauth_settings to match migration

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -49,7 +49,7 @@ class SiteConfiguration(models.Model):
         help_text=_('JSON string containing OAuth backend settings.'),
         null=False,
         blank=False,
-        default='{}'
+        default={}
     )
 
     class Meta(object):


### PR DESCRIPTION
This is a followup PR to https://github.com/edx/ecommerce/pull/641 which fixed the default value of the SiteConfiguration.oauth_settings field in migrations, but not in the actual model. This PR remedies that condition.

@mjfrey @clintonb 
