### PR TITLE
[SOL-1863] Check if course seat types attribute exists before using it

### DIFF
--- a/ecommerce/static/js/test/specs/views/coupon_detail_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/coupon_detail_view_spec.js
@@ -128,6 +128,8 @@ define([
                 expect(view.$el.find('.tax-deducted-source-value > .value').text()).toEqual(
                     view.taxDeductedSource(model.get('tax_deducted_source'))
                 );
+                expect(view.$('.seat-types > .value').text()).toEqual('');
+                expect(view.$('.catalog-query > .value').text()).toEqual('');
             });
 
             it('should not display invoice discount type on render.', function() {
@@ -138,6 +140,17 @@ define([
                 view.render();
                 expect(view.$el.find('.invoice-discount-value > .value').text()).toEqual('');
                 expect(view.$el.find('.invoice-discount-type > .value').text()).toEqual('');
+            });
+
+            it('should format seat types.', function() {
+                view.model.unset('course_seat_types');
+                expect(view.formatSeatTypes()).toEqual(null);
+
+                view.model.set({'course_seat_types': ['verified']});
+                expect(view.formatSeatTypes()).toEqual('verified');
+
+                view.model.set({'course_seat_types': ['verified', 'professional']});
+                expect(view.formatSeatTypes()).toEqual('verified, professional');
             });
 
             it('should render course data', function () {

--- a/ecommerce/static/js/views/coupon_detail_view.js
+++ b/ecommerce/static/js/views/coupon_detail_view.js
@@ -109,10 +109,14 @@ define([
 
             formatSeatTypes: function() {
                 var courseSeatTypes = this.model.get('course_seat_types');
-                if(courseSeatTypes.length === 1){
-                    return courseSeatTypes[0];
+                if (courseSeatTypes) {
+                    if(courseSeatTypes.length === 1){
+                        return courseSeatTypes[0];
+                    } else {
+                        return courseSeatTypes.join(', ');
+                    }
                 } else {
-                    return courseSeatTypes.join(', ');
+                    return null;
                 }
             },
 


### PR DESCRIPTION
Old coupons (created before addition of dynamic coupons) do not contain `course_seat_types` attribute which causes error in the coupon details page.

This PR contains changes that fix that error in addition with a test verifying that the dynamic coupon specific attributes are empty. There is a test for when they exist: https://github.com/edx/ecommerce/blob/61bb1a0dcd34a5a660bb5b8ca750e3ea9be91c1e/ecommerce/static/js/test/specs/views/coupon_detail_view_spec.js#L145-L169

Reviewers:
- [x] @marjev 
- [x] @mattdrayer 

https://openedx.atlassian.net/browse/SOL-1863
