### PR TITLE
WL-434: Support theme previews via URL parameter

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -220,6 +220,7 @@ MIDDLEWARE_CLASSES = (
     'simple_history.middleware.HistoryRequestMiddleware',
     'threadlocals.middleware.ThreadLocalMiddleware',
     'ecommerce.theming.middleware.CurrentSiteThemeMiddleware',
+    'ecommerce.theming.middleware.ThemePreviewMiddleware',
 )
 # END MIDDLEWARE CONFIGURATION
 

--- a/ecommerce/theming/middleware.py
+++ b/ecommerce/theming/middleware.py
@@ -16,3 +16,25 @@ class CurrentSiteThemeMiddleware(object):
 
     def process_request(self, request):
         request.site_theme = SiteTheme.get_theme(request.site)
+
+
+class ThemePreviewMiddleware(object):
+    """
+    Middleware for previewing themes. This middleware should be added after
+    CurrentSiteThemeMiddleware and SessionMiddleware.
+    """
+
+    def process_request(self, request):
+
+        if 'clear-theme' in request.GET and 'preview-theme' in request.session:
+            del request.session['preview-theme']
+
+        preview_theme = request.GET.get('preview-theme') or request.session.get('preview-theme')
+
+        if request.user.is_staff and preview_theme:
+            request.session['preview-theme'] = preview_theme
+
+            request.site_theme = SiteTheme(
+                site=getattr(request, 'site', None),
+                theme_dir_name=preview_theme,
+            )

--- a/ecommerce/theming/tests/test_middleware.py
+++ b/ecommerce/theming/tests/test_middleware.py
@@ -1,0 +1,82 @@
+"""
+Tests for theming middleware.
+"""
+
+from django.core.urlresolvers import reverse
+
+from ecommerce.tests.testcases import TestCase
+
+
+class TestPreviewTheme(TestCase):
+    """
+    Test preview-theme and clear-theme parameters work as expected.
+    """
+
+    def setUp(self):
+        """
+        Clear static file finders cache and register cleanup methods.
+        """
+        super(TestPreviewTheme, self).setUp()
+        self.dashboard_index_url = reverse('dashboard:index')
+
+        # create a user and log in
+        self.user = self.create_user(is_staff=True)
+        self.client.login(username=self.user.username, password=self.password)
+
+    def tearDown(self):
+        # clear any theme overrides
+        self.client.get(self.dashboard_index_url + '?clear-theme')
+
+    def test_templates(self):
+        """
+        Test templates are overridden with preview theme.
+        """
+        # Test default theme without preview theme parameters
+        self.assertContains(
+            self.client.get(self.dashboard_index_url),
+            "This is a Test Theme.",
+        )
+
+        # Test test-theme-2 overrides via preview-theme
+        self.assertContains(
+            self.client.get(self.dashboard_index_url + '?preview-theme=test-theme-2'),
+            "This is second Test Theme.",
+        )
+
+        # make sure once theme is accessed via preview-theme, it is stored in session data
+        self.assertContains(
+            self.client.get(self.dashboard_index_url),
+            "This is second Test Theme.",
+        )
+
+        # test that clear-theme parameter clears any theme applied via preview-theme
+        # In this case once preview theme is cleared, we should be back to default theme
+        self.assertContains(
+            self.client.get(self.dashboard_index_url + '?clear-theme'),
+            "This is a Test Theme.",
+        )
+
+        # Verify that theme clearing is persisted in the user's session.
+        self.assertContains(
+            self.client.get(self.dashboard_index_url),
+            "This is a Test Theme.",
+        )
+
+        # Test test-theme-3 overrides via preview-theme
+        self.assertContains(
+            self.client.get(self.dashboard_index_url + '?preview-theme=test-theme-3'),
+            "This is third Test Theme in a separate theme directory.",
+        )
+
+        # Test test-theme-2 overrides via preview-theme
+        self.assertContains(
+            self.client.get(self.dashboard_index_url + '?preview-theme=test-theme-2'),
+            "This is second Test Theme.",
+        )
+
+        # make sure there is no error if theme specified by preview-theme parameter does not exist.
+        # If given theme does not exist then open source theme will be used not the default theme.
+        self.assertContains(
+            self.client.get(self.dashboard_index_url + '?preview-theme=test-theme-non-existent'),
+            "Dashboard",
+        )


### PR DESCRIPTION
Hi @mattdrayer , @clintonb  

Kindly review this PR, it contains changes for WL-434.

**Description of Changes:**
- Support a URL parameter to switch themes, e.g. ?preview-theme=edx.org
- Write tests to verify that the theme switch is obeyed
