### PR TITLE
[SOL-1859] Omit unavailable seats in offer landing page.

### DIFF
--- a/ecommerce/coupons/tests/mixins.py
+++ b/ecommerce/coupons/tests/mixins.py
@@ -19,22 +19,23 @@ class CatalogPreviewMockMixin(object):
     def setUp(self):
         super(CatalogPreviewMockMixin, self).setUp()
 
-    def mock_dynamic_catalog_course_runs_api(self, course_run=None, query=None):
+    def mock_dynamic_catalog_course_runs_api(self, course_run=None, query=None, course_run_info=None):
         """ Helper function to register a dynamic course catalog API endpoint for the course run information. """
-        course_run_info = {
-            'count': 1,
-            'results': [{
-                'key': course_run.id,
-                'title': course_run.name,
-                'start': '2016-05-01T00:00:00Z',
-                'image': {
-                    'src': 'path/to/the/course/image'
-                }
-            }] if course_run else [{
-                'key': 'test',
-                'title': 'Test course',
-            }],
-        }
+        if not course_run_info:
+            course_run_info = {
+                'count': 1,
+                'results': [{
+                    'key': course_run.id,
+                    'title': course_run.name,
+                    'start': '2016-05-01T00:00:00Z',
+                    'image': {
+                        'src': 'path/to/the/course/image'
+                    }
+                }] if course_run else [{
+                    'key': 'test',
+                    'title': 'Test course',
+                }],
+            }
         course_run_info_json = json.dumps(course_run_info)
         course_run_url = '{}course_runs/?q={}'.format(
             settings.COURSE_CATALOG_API_URL,

--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -64,7 +64,7 @@ class CouponAppViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
 
 
-class GetVoucherTests(TestCase):
+class GetVoucherTests(CourseCatalogTestMixin, TestCase):
     def test_get_voucher_and_products_from_code(self):
         """ Verify that get_voucher_and_products_from_code() returns products and voucher. """
         original_voucher, original_product = prepare_voucher(code=COUPON_CODE)
@@ -129,6 +129,15 @@ class GetVoucherTests(TestCase):
         product.expires = pytz.utc.localize(datetime.datetime.min)
         valid, __ = voucher_is_valid(voucher=voucher, products=[product], request=request)
         self.assertFalse(valid)
+
+    def test_omitting_unavailable_voucher(self):
+        """ Verify if there are more than one product, that availability check is omitted. """
+        request = RequestFactory().request()
+        voucher, product = prepare_voucher(code=COUPON_CODE)
+        product.expires = pytz.utc.localize(datetime.datetime.min)
+        __, seat = self.create_course_and_seat()
+        valid, __ = voucher_is_valid(voucher=voucher, products=[product, seat], request=request)
+        self.assertTrue(valid)
 
     def assert_error_messages(self, voucher, product, user, error_msg):
         """ Assert the proper error message is returned. """

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -90,10 +90,10 @@ def voucher_is_valid(voucher, products, request):
             voucher_msg = msg.replace('voucher', 'coupon')
             return False, voucher_msg
 
-    for product in products:
-        purchase_info = request.strategy.fetch_for_product(product)
+    if len(products) == 1:
+        purchase_info = request.strategy.fetch_for_product(products[0])
         if not purchase_info.availability.is_available_to_buy:
-            return False, _('Product [{product}] not available for purchase.'.format(product=product))
+            return False, _('Product [{product}] not available for purchase.'.format(product=products[0]))
 
     # If the voucher's number of applications exceeds it's limit.
     offer = voucher.offers.first()


### PR DESCRIPTION
If a dynamic coupon would contain one or more seats that are unavailable (expired) an error message would be displayed to the user trying to redeem some of the seats, so one expired seat could render the coupon for 1000 seats useless.
This PR contains changes that omit unavailable seats for the coupon offer landing page, displaying to the user only the seats that are available to her.

The offer page for single-course coupons works are before, displaying an error when the seat is unavailable.

https://openedx.atlassian.net/browse/SOL-1859
