### PR TITLE
mattdrayer/serialize-prodattr-code: Include 'code' attribute value property in API response

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -66,10 +66,14 @@ class BillingAddressSerializer(serializers.ModelSerializer):
 class ProductAttributeValueSerializer(serializers.ModelSerializer):
     """ Serializer for ProductAttributeValue objects. """
     name = serializers.SerializerMethodField()
+    code = serializers.SerializerMethodField()
     value = serializers.SerializerMethodField()
 
     def get_name(self, instance):
         return instance.attribute.name
+
+    def get_code(self, instance):
+        return instance.attribute.code
 
     def get_value(self, obj):
         if obj.attribute.name == 'Coupon vouchers':
@@ -81,7 +85,7 @@ class ProductAttributeValueSerializer(serializers.ModelSerializer):
 
     class Meta(object):
         model = ProductAttributeValue
-        fields = ('name', 'value',)
+        fields = ('name', 'code', 'value',)
 
 
 class StockRecordSerializer(serializers.ModelSerializer):

--- a/ecommerce/extensions/api/v2/tests/views/__init__.py
+++ b/ecommerce/extensions/api/v2/tests/views/__init__.py
@@ -49,7 +49,13 @@ class OrderDetailViewTestMixin(ThrottlingMixin):
 class ProductSerializerMixin(object):
     def serialize_product(self, product):
         """ Serializes a Product to a Python dict. """
-        attribute_values = [{'name': av.attribute.name, 'value': av.value} for av in product.attribute_values.all()]
+        attribute_values = [
+            {
+                'name': av.attribute.name,
+                'code': av.attribute.code,
+                'value': av.value
+            } for av in product.attribute_values.all()
+        ]
         data = {
             'id': product.id,
             'url': self.get_full_url(reverse('api:v2:product-detail', kwargs={'pk': product.id})),


### PR DESCRIPTION
@vkaracic @mjfrey -- adding a piece of data to the Order API response for the receipt page to be able to determine the proper course_key value regardless of the product class -- this is used to populate the course name in the "We have received your payment for (course_name)." message.  see https://github.com/edx/edx-platform/pull/12466 for more information and the LMS-side of the fix.
