### PR TITLE
mattdrayer/e2etest-receipt-msg: Assert course name appears in thank you message

### DIFF
--- a/acceptance_tests/mixins.py
+++ b/acceptance_tests/mixins.py
@@ -320,6 +320,12 @@ class PaymentMixin(object):
         actual = [cell.text for cell in cells]
         self.assertListEqual(actual, expected)
 
+        # Confirm the thank you message is not broken (ref: WL-466 + edx/edx-platform#12476)
+        css_selector = 'span.course_name_placeholder'
+        course_name_placeholder_text = self.browser.find_elements_by_css_selector(css_selector)[0].text
+        title = line['product']['title']
+        self.assertIn(course_name_placeholder_text, title)
+
 
 class CouponMixin(EcommerceApiMixin):
     discount_coupon_name = 'test-discount-code-'


### PR DESCRIPTION
@rlucioni @mjfrey -- I've added a check for a valid "Thank you" message to protect against regressions -- this check should pass after the current RC lands in the staging environment with the course name fix (maybe it already has).
