### PR TITLE
[WIP] [SOL-1847] Change not-selected values to null on toggling catalog type.

### DIFF
--- a/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
@@ -219,6 +219,23 @@ define([
                     view.updateCourseSeatTypes();
                     expect(view.dynamic_catalog_view.seat_types).toEqual(model.get('course_seat_types'));
                 });
+
+                it('should remove dynamic catalog values from fields when toggled to single course', function() {
+                    var catalog_query = '*:*',
+                        course_seat_types = ['verified'];
+
+                    model.set('catalog_query', catalog_query);
+                    model.set('course_seat_types', course_seat_types);
+                    view.updateCatalogQuery();
+                    view.updateCourseSeatTypes();
+                    expect(view.dynamic_catalog_view.query).toEqual(catalog_query);
+                    expect(view.dynamic_catalog_view.seat_types).toEqual(course_seat_types);
+
+                    view.$('#single-course').prop('checked', true);
+                    view.toggleCatalogTypeField();
+                    expect(view.dynamic_catalog_view.query).toEqual(undefined);
+                    expect(view.dynamic_catalog_view.seat_types).toEqual([ ]);
+                });
             });
         });
     }

--- a/ecommerce/static/js/views/coupon_form_view.js
+++ b/ecommerce/static/js/views/coupon_form_view.js
@@ -338,8 +338,10 @@ define([
                 }
             },
 
-            toggleCatalogTypeField: function () {
+            toggleCatalogTypeField: function() {
                 if (this.model.get('catalog_type') === 'Single course') {
+                    this.model.set('course_seat_types', []);
+                    this.model.unset('catalog_query');
                     this.formGroup('[name=catalog_query]').addClass(this.hiddenClass);
                     this.formGroup('[name=course_seat_types]').addClass(this.hiddenClass);
                     this.formGroup('[name=course_id]').removeClass(this.hiddenClass);
@@ -349,6 +351,8 @@ define([
                     this.formGroup('[name=course_seat_types]').removeClass(this.hiddenClass);
                     this.formGroup('[name=course_id]').addClass(this.hiddenClass);
                     this.formGroup('[name=seat_type]').addClass(this.hiddenClass);
+                    this.model.unset('course_id');
+                    this.model.unset('seat_type');
                 }
             },
 


### PR DESCRIPTION
When toggling between single and multi course catalog types, the input fields are hidden but the values in them remain, hence it can happen that a single and multi course coupon is created.
This PR contains code that resets the values of non-selected input fields on catalog type toggle.

https://openedx.atlassian.net/browse/SOL-1847
