### PR TITLE
Add missing customer and voucher migrations.

### DIFF
--- a/ecommerce/extensions/customer/migrations/0002_auto_20160517_0930.py
+++ b/ecommerce/extensions/customer/migrations/0002_auto_20160517_0930.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import oscar.models.fields.autoslugfield
+import django.core.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('customer', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='communicationeventtype',
+            name='code',
+            field=oscar.models.fields.autoslugfield.AutoSlugField(populate_from=b'name', validators=[django.core.validators.RegexValidator(regex=b'^[a-zA-Z_][0-9a-zA-Z_]*$', message="Code can only contain the letters a-z, A-Z, digits, and underscores, and can't start with a digit.")], editable=False, max_length=128, separator='_', blank=True, help_text='Code used for looking up this event programmatically', unique=True, verbose_name='Code'),
+        ),
+    ]

--- a/ecommerce/extensions/voucher/migrations/0004_auto_20160517_0930.py
+++ b/ecommerce/extensions/voucher/migrations/0004_auto_20160517_0930.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('voucher', '0003_orderlinevouchers'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='orderlinevouchers',
+            name='vouchers',
+            field=models.ManyToManyField(related_name='order_line_vouchers', to='voucher.Voucher'),
+        ),
+    ]


### PR DESCRIPTION
On a fresh install from current master these migrations are missing.
The voucher migration removes the blank parameter from orderlinevouchers.vouchers.
The customer migration changes the editable parameter to False.

The voucher migration is on me, because I removed blank parameter and forgot to make migrations. Don't know about the customer one though. @mattdrayer do you have an idea?

FYI @clintonb 
