### PR TITLE
[SOL-1907] Set coupon custom code lower bound limit to 1.

### DIFF
--- a/ecommerce/static/js/models/coupon_model.js
+++ b/ecommerce/static/js/models/coupon_model.js
@@ -92,9 +92,10 @@ define([
                     }
                 },
                 code: {
+                    pattern: /^[a-zA-Z0-9]+$/,
                     required: false,
-                    rangeLength: [8, 16],
-                    msg: gettext('Code field must be empty or between 8 and 16 characters')
+                    rangeLength: [1, 16],
+                    msg: gettext('This field must be empty or contain 1-16 alphanumeric characters.')
                 },
                 catalog_query: {
                     required: function () {

--- a/ecommerce/static/js/test/specs/models/coupon_model_spec.js
+++ b/ecommerce/static/js/test/specs/models/coupon_model_spec.js
@@ -100,6 +100,16 @@ define([
                     model.validate();
                     expect(model.isValid()).toBeTruthy();
                 });
+
+                it('should validate coupon code.', function() {
+                    model.set('code', '!#$%&/()=');
+                    model.validate();
+                    expect(model.isValid()).toBeFalsy();
+
+                    model.set('code', 'CODE12345');
+                    model.validate();
+                    expect(model.isValid()).toBeTruthy();
+                });
             });
 
             describe('test model methods', function () {


### PR DESCRIPTION
There are legacy codes from ShoppingCart that need to be moved to Otto which have their code length lower than 8, and Otto has a lower bound limit of 8 for custom codes.

This PR changes the lower bound limit from 8 to 1 and adds a check if the code already exists.

https://openedx.atlassian.net/browse/SOL-1907
