### PR TITLE
[SOL-1820] Remove code that retrieves clients from baskets.

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -6,8 +6,6 @@ import logging
 
 from dateutil.parser import parse
 from django.db import transaction
-from django.http import Http404
-from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth import get_user_model
 from oscar.core.loading import get_model, get_class
@@ -471,13 +469,7 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
         return serializer.data
 
     def get_client(self, obj):
-        basket = Basket.objects.filter(lines__product_id=obj.id).first()
-        try:
-            order = get_object_or_404(Order, basket=basket)
-            invoice = get_object_or_404(Invoice, order=order)
-            return invoice.business_client.name
-        except Http404:
-            return basket.owner.username
+        return Invoice.objects.get(order__basket__lines__product=obj).business_client.name
 
     def get_vouchers(self, obj):
         vouchers = obj.attr.coupon_vouchers.vouchers.all()

--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -521,16 +521,6 @@ class CouponViewSetFunctionalTest(CouponMixin, CourseCatalogTestMixin, CourseCat
         invoice = Invoice.objects.get(order__basket=basket)
         self.assertEqual(invoice.business_client.name, client_username)
 
-        # To test the old coupon clients, we need to delete all basket orders
-        Order.objects.filter(basket__in=baskets).delete()
-        CouponViewSet().update_coupon_client(
-            baskets=baskets,
-            client_username=client_username
-        )
-
-        baskets = Basket.objects.filter(lines__product_id=self.coupon.id)
-        self.assertEqual(baskets.first().owner.username, client_username)
-
     def test_update_invoice_data(self):
         invoice = Invoice.objects.get(order__basket__lines__product=self.coupon)
         self.assertEqual(invoice.discount_type, Invoice.PERCENTAGE)

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -13,7 +13,7 @@ from rest_framework import filters, generics, status, viewsets
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 
-from ecommerce.core.models import BusinessClient, User
+from ecommerce.core.models import BusinessClient
 from ecommerce.coupons.utils import prepare_course_seat_types
 from ecommerce.extensions.api import data as data_api
 from ecommerce.extensions.api.constants import APIConstants as AC
@@ -437,22 +437,13 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
 
     def update_coupon_client(self, baskets, client_username):
         """
-        Update Invoice client for new coupons or Basket owner for old coupons
+        Update Invoice client for new coupons.
         Arguments:
             baskets (QuerySet): Baskets associated with the coupons
             client_username (str): Client username
         """
-        try:
-            client, __ = BusinessClient.objects.get_or_create(name=client_username)
-            order = get_object_or_404(Order, basket=baskets.first())
-            invoices = Invoice.objects.filter(order=order)
-            if invoices:
-                invoices.update(business_client=client)
-            else:
-                raise Http404
-        except Http404:
-            user, __ = User.objects.get_or_create(username=client_username)
-            baskets.update(owner=user)
+        client, __ = BusinessClient.objects.get_or_create(name=client_username)
+        Invoice.objects.filter(order__basket=baskets.first()).update(business_client=client)
 
     def update_invoice_data(self, coupon, data):
         """

--- a/ecommerce/extensions/voucher/tests/test_utils.py
+++ b/ecommerce/extensions/voucher/tests/test_utils.py
@@ -360,20 +360,6 @@ class UtilTests(CouponMixin, CourseCatalogMockMixin, CourseCatalogTestMixin, Lms
         self.assertEqual(inactive_coupon_row['Coupon Name'], coupon_name)
         self.assertEqual(inactive_coupon_row['Status'], _('Inactive'))
 
-    def test_generate_coupon_report_for_old_coupons(self):
-        """ Verify that the client info is present for old coupons. """
-        self.setup_coupons_for_report()
-
-        Order.objects.get(basket=self.basket).delete()
-        ProductCategory.objects.all().delete()
-
-        self.mock_course_api_response(course=self.course)
-        __, rows = generate_coupon_report(self.coupon_vouchers)
-
-        for row in rows:
-            self.assertEqual(row['Client'], self.basket.owner.username)
-            self.assertEqual(row['Category'], '')
-
     def test_generate_coupon_report_for_query_coupons(self):
         """ Verify empty report fields for query coupons. """
         catalog_query = 'course:*'

--- a/ecommerce/extensions/voucher/utils.py
+++ b/ecommerce/extensions/voucher/utils.py
@@ -7,8 +7,6 @@ import uuid
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from django.http import Http404
-from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext_lazy as _
 from opaque_keys.edx.keys import CourseKey
 from oscar.core.loading import get_model
@@ -205,17 +203,7 @@ def generate_coupon_report(coupon_vouchers):
 
     for coupon_voucher in coupon_vouchers:
         coupon = coupon_voucher.coupon
-
-        # Get client based on the invoice that was created during coupon creation.
-        # We used to save the client as the basket owner and therefor the exception
-        # catch is put in place for backwards compatibility with older coupons.
-        basket = Basket.objects.filter(lines__product_id=coupon.id).first()
-        try:
-            order = get_object_or_404(Order, basket=basket)
-            invoice = get_object_or_404(Invoice, order=order)
-            client = invoice.business_client.name
-        except Http404:
-            client = basket.owner.username
+        client = Invoice.objects.get(order__basket__lines__product=coupon).business_client.name
 
         for voucher in coupon_voucher.vouchers.all():
             row = _get_info_for_coupon_report(coupon, voucher)


### PR DESCRIPTION
By running a management command (https://github.com/edx/ecommerce/pull/839) all coupons should have invoices associated with them. This PR removes the try-except blocks that accounted for coupons without invoices as it's no longer needed.

https://openedx.atlassian.net/browse/SOL-1820
