### PR TITLE
WL-495: Update edx-django-sites-extensions version to 2.0.1 for ecommerce

### DIFF
--- a/ecommerce/extensions/checkout/tests/test_mixins.py
+++ b/ecommerce/extensions/checkout/tests/test_mixins.py
@@ -212,6 +212,7 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, RefundTestMixin, Te
         Verify the send confirmation message override functions as expected
         """
         request = RequestFactory()
+        request.get_host = lambda: None
         user = self.create_user()
         user.email = 'test_user@example.com'
         request.user = user

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -68,11 +68,8 @@ TIME_ZONE = 'America/New_York'
 LANGUAGE_CODE = 'en-us'
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#site-id
-# This needs to be set to None in order to support multitenancy
-SITE_ID = None
-
 # See: https://github.com/edx/edx-django-sites-extensions
-DEFAULT_SITE_ID = 1
+SITE_ID = 1
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#use-i18n
 USE_I18N = True
@@ -209,7 +206,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django_sites_extensions.middleware.CurrentSiteWithDefaultMiddleware',
+    'django.contrib.sites.middleware.CurrentSiteMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'waffle.middleware.WaffleMiddleware',
     # NOTE: The overridden BasketMiddleware relies on request.site. This middleware
@@ -257,6 +254,9 @@ DJANGO_APPS = [
     'waffle',
     'django_filters',
     'rest_framework_swagger',
+
+    # Enables default site
+    'django_sites_extensions',
 ]
 
 # Apps specific to this project go here.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ djangorestframework==3.2.3
 djangorestframework-jwt==1.8.0
 drf-extensions==0.2.8
 edx-auth-backends==0.3.1
-edx-django-sites-extensions==1.0.0
+edx-django-sites-extensions==2.0.1
 edx-drf-extensions==0.5.1
 edx-ecommerce-worker==0.4.0
 edx-opaque-keys==0.3.1


### PR DESCRIPTION
Hi @mattdrayer , @douglashall , @clintonb 

Kindly review this PR, I have updated the version of edx-django-sites-extensions from `1.0.0` to `2.0.1`.

**Details of Changes:**
With the new version of `edx-django-sites-extensions`, the way default sites are handled is changed, old middleware named `CurrentSiteWithDefaultMiddleware` is now removed and middleware `CurrentSiteMiddleware` is used instead now, which is monkey patched to offer default site functionality.
