### PR TITLE
mattdrayer/ECOM-4682: Improve support for Audit seat products in publishing worfklow

### DIFF
--- a/ecommerce/courses/publishers.py
+++ b/ecommerce/courses/publishers.py
@@ -33,11 +33,13 @@ class LMSPublisher(object):
     def serialize_seat_for_commerce_api(self, seat):
         """ Serializes a course seat product to a dict that can be further serialized to JSON. """
         stock_record = seat.stockrecords.first()
+
         bulk_sku = None
-        if seat.attr.certificate_type in ENROLLMENT_CODE_SEAT_TYPES:
+        if getattr(seat.attr, 'certificate_type', '') in ENROLLMENT_CODE_SEAT_TYPES:
             enrollment_code = seat.course.enrollment_code_product
             if enrollment_code:
                 bulk_sku = enrollment_code.stockrecords.first().partner_sku
+
         return {
             'name': mode_for_seat(seat),
             'currency': stock_record.price_currency,

--- a/ecommerce/courses/tests/test_models.py
+++ b/ecommerce/courses/tests/test_models.py
@@ -38,9 +38,10 @@ class CourseTests(CourseCatalogTestMixin, TestCase):
         self.assertEqual(len(course.seat_products), 0)
 
         # Create the seat products
+        toggle_switch(ENROLLMENT_CODE_SWITCH, True)
         seats = [course.create_or_update_seat('honor', False, 0, self.partner),
                  course.create_or_update_seat('verified', True, 50, self.partner)]
-        self.assertEqual(course.products.count(), 3)
+        self.assertEqual(course.products.count(), 4)
 
         # The property should return only the child seats.
         self.assertEqual(set(course.seat_products), set(seats))


### PR DESCRIPTION
@bderusha @mjfrey @clintonb -- Enrollment Code products were being included by this seat product serializer in its response, which was causing invalid downstream behavior
