### PR TITLE
Remove student logout when checking out

### DIFF
--- a/ecommerce/templates/edx/partials/_base_navbar.html
+++ b/ecommerce/templates/edx/partials/_base_navbar.html
@@ -26,12 +26,14 @@
               <span class="sr-only">{% trans "Dashboard for:" %}</span>
               {{ user.username }}
             </button>
-            <button type="button" class="btn btn-default dropdown-toggle hidden-xs nav-button"
-                    data-toggle="dropdown"
-                    aria-haspopup="true">
-              <span class="caret"></span>
-              <span class="sr-only">{% trans "Toggle Dropdown" %}</span>
-            </button>
+            {% block logout_dropdown %}
+                <button type="button" class="btn btn-default dropdown-toggle hidden-xs nav-button"
+                        data-toggle="dropdown"
+                        aria-haspopup="true">
+                  <span class="caret"></span>
+                  <span class="sr-only">{% trans "Toggle Dropdown" %}</span>
+                </button>
+            {% endblock logout_dropdown %}
             <ul class="dropdown-menu" aria-expanded="false">
               {% block dropdown_menu %}{% endblock dropdown_menu %}
             </ul>

--- a/ecommerce/templates/edx/partials/_student_navbar.html
+++ b/ecommerce/templates/edx/partials/_student_navbar.html
@@ -1,9 +1,6 @@
 {% extends 'edx/partials/_base_navbar.html' %}
 
-{% block dropdown_menu %}
-  {% include "edx/base_menu.html" %}
-{% endblock dropdown_menu %}
 
-{% block small_dropdown_menu %}
-  {% include "edx/base_menu.html" with additional_class="visible-xs" %}
-{% endblock small_dropdown_menu %}
+{% block logout_dropdown %}
+    <!-- Students shouldn't be able to log out when checking out -->
+{% endblock logout_dropdown %}


### PR DESCRIPTION
SOL-1761: Remove Logout from Checkout

Put the base navbar's logout dropdown in a named block and override it to be empty in student navbars.

Reviewer: @mjfrey 
