### PR TITLE
[WIP] [SOL-1814] Deprecate the old catalog from coupons

### DIFF
--- a/ecommerce/coupons/tests/mixins.py
+++ b/ecommerce/coupons/tests/mixins.py
@@ -100,7 +100,7 @@ class CouponMixin(object):
 
         return pc
 
-    def create_coupon(self, title='Test coupon', price=100, client=None, partner=None, catalog=None, code='',
+    def create_coupon(self, title='Test coupon', price=100, client=None, partner=None, code='',
                       benefit_value=100, note=None, max_uses=None, quantity=5, catalog_query=None,
                       course_seat_types=None):
         """Helper method for creating a coupon.
@@ -108,8 +108,7 @@ class CouponMixin(object):
         Arguments:
             title(str): Title of the coupon
             price(int): Price of the coupon
-            partner(Partner): Partner used for creating a catalog
-            catalog(Catalog): Catalog of courses for which the coupon applies
+            partner(Partner): Partner used for creating a coupon stock record
             code(str): Custom coupon code
             benefit_value(int): The voucher benefit value
             catalog_query(str): Course query string
@@ -123,15 +122,12 @@ class CouponMixin(object):
             partner = PartnerFactory(name='Tester')
         if client is None:
             client, __ = BusinessClient.objects.get_or_create(name='Test Client')
-        if catalog is None and not (catalog_query and course_seat_types):
-            catalog = Catalog.objects.create(partner=partner)
         if code is not '':
             quantity = 1
         data = {
             'partner': partner,
             'benefit_type': Benefit.PERCENTAGE,
             'benefit_value': benefit_value,
-            'catalog': catalog,
             'end_date': datetime.date(2020, 1, 1),
             'code': code,
             'quantity': quantity,

--- a/ecommerce/coupons/tests/mixins.py
+++ b/ecommerce/coupons/tests/mixins.py
@@ -10,7 +10,7 @@ from ecommerce.core.models import BusinessClient
 from ecommerce.extensions.api.v2.views.coupons import CouponViewSet
 from ecommerce.extensions.basket.utils import prepare_basket
 from ecommerce.tests.factories import PartnerFactory
-from ecommerce.tests.mixins import ProductClass, Catalog, Benefit, Voucher, Applicator
+from ecommerce.tests.mixins import ProductClass, Benefit, Voucher, Applicator
 
 
 class CatalogPreviewMockMixin(object):
@@ -48,23 +48,13 @@ class CatalogPreviewMockMixin(object):
 
     def mock_dynamic_catalog_contains_api(self, course_run_ids, query):
         """ Helper function to register a dynamic course catalog API endpoint for the contains information. """
-        course_contains_info = {
-            'course_runs': {}
-        }
-        for course_run_id in course_run_ids:
-            course_contains_info['course_runs'][course_run_id] = True
-
-        course_run_info_json = json.dumps(course_contains_info)
-        course_run_url = '{}course_runs/contains/?course_run_ids={}&query={}'.format(
-            settings.COURSE_CATALOG_API_URL,
-            (course_run_id for course_run_id in course_run_ids),
-            query if query else 'id:course*'
+        body = json.dumps({'course_runs': {course_run_id: True for course_run_id in course_run_ids}})
+        url = '{root}course_runs/contains/?course_run_ids={course_run_ids}&query={query}'.format(
+            root=settings.COURSE_CATALOG_API_URL,
+            course_run_ids=','.join(course_run_ids),
+            query=query
         )
-        httpretty.register_uri(
-            httpretty.GET, course_run_url,
-            body=course_run_info_json,
-            content_type='application/json'
-        )
+        httpretty.register_uri(httpretty.GET, url, body=body, content_type='application/json')
 
 
 class CouponMixin(object):

--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -13,8 +13,9 @@ from oscar.test.factories import (
 )
 from oscar.test.utils import RequestFactory
 
+from ecommerce.core.tests.decorators import mock_course_catalog_api_client
 from ecommerce.core.url_utils import get_lms_url
-from ecommerce.coupons.tests.mixins import CouponMixin
+from ecommerce.coupons.tests.mixins import CatalogPreviewMockMixin, CouponMixin
 from ecommerce.coupons.views import get_voucher_and_products_from_code, voucher_is_valid
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.api import exceptions
@@ -23,7 +24,6 @@ from ecommerce.extensions.test.factories import prepare_voucher
 from ecommerce.tests.mixins import LmsApiMockMixin
 from ecommerce.tests.testcases import TestCase
 
-Applicator = get_class('offer.utils', 'Applicator')
 Basket = get_model('basket', 'Basket')
 Benefit = get_model('offer', 'Benefit')
 Catalog = get_model('catalogue', 'Catalog')
@@ -78,12 +78,13 @@ class GetVoucherTests(TestCase):
 
     def test_no_product(self):
         """ Verify that an exception is raised if there is no product. """
-        voucher = VoucherFactory(code='NOPRODUCT')
+        code = 'NOPRODUCT'
+        voucher = VoucherFactory(code=code)
         offer = ConditionalOfferFactory()
         voucher.offers.add(offer)
 
         with self.assertRaises(exceptions.ProductNotFoundError):
-            get_voucher_and_products_from_code(code='NOPRODUCT')
+            get_voucher_and_products_from_code(code=code)
 
     def test_get_non_existing_voucher(self):
         """ Verify that get_voucher_and_products_from_code() raises exception for a non-existing voucher. """
@@ -220,27 +221,23 @@ class CouponOfferViewTests(CourseCatalogTestMixin, LmsApiMockMixin, TestCase):
         self.assertEqual(response.context['error'], _('The voucher is not applicable to your current basket.'))
 
 
-class CouponRedeemViewTests(CouponMixin, CourseCatalogTestMixin, LmsApiMockMixin, TestCase):
+class CouponRedeemViewTests(CouponMixin, CourseCatalogTestMixin, CatalogPreviewMockMixin, LmsApiMockMixin, TestCase):
     redeem_url = reverse('coupons:redeem')
 
     def setUp(self):
         super(CouponRedeemViewTests, self).setUp()
         self.user = self.create_user()
         self.client.login(username=self.user.username, password=self.password)
-        self.course, self.seat = self.create_course_and_seat(
-            seat_type='verified',
-            id_verification=True,
-            price=50,
-            partner=self.partner
-        )
-        self.stock_record = StockRecord.objects.get(product=self.seat)
-        self.catalog = Catalog.objects.create(partner=self.partner)
-        self.catalog.stock_records.add(StockRecord.objects.get(product=self.seat))
+        self.course = CourseFactory()
+        self.seat = self.course.create_or_update_seat('verified', True, 50, self.partner)
         self.student_dashboard_url = get_lms_url(self.site.siteconfiguration.student_dashboard_url)
+        self.catalog_query = 'key:*'
 
     def create_and_test_coupon(self):
         """ Creates enrollment code coupon. """
-        self.create_coupon(catalog=self.catalog, code=COUPON_CODE)
+        self.mock_dynamic_catalog_course_runs_api(query=self.catalog_query, course_run=self.course)
+        self.mock_dynamic_catalog_contains_api(query=self.catalog_query, course_run_ids=[self.course.id])
+        self.create_coupon(catalog_query=self.catalog_query, course_seat_types='verified', code=COUPON_CODE)
         self.assertEqual(Voucher.objects.filter(code=COUPON_CODE).count(), 1)
 
     def assert_redemption_page_redirects(self, expected_url, target=200):
@@ -284,14 +281,17 @@ class CouponRedeemViewTests(CouponMixin, CourseCatalogTestMixin, LmsApiMockMixin
         self.assertEqual(response.context['error'], _('The product does not exist.'))
 
     @httpretty.activate
+    @mock_course_catalog_api_client
     def test_basket_redirect_discount_code(self):
         """ Verify the view redirects to the basket single-item view when a discount code is provided. """
-        self.mock_course_api_response(course=self.course)
-        self.create_coupon(catalog=self.catalog, code=COUPON_CODE, benefit_value=5)
+        self.mock_dynamic_catalog_course_runs_api(query=self.catalog_query, course_run=self.course)
+        self.mock_dynamic_catalog_contains_api(query=self.catalog_query, course_run_ids=[self.course.id])
+        self.create_coupon(catalog_query=self.catalog_query, course_seat_types='verified', code=COUPON_CODE, benefit_value=5)
         expected_url = self.get_full_url(path=reverse('basket:summary'))
         self.assert_redemption_page_redirects(expected_url)
 
     @httpretty.activate
+    @mock_course_catalog_api_client
     def test_basket_redirect_enrollment_code(self):
         """ Verify the view redirects to LMS when an enrollment code is provided. """
         self.create_and_test_coupon()
@@ -299,6 +299,7 @@ class CouponRedeemViewTests(CouponMixin, CourseCatalogTestMixin, LmsApiMockMixin
         self.assert_redemption_page_redirects(self.student_dashboard_url, target=301)
 
     @httpretty.activate
+    @mock_course_catalog_api_client
     def test_multiple_vouchers(self):
         """ Verify a redirect to LMS happens when a basket with already existing vouchers is used. """
         self.create_and_test_coupon()

--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -230,6 +230,7 @@ class CouponRedeemViewTests(CouponMixin, CourseCatalogTestMixin, CatalogPreviewM
         self.client.login(username=self.user.username, password=self.password)
         self.course = CourseFactory()
         self.seat = self.course.create_or_update_seat('verified', True, 50, self.partner)
+        self.stock_record = StockRecord.objects.get(product=self.seat)
         self.student_dashboard_url = get_lms_url(self.site.siteconfiguration.student_dashboard_url)
         self.catalog_query = 'key:*'
 
@@ -287,10 +288,7 @@ class CouponRedeemViewTests(CouponMixin, CourseCatalogTestMixin, CatalogPreviewM
         self.mock_dynamic_catalog_course_runs_api(query=self.catalog_query, course_run=self.course)
         self.mock_dynamic_catalog_contains_api(query=self.catalog_query, course_run_ids=[self.course.id])
         self.create_coupon(
-            catalog_query=self.catalog_query,
-            course_seat_types='verified',
-            code=COUPON_CODE,
-            benefit_value=5
+            catalog_query=self.catalog_query, course_seat_types='verified', code=COUPON_CODE, benefit_value=5
         )
         expected_url = self.get_full_url(path=reverse('basket:summary'))
         self.assert_redemption_page_redirects(expected_url)

--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
-from oscar.core.loading import get_class, get_model
+from oscar.core.loading import get_model
 from oscar.test.factories import (
     ConditionalOfferFactory, OrderFactory, OrderLineFactory, RangeFactory, VoucherFactory
 )
@@ -286,7 +286,12 @@ class CouponRedeemViewTests(CouponMixin, CourseCatalogTestMixin, CatalogPreviewM
         """ Verify the view redirects to the basket single-item view when a discount code is provided. """
         self.mock_dynamic_catalog_course_runs_api(query=self.catalog_query, course_run=self.course)
         self.mock_dynamic_catalog_contains_api(query=self.catalog_query, course_run_ids=[self.course.id])
-        self.create_coupon(catalog_query=self.catalog_query, course_seat_types='verified', code=COUPON_CODE, benefit_value=5)
+        self.create_coupon(
+            catalog_query=self.catalog_query,
+            course_seat_types='verified',
+            code=COUPON_CODE,
+            benefit_value=5
+        )
         expected_url = self.get_full_url(path=reverse('basket:summary'))
         self.assert_redemption_page_redirects(expected_url)
 

--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -26,6 +26,7 @@ from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
 from ecommerce.extensions.voucher.models import CouponVouchers
 from ecommerce.invoice.models import Invoice
 from ecommerce.tests.factories import SiteConfigurationFactory, SiteFactory
+from ecommerce.tests.mixins import ThrottlingMixin
 from ecommerce.tests.testcases import TestCase
 
 Basket = get_model('basket', 'Basket')
@@ -264,7 +265,8 @@ class CouponViewSetTest(CouponMixin, CourseCatalogTestMixin, TestCase):
 
 
 @ddt.ddt
-class CouponViewSetFunctionalTest(CouponMixin, CourseCatalogTestMixin, CatalogPreviewMockMixin, TestCase):
+class CouponViewSetFunctionalTest(CouponMixin, CourseCatalogTestMixin, CatalogPreviewMockMixin, ThrottlingMixin,
+                                  TestCase):
     """Test the coupon order creation functionality."""
 
     def setUp(self):

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -128,8 +128,8 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
             # Audit modes do not have a certificate type and therefore will raise
             # an AttributeError exception.
             if any(
-                unsupported_seat in course_seat_types for
-                unsupported_seat in settings.BLACK_LIST_COUPON_COURSE_MODES
+                    unsupported_seat in course_seat_types for
+                    unsupported_seat in settings.BLACK_LIST_COUPON_COURSE_MODES
             ):
                 return Response('Course mode not supported', status=status.HTTP_400_BAD_REQUEST)
 

--- a/ecommerce/extensions/basket/models.py
+++ b/ecommerce/extensions/basket/models.py
@@ -45,6 +45,9 @@ class Basket(AbstractBasket):
 
         return basket
 
+    class Meta(AbstractBasket.Meta):
+        get_latest_by = 'date_created'
+
     def __unicode__(self):
         return _(u"{id} - {status} basket (owner: {owner}, lines: {num_lines})").format(
             id=self.id,

--- a/ecommerce/extensions/catalogue/models.py
+++ b/ecommerce/extensions/catalogue/models.py
@@ -11,6 +11,9 @@ class Product(AbstractProduct):
                                    help_text=_('Last date/time on which this product can be purchased.'))
     history = HistoricalRecords()
 
+    class Meta(AbstractProduct.Meta):
+        get_latest_by = 'date_created'
+
 
 class ProductAttributeValue(AbstractProductAttributeValue):
     history = HistoricalRecords()

--- a/ecommerce/extensions/catalogue/tests/test_utils.py
+++ b/ecommerce/extensions/catalogue/tests/test_utils.py
@@ -6,16 +6,13 @@ from oscar.core.loading import get_model
 
 from ecommerce.coupons.tests.mixins import CouponMixin
 from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
-from ecommerce.extensions.catalogue.utils import generate_sku, get_or_create_catalog
+from ecommerce.extensions.catalogue.utils import generate_sku
 from ecommerce.tests.factories import ProductFactory
 from ecommerce.tests.testcases import TestCase
 
-Benefit = get_model('offer', 'Benefit')
 Catalog = get_model('catalogue', 'Catalog')
 Course = get_model('courses', 'Course')
 Product = get_model('catalogue', 'Product')
-StockRecord = get_model('partner', 'StockRecord')
-Voucher = get_model('voucher', 'Voucher')
 
 COURSE_ID = 'sku/test_course/course'
 
@@ -54,36 +51,6 @@ class UtilsTests(CourseCatalogTestMixin, TestCase):
         actual = generate_sku(product, self.partner)
         self.assertEqual(actual, expected)
 
-    def test_get_or_create_catalog(self):
-        """Verify that the proper catalog is fetched."""
-        stock_record = self.seat.stockrecords.first()
-        self.catalog.stock_records.add(stock_record)
-
-        self.assertEqual(self.catalog.id, 1)
-
-        existing_catalog, created = get_or_create_catalog(
-            name='Test',
-            partner=self.partner,
-            stock_record_ids=[stock_record.id]
-        )
-        self.assertFalse(created)
-        self.assertEqual(self.catalog, existing_catalog)
-        self.assertEqual(Catalog.objects.count(), 1)
-
-        course_id = 'sku/test2/course'
-        course = Course.objects.create(id=course_id, name='Test Course 2')
-        seat_2 = course.create_or_update_seat('verified', False, 0, self.partner)
-        stock_record_2 = seat_2.stockrecords.first()
-
-        new_catalog, created = get_or_create_catalog(
-            name='Test',
-            partner=self.partner,
-            stock_record_ids=[stock_record.id, stock_record_2.id]
-        )
-        self.assertTrue(created)
-        self.assertNotEqual(self.catalog, new_catalog)
-        self.assertEqual(Catalog.objects.count(), 2)
-
 
 class CouponUtilsTests(CouponMixin, CourseCatalogTestMixin, TestCase):
     def setUp(self):
@@ -93,7 +60,7 @@ class CouponUtilsTests(CouponMixin, CourseCatalogTestMixin, TestCase):
 
     def test_generate_sku_for_coupon(self):
         """Verify the method generates a SKU for a coupon."""
-        coupon = self.create_coupon(partner=self.partner, catalog=self.catalog)
+        coupon = self.create_coupon(partner=self.partner)
         _hash = ' '.join((
             unicode(coupon.id),
             str(self.partner.id)

--- a/ecommerce/extensions/catalogue/utils.py
+++ b/ecommerce/extensions/catalogue/utils.py
@@ -47,22 +47,3 @@ def generate_sku(product, partner):
     digest = md5_hash.hexdigest()[-7:]
 
     return digest.upper()
-
-
-def get_or_create_catalog(name, partner, stock_record_ids):
-    """
-    Returns the catalog which has the same name, partner and stock records.
-    If there isn't one with that data, creates and returns a new one.
-    """
-    catalogs = Catalog.objects.all()
-    stock_records = [StockRecord.objects.get(id=id) for id in stock_record_ids]  # pylint: disable=redefined-builtin
-
-    for catalog in catalogs:
-        if catalog.name == name and catalog.partner == partner:
-            if set(catalog.stock_records.all()) == set(stock_records):
-                return catalog, False
-
-    catalog = Catalog.objects.create(name=name, partner=partner)
-    for stock_record in stock_records:
-        catalog.stock_records.add(stock_record)
-    return catalog, True

--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -411,7 +411,6 @@ class EnrollmentCodeFulfillmentModule(BaseFulfillmentModule):
                 name='Enrollment code voucher [{}]'.format(line.product.title),
                 benefit_type=Benefit.PERCENTAGE,
                 benefit_value=100,
-                catalog=None,
                 coupon=seat,
                 end_datetime=settings.ENROLLMENT_CODE_EXIPRATION_DATE,
                 quantity=line.quantity,

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -1,5 +1,4 @@
 """Tests of the Fulfillment API's fulfillment modules."""
-import datetime
 import json
 
 import ddt
@@ -27,7 +26,6 @@ from ecommerce.extensions.fulfillment.modules import (
 from ecommerce.extensions.fulfillment.status import LINE
 from ecommerce.extensions.fulfillment.tests.mixins import FulfillmentTestMixin
 from ecommerce.extensions.voucher.models import OrderLineVouchers
-from ecommerce.extensions.voucher.utils import create_vouchers
 from ecommerce.tests.testcases import TestCase
 
 JSON = 'application/json'

--- a/ecommerce/extensions/order/models.py
+++ b/ecommerce/extensions/order/models.py
@@ -21,6 +21,9 @@ class Order(AbstractOrder):
         return any(line.product.get_product_class().name == 'Coupon' for line in
                    self.basket.all_lines())
 
+    class Meta(AbstractOrder.Meta):
+        get_latest_by = 'date_placed'
+
 
 class PaymentEvent(AbstractPaymentEvent):
     processor_name = models.CharField(_("Payment Processor"), max_length=32, blank=True, null=True)

--- a/ecommerce/extensions/voucher/tests/test_utils.py
+++ b/ecommerce/extensions/voucher/tests/test_utils.py
@@ -289,7 +289,6 @@ class UtilTests(CouponMixin, CourseCatalogTestMixin, CatalogPreviewMockMixin, Lm
         create_vouchers(
             benefit_type=Benefit.FIXED,
             benefit_value=100.00,
-            catalog=self.catalog,
             coupon=self.coupon,
             end_datetime=datetime.date(2015, 10, 30),
             name="Inactive code",
@@ -306,8 +305,8 @@ class UtilTests(CouponMixin, CourseCatalogTestMixin, CatalogPreviewMockMixin, Lm
 
     @httpretty.activate
     def test_generate_coupon_report_for_old_coupons(self):
-        self.skipTest('Coupon report is pending restructure.')
         """ Verify that the client info is present for old coupons. """
+        self.skipTest('Coupon report is pending restructure.')
         self.setup_coupons_for_report()
 
         Order.objects.get(basket=self.basket).delete()
@@ -322,8 +321,8 @@ class UtilTests(CouponMixin, CourseCatalogTestMixin, CatalogPreviewMockMixin, Lm
 
     @httpretty.activate
     def test_generate_coupon_report_for_query_coupons(self):
-        self.skipTest('Coupon report is pending restructure.')
         """ Verify empty report fields for query coupons. """
+        self.skipTest('Coupon report is pending restructure.')
         query_coupon = self.create_coupon(
             title='Query coupon',
             quantity=1,

--- a/ecommerce/extensions/voucher/utils.py
+++ b/ecommerce/extensions/voucher/utils.py
@@ -222,7 +222,7 @@ def generate_coupon_report(coupon_vouchers):
 
 def _get_or_create_offer(product_range, benefit_type, benefit_value, coupon_id=None, max_uses=None):
     """
-    Return an offer for a catalog with condition and benefit.
+    Return an offer for a range with condition and benefit.
 
     If offer doesn't exist, new offer will be created and associated with
     provided Offer condition and benefit.
@@ -326,7 +326,6 @@ def _create_new_voucher(code, coupon, end_datetime, name, offer, start_datetime,
 def create_vouchers(
         benefit_type,
         benefit_value,
-        catalog,
         coupon,
         end_datetime,
         name,
@@ -344,8 +343,6 @@ def create_vouchers(
     Args:
             benefit_type (str): Type of benefit associated with vouchers.
             benefit_value (Decimal): Value of benefit associated with vouchers.
-            catalog (Catalog): Catalog associated with range of products
-                               to which a voucher can be applied to.
             coupon (Coupon): Coupon entity associated with vouchers.
             end_datetime (datetime): End date for voucher offer.
             name (str): Voucher name.
@@ -369,7 +366,6 @@ def create_vouchers(
         range_name = (_('Range for coupon [{coupon_id}]').format(coupon_id=coupon.id))
         product_range, __ = Range.objects.get_or_create(
             name=range_name,
-            catalog=catalog,
             catalog_query=catalog_query,
             course_seat_types=course_seat_types
         )

--- a/ecommerce/extensions/voucher/utils.py
+++ b/ecommerce/extensions/voucher/utils.py
@@ -350,6 +350,8 @@ def create_vouchers(
             start_datetime (datetime): Start date for voucher offer.
             voucher_type (str): Type of voucher.
             code (str): Code associated with vouchers. Defaults to None.
+            catalog_query (str): Dynamic course catalog search query.
+            course_seat_types (str): Comma-separated accepted course modes.
 
     Returns:
             List[Voucher]

--- a/ecommerce/settings/test.py
+++ b/ecommerce/settings/test.py
@@ -127,7 +127,7 @@ CELERY_ALWAYS_EAGER = True
 
 # Use production settings for asset compression so that asset compilation can be tested on the CI server.
 COMPRESS_ENABLED = True
-COMPRESS_OFFLINE = False
+COMPRESS_OFFLINE = True
 
 # Comprehensive theme settings for testing environment
 COMPREHENSIVE_THEME_DIRS = [

--- a/ecommerce/settings/test.py
+++ b/ecommerce/settings/test.py
@@ -127,7 +127,7 @@ CELERY_ALWAYS_EAGER = True
 
 # Use production settings for asset compression so that asset compilation can be tested on the CI server.
 COMPRESS_ENABLED = True
-COMPRESS_OFFLINE = True
+COMPRESS_OFFLINE = False
 
 # Comprehensive theme settings for testing environment
 COMPREHENSIVE_THEME_DIRS = [


### PR DESCRIPTION
Some of the changes are adopted from https://github.com/edx/ecommerce/pull/765 FYI @clintonb 

Coupon report tests are skipped because the report needs to be revamped for multi-course coupons, which I guess blocks this PR, @mjfrey ?

https://openedx.atlassian.net/browse/SOL-1814
