### PR TITLE
[SOL-1772] Add course query preview endpoint

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -8,6 +8,7 @@ import ddt
 from django.core.urlresolvers import reverse
 from django.db.utils import IntegrityError
 from django.test import RequestFactory
+import httpretty
 from oscar.apps.catalogue.categories import create_from_breadcrumbs
 from oscar.core.loading import get_class, get_model
 from oscar.test import factories
@@ -39,6 +40,7 @@ Voucher = get_model('voucher', 'Voucher')
 COUPONS_LINK = reverse('api:v2:coupons-list')
 
 
+@httpretty.activate
 @ddt.ddt
 class CouponViewSetTest(CouponMixin, CourseCatalogTestMixin, TestCase):
     """Unit tests for creating coupon order."""

--- a/ecommerce/extensions/api/v2/views/catalog.py
+++ b/ecommerce/extensions/api/v2/views/catalog.py
@@ -1,15 +1,49 @@
+import logging
+
 from oscar.core.loading import get_model
+from requests.exceptions import ConnectionError, Timeout
+from rest_framework import status
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
+from rest_framework.response import Response
 from rest_framework.viewsets import ReadOnlyModelViewSet
+from rest_framework_extensions.decorators import action
 from rest_framework_extensions.mixins import NestedViewSetMixin
+from slumber.exceptions import SlumberBaseException
 
 from ecommerce.extensions.api import serializers
+from ecommerce.core.url_utils import get_course_catalog_api_client
 
 
 Catalog = get_model('catalogue', 'Catalog')
+logger = logging.getLogger(__name__)
 
 
 class CatalogViewSet(NestedViewSetMixin, ReadOnlyModelViewSet):
     queryset = Catalog.objects.all()
     serializer_class = serializers.CatalogSerializer
     permission_classes = (IsAuthenticated, IsAdminUser,)
+
+    @action(is_for_list=True, methods=['get'])
+    def preview(self, request):
+        """
+        Preview the results of the catalog query.
+        A list of course runs, indicating a course run presence within the catalog, will be returned.
+        ---
+        parameters:
+            - name: query
+              description: Elasticsearch querystring query
+              required: true
+              type: string
+              paramType: query
+              multiple: false
+        """
+        query = request.GET.get('query', '')
+        if query:
+            try:
+                api = get_course_catalog_api_client(request.site)
+                response = api.course_runs.get(q=query)
+                return Response(response)
+            except (ConnectionError, SlumberBaseException, Timeout):
+                logger.error('Unable to connect to Course Catalog service.')
+                return Response(status=status.HTTP_400_BAD_REQUEST)
+        return Response(status=status.HTTP_400_BAD_REQUEST)

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -41,11 +41,7 @@ Voucher = get_model('voucher', 'Voucher')
 
 
 class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
-    """Endpoint for creating coupons.
-
-    Creates a new coupon product, adds it to a basket and creates a
-    new order from that basket.
-    """
+    """ Coupon resource. """
     queryset = Product.objects.filter(product_class__name='Coupon')
     permission_classes = (IsAuthenticated, IsAdminUser)
     filter_backends = (filters.DjangoFilterBackend, )


### PR DESCRIPTION
This PR adds a proxy API endpoint that connects ecommerce and Course Catalog(Discovery) app.

We need to get the list of course runs that are a result of the filtering by ES query, done on the Course Catalog(Discovery) side. This will be used during the processes of coupon creation/editing/previewing.

JIRA story: https://openedx.atlassian.net/browse/SOL-1772

@mjfrey already did the 1st review. @clintonb, can you or someone from your team take a look as the 2nd reviewer?

FYI @rlucioni 
