### PR TITLE
Add the current site domain to the email template context

### DIFF
--- a/ecommerce/notifications/notifications.py
+++ b/ecommerce/notifications/notifications.py
@@ -28,6 +28,7 @@ def send_notification(user, commtype_code, context, site):
     full_name = user.get_full_name()
     context.update({
         'full_name': full_name,
+        'site_domain': site.domain,
         'platform_name': site.name,
         'tracking_pixel': tracking_pixel,
     })


### PR DESCRIPTION
We need to know the current site domain when rendering email templates so that we can properly construct absolute URLs to the HTML email header logo image.

@mattdrayer @saleem-latif 

FYI @mjfrey 
