### PR TITLE
Disabled JWT audience claim verification

### DIFF
--- a/ecommerce/extensions/api/handlers.py
+++ b/ecommerce/extensions/api/handlers.py
@@ -23,6 +23,7 @@ def jwt_decode_handler(token):
         """
     options = {
         'verify_exp': api_settings.JWT_VERIFY_EXPIRATION,
+        'verify_aud': settings.JWT_AUTH['JWT_VERIFY_AUDIENCE'],
     }
 
     # JWT_ISSUERS is not one of DRF-JWT's default settings, and cannot be accessed

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -325,6 +325,9 @@ JWT_AUTH = {
     'JWT_SECRET_KEY': None,
     'JWT_ALGORITHM': 'HS256',
     'JWT_VERIFY_EXPIRATION': True,
+    # NOTE (CCB): This is temporarily set to False until we decide what values
+    # are acceptable.
+    'JWT_VERIFY_AUDIENCE': False,
     'JWT_LEEWAY': 1,
     'JWT_DECODE_HANDLER': 'ecommerce.extensions.api.handlers.jwt_decode_handler',
     # This setting is not one of DRF-JWT's defaults.

--- a/ecommerce/settings/production.py
+++ b/ecommerce/settings/production.py
@@ -40,12 +40,23 @@ def get_env_setting(setting):
 ALLOWED_HOSTS = ['*']
 # END HOST CONFIGURATION
 
-CONFIG_FILE = get_env_setting('ECOMMERCE_CFG')
+# Keep track of the names of settings that represent dicts. Instead of overriding the values in base.py,
+# the values read from disk should UPDATE the pre-configured dicts.
+DICT_UPDATE_KEYS = ('JWT_AUTH',)
 
+CONFIG_FILE = get_env_setting('ECOMMERCE_CFG')
 with open(CONFIG_FILE) as f:
     config_from_yaml = yaml.load(f)
 
-vars().update(config_from_yaml)
+    # Remove the items that should be used to update dicts, and apply them separately rather
+    # than pumping them into the local vars.
+    dict_updates = {key: config_from_yaml.pop(key, None) for key in DICT_UPDATE_KEYS}
+
+    for key, value in dict_updates.items():
+        if value:
+            vars()[key].update(value)
+
+    vars().update(config_from_yaml)
 
 DB_OVERRIDES = dict(
     PASSWORD=environ.get('DB_MIGRATION_PASS', DATABASES['default']['PASSWORD']),


### PR DESCRIPTION
The value of this claim for JWTs issued by LMS is the OAuth client ID, which we don't have access to here in Otto. Verification is disabled until this issue can be resolved.

ECOM-4414
