### PR TITLE
mattdrayer/WL-511-seatmode: Consider enrollment code products for mode lookups

### DIFF
--- a/ecommerce/core/constants.py
+++ b/ecommerce/core/constants.py
@@ -15,7 +15,7 @@ SEAT_PRODUCT_CLASS_NAME = "Seat"
 # Enrollment Code constants
 ENROLLMENT_CODE_PRODUCT_CLASS_NAME = 'Enrollment Code'
 ENROLLMENT_CODE_SWITCH = 'create_enrollment_codes'
-ENROLLMENT_CODE_SEAT_TYPES = ['verified', 'professional']
+ENROLLMENT_CODE_SEAT_TYPES = ['verified', 'professional', 'no-id-professional']
 
 
 class Status(object):

--- a/ecommerce/courses/publishers.py
+++ b/ecommerce/courses/publishers.py
@@ -35,11 +35,9 @@ class LMSPublisher(object):
         stock_record = seat.stockrecords.first()
         bulk_sku = None
         if seat.attr.certificate_type in ENROLLMENT_CODE_SEAT_TYPES:
-            try:
-                enrollment_code = seat.course.enrollment_code_product
+            enrollment_code = seat.course.enrollment_code_product
+            if enrollment_code:
                 bulk_sku = enrollment_code.stockrecords.first().partner_sku
-            except Product.DoesNotExist:
-                pass
         return {
             'name': mode_for_seat(seat),
             'currency': stock_record.price_currency,

--- a/ecommerce/courses/tests/test_models.py
+++ b/ecommerce/courses/tests/test_models.py
@@ -145,6 +145,12 @@ class CourseTests(CourseCatalogTestMixin, TestCase):
         self.assertEqual(enrollment_code.attr.course_key, course.id)
         self.assertEqual(enrollment_code.attr.seat_type, seat_type)
 
+        # Second time should skip over the enrollment code creation logic but result in the same data
+        course.create_or_update_seat(seat_type, True, price, self.partner)
+        enrollment_code = Product.objects.get(product_class__name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME)
+        self.assertEqual(enrollment_code.attr.course_key, course.id)
+        self.assertEqual(enrollment_code.attr.seat_type, seat_type)
+
         stock_record = StockRecord.objects.get(product=enrollment_code)
         self.assertEqual(stock_record.price_excl_tax, price)
         self.assertEqual(stock_record.price_currency, settings.OSCAR_DEFAULT_CURRENCY)

--- a/ecommerce/courses/tests/test_utils.py
+++ b/ecommerce/courses/tests/test_utils.py
@@ -5,6 +5,8 @@ import httpretty
 
 from django.core.cache import cache
 
+from ecommerce.core.constants import ENROLLMENT_CODE_SWITCH
+from ecommerce.core.tests import toggle_switch
 from ecommerce.core.url_utils import get_lms_url
 from ecommerce.courses.models import Course
 from ecommerce.courses.tests.factories import CourseFactory
@@ -30,8 +32,12 @@ class UtilsTests(CourseCatalogTestMixin, TestCase):
     def test_mode_for_seat(self, certificate_type, id_verification_required, mode):
         """ Verify the correct enrollment mode is returned for a given seat. """
         course = Course.objects.create(id='edx/Demo_Course/DemoX')
+        toggle_switch(ENROLLMENT_CODE_SWITCH, True)
         seat = course.create_or_update_seat(certificate_type, id_verification_required, 10.00, self.partner)
         self.assertEqual(mode_for_seat(seat), mode)
+        enrollment_code = course.enrollment_code_product
+        if enrollment_code:  # We should only have enrollment codes for allowed types
+            self.assertEqual(mode_for_seat(enrollment_code), mode)
 
     def test_get_course_info_from_lms(self):
         """ Check to see if course info gets cached """

--- a/ecommerce/courses/utils.py
+++ b/ecommerce/courses/utils.py
@@ -7,16 +7,19 @@ from edx_rest_api_client.client import EdxRestApiClient
 from ecommerce.core.url_utils import get_lms_url
 
 
-def mode_for_seat(seat):
-    """ Returns the Enrollment mode for a given seat product. """
-    certificate_type = getattr(seat.attr, 'certificate_type', '')
-
-    if certificate_type == 'professional' and not seat.attr.id_verification_required:
-        return 'no-id-professional'
-    elif certificate_type == '':
+def mode_for_seat(product):
+    """
+    Returns the enrollment mode (aka course mode) for the specified product.
+    If the specified product does not include a 'certificate_type' attribute it is likely the
+    bulk purchase "enrollment code" product variant of the single-seat product, so we attempt
+    to locate the 'seat_type' attribute in its place.
+    """
+    mode = getattr(product.attr, 'certificate_type', getattr(product.attr, 'seat_type', None))
+    if not mode:
         return 'audit'
-
-    return certificate_type
+    if mode == 'professional' and not product.attr.id_verification_required:
+        return 'no-id-professional'
+    return mode
 
 
 def get_course_info_from_lms(course_key):

--- a/ecommerce/extensions/catalogue/migrations/0019_enrollment_code_idverifyreq_attribute.py
+++ b/ecommerce/extensions/catalogue/migrations/0019_enrollment_code_idverifyreq_attribute.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from oscar.core.loading import get_model
+
+from ecommerce.core.constants import ENROLLMENT_CODE_PRODUCT_CLASS_NAME
+
+ProductAttribute = get_model("catalogue", "ProductAttribute")
+ProductClass = get_model("catalogue", "ProductClass")
+
+
+def create_idverifyreq_attribute(apps, schema_editor):
+    """Create enrollment code 'id_verification_required' attribute."""
+    enrollment_code_class = ProductClass.objects.get(name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME)
+    ProductAttribute.objects.create(
+        product_class=enrollment_code_class,
+        name='id_verification_required',
+        code='id_verification_required',
+        type='boolean',
+        required=False
+    )
+
+
+def remove_idverifyreq_attribute(apps, schema_editor):
+    """Remove enrollment code 'id_verification_required' attribute."""
+    enrollment_code_class = ProductClass.objects.get(name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME)
+    ProductAttribute.objects.get(product_class=enrollment_code_class, name='id_verification_required').delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('catalogue', '0001_initial'),
+        ('catalogue', '0018_auto_20160530_0134')
+    ]
+    operations = [
+        migrations.RunPython(create_idverifyreq_attribute, remove_idverifyreq_attribute)
+    ]

--- a/ecommerce/extensions/catalogue/tests/mixins.py
+++ b/ecommerce/extensions/catalogue/tests/mixins.py
@@ -94,7 +94,8 @@ class CourseCatalogTestMixin(object):
     def enrollment_code_product_class(self):
         attributes = (
             ('seat_type', 'text'),
-            ('course_key', 'text')
+            ('course_key', 'text'),
+            ('id_verification_required', 'boolean')
         )
         product_class = self._create_product_class(ENROLLMENT_CODE_PRODUCT_CLASS_NAME, 'enrollment_code', attributes)
         return product_class


### PR DESCRIPTION
Enrollment Code product classes were not being considered for product 'course mode' lookups, and one result of this was an invalid enrollment check in certain basket workflows.  Because enrollment code products do not have a 'certificate_type' attribute -- they instead have a 'seat-type' attribute -- we needed to broaden the mode lookup operation, which also required some additional changes/enhancements.
