### PR TITLE
vkaracic/enrollment-code-implementation: Add Enrollment Code products to support Bulk Purchasing

### DIFF
--- a/ecommerce/core/constants.py
+++ b/ecommerce/core/constants.py
@@ -8,6 +8,12 @@ COURSE_ID_REGEX = r'[^/+]+(/|\+)[^/+]+(/|\+)[^/]+'
 COURSE_ID_PATTERN = r'(?P<course_id>{})'.format(COURSE_ID_REGEX)
 
 
+# Enrollment Code constants
+ENROLLMENT_CODE_PRODUCT_CLASS_NAME = 'Enrollment Code'
+ENROLLMENT_CODE_SWITCH = 'create_enrollment_codes'
+ENROLLMENT_CODE_SEAT_TYPES = ['verified', 'professional']
+
+
 class Status(object):
     """Health statuses."""
     OK = u"OK"

--- a/ecommerce/core/migrations/0014_enrollment_code_switch.py
+++ b/ecommerce/core/migrations/0014_enrollment_code_switch.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.db import migrations
+
+from ecommerce.core.constants import ENROLLMENT_CODE_SWITCH
+
+
+def create_switch(apps, schema_editor):
+    """Create a switch for automatic creation of enrollment code products."""
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.get_or_create(name=ENROLLMENT_CODE_SWITCH, defaults={'active': False})
+
+
+def remove_switch(apps, schema_editor):
+    """Remove enrollment code switch."""
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.filter(name=ENROLLMENT_CODE_SWITCH).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0001_initial'),
+        ('core', '0013_siteconfiguration_segment_key')
+    ]
+    operations = [
+        migrations.RunPython(create_switch, remove_switch)
+    ]

--- a/ecommerce/extensions/catalogue/migrations/0017_enrollment_code_product_class.py
+++ b/ecommerce/extensions/catalogue/migrations/0017_enrollment_code_product_class.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from oscar.core.loading import get_model
+
+from ecommerce.core.constants import ENROLLMENT_CODE_PRODUCT_CLASS_NAME
+
+Category = get_model('catalogue', 'Category')
+ProductAttribute = get_model('catalogue', 'ProductAttribute')
+ProductClass = get_model('catalogue', 'ProductClass')
+
+
+def create_enrollment_code_product_class(apps, schema_editor):
+    """Create an Enrollment code product class and switch to turn automatic creation on."""
+
+    enrollment_code = ProductClass.objects.create(
+        track_stock=False,
+        requires_shipping=False,
+        name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME,
+        slug='enrollment_code',
+    )
+
+    ProductAttribute.objects.create(
+        product_class=enrollment_code,
+        name='Course Key',
+        code='course_key',
+        type='text',
+        required=True
+    )
+
+    ProductAttribute.objects.create(
+        product_class=enrollment_code,
+        name='Seat Type',
+        code='seat_type',
+        type='text',
+        required=True
+    )
+
+
+def remove_enrollment_code_product_class(apps, schema_editor):
+    """Remove the Enrollment code product class and the waffle switch."""
+    ProductClass.objects.filter(name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('catalogue', '0001_initial'),
+        ('catalogue', '0016_coupon_note_attribute')
+    ]
+    operations = [
+        migrations.RunPython(create_enrollment_code_product_class, remove_enrollment_code_product_class)
+    ]

--- a/ecommerce/extensions/catalogue/tests/test_utils.py
+++ b/ecommerce/extensions/catalogue/tests/test_utils.py
@@ -6,12 +6,14 @@ from oscar.core.loading import get_model
 
 from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
 from ecommerce.extensions.catalogue.utils import generate_sku, get_or_create_catalog, generate_coupon_slug
+from ecommerce.tests.factories import ProductFactory
 from ecommerce.tests.mixins import CouponMixin
 from ecommerce.tests.testcases import TestCase
 
 Benefit = get_model('offer', 'Benefit')
 Catalog = get_model('catalogue', 'Catalog')
 Course = get_model('courses', 'Course')
+Product = get_model('catalogue', 'Product')
 StockRecord = get_model('partner', 'StockRecord')
 Voucher = get_model('voucher', 'Voucher')
 
@@ -26,6 +28,17 @@ class UtilsTests(CourseCatalogTestMixin, TestCase):
         self.course = Course.objects.create(id=COURSE_ID, name='Test Course')
         self.course.create_or_update_seat('verified', False, 0, self.partner)
         self.catalog = Catalog.objects.create(name='Test', partner_id=self.partner.id)
+
+    def test_generate_sku_with_missing_product_class(self):
+        """Verify the method raises an exception if the product class is missing."""
+        with self.assertRaises(AttributeError):
+            generate_sku(Product(), self.partner)
+
+    def test_generate_sku_with_unexpected_product_class(self):
+        """Verify the method raises an exception for unsupported product class."""
+        product = ProductFactory()
+        with self.assertRaises(Exception):
+            generate_sku(product, self.partner)
 
     def test_generate_sku_for_course_seat(self):
         """Verify the method generates a SKU for a course seat."""

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -145,7 +145,7 @@ class EnrollmentFulfillmentModuleTests(CourseCatalogTestMixin, FulfillmentTestMi
 
     def test_enrollment_module_fulfill_bad_attributes(self):
         """Test that use of the Fulfillment Module fails when the product does not have attributes."""
-        ProductAttribute.objects.get(code='course_key').delete()
+        ProductAttribute.objects.get(product_class__name='Seat', code='course_key').delete()
         EnrollmentFulfillmentModule().fulfill_product(self.order, list(self.order.lines.all()))
         self.assertEqual(LINE.FULFILLMENT_CONFIGURATION_ERROR, self.order.lines.all()[0].status)
 

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -416,7 +416,7 @@ REST_FRAMEWORK = {
         'rest_framework.throttling.UserRateThrottle',
     ),
     'DEFAULT_THROTTLE_RATES': {
-        'user': '40/minute',
+        'user': '50/minute',
     },
 }
 


### PR DESCRIPTION
This PR contains logic to create `Enrollment code` products and associate them with a seat.
Includes:
- a private method to create the `Enrollment code` product
- migrations for new `Enrollment code` product class and a new product attribute for the `Seat` product class
- settings for enabling automatic creation of enrollment codes
- tests

Part of https://openedx.atlassian.net/browse/WL-381
