### PR TITLE
Return 400 Bad Request for invalid seat type when creating Coupons.

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -516,9 +516,8 @@ class CouponViewSetFunctionalTest(CouponMixin, CourseCatalogTestMixin, Throttlin
         if mode == 'audit':
             seat = ProductFactory()
         self.data.update({'stock_record_ids': [StockRecord.objects.get(product=seat).id], })
-        with self.assertRaises(Exception):
-            response = self.client.post(COUPONS_LINK, data=self.data, format='json')
-            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        response = self.client.post(COUPONS_LINK, data=self.data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
 class CouponCategoriesListViewTests(TestCase):

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -113,9 +113,9 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
             for seat in seats:
                 try:
                     if seat.attr.certificate_type in settings.BLACK_LIST_COUPON_COURSE_MODES:
-                        raise Exception('Course mode not supported')
+                        return Response('Course mode not supported', status=status.HTTP_400_BAD_REQUEST)
                 except AttributeError:
-                    raise Exception('Course mode not supported')
+                    return Response('Course mode not supported', status=status.HTTP_400_BAD_REQUEST)
 
             stock_records_string = ' '.join(str(id) for id in stock_record_ids)
 


### PR DESCRIPTION
Do not throw an exception that is not handled as it creates noise in the logs.  Just return a 400 Bad Request instead.
