### PR TITLE
mattdrayer/site-aware-fulfillment: Specify site code in worker task

### DIFF
--- a/ecommerce/extensions/checkout/mixins.py
+++ b/ecommerce/extensions/checkout/mixins.py
@@ -112,7 +112,7 @@ class EdxOrderPlacementMixin(OrderPlacementMixin):
             # There's potential for a race condition here if the task starts executing before the active
             # transaction has been committed; the necessary order doesn't exist in the database yet.
             # See http://celery.readthedocs.org/en/latest/userguide/tasks.html#database-transactions.
-            fulfill_order.delay(order.number)
+            fulfill_order.delay(order.number, site_code=order.site.siteconfiguration.partner.short_code)
         else:
             post_checkout.send(sender=self, order=order)
 

--- a/ecommerce/extensions/checkout/tests/test_mixins.py
+++ b/ecommerce/extensions/checkout/tests/test_mixins.py
@@ -188,6 +188,7 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, RefundTestMixin, Te
         with patch('ecommerce.extensions.checkout.mixins.fulfill_order.delay') as mock_delay:
             EdxOrderPlacementMixin().handle_successful_order(self.order)
             self.assertTrue(mock_delay.called)
+            mock_delay.assert_called_once_with(self.order.number, site_code='edX')
 
     def test_place_free_order(self, __):
         """ Verify an order is placed and the basket is submitted. """

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ drf-extensions==0.2.8
 edx-auth-backends==0.2.3
 edx-django-sites-extensions==1.0.0
 edx-drf-extensions==0.5.1
-edx-ecommerce-worker==0.3.3
+edx-ecommerce-worker==0.4.0
 edx-opaque-keys==0.3.1
 edx-rest-api-client==1.6.0
 jsonfield==1.0.3


### PR DESCRIPTION
@rlucioni @mjfrey -- here is the ecommerce side of making the async fulfillment workflow site aware (ref: https://github.com/edx/ecommerce-worker/pull/16).  This was the only reference I could find to the fulfill_order task, so please let me know if there are other spots that need to be updated.
