### PR TITLE
Capture acceptance test results in an xunit.xml file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ fast_diff_coverage:
 	diff-cover coverage.xml --compare-branch=$(DIFF_COVER_BASE_BRANCH)
 
 accept:
-	nosetests --with-ignore-docstrings -v acceptance_tests
+	nosetests --with-ignore-docstrings -v acceptance_tests --with-xunit --xunit-file=acceptance_tests/xunit.xml
 
 extract_translations:
 	cd ecommerce && i18n_tool extract -v


### PR DESCRIPTION
This will allow test results to be more easily consumed by:
- CI infrastructure
- A developer who wants to understand results
- Logging infrastructure we use wherein we can roll together test results across repos
