### PR TITLE
ECOM-3206 Fix the issuer and make it consistent with LMS

### DIFF
--- a/ecommerce/settings/local.py
+++ b/ecommerce/settings/local.py
@@ -64,7 +64,7 @@ INTERNAL_IPS = ('127.0.0.1',)
 JWT_AUTH.update({
     'JWT_SECRET_KEY': 'insecure-secret-key',
     'JWT_ISSUERS': (
-        '127.0.0.1:8000/oauth2',
+        'http://127.0.0.1:8000/oauth2',
         # Must match the value of JWT_ISSUER configured for the ecommerce worker.
         'ecommerce_worker',
     ),


### PR DESCRIPTION
Apparently, if the issuers are not the same between ecommerce and edx-platform, the jwt verification would fail. This change is to make these values consistent between the two platforms
@clintonb @bderusha Please review
