### PR TITLE
Fix payment processor settings overrides

### DIFF
--- a/ecommerce/settings/production.py
+++ b/ecommerce/settings/production.py
@@ -61,10 +61,11 @@ for override, value in DB_OVERRIDES.iteritems():
 
 
 # PAYMENT PROCESSOR OVERRIDES
-for __, config in PAYMENT_PROCESSOR_CONFIG.iteritems():
-    config.update({
-        'receipt_path': PAYMENT_PROCESSOR_RECEIPT_PATH,
-        'cancel_path': PAYMENT_PROCESSOR_CANCEL_PATH,
-        'error_path': PAYMENT_PROCESSOR_ERROR_PATH,
-    })
+for __, configs in PAYMENT_PROCESSOR_CONFIG.iteritems():
+    for __, config in configs.iteritems():
+        config.update({
+            'receipt_path': PAYMENT_PROCESSOR_RECEIPT_PATH,
+            'cancel_path': PAYMENT_PROCESSOR_CANCEL_PATH,
+            'error_path': PAYMENT_PROCESSOR_ERROR_PATH,
+        })
 # END PAYMENT PROCESSOR OVERRIDES


### PR DESCRIPTION
We missed this in https://github.com/edx/ecommerce/pull/654. Payment processor path settings need to be overridden in production settings.

@e-kolpakov @mjfrey @clintonb 
