### PR TITLE
Fix acceptance/end-to-end tests

### DIFF
--- a/acceptance_tests/api.py
+++ b/acceptance_tests/api.py
@@ -1,7 +1,7 @@
 import requests
 from requests.auth import AuthBase
 
-from acceptance_tests.config import ENROLLMENT_API_URL, ENROLLMENT_API_TOKEN
+from acceptance_tests.config import ACCESS_TOKEN, ENROLLMENT_API_URL
 
 
 class BearerAuth(AuthBase):
@@ -20,7 +20,7 @@ class BearerAuth(AuthBase):
 class EnrollmentApiClient(object):
     def __init__(self, host=None, key=None):
         self.host = host or ENROLLMENT_API_URL
-        self.key = key or ENROLLMENT_API_TOKEN
+        self.key = key or ACCESS_TOKEN
 
     def get_enrollment_status(self, username, course_id):
         """

--- a/acceptance_tests/config.py
+++ b/acceptance_tests/config.py
@@ -1,72 +1,50 @@
 import os
+from acceptance_tests.utils import str2bool
 
 
-def str2bool(s):
-    s = unicode(s)
-    return s.lower() in (u'yes', u'true', u't', u'1')
-
-# GENERAL CONFIGURATION
 ACCESS_TOKEN = os.environ.get('ACCESS_TOKEN')
-ENABLE_OAUTH2_TESTS = str2bool(os.environ.get('ENABLE_OAUTH2_TESTS', True))
-HONOR_COURSE_ID = os.environ.get('HONOR_COURSE_ID', 'course-v1:edX+DemoX+Demo_Course')
-VERIFIED_COURSE_ID = os.environ.get('VERIFIED_COURSE_ID', 'course-v1:BerkeleyX+ColWri.3.6x+3T2015')
-PROFESSIONAL_COURSE_ID = os.environ.get('PROFESSIONAL_COURSE_ID', 'course-v1:UBCx+Marketing5501x+2T2015')
-
 if ACCESS_TOKEN is None:
-    raise RuntimeError('A valid OAuth2 access token is required to run acceptance tests.')
-# END GENERAL CONFIGURATION
+    raise RuntimeError('A valid OAuth2 access token is required.')
 
+HONOR_COURSE_ID = os.environ.get('HONOR_COURSE_ID')
+VERIFIED_COURSE_ID = os.environ.get('VERIFIED_COURSE_ID')
+if not all([HONOR_COURSE_ID, VERIFIED_COURSE_ID]):
+    raise RuntimeError('IDs for courses with honor and verified modes are required.')
 
-# OTTO CONFIGURATION
+PROFESSIONAL_COURSE_ID = os.environ.get('PROFESSIONAL_COURSE_ID')
+
 try:
     ECOMMERCE_URL_ROOT = os.environ.get('ECOMMERCE_URL_ROOT').strip('/')
 except AttributeError:
-    raise RuntimeError('You must provide a valid URL root for the E-Commerce Service to run acceptance tests.')
+    raise RuntimeError('A valid URL root for the E-Commerce Service is required.')
 
 ECOMMERCE_API_URL = os.environ.get('ECOMMERCE_API_URL', ECOMMERCE_URL_ROOT + '/api/v2')
-ECOMMERCE_API_TOKEN = os.environ.get('ECOMMERCE_API_TOKEN', ACCESS_TOKEN)
 MAX_COMPLETION_RETRIES = int(os.environ.get('MAX_COMPLETION_RETRIES', 3))
 PAYPAL_EMAIL = os.environ.get('PAYPAL_EMAIL')
 PAYPAL_PASSWORD = os.environ.get('PAYPAL_PASSWORD')
-# It can be a pain to set up CyberSource for local testing. This flag allows CyberSource
-# tests to be disabled.
 ENABLE_CYBERSOURCE_TESTS = str2bool(os.environ.get('ENABLE_CYBERSOURCE_TESTS', True))
-# END OTTO CONFIGURATION
 
+try:
+    MARKETING_URL_ROOT = os.environ.get('MARKETING_URL_ROOT').strip('/')
+except AttributeError:
+    MARKETING_URL_ROOT = None
 
-# MARKETING CONFIGURATION
-ENABLE_MARKETING_SITE = str2bool(os.environ.get('ENABLE_MARKETING_SITE', False))
-
-MARKETING_URL_ROOT = os.environ.get('MARKETING_URL_ROOT').strip('/') if ENABLE_MARKETING_SITE else None
-
-# These must correspond to the course IDs provided for each enrollment mode.
-VERIFIED_COURSE_SLUG = os.environ.get(
-    'VERIFIED_COURSE_SLUG',
-    'dracula-stoker-berkeleyx-book-club-uc-berkeleyx-colwri3-6x'
-)
-PROFESSIONAL_COURSE_SLUG = os.environ.get(
-    'PROFESSIONAL_COURSE_SLUG',
-    'marketing-non-marketers-ubcx-marketing5501x'
-)
-# END MARKETING CONFIGURATION
-
-
-# LMS CONFIGURATION
 try:
     LMS_URL_ROOT = os.environ.get('LMS_URL_ROOT').strip('/')
 except AttributeError:
-    raise RuntimeError('You must provide a valid URL root for the LMS to run acceptance tests.')
+    raise RuntimeError('A valid LMS URL root is required.')
 
+ENABLE_OAUTH2_TESTS = str2bool(os.environ.get('ENABLE_OAUTH2_TESTS', True))
 LMS_USERNAME = os.environ.get('LMS_USERNAME')
 LMS_EMAIL = os.environ.get('LMS_EMAIL')
 LMS_PASSWORD = os.environ.get('LMS_PASSWORD')
 LMS_AUTO_AUTH = str2bool(os.environ.get('LMS_AUTO_AUTH', False))
 LMS_HTTPS = str2bool(os.environ.get('LMS_HTTPS', True))
 ENROLLMENT_API_URL = os.environ.get('ENROLLMENT_API_URL', LMS_URL_ROOT + '/api/enrollment/v1')
-ENROLLMENT_API_TOKEN = os.environ.get('ENROLLMENT_API_TOKEN', ACCESS_TOKEN)
 BASIC_AUTH_USERNAME = os.environ.get('BASIC_AUTH_USERNAME')
 BASIC_AUTH_PASSWORD = os.environ.get('BASIC_AUTH_PASSWORD')
 
-if ENABLE_OAUTH2_TESTS and not (LMS_URL_ROOT and LMS_USERNAME and LMS_PASSWORD):
-    raise RuntimeError('Configuring LMS settings is required to run OAuth2 tests.')
-# END LMS CONFIGURATION
+if ENABLE_OAUTH2_TESTS and not all([LMS_URL_ROOT, LMS_USERNAME, LMS_PASSWORD]):
+    raise RuntimeError('LMS settings are required to run OAuth2 tests.')
+
+ENABLE_COUPON_ADMIN_TESTS = str2bool(os.environ.get('ENABLE_COUPON_ADMIN_TESTS', False))

--- a/acceptance_tests/pages/marketing.py
+++ b/acceptance_tests/pages/marketing.py
@@ -1,27 +1,27 @@
-import urllib
-
 from bok_choy.page_object import PageObject
+import requests
 
 from acceptance_tests.config import MARKETING_URL_ROOT, BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD
 
 
 class MarketingCourseAboutPage(PageObject):
+    def __init__(self, browser, course_id):
+        super(MarketingCourseAboutPage, self).__init__(browser)
+
+        drupal_catalog_url = '{}/api/catalog/v2/courses/{}'.format(MARKETING_URL_ROOT, course_id)
+        response = requests.get(drupal_catalog_url)
+        data = response.json()
+
+        self.about_page_path = data['course_about_uri']
+
     def is_browser_on_page(self):
         return self.q(css='.js-enroll-btn').visible
 
-    def _build_url(self, path):
-        url = '{}/{}'.format(MARKETING_URL_ROOT, path)
+    @property
+    def url(self):
+        url = '{}/{}'.format(MARKETING_URL_ROOT, self.about_page_path)
 
         if BASIC_AUTH_USERNAME and BASIC_AUTH_PASSWORD:
             url = url.replace('://', '://{}:{}@'.format(BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD))
 
         return url
-
-    @property
-    def url(self):
-        path = 'course/{}'.format(urllib.quote_plus(self.slug))
-        return self._build_url(path)
-
-    def __init__(self, browser, slug):
-        super(MarketingCourseAboutPage, self).__init__(browser)
-        self.slug = slug

--- a/acceptance_tests/test_coupon_admin.py
+++ b/acceptance_tests/test_coupon_admin.py
@@ -1,12 +1,15 @@
 from datetime import date
+from unittest import skipUnless
 
 from bok_choy.web_app_test import WebAppTest
 
+from acceptance_tests.config import ENABLE_COUPON_ADMIN_TESTS
 from acceptance_tests.constants import DEFAULT_END_DATE, DEFAULT_START_DATE
 from acceptance_tests.mixins import CouponMixin, LogistrationMixin
 from acceptance_tests.pages import CouponsCreatePage, CouponsDetailsPage, CouponsListPage
 
 
+@skipUnless(ENABLE_COUPON_ADMIN_TESTS, 'Coupon admin tests are disabled.')
 class CouponAdministrationTests(CouponMixin, LogistrationMixin, WebAppTest):
     def setUp(self):
         """ Instantiate the page objects. """

--- a/acceptance_tests/test_payment.py
+++ b/acceptance_tests/test_payment.py
@@ -6,7 +6,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
-from acceptance_tests.config import (VERIFIED_COURSE_ID, ENABLE_MARKETING_SITE, VERIFIED_COURSE_SLUG,
+from acceptance_tests.config import (VERIFIED_COURSE_ID, MARKETING_URL_ROOT,
                                      PAYPAL_PASSWORD, PAYPAL_EMAIL, ENABLE_CYBERSOURCE_TESTS)
 from acceptance_tests.constants import CYBERSOURCE_DATA1, CYBERSOURCE_DATA2
 from acceptance_tests.mixins import (LogistrationMixin, EnrollmentApiMixin, EcommerceApiMixin,
@@ -26,18 +26,17 @@ class VerifiedCertificatePaymentTests(UnenrollmentMixin, EcommerceApiMixin, Enro
         """ Begin the checkout process for a verified certificate. """
         self.login_with_lms(self.email, self.password)
 
-        # If a slug is provided, use the marketing site.
-        if ENABLE_MARKETING_SITE:
-            course_about_page = MarketingCourseAboutPage(self.browser, VERIFIED_COURSE_SLUG)
+        if MARKETING_URL_ROOT:
+            course_about_page = MarketingCourseAboutPage(self.browser, self.course_id)
             course_about_page.visit()
 
             # Click the first enroll button on the page to take the browser to the track selection page.
             course_about_page.q(css='.js-enroll-btn').first.click()
 
             # Wait for the track selection page to load.
-            WebDriverWait(self.browser, 10).until(
-                EC.presence_of_element_located((By.CLASS_NAME, 'form-register-choose'))
-            )
+            wait = WebDriverWait(self.browser, 10)
+            track_selection_present = EC.presence_of_element_located((By.CLASS_NAME, 'form-register-choose'))
+            wait.until(track_selection_present)
         else:
             course_modes_page = LMSCourseModePage(self.browser, self.course_id)
             course_modes_page.visit()
@@ -59,7 +58,6 @@ class VerifiedCertificatePaymentTests(UnenrollmentMixin, EcommerceApiMixin, Enro
 
     def test_paypal(self):
         """ Test checkout with PayPal. """
-
         if not (PAYPAL_EMAIL and PAYPAL_PASSWORD):
             self.fail('No PayPal credentials supplied!')
 

--- a/acceptance_tests/test_profed_enrollment.py
+++ b/acceptance_tests/test_profed_enrollment.py
@@ -1,29 +1,30 @@
+from unittest import skipUnless
+
 from bok_choy.web_app_test import WebAppTest
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
-from acceptance_tests.config import PROFESSIONAL_COURSE_ID, ENABLE_MARKETING_SITE, PROFESSIONAL_COURSE_SLUG
+from acceptance_tests.config import PROFESSIONAL_COURSE_ID, MARKETING_URL_ROOT
 from acceptance_tests.mixins import LogistrationMixin, EnrollmentApiMixin
 from acceptance_tests.pages import LMSCourseModePage, MarketingCourseAboutPage
 
 
+@skipUnless(PROFESSIONAL_COURSE_ID, 'Professional education tests are not enabled.')
 class ProfessionalEducationEnrollmentTests(EnrollmentApiMixin, LogistrationMixin, WebAppTest):
     def test_payment_required(self):
         """Verify payment is required before enrolling in a professional education course."""
-
-        # Sign into LMS
         username, password, email = self.get_lms_user()
         self.login_with_lms(email, password)
 
-        if ENABLE_MARKETING_SITE:
-            course_about_page = MarketingCourseAboutPage(self.browser, PROFESSIONAL_COURSE_SLUG)
+        if MARKETING_URL_ROOT:
+            course_about_page = MarketingCourseAboutPage(self.browser, PROFESSIONAL_COURSE_ID)
             course_about_page.visit()
 
             # Click the first enroll button on the page to take the browser to the track selection page,
             # and allow it to load.
             course_about_page.q(css='.js-enroll-btn').first.click()
-            WebDriverWait(self.browser, 10).until(EC.presence_of_element_located((By.CLASS_NAME, 'make-payment-step')))
+            WebDriverWait(self.browser, 10).until(EC.presence_of_element_located((By.CLASS_NAME, 'basket')))
         else:
             # Visit the course mode page (where auto-enrollment normally occurs)
             LMSCourseModePage(self.browser, PROFESSIONAL_COURSE_ID).visit()

--- a/acceptance_tests/utils.py
+++ b/acceptance_tests/utils.py
@@ -1,0 +1,6 @@
+"""Utilities for end-to-end tests."""
+
+
+def str2bool(s):
+    s = unicode(s)
+    return s.lower() in (u'yes', u'true', u't', u'1')

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -101,7 +101,7 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
                 raise NotImplementedError('Multi-use voucher types are not supported')
 
             # When a black-listed course mode is received raise an exception.
-            # Audit modes do not have a certificate type and therefor will raise
+            # Audit modes do not have a certificate type and therefore will raise
             # an AttributeError exception.
             seats = Product.objects.filter(stockrecords__id__in=stock_record_ids)
             for seat in seats:


### PR DESCRIPTION
Fixes include: interacting with the iframe on PayPal's new login page, updates to deal with the new edX checkout page, loading the edX receipt page several times to deal with slow payment processing, more robust interaction with the coupon admin app, and allowing coupon admin tests to be skipped (which they are, by default).

@schenedx @jimabramson @ronaldmulero @mjfrey FYI
