### PR TITLE
[SOL-1861] Include max_uses when editing a coupon.

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -480,14 +480,17 @@ class CouponViewSetFunctionalTest(CouponMixin, CourseCatalogTestMixin, CatalogPr
     def test_update_coupon_benefit_value(self):
         coupon = Product.objects.get(title='Test coupon')
         vouchers = coupon.attr.coupon_vouchers.vouchers.all()
+        max_uses = vouchers[0].offers.first().max_global_applications
+        benefit_value = Decimal(54)
+
         CouponViewSet().update_coupon_benefit_value(
-            benefit_value=Decimal(54),
+            benefit_value=benefit_value,
             vouchers=vouchers,
             coupon=coupon
         )
-
         for voucher in vouchers:
-            self.assertEqual(voucher.offers.first().benefit.value, Decimal(54))
+            self.assertEqual(voucher.offers.first().benefit.value, benefit_value)
+            self.assertEqual(voucher.offers.first().max_global_applications, max_uses)
 
     def test_update_coupon_category(self):
         coupon = Product.objects.get(title='Test coupon')

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -394,7 +394,8 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
             offer=voucher_offer,
             benefit_value=benefit_value,
             benefit_type=voucher_offer.benefit.type,
-            coupon=coupon
+            coupon=coupon,
+            max_uses=voucher_offer.max_global_applications
         )
         for voucher in vouchers.all():
             voucher.offers.clear()

--- a/ecommerce/extensions/voucher/utils.py
+++ b/ecommerce/extensions/voucher/utils.py
@@ -450,7 +450,7 @@ def get_voucher_discount_info(benefit, price):
         }
 
 
-def update_voucher_offer(offer, benefit_value, benefit_type, coupon):
+def update_voucher_offer(offer, benefit_value, benefit_type, coupon, max_uses=None):
     """
     Update voucher offer with new benefit value.
 
@@ -466,5 +466,6 @@ def update_voucher_offer(offer, benefit_value, benefit_type, coupon):
         product_range=offer.benefit.range,
         benefit_value=benefit_value,
         benefit_type=benefit_type,
-        coupon_id=coupon.id
+        coupon_id=coupon.id,
+        max_uses=max_uses
     )


### PR DESCRIPTION
When editing a coupon, `max_uses` attribute was not accounted for causing the coupon to default to 10000 max uses when edited.
This PR contains changes that account for the `max_uses` attribute when updating a coupon.

Reviewers:
- [x] @marjev 
- [x] @mattdrayer 

https://openedx.atlassian.net/browse/SOL-1861
