### PR TITLE
call analytics.page on ecommerce pages

### DIFF
--- a/ecommerce/core/context_processors.py
+++ b/ecommerce/core/context_processors.py
@@ -3,9 +3,9 @@ from django.conf import settings
 from ecommerce.core.url_utils import get_lms_dashboard_url
 
 
-def core(_request):
+def core(request):
     return {
         'lms_dashboard_url': get_lms_dashboard_url(),
-        'platform_name': _request.site.name,
+        'platform_name': request.site.name,
         'support_url': settings.SUPPORT_URL,
     }

--- a/ecommerce/core/management/commands/create_or_update_site.py
+++ b/ecommerce/core/management/commands/create_or_update_site.py
@@ -17,65 +17,71 @@ class Command(BaseCommand):
     help = 'Create or update Site, Partner, and SiteConfiguration'
 
     def add_arguments(self, parser):
-        parser.add_argument('-i', '--site-id',
+        parser.add_argument('--site-id',
                             action='store',
                             dest='site_id',
                             type=int,
                             help='ID of the Site to update.')
-        parser.add_argument('-d', '--site-domain',
+        parser.add_argument('--site-domain',
                             action='store',
                             dest='site_domain',
                             type=str,
                             required=True,
                             help='Domain of the Site to create or update.')
-        parser.add_argument('-n', '--site-name',
+        parser.add_argument('--site-name',
                             action='store',
                             dest='site_name',
                             type=str,
                             default='',
                             help='Name of the Site to create or update.')
-        parser.add_argument('-c', '--partner-code',
+        parser.add_argument('--partner-code',
                             action='store',
                             dest='partner_code',
                             type=str,
                             required=True,
                             help='Partner code to select/create and associate with site.')
-        parser.add_argument('-p', '--partner-name',
+        parser.add_argument('--partner-name',
                             action='store',
                             dest='partner_name',
                             type=str,
                             default='',
                             help='Partner name to select/create and associate with site.')
-        parser.add_argument('-l', '--lms-url-root',
+        parser.add_argument('--lms-url-root',
                             action='store',
                             dest='lms_url_root',
                             type=str,
                             required=True,
                             help='Root URL of LMS (e.g. https://localhost:8000)')
-        parser.add_argument('-t', '--theme-scss-path',
+        parser.add_argument('--theme-scss-path',
                             action='store',
                             dest='theme_scss_path',
                             type=str,
                             default='',
                             help='Path to theme SCSS relative to STATIC_DIR (e.g. sass/themes/edx.scss)')
-        parser.add_argument('-m', '--payment-processors',
+        parser.add_argument('--payment-processors',
                             action='store',
                             dest='payment_processors',
                             type=str,
                             default='',
                             help='Comma-delimited list of payment processors (e.g. cybersource,paypal)')
-        parser.add_argument('-k', '--client-id',
+        parser.add_argument('--client-id',
                             action='store',
                             dest='client_id',
                             type=str,
                             required=True,
                             help='client ID')
-        parser.add_argument('-s', '--client-secret',
+        parser.add_argument('--client-secret',
                             action='store',
                             dest='client_secret',
                             type=str,
                             required=True,
                             help='client secret')
+        parser.add_argument('--segment-key',
+                            action='store',
+                            dest='segment_key',
+                            type=str,
+                            required=False,
+                            help='segment key')
 
     def handle(self, *args, **options):
         site_id = options.get('site_id')
@@ -86,6 +92,7 @@ class Command(BaseCommand):
         lms_url_root = options.get('lms_url_root')
         client_id = options.get('client_id')
         client_secret = options.get('client_secret')
+        segment_key = options.get('segment_key')
 
         try:
             site = Site.objects.get(id=site_id)
@@ -113,6 +120,7 @@ class Command(BaseCommand):
                 'lms_url_root': lms_url_root,
                 'theme_scss_path': options['theme_scss_path'],
                 'payment_processors': options['payment_processors'],
+                'segment_key': segment_key,
                 'oauth_settings': {
                     'SOCIAL_AUTH_EDX_OIDC_URL_ROOT': '{lms_url_root}/oauth2'.format(lms_url_root=lms_url_root),
                     'SOCIAL_AUTH_EDX_OIDC_KEY': client_id,

--- a/ecommerce/core/migrations/0013_siteconfiguration_segment_key.py
+++ b/ecommerce/core/migrations/0013_siteconfiguration_segment_key.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0012_businessclient'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='siteconfiguration',
+            name='segment_key',
+            field=models.CharField(help_text='Segment write/API key.', max_length=255, null=True, verbose_name='Segment key', blank=True),
+        ),
+    ]

--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -1,9 +1,11 @@
 import logging
 
+from analytics import Client as SegmentClient
 from django.conf import settings
 from django.contrib.auth.models import AbstractUser
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 from jsonfield.fields import JSONField
 
@@ -50,6 +52,13 @@ class SiteConfiguration(models.Model):
         null=False,
         blank=False,
         default={}
+    )
+    segment_key = models.CharField(
+        verbose_name=_('Segment key'),
+        help_text=_('Segment write/API key.'),
+        max_length=255,
+        null=True,
+        blank=True
     )
 
     class Meta(object):
@@ -116,6 +125,10 @@ class SiteConfiguration(models.Model):
         """ Validates model fields """
         if not exclude or 'payment_processors' not in exclude:
             self._clean_payment_processors()
+
+    @cached_property
+    def segment_client(self):
+        return SegmentClient(self.segment_key, debug=settings.DEBUG)
 
 
 class User(AbstractUser):

--- a/ecommerce/core/tests/test_commands.py
+++ b/ecommerce/core/tests/test_commands.py
@@ -23,6 +23,7 @@ class CreateOrUpdateSiteCommandTests(TestCase):
         self.payment_processors = 'cybersource,paypal'
         self.client_id = 'ecommerce-key'
         self.client_secret = 'ecommerce-secret'
+        self.segment_key = 'test-segment-key'
 
     def _check_site_configuration(self, site, partner):
         site_configuration = site.siteconfiguration
@@ -33,6 +34,7 @@ class CreateOrUpdateSiteCommandTests(TestCase):
         self.assertEqual(site_configuration.payment_processors, self.payment_processors)
         self.assertEqual(site_configuration.oauth_settings['SOCIAL_AUTH_EDX_OIDC_KEY'], self.client_id)
         self.assertEqual(site_configuration.oauth_settings['SOCIAL_AUTH_EDX_OIDC_SECRET'], self.client_secret)
+        self.assertEqual(site_configuration.segment_key, self.segment_key)
 
     def test_create_site(self):
         """ Verify the command creates Site, Partner, and SiteConfiguration. """
@@ -45,7 +47,8 @@ class CreateOrUpdateSiteCommandTests(TestCase):
             '--theme-scss-path={theme_scss_path}'.format(theme_scss_path=self.theme_scss_path),
             '--payment-processors={payment_processors}'.format(payment_processors=self.payment_processors),
             '--client-id={client_id}'.format(client_id=self.client_id),
-            '--client-secret={client_secret}'.format(client_secret=self.client_secret)
+            '--client-secret={client_secret}'.format(client_secret=self.client_secret),
+            '--segment-key={segment_key}'.format(segment_key=self.segment_key)
         )
 
         site = Site.objects.get(domain=site_domain)
@@ -69,7 +72,8 @@ class CreateOrUpdateSiteCommandTests(TestCase):
             '--theme-scss-path={theme_scss_path}'.format(theme_scss_path=self.theme_scss_path),
             '--payment-processors={payment_processors}'.format(payment_processors=self.payment_processors),
             '--client-id={client_id}'.format(client_id=self.client_id),
-            '--client-secret={client_secret}'.format(client_secret=self.client_secret)
+            '--client-secret={client_secret}'.format(client_secret=self.client_secret),
+            '--segment-key={segment_key}'.format(segment_key=self.segment_key)
         )
 
         site = Site.objects.get(id=site.id)

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -157,8 +157,13 @@ class CouponOfferView(TemplateView):
                     new_price = price - benefit.value
                     if new_price < 0:
                         new_price = Decimal(0)
+
                 context.update({
-                    'analytics_data': prepare_analytics_data(product.course_id, self.request.user),
+                    'analytics_data': prepare_analytics_data(
+                        self.request.user,
+                        self.request.site.siteconfiguration.segment_key,
+                        product.course_id
+                    ),
                     'benefit_value': benefit_value,
                     'course': course,
                     'code': code,

--- a/ecommerce/credit/views.py
+++ b/ecommerce/credit/views.py
@@ -88,7 +88,11 @@ class Checkout(TemplateView):
             'payment_processors': processors_dict,
             'deadline': deadline,
             'providers': providers,
-            'analytics_data': prepare_analytics_data(course.id, self.request.user)
+            'analytics_data': prepare_analytics_data(
+                self.request.user,
+                self.request.site.siteconfiguration.segment_key,
+                course.id
+            ),
         })
 
         return context

--- a/ecommerce/extensions/analytics/config.py
+++ b/ecommerce/extensions/analytics/config.py
@@ -1,4 +1,3 @@
-import analytics
 from django.conf import settings
 from oscar.apps.analytics import config
 
@@ -9,7 +8,3 @@ class AnalyticsConfig(config.AnalyticsConfig):
     def ready(self):
         if settings.INSTALL_DEFAULT_ANALYTICS_RECEIVERS:
             from oscar.apps.analytics import receivers  # noqa pylint: disable=unused-variable
-
-        # Initialize Segment
-        analytics.write_key = settings.SEGMENT_KEY
-        analytics.debug = settings.DEBUG

--- a/ecommerce/extensions/analytics/context_processors.py
+++ b/ecommerce/extensions/analytics/context_processors.py
@@ -1,0 +1,9 @@
+from ecommerce.extensions.analytics.utils import prepare_analytics_data
+
+
+def analytics(request):
+    analytics_data = prepare_analytics_data(request.user, request.site.siteconfiguration.segment_key)
+
+    return {
+        'analytics_data': analytics_data,
+    }

--- a/ecommerce/extensions/analytics/tests/test_context_processors.py
+++ b/ecommerce/extensions/analytics/tests/test_context_processors.py
@@ -1,0 +1,19 @@
+from django.test import RequestFactory
+from ecommerce.extensions.analytics.context_processors import analytics
+from ecommerce.extensions.analytics.utils import prepare_analytics_data
+from ecommerce.tests.testcases import TestCase
+
+
+class AnalyticsContextProcessorTests(TestCase):
+    def test_analytics(self):
+        request = RequestFactory().get('/')
+        request.user = self.create_user()
+        request.site = self.site
+        analytics_data = prepare_analytics_data(request.user, request.site.siteconfiguration.segment_key)
+
+        self.assertDictEqual(
+            analytics(request),
+            {
+                'analytics_data': analytics_data,
+            }
+        )

--- a/ecommerce/extensions/analytics/tests/test_utils.py
+++ b/ecommerce/extensions/analytics/tests/test_utils.py
@@ -1,13 +1,11 @@
 import json
 
 from django.contrib.auth.models import AnonymousUser
-from django.test import override_settings
 
 from ecommerce.extensions.analytics.utils import prepare_analytics_data
 from ecommerce.tests.testcases import TestCase
 
 
-@override_settings(SEGMENT_KEY='TEST123')
 class UtilsTest(TestCase):
     """ Tests for the analytics utils. """
 
@@ -22,7 +20,7 @@ class UtilsTest(TestCase):
         data = prepare_analytics_data('a/b/c', user)
         self.assertDictEqual(json.loads(data), {
             'course': {'courseId': 'a/b/c'},
-            'tracking': {'segmentApplicationId': 'TEST123'},
+            'tracking': {'segmentApplicationId': self.site.siteconfiguration.segment_key},
             'user': {'username': 'Tester', 'name': 'John Doe', 'email': 'test@example.com'}
         })
 
@@ -32,6 +30,6 @@ class UtilsTest(TestCase):
         data = prepare_analytics_data('a/b/c', user)
         self.assertDictEqual(json.loads(data), {
             'course': {'courseId': 'a/b/c'},
-            'tracking': {'segmentApplicationId': 'TEST123'},
+            'tracking': {'segmentApplicationId': self.site.siteconfiguration.segment_key},
             'user': 'AnonymousUser'
         })

--- a/ecommerce/extensions/analytics/tests/test_utils.py
+++ b/ecommerce/extensions/analytics/tests/test_utils.py
@@ -17,7 +17,7 @@ class UtilsTest(TestCase):
             last_name='Doe',
             email='test@example.com'
         )
-        data = prepare_analytics_data('a/b/c', user)
+        data = prepare_analytics_data(user, self.site.siteconfiguration.segment_key, 'a/b/c')
         self.assertDictEqual(json.loads(data), {
             'course': {'courseId': 'a/b/c'},
             'tracking': {'segmentApplicationId': self.site.siteconfiguration.segment_key},
@@ -27,7 +27,7 @@ class UtilsTest(TestCase):
     def test_anon_prepare_analytics_data(self):
         """ Verify the function returns correct analytics data for an anonymous user."""
         user = AnonymousUser()
-        data = prepare_analytics_data('a/b/c', user)
+        data = prepare_analytics_data(user, self.site.siteconfiguration.segment_key, 'a/b/c')
         self.assertDictEqual(json.loads(data), {
             'course': {'courseId': 'a/b/c'},
             'tracking': {'segmentApplicationId': self.site.siteconfiguration.segment_key},

--- a/ecommerce/extensions/analytics/utils.py
+++ b/ecommerce/extensions/analytics/utils.py
@@ -4,6 +4,7 @@ import logging
 
 from threadlocals.threadlocals import get_current_request
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -87,22 +88,23 @@ def audit_log(name, **kwargs):
     logger.info(message)
 
 
-def prepare_analytics_data(course_id, user):
+def prepare_analytics_data(user, segment_key, course_id=None):
     """ Helper function for preparing necessary data for analytics.
 
     Arguments:
-        course_id (str): The course ID.
         user (User): The user making the request.
+        segment_key (str): Segment write/API key.
+        course_id (str): The course ID.
 
     Returns:
-        JSON object with the data for analytics.
+        str: JSON object with the data for analytics.
     """
     data = {
         'course': {
             'courseId': course_id
         },
         'tracking': {
-            'segmentApplicationId': get_current_request().site.siteconfiguration.segment_key
+            'segmentApplicationId': segment_key
         }
     }
 

--- a/ecommerce/extensions/analytics/utils.py
+++ b/ecommerce/extensions/analytics/utils.py
@@ -2,14 +2,14 @@ from functools import wraps
 import json
 import logging
 
-from django.conf import settings
+from threadlocals.threadlocals import get_current_request
 
 logger = logging.getLogger(__name__)
 
 
 def is_segment_configured():
     """Returns a Boolean indicating if Segment has been configured for use."""
-    return bool(settings.SEGMENT_KEY)
+    return bool(get_current_request().site.siteconfiguration.segment_key)
 
 
 def parse_tracking_context(user):
@@ -102,7 +102,7 @@ def prepare_analytics_data(course_id, user):
             'courseId': course_id
         },
         'tracking': {
-            'segmentApplicationId': settings.SEGMENT_KEY
+            'segmentApplicationId': get_current_request().site.siteconfiguration.segment_key
         }
     }
 

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -94,7 +94,11 @@ class BasketSummaryView(BasketView):
                 line.benefit_value = None
 
             context.update({
-                'analytics_data': prepare_analytics_data(course_id, self.request.user)
+                'analytics_data': prepare_analytics_data(
+                    self.request.user,
+                    self.request.site.siteconfiguration.segment_key,
+                    course_id
+                ),
             })
 
         context.update({

--- a/ecommerce/extensions/checkout/signals.py
+++ b/ecommerce/extensions/checkout/signals.py
@@ -1,6 +1,5 @@
 import logging
 
-import analytics
 from django.conf import settings
 from django.dispatch import receiver
 from oscar.core.loading import get_class
@@ -29,7 +28,7 @@ def track_completed_order(sender, order=None, **kwargs):  # pylint: disable=unus
 
     user_tracking_id, lms_client_id, lms_ip = parse_tracking_context(order.user)
 
-    analytics.track(
+    order.site.siteconfiguration.segment_client.track(
         user_tracking_id,
         'Completed Order',
         {

--- a/ecommerce/extensions/refund/signals.py
+++ b/ecommerce/extensions/refund/signals.py
@@ -1,4 +1,3 @@
-import analytics
 from django.dispatch import receiver, Signal
 
 from ecommerce.courses.utils import mode_for_seat
@@ -21,7 +20,7 @@ def track_completed_refund(sender, refund=None, **kwargs):  # pylint: disable=un
     # Ecommerce transaction reversal, performed by emitting an event which is the inverse of an
     # order completion event emitted previously.
     # See: https://support.google.com/analytics/answer/1037443?hl=en
-    analytics.track(
+    refund.order.site.siteconfiguration.segment_client.track(
         user_tracking_id,
         'Completed Order',
         {

--- a/ecommerce/extensions/refund/tests/test_models.py
+++ b/ecommerce/extensions/refund/tests/test_models.py
@@ -185,6 +185,7 @@ class RefundTests(RefundTestMixin, StatusTestsMixin, TestCase):
         If payment refund and fulfillment revocation succeed, the method should update the status of the Refund and
         RefundLine objects to Complete, and return True.
         """
+        self.site.siteconfiguration.segment_key = None
         refund = self.create_refund()
         with LogCapture(LOGGER_NAME) as l:
             self.approve(refund)

--- a/ecommerce/extensions/refund/tests/test_signals.py
+++ b/ecommerce/extensions/refund/tests/test_signals.py
@@ -1,15 +1,14 @@
-from django.test import override_settings
 from mock import patch
 from oscar.test.newfactories import UserFactory
 
+from ecommerce.core.models import SegmentClient
 from ecommerce.extensions.refund.api import create_refunds
 from ecommerce.extensions.refund.tests.mixins import RefundTestMixin
 from ecommerce.tests.mixins import BusinessIntelligenceMixin
 from ecommerce.tests.testcases import TestCase
 
 
-@override_settings(SEGMENT_KEY='dummy-key')
-@patch('analytics.track')
+@patch.object(SegmentClient, 'track')
 class RefundTrackingTests(BusinessIntelligenceMixin, RefundTestMixin, TestCase):
     """Tests verifying the behavior of refund tracking."""
 
@@ -76,9 +75,10 @@ class RefundTrackingTests(BusinessIntelligenceMixin, RefundTestMixin, TestCase):
             self.refund.total_credit_excl_tax
         )
 
-    @override_settings(SEGMENT_KEY=None)
     def test_successful_refund_no_segment_key(self, mock_track):
         """Verify that a successfully placed refund is not tracked when Segment is disabled."""
+        self.site.siteconfiguration.segment_key = None
+
         # Approve the refund.
         self.approve(self.refund)
 

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -175,6 +175,7 @@ TEMPLATES = [
                 'oscar.apps.customer.notifications.context_processors.notifications',
                 'oscar.core.context_processors.metadata',
                 'ecommerce.core.context_processors.core',
+                'ecommerce.extensions.analytics.context_processors.analytics',
             ),
             'debug': True,  # Django will only display debug pages if the global DEBUG setting is set to True.
         }

--- a/ecommerce/static/js/common.js
+++ b/ecommerce/static/js/common.js
@@ -4,14 +4,25 @@ require([
         'backbone.validation',
         'bootstrap',
         'bootstrap_accessibility',
-        'underscore'
+        'underscore',
+        'utils/analytics_utils'
     ],
-    function () {
+    function (
+        $,
+        Backbone,
+        BackboneValidation,
+        Bootstrap,
+        BootstrapAccessibility,
+        _,
+        AnalyticsUtils) {
         'use strict';
 
         $(function () {
             // Activate all pre-rendered tooltips.
             $('[data-toggle="tooltip"]').tooltip();
+
+            // Initialize analytics.js
+            AnalyticsUtils.analyticsSetUp();
         });
 
         // NOTE (CCB): Even if validation fails, force the model to be updated. This will ensure calls

--- a/ecommerce/static/js/views/analytics_view.js
+++ b/ecommerce/static/js/views/analytics_view.js
@@ -55,7 +55,7 @@ define([
              * this.segment is set for convenience.
              */
             initSegment: function (applicationKey) {
-                var analytics;
+                var analytics, pageData;
 
                 /* jshint ignore:start */
                 // jscs:disable
@@ -66,8 +66,19 @@ define([
                 // provide our application key for logging
                 analytics.load(applicationKey);
 
-                // this needs to be called once
-                analytics.page(this.buildCourseProperties());
+                pageData = this.getSegmentPageData();
+                analytics.page(pageData);
+            },
+
+            /**
+             * Get data for initializing segment.
+             */
+            getSegmentPageData: function () {
+                if (this.options.courseModel.get('courseId')) {
+                    return this.buildCourseProperties();
+                }
+
+                return {};
             },
 
             /**

--- a/ecommerce/templates/edx/base.html
+++ b/ecommerce/templates/edx/base.html
@@ -40,6 +40,10 @@
 {# Translation support for JavaScript strings. #}
 <script type="text/javascript" src="{% url 'django.views.i18n.javascript_catalog' %}"></script>
 
+<script type="text/javascript">
+    var initModelData = {{ analytics_data|safe }};
+</script>
+
 {% compress js %}
     <script src="{% static 'bower_components/requirejs/require.js' %}"></script>
     <script src="{% static 'js/config.js' %}"></script>

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -256,7 +256,8 @@ class SiteMixin(object):
         site_configuration = SiteConfigurationFactory(
             partner__name='edX',
             site__id=settings.SITE_ID,
-            site__domain=domain
+            site__domain=domain,
+            segment_key='fake_segment_key'
         )
         self.partner = site_configuration.partner
         self.site = site_configuration.site


### PR DESCRIPTION
ECOM-4100
@awais786 @ahsan-ul-haq @tasawernawaz @waheedahmed 
- Add `segment` script for `Otto` in `base.html` so that the event `analytics.page()` is called on all pages.

_**Note:**The field `segment_key` in the model `SiteConfiguration` is introduced in a separate PR: https://github.com/edx/ecommerce/pull/682/_
