### PR TITLE
Adjust PayPal information for checking out baskets with >1 quantity lines

### DIFF
--- a/ecommerce/extensions/payment/processors/paypal.py
+++ b/ecommerce/extensions/payment/processors/paypal.py
@@ -110,7 +110,9 @@ class Paypal(BasePaymentProcessor):
                             'quantity': line.quantity,
                             # PayPal requires that item names be at most 127 characters long.
                             'name': middle_truncate(line.product.title, 127),
-                            'price': unicode(line.line_price_incl_tax_incl_discounts),
+                            # PayPal requires that the sum of all the item prices (where price = price * quantity)
+                            # equals to the total amount set in amount['total'].
+                            'price': unicode(line.line_price_incl_tax_incl_discounts / line.quantity),
                             'currency': line.stockrecord.price_currency,
                         }
                         for line in basket.all_lines()

--- a/ecommerce/extensions/payment/tests/mixins.py
+++ b/ecommerce/extensions/payment/tests/mixins.py
@@ -262,7 +262,7 @@ class PaypalMixin(object):
                         {
                             u'quantity': line.quantity,
                             u'name': line.product.title,
-                            u'price': unicode(line.price_incl_tax),
+                            u'price': unicode(line.line_price_incl_tax_incl_discounts / line.quantity),
                             u'currency': line.stockrecord.price_currency,
                         }
                         for line in basket.all_lines()
@@ -325,7 +325,7 @@ class PaypalMixin(object):
                         {
                             u'quantity': line.quantity,
                             u'name': line.product.title,
-                            u'price': unicode(line.price_incl_tax),
+                            u'price': unicode(line.line_price_incl_tax_incl_discounts / line.quantity),
                             u'currency': line.stockrecord.price_currency,
                         }
                         for line in basket.all_lines()


### PR DESCRIPTION
The PayPal API requires for the [ `item_list` ](https://developer.paypal.com/docs/api/#item-object) to be populated with item data so that the sum of item prices, where every item price is `price * quantity`, equals to the `amount['total']` that you're sending in the `transactions` values.
