### PR TITLE
mattdrayer/WL-511: Repair invalid SKU publishing/selection workflows

### DIFF
--- a/ecommerce/courses/publishers.py
+++ b/ecommerce/courses/publishers.py
@@ -9,6 +9,7 @@ from edx_rest_api_client.exceptions import SlumberHttpBaseException
 from oscar.core.loading import get_model
 import requests
 
+from ecommerce.core.constants import ENROLLMENT_CODE_SEAT_TYPES
 from ecommerce.core.url_utils import get_lms_url, get_lms_commerce_api_url
 from ecommerce.courses.utils import mode_for_seat
 
@@ -32,11 +33,13 @@ class LMSPublisher(object):
     def serialize_seat_for_commerce_api(self, seat):
         """ Serializes a course seat product to a dict that can be further serialized to JSON. """
         stock_record = seat.stockrecords.first()
-        try:
-            enrollment_code = seat.course.enrollment_code_product
-            bulk_sku = enrollment_code.stockrecords.first().partner_sku
-        except Product.DoesNotExist:
-            bulk_sku = None
+        bulk_sku = None
+        if seat.attr.certificate_type in ENROLLMENT_CODE_SEAT_TYPES:
+            try:
+                enrollment_code = seat.course.enrollment_code_product
+                bulk_sku = enrollment_code.stockrecords.first().partner_sku
+            except Product.DoesNotExist:
+                pass
         return {
             'name': mode_for_seat(seat),
             'currency': stock_record.price_currency,

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -77,11 +77,26 @@ def get_basket_switch_data(product):
         switch_link_text = _('Click here to purchase multiple seats in this course')
         structure = 'standalone'
 
-    try:
-        partner_sku = StockRecord.objects.get(
-            product__course_id=product.course_id,
-            product__structure=structure).partner_sku
-    except StockRecord.DoesNotExist:
-        partner_sku = None
+    stock_records = StockRecord.objects.filter(
+        product__course_id=product.course_id,
+        product__structure=structure
+    )
 
+    # Determine the proper partner SKU to embed in the single/multiple basket switch link
+    # The logic here is a little confusing.  "Seat" products have "certificate_type" attributes, and
+    # "Enrollment Code" products have "seat_type" attributes.  If the basket is in single-purchase
+    # mode, we are working with a Seat product and must present the 'buy multiple' switch link and
+    # SKU from the corresponding Enrollment Code product.  If the basket is in multi-purchase mode,
+    # we are working with an Enrollment Code product and must present the 'buy single' switch link
+    # and SKU from the corresponding Seat product.
+    partner_sku = None
+    product_cert_type = getattr(product.attr, 'certificate_type', None)
+    product_seat_type = getattr(product.attr, 'seat_type', None)
+    for stock_record in stock_records:
+        stock_record_cert_type = getattr(stock_record.product.attr, 'certificate_type', None)
+        stock_record_seat_type = getattr(stock_record.product.attr, 'seat_type', None)
+        if (product_seat_type and product_seat_type == stock_record_cert_type) or \
+           (product_cert_type and product_cert_type == stock_record_seat_type):
+            partner_sku = stock_record.partner_sku
+            break
     return switch_link_text, partner_sku


### PR DESCRIPTION
@mjfrey @douglashall -- this branch fixes the issue observed in WL-511 -- basically the SKU lookup logic was assuming a single stock record, but in some cases there were multiple stock records to choose from.  I also updated the SKU publishing logic (creates course mode records @ LMS) to only publish bulk SKUs if the product class is one of the allowable types for enrollment codes.
