### PR TITLE
mattdrayer/ECOM-4683: Return only child seat products in API response

### DIFF
--- a/ecommerce/static/js/models/course_model.js
+++ b/ecommerce/static/js/models/course_model.js
@@ -134,7 +134,7 @@ define([
 
             initialize: function () {
                 this.get('products').on('change:id_verification_required', this.triggerIdVerified, this);
-                this.on('sync', this.removeParentProducts, this);
+                this.on('sync', this.prepareProducts, this);
                 this.on('sync', this.honorModeInit, this);
             },
 
@@ -184,15 +184,19 @@ define([
             },
 
             /**
-             * Removes the parent products from the Product collection.
-             *
-             * This product is never exposed to the user, and should be ignored for all data operations.
+             * Returns the subset of pertinent child seat products from the Product collection.
              */
-            removeParentProducts: function () {
-                var products = this.get('products'),
-                    parents = products.where({structure: 'parent'});
+            prepareProducts: function () {
+                // Create a reference to the current product collection
+                var products = this.get('products');
 
+                // Ignore any parent product models
+                var parents = products.where({structure: 'parent'});
                 products.remove(parents);
+
+                // Ignore any non-Seat models (such as an Enrollment Code)
+                var seats = products.where({product_class: 'Seat'});
+                products.reset(seats);
             },
 
             /**
@@ -203,7 +207,9 @@ define([
             seats: function () {
                 return this.get('products').filter(function (product) {
                     // Filter out parent products since there is no need to display or modify.
-                    return (product instanceof CourseSeat) && product.get('structure') !== 'parent';
+                    return (product instanceof CourseSeat) &&
+                        product.get('structure') !== 'parent' &&
+                        product.get('product_class') === 'Seat';
                 });
             },
 

--- a/ecommerce/static/js/test/specs/models/course_model_spec.js
+++ b/ecommerce/static/js/test/specs/models/course_model_spec.js
@@ -154,6 +154,30 @@ define([
                 ],
                 is_available_to_buy: true
             },
+            enrollmentCodeProduct = {
+                id: 12,
+                url: 'http://ecommerce.local:8002/api/v2/products/12/',
+                structure: 'standalone',
+                product_class: 'Enrollment Code',
+                title: 'Enrollent Code for Professional Seat in edX Demonstration Course',
+                price: '300.00',
+                expires: null,
+                attribute_values: [
+                    {
+                        name: 'seat_type',
+                        value: 'professional'
+                    },
+                    {
+                        name: 'course_key',
+                        value: 'edX/DemoX/Demo_Course'
+                    },
+                    {
+                        name: 'id_verification_required',
+                        value: true
+                    },
+                ],
+                is_available_to_buy: true
+            },
             data = {
                 id: 'edX/DemoX/Demo_Course',
                 url: 'http://ecommerce.local:8002/api/v2/courses/edX/DemoX/Demo_Course/',
@@ -169,6 +193,7 @@ define([
                     verifiedSeat,
                     creditSeat,
                     alternateCreditSeat,
+                    enrollmentCodeProduct,
                     {
                         id: 7,
                         url: 'http://ecommerce.local:8002/api/v2/products/7/',
@@ -192,25 +217,25 @@ define([
             beforeEach(function () {
                 model = Course.findOrCreate(data, {parse: true});
 
-                // Remove the parent products
-                model.removeParentProducts();
+                // Remove the non-essential products
+                model.prepareProducts();
             });
 
-            describe('removeParentProducts', function () {
-                it('should remove all parent products from the products collection', function () {
+            describe('prepareProducts', function () {
+                it('should remove all non-essential products from the products collection', function () {
                     var products;
 
-                    // Re-initialize the model since the beforeEach removes the parents
+                    // Re-initialize the model since the beforeEach removes the products we don't need
                     model = Course.findOrCreate(data, {parse: true});
 
                     // Sanity check to ensure the products were properly parsed
                     products = model.get('products');
-                    expect(products.length).toEqual(6);
+                    expect(products.length).toEqual(7);
 
-                    // Remove the parent products
-                    model.removeParentProducts();
+                    // Re-remove the non-essential products
+                    model.prepareProducts();
 
-                    // Only the children survived...
+                    // Only the strong survived...
                     expect(products.length).toEqual(5);
                     expect(products.where({structure: 'child'}).length).toEqual(5);
                 });


### PR DESCRIPTION
@mjfrey @bderusha -- Enrollment Code products were being included in the serialization workflow for the Course Administration Tool course product list.  I've added a filter to return only "child" products for the course (Enrollment Codes are "standalone").
