### PR TITLE
WL-330: Update edx.org sass to show edx.org logo

### DIFF
--- a/ecommerce/themes/edx.org/static/sass/partials/utilities/_mixins.scss
+++ b/ecommerce/themes/edx.org/static/sass/partials/utilities/_mixins.scss
@@ -1,0 +1,6 @@
+@import 'ecommerce/static/sass/partials/utilities/mixins';
+
+// Logo override for edx.org theme
+$brand-logo-path: '/static/edx.org/images/default-logo.png' !default;
+$brand-logo-width: 93px !default;
+$brand-logo-height: 47px !default;


### PR DESCRIPTION
Hi @mattdrayer ,  @jimabramson  , @clintonb  

kindly review this change set, I have updated sass for edx.org to override default header logo.
