### PR TITLE
SOL-1834 Use coupon ID when creating ConditionalOffer models

### DIFF
--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -211,7 +211,6 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
                 start_datetime=data['start_date'],
                 voucher_type=data['voucher_type'],
                 max_uses=data['max_uses'],
-                coupon_id=coupon_product.id,
                 catalog_query=data['catalog_query'],
                 course_seat_types=data['course_seat_types']
             )

--- a/ecommerce/extensions/voucher/utils.py
+++ b/ecommerce/extensions/voucher/utils.py
@@ -333,7 +333,6 @@ def create_vouchers(
         quantity,
         start_datetime,
         voucher_type,
-        coupon_id=None,
         code=None,
         max_uses=None,
         _range=None,
@@ -380,7 +379,7 @@ def create_vouchers(
         benefit_type=benefit_type,
         benefit_value=benefit_value,
         max_uses=max_uses,
-        coupon_id=coupon_id
+        coupon_id=coupon.id
     )
     for __ in range(quantity):
         voucher = _create_new_voucher(


### PR DESCRIPTION
During the fulfillment step in the Otto bulk purchase workflow, ConditionalOffer models were created with a "None" coupon ID in their name and slug fields. This fixes the issue.

@vkaracic @mjfrey

FYI @mattdrayer 
