### PR TITLE
MAYN:208: Add lms_main_url to template context.

### DIFF
--- a/ecommerce/core/context_processors.py
+++ b/ecommerce/core/context_processors.py
@@ -1,10 +1,11 @@
 from django.conf import settings
 
-from ecommerce.core.url_utils import get_lms_dashboard_url
+from ecommerce.core.url_utils import get_lms_dashboard_url, get_lms_url
 
 
 def core(request):
     return {
+        'lms_base_url': get_lms_url(),
         'lms_dashboard_url': get_lms_dashboard_url(),
         'platform_name': request.site.name,
         'support_url': settings.SUPPORT_URL,

--- a/ecommerce/core/tests/test_context_processors.py
+++ b/ecommerce/core/tests/test_context_processors.py
@@ -2,7 +2,7 @@ from django.test import override_settings
 from threadlocals.threadlocals import get_current_request
 
 from ecommerce.core.context_processors import core
-from ecommerce.core.url_utils import get_lms_dashboard_url
+from ecommerce.core.url_utils import get_lms_dashboard_url, get_lms_url
 from ecommerce.tests.testcases import TestCase
 
 SUPPORT_URL = 'example.com'
@@ -15,6 +15,7 @@ class CoreContextProcessorTests(TestCase):
         self.assertDictEqual(
             core(request),
             {
+                'lms_base_url': get_lms_url(),
                 'lms_dashboard_url': get_lms_dashboard_url(),
                 'platform_name': request.site.name,
                 'support_url': SUPPORT_URL


### PR DESCRIPTION
Hi @mattdrayer , @clintonb , @jimabramson 

Kindly review this PR, it adds a new context variable (lms_base_url) to django template context.

**Description of Changes:**
We are overriding footer for MIT theme [here](https://github.com/edx/edx-themes/pull/3/files#diff-7cac63a1d81a8af413e243197e2e6530R12) and in order to provide links like about, contact, honor code etc. We need LMS base url in Otto template. 
