### PR TITLE
(SOL-1760) Added default value 1 for Maximum Number of Uses field

### DIFF
--- a/ecommerce/static/js/models/coupon_model.js
+++ b/ecommerce/static/js/models/coupon_model.js
@@ -35,7 +35,8 @@ define([
                 stock_record_ids: [],
                 code: '',
                 price: 0,
-                invoiced_amount: 0
+                invoiced_amount: 0,
+                max_uses: 1
             },
 
             validation: {


### PR DESCRIPTION
@mjfrey Please review. When creating a new coupon default value for Maximum Number of Uses field was empty. Now the default value is set to 1.
