### PR TITLE
mattdrayer/add-enrollment-active-check: Include "is_active" in enrollment checks

### DIFF
--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -64,7 +64,7 @@ class BasketSingleItemView(View):
             status = api.enrollment(','.join([request.user.username, course_key])).get()
             username = request.user.username
             seat_type = mode_for_seat(product)
-            if status and status.get('mode') == seat_type:
+            if status and status.get('mode') == seat_type and status.get('is_active'):
                 logger.warning(
                     'User [%s] attempted to repurchase the [%s] seat of course [%s]',
                     username,


### PR DESCRIPTION
@clintonb @Ayub-Khan @douglashall -- I've been investigating bug [WL-487](https://openedx.atlassian.net/browse/WL-487) and it appears there is a scenario where the Enrollment API returns a valid response for an enrollment record request, but the enrollment record itself is actually marked inactive (ie, `{"mode": "verified", "is_active": "False"}`).

See 
- https://github.com/edx/edx-platform/blob/master/common/djangoapps/enrollment/api.py#L112
- https://github.com/edx/edx-platform/blob/master/common/djangoapps/enrollment/data.py#L81

This is a bit different from the list request, which does filter enrollment records according to active status: https://github.com/edx/edx-platform/blob/master/common/djangoapps/enrollment/data.py#L40

Looks like this issue was introduced in https://github.com/edx/ecommerce/pull/720 -- see [here](https://github.com/edx/ecommerce/pull/720/files#diff-398e80deb2588fea52e2551897aac3e2R67) -- so it's currently in production -- after this PR is approved we should probably put together an ecommerce release
