### PR TITLE
SOL-1774 Removed blank=False from SiteConfiguration.oauth_settings

### DIFF
--- a/ecommerce/core/migrations/0016_auto_20160517_2021.py
+++ b/ecommerce/core/migrations/0016_auto_20160517_2021.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import jsonfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0015_siteconfiguration_from_email'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='siteconfiguration',
+            name='oauth_settings',
+            field=jsonfield.fields.JSONField(default={}, help_text='JSON string containing OAuth backend settings.', verbose_name='OAuth settings', blank=True),
+        ),
+    ]

--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -50,7 +50,7 @@ class SiteConfiguration(models.Model):
         verbose_name=_('OAuth settings'),
         help_text=_('JSON string containing OAuth backend settings.'),
         null=False,
-        blank=False,
+        blank=True,
         default={}
     )
     segment_key = models.CharField(


### PR DESCRIPTION
SiteConfiguration.oauth_settings should not be a required field because we default back to settings for OAuth configuration for the default site. This field being required was causing issues with saving SiteConfiguration models in Django admin.

@clintonb Please review.
