### PR TITLE
Utility to access course discovery via edx-rest-api

### DIFF
--- a/ecommerce/core/tests/test_url_utils.py
+++ b/ecommerce/core/tests/test_url_utils.py
@@ -1,7 +1,13 @@
 import mock
 
+from django.conf import settings
+from edx_rest_api_client.auth import SuppliedJwtAuth
+from edx_rest_api_client.client import EdxRestApiClient
+
 from ecommerce.core.exceptions import MissingRequestError
-from ecommerce.core.url_utils import get_ecommerce_url, get_lms_url
+from ecommerce.core.url_utils import(get_course_catalog_api_client,
+                                     get_ecommerce_url, get_lms_url,
+                                     get_oauth2_provider_url)
 from ecommerce.tests.testcases import TestCase
 
 
@@ -15,3 +21,17 @@ class UrlUtilityTests(TestCase):
     def test_get_lms_url_with_no_current_request(self):
         with self.assertRaises(MissingRequestError):
             get_lms_url()
+
+    @mock.patch.object(EdxRestApiClient, 'get_oauth_access_token')
+    def test_get_course_catalog_api_client(self, mock_method):
+        mock_method.return_value = ('auth-token', 'now')
+        api = get_course_catalog_api_client(self.site)
+
+        mock_method.assert_called_with('{root}/access_token'.format(root=get_oauth2_provider_url()),
+                                       self.site.siteconfiguration.oauth_settings['SOCIAL_AUTH_EDX_OIDC_KEY'],
+                                       self.site.siteconfiguration.oauth_settings['SOCIAL_AUTH_EDX_OIDC_SECRET'],
+                                       token_type='jwt')
+        api_session = api._store['session']  # pylint: disable=protected-access
+        self.assertEqual('auth-token', api_session.auth.token)
+        self.assertEqual(SuppliedJwtAuth, type(getattr(api_session, 'auth')))
+        self.assertEqual(settings.COURSE_CATALOG_API_URL, api._store['base_url'])  # pylint: disable=protected-access

--- a/ecommerce/core/url_utils.py
+++ b/ecommerce/core/url_utils.py
@@ -1,5 +1,7 @@
 from urlparse import urljoin
 
+from django.conf import settings
+from edx_rest_api_client.client import EdxRestApiClient
 from threadlocals.threadlocals import get_current_request
 
 from ecommerce.core.exceptions import MissingRequestError
@@ -50,3 +52,27 @@ def get_lms_url(path=''):
 
 def get_oauth2_provider_url():
     return get_lms_url('/oauth2')
+
+
+def get_course_catalog_api_client(site):
+    """
+    Returns an API client to access the Course Catalog service.
+
+    Arguments:
+        site (Site): The site for which to retrieve settings.
+
+    Returns:
+        EdxRestApiClient: The client to access the Course Catalog service.
+    """
+
+    access_token, __ = EdxRestApiClient.get_oauth_access_token(
+        '{root}/access_token'.format(root=get_oauth2_provider_url()),
+        site.siteconfiguration.oauth_settings['SOCIAL_AUTH_EDX_OIDC_KEY'],
+        site.siteconfiguration.oauth_settings['SOCIAL_AUTH_EDX_OIDC_SECRET'],
+        token_type='jwt'
+    )
+    course_catalog_client = EdxRestApiClient(
+        settings.COURSE_CATALOG_API_URL,
+        jwt=access_token
+    )
+    return course_catalog_client

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -498,6 +498,9 @@ SUPPORT_URL = 'SET-ME-PLEASE'
 # Path to the receipt page
 RECEIPT_PAGE_PATH = '/commerce/checkout/receipt/'
 
+# URL for Course Catalog service
+COURSE_CATALOG_API_URL = 'http://localhost:8008/api/v1/'
+
 # Black-listed course modes not allowed to create coupons with
 BLACK_LIST_COUPON_COURSE_MODES = [u'audit', u'honor']
 

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -257,7 +257,11 @@ class SiteMixin(object):
             partner__name='edX',
             site__id=settings.SITE_ID,
             site__domain=domain,
-            segment_key='fake_segment_key'
+            segment_key='fake_segment_key',
+            oauth_settings={
+                'SOCIAL_AUTH_EDX_OIDC_KEY': 'key',
+                'SOCIAL_AUTH_EDX_OIDC_SECRET': 'secret'
+            }
         )
         self.partner = site_configuration.partner
         self.site = site_configuration.site

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ edx-django-sites-extensions==1.0.0
 edx-drf-extensions==0.5.1
 edx-ecommerce-worker==0.3.3
 edx-opaque-keys==0.3.1
-edx-rest-api-client==1.5.0
+edx-rest-api-client==1.6.0
 jsonfield==1.0.3
 libsass==0.9.2
 ndg-httpsclient==0.4.0


### PR DESCRIPTION
Utility to access course discovery service.  This is needed to support dynamic coupons that use course discovery as the backend range consisting of a query.

@vkaracic @marjev 
