### PR TITLE
Updated edx-auth-backends to 0.2.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ django-waffle==0.10.1
 djangorestframework==3.2.3
 djangorestframework-jwt==1.8.0
 drf-extensions==0.2.8
-edx-auth-backends==0.2.0
+edx-auth-backends==0.2.1
 edx-django-sites-extensions==1.0.0
 edx-drf-extensions==0.4.1
 edx-ecommerce-worker==0.3.3


### PR DESCRIPTION
This version of the package stores the token_type in the User.extra_data.

ECOM-4263
