### PR TITLE
[SOL-1741 Fix for the Coupon Invoice Django Admin Page]

### DIFF
--- a/ecommerce/invoice/admin.py
+++ b/ecommerce/invoice/admin.py
@@ -6,4 +6,6 @@ from ecommerce.invoice.models import Invoice
 
 @admin.register(Invoice)
 class InvoiceAdmin(SimpleHistoryAdmin):
-    pass
+    list_display = ('id', 'basket', 'order', 'business_client', 'state',)
+    list_filter = ('state',)
+    search_fields = ['order__number', 'business_client__name']

--- a/ecommerce/invoice/models.py
+++ b/ecommerce/invoice/models.py
@@ -17,9 +17,6 @@ class Invoice(TimeStampedModel):
 
     history = HistoricalRecords()
 
-    def __str__(self):
-        return 'Invoice {id} for order number {order}'.format(id=self.id, order=self.order.number)
-
     @property
     def total(self):
         """Total amount paid for this Invoice"""

--- a/ecommerce/invoice/tests.py
+++ b/ecommerce/invoice/tests.py
@@ -13,11 +13,6 @@ class InvoiceTests(TestCase):
         self.basket.save()
         self.invoice = Invoice.objects.create(order=self.basket.order, state='Paid')
 
-    def test_string(self):
-        """Test to check to Invoice string matches what is expected"""
-        self.assertEqual(str(self.invoice), 'Invoice {id} for order number {order}'.format(
-            id=self.invoice.id, order=self.basket.order.number))
-
     def test_order(self):
         """Test to check invoice order"""
         self.assertEqual(self.basket.order, self.invoice.order)


### PR DESCRIPTION
@mjfrey Here's a PR that fixes the broken Coupon Invoice Django Admin page. Please review.

JIRA ticket: [SOL-1741](https://openedx.atlassian.net/browse/SOL-1741)

Here's the screenshot that shows how it looks now:
![screencapture-localhost-8002-admin-invoice-invoice-1460723626570](https://cloud.githubusercontent.com/assets/6833568/14561522/28584060-0317-11e6-8ba6-d7a7976c5be8.png)
