### PR TITLE
WL-330: Add DEFAULT_SITE_THEME settings

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -507,6 +507,10 @@ DISABLE_THEMING_ON_RUNTIME_SWITCH = "disable_theming_on_runtime"
 # Directory that contains all themes
 COMPREHENSIVE_THEME_DIR = DJANGO_ROOT + "/themes"
 
+# Theme to use when no site or site theme is defined,
+# set to None if you want to use openedx theme
+DEFAULT_SITE_THEME = None
+
 # Cache time out for theme templates and related assets
 
 THEME_CACHE_TIMEOUT = 30 * 60

--- a/ecommerce/settings/test.py
+++ b/ecommerce/settings/test.py
@@ -129,3 +129,4 @@ COMPRESS_OFFLINE = True
 
 # Comprehensive theme settings for testing environment
 COMPREHENSIVE_THEME_DIR = DJANGO_ROOT + "/tests/themes"
+DEFAULT_SITE_THEME = "test-theme"

--- a/ecommerce/theming/helpers.py
+++ b/ecommerce/theming/helpers.py
@@ -10,6 +10,8 @@ import waffle
 from path import Path
 from threadlocals.threadlocals import get_current_request
 
+from ecommerce.theming.models import SiteTheme
+
 
 def get_current_site():
     """
@@ -153,7 +155,7 @@ def get_theme_dir():
     if not is_comprehensive_theming_enabled():
         return None
 
-    site_theme = site and site.themes.first()
+    site_theme = SiteTheme.get_theme(site)
     theme_dir = getattr(site_theme, "theme_dir_name") if site_theme else None
 
     if theme_dir:
@@ -207,11 +209,15 @@ def get_current_site_theme_dir():
     site = get_current_site()
     if not site:
         return None
+
+    if not is_comprehensive_theming_enabled():
+        return None
+
     site_theme_dir = cache.get(get_site_theme_cache_key(site))
 
     # if site theme dir is not in cache and comprehensive theming is enabled then pull it from db.
-    if not site_theme_dir and is_comprehensive_theming_enabled():
-        site_theme = site.themes.first()  # pylint: disable=no-member
+    if not site_theme_dir:
+        site_theme = SiteTheme.get_theme(site)
         if site_theme:
             site_theme_dir = site_theme.theme_dir_name
             cache_site_theme_dir(site, site_theme_dir)

--- a/ecommerce/theming/models.py
+++ b/ecommerce/theming/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.conf import settings
 from django.contrib.sites.models import Site
 
 
@@ -12,3 +13,25 @@ class SiteTheme(models.Model):
     """
     site = models.ForeignKey(Site, related_name='themes')
     theme_dir_name = models.CharField(max_length=255)
+
+    @staticmethod
+    def get_theme(site):
+        """
+        Get SiteTheme object for given site, returns default site theme if it can not
+        find a theme for the given site and `DEFAULT_SITE_THEME` setting has a proper value.
+
+        Args:
+            site (django.contrib.sites.models.Site): site object related to the current site.
+
+        Returns:
+            SiteTheme object for given site or a default site set by `DEFAULT_SITE_THEME`
+        """
+        if not site:
+            return None
+
+        theme = site.themes.first()
+
+        if (not theme) and settings.DEFAULT_SITE_THEME:
+            theme = SiteTheme(site=site, theme_dir_name=settings.DEFAULT_SITE_THEME)
+
+        return theme

--- a/ecommerce/theming/tests/test_helpers.py
+++ b/ecommerce/theming/tests/test_helpers.py
@@ -5,6 +5,8 @@ from mock import patch
 
 from django.test import override_settings
 from django.conf import settings, ImproperlyConfigured
+from django.contrib.sites.models import Site
+
 from path import Path
 
 from ecommerce.tests.testcases import TestCase
@@ -62,6 +64,27 @@ class TestHelpers(TestCase):
         with override_settings(ENABLE_COMPREHENSIVE_THEMING=False):
             theme_dir = get_theme_dir()
             self.assertIsNone(theme_dir)
+
+    def test_default_site_theme(self):
+        """
+        Tests get_theme_dir returns DEFAULT_SITE_THEME if theming is enabled and no site theme is present.
+        """
+        site, __ = Site.objects.get_or_create(domain="test.edx.org", name="test.edx.org")
+        with patch('ecommerce.theming.helpers.get_current_site', return_value=site):
+            theme_dir = get_theme_dir()
+            self.assertEqual(
+                settings.DJANGO_ROOT + "/tests/themes/{}".format(settings.DEFAULT_SITE_THEME),
+                theme_dir,
+            )
+
+    def test_default_current_site_theme_dir(self):
+        """
+        Tests get_current_site_theme_dir returns DEFAULT_SITE_THEME if theming is enabled and no site theme is present.
+        """
+        site, __ = Site.objects.get_or_create(domain="test.edx.org", name="test.edx.org")
+        with patch('ecommerce.theming.helpers.get_current_site', return_value=site):
+            theme_dir = get_current_site_theme_dir()
+            self.assertEqual(settings.DEFAULT_SITE_THEME, theme_dir)
 
     def test_improperly_configured_error(self):
         """


### PR DESCRIPTION
Hi @mattdrayer 

This PR contains addition of DEFAULT_SITE_THEME setting that can be used to define a default theme that should be used when theming is enabled and there is no theme for the current site.
