### PR TITLE
[WIP] [SOL-1938]

### DIFF
--- a/ecommerce/core/management/commands/create_or_update_site.py
+++ b/ecommerce/core/management/commands/create_or_update_site.py
@@ -88,6 +88,12 @@ class Command(BaseCommand):
                             type=str,
                             required=True,
                             help='from email')
+        parser.add_argument('--enable-enrollment-codes',
+                            action='store',
+                            dest='enable_enrollment_codes',
+                            type=bool,
+                            required=False,
+                            help='Enable the creation of enrollment codes.')
 
     def handle(self, *args, **options):
         site_id = options.get('site_id')
@@ -100,6 +106,7 @@ class Command(BaseCommand):
         client_secret = options.get('client_secret')
         segment_key = options.get('segment_key')
         from_email = options.get('from_email')
+        enable_enrollment_codes = True if options.get('enable_enrollment_codes') else False
 
         try:
             site = Site.objects.get(id=site_id)
@@ -120,7 +127,7 @@ class Command(BaseCommand):
             partner.save()
             logger.info('Partner created with code %s', partner_code)
 
-        _, _ = SiteConfiguration.objects.get_or_create(
+        SiteConfiguration.objects.update_or_create(
             site=site,
             defaults={
                 'partner': partner,
@@ -129,6 +136,7 @@ class Command(BaseCommand):
                 'payment_processors': options['payment_processors'],
                 'segment_key': segment_key,
                 'from_email': from_email,
+                'enable_enrollment_codes': enable_enrollment_codes,
                 'oauth_settings': {
                     'SOCIAL_AUTH_EDX_OIDC_URL_ROOT': '{lms_url_root}/oauth2'.format(lms_url_root=lms_url_root),
                     'SOCIAL_AUTH_EDX_OIDC_KEY': client_id,

--- a/ecommerce/core/migrations/0016_siteconfiguration_enable_enrollment_codes.py
+++ b/ecommerce/core/migrations/0016_siteconfiguration_enable_enrollment_codes.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0015_siteconfiguration_from_email'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='siteconfiguration',
+            name='enable_enrollment_codes',
+            field=models.BooleanField(default=False, help_text='Enable the creation of enrollment codes.', verbose_name='Enable enrollment codes'),
+        ),
+    ]

--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -74,6 +74,12 @@ class SiteConfiguration(models.Model):
         null=True,
         blank=True
     )
+    enable_enrollment_codes = models.BooleanField(
+        verbose_name=_('Enable enrollment codes'),
+        help_text=_('Enable the creation of enrollment codes.'),
+        blank=True,
+        default=False
+    )
 
     class Meta(object):
         unique_together = ('site', 'partner')

--- a/ecommerce/courses/models.py
+++ b/ecommerce/courses/models.py
@@ -119,10 +119,33 @@ class Course(models.Model):
 
         return name
 
-    def create_or_update_seat(self, certificate_type, id_verification_required, price, partner,
-                              credit_provider=None, expires=None, credit_hours=None, remove_stale_modes=True):
+    def create_or_update_seat(
+            self,
+            certificate_type,
+            id_verification_required,
+            price,
+            partner,
+            credit_provider=None,
+            expires=None,
+            credit_hours=None,
+            remove_stale_modes=True,
+            create_enrollment_code=False
+    ):
         """
         Creates course seat products.
+
+        Arguments:
+            certificate_type(str): The seat type.
+            id_verification_required(bool): Whether an ID verification is required.
+            price(int): Price of the seat.
+            partner(Partner): Site partner.
+
+        Optional arguments:
+            credit_provider(str): Name of the organization that provides the credit
+            expires(Datetime): Date when the seat type expires.
+            credit_hours(int): Number of credit hours provided.
+            remove_stale_modes(bool): Remove stale modes.
+            create_enrollment_code(bool): Whether an enrollment code is created in additon to the seat.
 
         Returns:
             Product:  The seat that has been created or updated.
@@ -188,8 +211,9 @@ class Course(models.Model):
         seat.attr.certificate_type = certificate_type
         seat.attr.course_key = course_id
         seat.attr.id_verification_required = id_verification_required
-
-        if waffle.switch_is_active(ENROLLMENT_CODE_SWITCH) and certificate_type in ENROLLMENT_CODE_SEAT_TYPES:
+        if waffle.switch_is_active(ENROLLMENT_CODE_SWITCH) and \
+                certificate_type in ENROLLMENT_CODE_SEAT_TYPES and \
+                create_enrollment_code:
             self._create_or_update_enrollment_code(certificate_type, id_verification_required, partner, price)
 
         if credit_provider:
@@ -261,7 +285,6 @@ class Course(models.Model):
         Returns:
             Enrollment code product.
         """
-
         enrollment_code_product_class = ProductClass.objects.get(name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME)
         enrollment_code = self.enrollment_code_product
         if not enrollment_code:

--- a/ecommerce/courses/tests/test_models.py
+++ b/ecommerce/courses/tests/test_models.py
@@ -40,7 +40,7 @@ class CourseTests(CourseCatalogTestMixin, TestCase):
         # Create the seat products
         toggle_switch(ENROLLMENT_CODE_SWITCH, True)
         seats = [course.create_or_update_seat('honor', False, 0, self.partner),
-                 course.create_or_update_seat('verified', True, 50, self.partner)]
+                 course.create_or_update_seat('verified', True, 50, self.partner, create_enrollment_code=True)]
         self.assertEqual(course.products.count(), 4)
 
         # The property should return only the child seats.
@@ -140,7 +140,7 @@ class CourseTests(CourseCatalogTestMixin, TestCase):
         seat_type = 'verified'
         price = 5
         toggle_switch(ENROLLMENT_CODE_SWITCH, True)
-        course.create_or_update_seat(seat_type, True, price, self.partner)
+        course.create_or_update_seat(seat_type, True, price, self.partner, create_enrollment_code=True)
 
         enrollment_code = Product.objects.get(product_class__name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME)
         self.assertEqual(enrollment_code.attr.course_key, course.id)
@@ -301,7 +301,7 @@ class CourseTests(CourseCatalogTestMixin, TestCase):
             enrollment_code = Product.objects.get(product_class__name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME)
 
         # Verified seat products should have a corresponding enrollment code
-        course.create_or_update_seat('verified', True, 10, self.partner)
+        course.create_or_update_seat('verified', True, 10, self.partner, create_enrollment_code=True)
         enrollment_code = Product.objects.get(product_class__name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME)
         self.assertEqual(enrollment_code.attr.course_key, course.id)
         self.assertEqual(enrollment_code.attr.seat_type, 'verified')

--- a/ecommerce/courses/tests/test_publishers.py
+++ b/ecommerce/courses/tests/test_publishers.py
@@ -190,7 +190,7 @@ class LMSPublisherTests(CourseCatalogTestMixin, TestCase):
 
     def test_serialize_seat_with_enrollment_code(self):
         toggle_switch(ENROLLMENT_CODE_SWITCH, True)
-        seat = self.course.create_or_update_seat('verified', False, 10, self.partner)
+        seat = self.course.create_or_update_seat('verified', False, 10, self.partner, create_enrollment_code=True)
         stock_record = seat.stockrecords.first()
         ec_stock_record = StockRecord.objects.get(product__product_class__name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME)
 

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -14,6 +14,7 @@ from rest_framework.reverse import reverse
 import waffle
 
 from ecommerce.core.constants import ISO_8601_FORMAT, COURSE_ID_REGEX
+from ecommerce.core.models import Site, SiteConfiguration
 from ecommerce.core.url_utils import get_ecommerce_url
 from ecommerce.courses.models import Course
 from ecommerce.coupons.utils import get_seats_from_query
@@ -299,6 +300,8 @@ class AtomicPublicationSerializer(serializers.Serializer):  # pylint: disable=ab
 
                     # Extract arguments required for Seat creation, deserializing as necessary.
                     certificate_type = attrs.get('certificate_type', '')
+                    create_enrollment_code = product['course'].get('create_enrollment_code') and \
+                        self.context['request'].site.siteconfiguration.enable_enrollment_codes
                     id_verification_required = attrs['id_verification_required']
                     price = Decimal(product['price'])
 
@@ -317,6 +320,7 @@ class AtomicPublicationSerializer(serializers.Serializer):  # pylint: disable=ab
                         expires=expires,
                         credit_provider=credit_provider,
                         credit_hours=credit_hours,
+                        create_enrollment_code=create_enrollment_code
                     )
 
                 resp_message = course.publish_to_lms(access_token=self.access_token)
@@ -530,3 +534,15 @@ class CheckoutSerializer(serializers.Serializer):  # pylint: disable=abstract-me
 class InvoiceSerializer(serializers.ModelSerializer):
     class Meta(object):
         model = Invoice
+
+
+class SiteSerializer(serializers.ModelSerializer):
+    class Meta(object):
+        model = Site
+
+
+class SiteConfigurationSerializer(serializers.ModelSerializer):
+    site = SiteSerializer(read_only=True)
+
+    class Meta(object):
+        model = SiteConfiguration

--- a/ecommerce/extensions/api/v2/tests/views/test_publication.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_publication.py
@@ -41,7 +41,15 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
                             'name': 'id_verification_required',
                             'value': False
                         }
-                    ]
+                    ],
+                    'course': {
+                        'create_enrollment_code': 'true',
+                        'honor_mode': True,
+                        'id': self.course_id,
+                        'name': self.course_name,
+                        'type': 'verified',
+                        'verification_deadline': None
+                    }
                 },
                 {
                     'product_class': 'Seat',
@@ -56,7 +64,15 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
                             'name': 'id_verification_required',
                             'value': False
                         }
-                    ]
+                    ],
+                    'course': {
+                        'create_enrollment_code': 'true',
+                        'honor_mode': True,
+                        'id': self.course_id,
+                        'name': self.course_name,
+                        'type': 'verified',
+                        'verification_deadline': None
+                    }
                 },
                 {
                     'product_class': 'Seat',
@@ -71,7 +87,15 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
                             'name': 'id_verification_required',
                             'value': True
                         }
-                    ]
+                    ],
+                    'course': {
+                        'create_enrollment_code': 'true',
+                        'honor_mode': True,
+                        'id': self.course_id,
+                        'name': self.course_name,
+                        'type': 'verified',
+                        'verification_deadline': None
+                    }
                 },
                 {
                     'product_class': 'Seat',
@@ -94,7 +118,15 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
                             'name': 'credit_hours',
                             'value': 1
                         }
-                    ]
+                    ],
+                    'course': {
+                        'create_enrollment_code': 'true',
+                        'honor_mode': True,
+                        'id': self.course_id,
+                        'name': self.course_name,
+                        'type': 'verified',
+                        'verification_deadline': None
+                    }
                 }
             ]
         }

--- a/ecommerce/extensions/api/v2/tests/views/test_siteconfiguration.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_siteconfiguration.py
@@ -1,0 +1,48 @@
+import json
+
+from django.core.urlresolvers import reverse
+
+from ecommerce.extensions.api.serializers import SiteConfigurationSerializer
+from ecommerce.tests.testcases import TestCase
+from ecommerce.tests.factories import SiteConfigurationFactory
+
+
+class SiteConfigurationViewSetTests(TestCase):
+    """Tests for the site configuration API endpoint."""
+
+    def setUp(self):
+        super(SiteConfigurationViewSetTests, self).setUp()
+        self.site_configuration = SiteConfigurationFactory(
+            partner__name='TestX',
+            site__domain='test.api.endpoint',
+            segment_key='test_segment_key',
+            enable_enrollment_codes=True
+        )
+        self.path = reverse('api:v2:siteconfiguration-list')
+
+        self.user = self.create_user(is_staff=True)
+        self.client.login(username=self.user.username, password=self.password)
+
+    def test_authentication_required(self):
+        """Test that a guest cannot access the view."""
+        response = self.client.get(self.path)
+        self.assertEqual(response.status_code, 200)
+
+        self.client.logout()
+        response = self.client.get(self.path)
+        self.assertEqual(response.status_code, 401)
+
+    def test_authorization_required(self):
+        """Test that a non-staff user cannot access the view."""
+        user = self.create_user(is_staff=False)
+        self.client.login(username=user.username, password=self.password)
+
+        response = self.client.get(self.path)
+        self.assertEqual(response.status_code, 403)
+
+    def test_site_configuration_response(self):
+        """Verify proper site configuration data was returned."""
+        response = self.client.get(self.path)
+        self.assertEqual(response.status_code, 200)
+        response_content = json.loads(response.content)
+        self.assertEqual(response_content['results'][1], SiteConfigurationSerializer(self.site_configuration).data)

--- a/ecommerce/extensions/api/v2/urls.py
+++ b/ecommerce/extensions/api/v2/urls.py
@@ -2,13 +2,22 @@ from django.conf.urls import url, include
 from rest_framework_extensions.routers import ExtendedSimpleRouter
 
 from ecommerce.core.constants import COURSE_ID_PATTERN
-from ecommerce.extensions.api.v2.views import (baskets as basket_views,
-                                               checkout as checkout_views, payments as payment_views,
-                                               orders as order_views, refunds as refund_views,
-                                               products as product_views, courses as course_views,
-                                               publication as publication_views, partners as partner_views,
-                                               catalog as catalog_views, stockrecords as stockrecords_views,
-                                               coupons as coupon_views, vouchers as voucher_views)
+from ecommerce.extensions.api.v2.views import (
+    baskets as basket_views,
+    catalog as catalog_views,
+    checkout as checkout_views,
+    coupons as coupon_views,
+    courses as course_views,
+    orders as order_views,
+    partners as partner_views,
+    payments as payment_views,
+    products as product_views,
+    publication as publication_views,
+    refunds as refund_views,
+    siteconfiguration as siteconfiguration_views,
+    stockrecords as stockrecords_views,
+    vouchers as voucher_views
+)
 from ecommerce.extensions.voucher.views import CouponReportCSVView
 
 ORDER_NUMBER_PATTERN = r'(?P<number>[-\w]+)'
@@ -86,5 +95,5 @@ router.register(r'coupons', coupon_views.CouponViewSet, base_name='coupons')
 router.register(r'orders', order_views.OrderViewSet)
 
 router.register(r'vouchers', voucher_views.VoucherViewSet, base_name='vouchers')
-
+router.register(r'siteconfiguration', siteconfiguration_views.SiteConfigurationViewSet, base_name='siteconfiguration')
 urlpatterns += router.urls

--- a/ecommerce/extensions/api/v2/views/siteconfiguration.py
+++ b/ecommerce/extensions/api/v2/views/siteconfiguration.py
@@ -1,0 +1,12 @@
+"""API endpoint for site configuration."""
+from rest_framework import viewsets
+from rest_framework.permissions import IsAdminUser, IsAuthenticated
+
+from ecommerce.core.models import SiteConfiguration
+from ecommerce.extensions.api import serializers
+
+
+class SiteConfigurationViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = SiteConfiguration.objects.all()
+    serializer_class = serializers.SiteConfigurationSerializer
+    permission_classes = (IsAuthenticated, IsAdminUser,)

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -114,13 +114,14 @@ class BasketSummaryView(BasketView):
                 logger.exception('Failed to retrieve data from Course API for course [%s].', course_key)
 
             # Set to true if any course in basket has bulk purchase scenario
-            if line.product.get_product_class().name == ENROLLMENT_CODE_PRODUCT_CLASS_NAME:
+            if line.product.get_product_class().name == ENROLLMENT_CODE_PRODUCT_CLASS_NAME and \
+                    self.request.site.siteconfiguration.enable_enrollment_codes:
                 is_bulk_purchase = True
                 # Iterate on message storage so all messages are marked as read
                 list(messages.get_messages(self.request))
 
-            # Get variables for alternative basket view
-            switch_link_text, partner_sku = get_basket_switch_data(line.product)
+                # Get variables for alternative basket view
+                switch_link_text, partner_sku = get_basket_switch_data(line.product)
 
             if line.has_discount:
                 benefit = self.request.basket.applied_offers().values()[0].benefit

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -444,7 +444,7 @@ class EnrollmentCodeFulfillmentModuleTests(CourseCatalogTestMixin, TestCase):
         super(EnrollmentCodeFulfillmentModuleTests, self).setUp()
         toggle_switch(ENROLLMENT_CODE_SWITCH, True)
         course = CourseFactory()
-        course.create_or_update_seat('verified', True, 50, self.partner)
+        course.create_or_update_seat('verified', True, 50, self.partner, create_enrollment_code=True)
         enrollment_code = Product.objects.get(product_class__name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME)
         user = UserFactory()
         basket = BasketFactory()

--- a/ecommerce/static/js/test/spec-utils.js
+++ b/ecommerce/static/js/test/spec-utils.js
@@ -39,6 +39,18 @@ define([
                         return { pass: $(actual).hasClass(className) };
                     }
                 };
+            },
+
+            /**
+              * Helper function to check if a form field is visible.
+              */
+            visibleElement: function(view, selector, groupSelector) {
+                var formGroup = view.$(selector).closest(groupSelector);
+                if (formGroup.length > 0) {
+                    return !formGroup.hasClass('hidden');
+                } else {
+                    return false;
+                }
             }
         };
     }

--- a/ecommerce/static/js/test/specs/views/coupon_detail_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/coupon_detail_view_spec.js
@@ -4,6 +4,7 @@ define([
         'models/coupon_model',
         'views/coupon_detail_view',
         'test/mock_data/coupons',
+        'test/spec-utils',
         'moment',
     ],
     function ($,
@@ -11,6 +12,7 @@ define([
               Coupon,
               CouponDetailView,
               Mock_Coupons,
+              SpecUtils,
               moment) {
         'use strict';
 
@@ -23,18 +25,6 @@ define([
                 valueDiscountCodeVoucher,
                 verifiedSeat,
                 view;
-
-            /**
-              * Helper function to check if a form field is shown.
-              */
-            function visible(selector) {
-                var formGroup = view.$(selector).closest('.info-item');
-                if (formGroup.length > 0) {
-                    return !formGroup.hasClass('hidden');
-                } else {
-                    return false;
-                }
-            }
 
             beforeEach(function () {
                 data = Mock_Coupons.enrollmentCodeCouponData;
@@ -208,8 +198,8 @@ define([
                 expect(view.$('.invoice-payment-date .value').text()).toEqual(
                     view.formatDateTime(model.get('invoice_payment_date'))
                 );
-                expect(visible('.invoice_discount_type')).toBe(false);
-                expect(visible('.invoice_discount_value')).toBe(false);
+                expect(SpecUtils.visibleElement(view, '.invoice_discount_type', '.info-item')).toBe(false);
+                expect(SpecUtils.visibleElement(view, '.invoice_discount_value', '.info-item')).toBe(false);
             });
 
             it('should render postpaid invoice data.', function() {
@@ -226,28 +216,28 @@ define([
                         model.get('invoice_discount_value')
                     )
                 );
-                expect(visible('.invoice-number')).toBe(false);
-                expect(visible('.invoiced-amount')).toBe(false);
-                expect(visible('.invoice-payment-date')).toBe(false);
+                expect(SpecUtils.visibleElement(view, '.invoice-number', '.info-item')).toBe(false);
+                expect(SpecUtils.visibleElement(view, '.invoiced-amount', '.info-item')).toBe(false);
+                expect(SpecUtils.visibleElement(view, '.invoice-payment-date', '.info-item')).toBe(false);
             });
 
             it('should render not-applicable invoice data.', function() {
                 view.model.set('invoice_type', 'Not-Applicable');
                 view.render();
-                expect(visible('.invoice_discount_type')).toBe(false);
-                expect(visible('.invoice-number')).toBe(false);
-                expect(visible('.invoiced-amount')).toBe(false);
-                expect(visible('.invoice-payment-date')).toBe(false);
+                expect(SpecUtils.visibleElement(view, '.invoice_discount_type', '.info-item')).toBe(false);
+                expect(SpecUtils.visibleElement(view, '.invoice-number', '.info-item')).toBe(false);
+                expect(SpecUtils.visibleElement(view, '.invoiced-amount', '.info-item')).toBe(false);
+                expect(SpecUtils.visibleElement(view, '.invoice-payment-date', '.info-item')).toBe(false);
             });
 
             it('should display tax deducted source input field.', function() {
                 view.model.set('tax_deduction', 'Yes');
                 view.render();
-                expect(visible('.tax-deducted-source-value')).toBe(true);
+                expect(SpecUtils.visibleElement(view, '.tax-deducted-source-value', '.info-item')).toBe(true);
 
                 view.model.set('tax_deduction', 'No');
                 view.render();
-                expect(visible('.tax-deducted-source-value')).toBe(false);
+                expect(SpecUtils.visibleElement(view, '.tax-deducted-source-value', '.info-item')).toBe(false);
             });
 
             it('should display data table', function () {

--- a/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
@@ -6,6 +6,7 @@ define([
         'models/coupon_model',
         'test/mock_data/categories',
         'test/mock_data/coupons',
+        'test/spec-utils',
         'ecommerce'
     ],
     function ($,
@@ -15,6 +16,7 @@ define([
               Coupon,
               Mock_Categories,
               Mock_Coupons,
+              SpecUtils,
               ecommerce) {
         'use strict';
 
@@ -22,18 +24,6 @@ define([
             var view,
                 model,
                 courseData = Mock_Coupons.courseData;
-
-            /**
-              * Helper function to check if a form field is shown.
-              */
-            function visible(selector) {
-                var formGroup = view.$el.find(selector).closest('.form-group');
-                if (formGroup.length > 0) {
-                    return !formGroup.hasClass('hidden');
-                } else {
-                    return false;
-                }
-            }
 
             beforeEach(function () {
                 ecommerce.coupons = {
@@ -92,12 +82,12 @@ define([
                 });
 
                 it('should show the price field', function () {
-                    expect(visible('[name=price]')).toBe(true);
+                    expect(SpecUtils.visibleElement(view, '[name=price]', '.form-group')).toBe(true);
                 });
 
                 it('should hide discount and code fields', function () {
-                    expect(visible('[name=benefit_value]')).toBe(false);
-                    expect(visible('[name=code]')).toBe(false);
+                    expect(SpecUtils.visibleElement(view, '[name=benefit_value]', '.form-group')).toBe(false);
+                    expect(SpecUtils.visibleElement(view, '[name=code]', '.form-group')).toBe(false);
                 });
 
                 it('should set model attribute category_ids on render', function () {
@@ -127,7 +117,7 @@ define([
                 });
 
                 it('should show the discount field', function () {
-                    expect(visible('[name=benefit_value]')).toBe(true);
+                    expect(SpecUtils.visibleElement(view, '[name=benefit_value]', '.form-group')).toBe(true);
                 });
 
                 it('should indicate the benefit type', function () {
@@ -163,85 +153,89 @@ define([
 
                 it('should show the code field for once-per-customer and singe-use vouchers', function () {
                     view.$el.find('[name=voucher_type]').val('Single use').trigger('change');
-                    expect(visible('[name=code]')).toBe(true);
+                    expect(SpecUtils.visibleElement(view, '[name=code]', '.form-group')).toBe(true);
                     view.$el.find('[name=voucher_type]').val('Once per customer').trigger('change');
-                    expect(visible('[name=code]')).toBe(true);
+                    expect(SpecUtils.visibleElement(view, '[name=code]', '.form-group')).toBe(true);
                 });
 
                 it('should show the usage number field only for once-per-customer vouchers', function () {
                     view.$el.find('[name=voucher_type]').val('Single use').trigger('change');
-                    expect(visible('[name=max_uses]')).toBe(false);
+                    expect(SpecUtils.visibleElement(view, '[name=max_uses]', '.form-group')).toBe(false);
                     view.$el.find('[name=voucher_type]').val('Once per customer').trigger('change');
-                    expect(visible('[name=max_uses]')).toBe(true);
+                    expect(SpecUtils.visibleElement(view, '[name=max_uses]', '.form-group')).toBe(true);
                 });
 
                 it('should hide quantity field when code entered', function () {
                     view.$el.find('[name=code]').val('E34T4GR342').trigger('input');
-                    expect(visible('[name=quantity]')).toBe(false);
+                    expect(SpecUtils.visibleElement(view, '[name=quantity]', '.form-group')).toBe(false);
                     view.$el.find('[name=code]').val('').trigger('input');
-                    expect(visible('[name=quantity]')).toBe(true);
+                    expect(SpecUtils.visibleElement(view, '[name=quantity]', '.form-group')).toBe(true);
                 });
 
                 it('should hide code field when quantity not 1', function () {
                     view.$el.find('[name=quantity]').val(21).trigger('change');
-                    expect(visible('[name=code]')).toBe(false);
+                    expect(SpecUtils.visibleElement(view, '[name=code]', '.form-group')).toBe(false);
                     view.$el.find('[name=quantity]').val(1).trigger('change');
-                    expect(visible('[name=code]')).toBe(true);
+                    expect(SpecUtils.visibleElement(view, '[name=code]', '.form-group')).toBe(true);
                 });
 
                 it('should hide code field for every voucher type if quantity is not 1.', function() {
                     view.$el.find('[name=quantity]').val(2).trigger('change');
                     view.$el.find('[name=voucher_type]').val('Single use').trigger('change');
-                    expect(visible('[name=code]')).toBe(false);
+                    expect(SpecUtils.visibleElement(view, '[name=code]', '.form-group')).toBe(false);
 
                     view.$el.find('[name=voucher_type]').val('Once per customer').trigger('change');
-                    expect(visible('[name=code]')).toBe(false);
+                    expect(SpecUtils.visibleElement(view, '[name=code]', '.form-group')).toBe(false);
 
                     view.$el.find('[name=voucher_type]').val('Multi-use').trigger('change');
-                    expect(visible('[name=code]')).toBe(false);
+                    expect(SpecUtils.visibleElement(view, '[name=code]', '.form-group')).toBe(false);
                 });
 
                 it('should show the code field for every voucher type if quantity is 1.', function() {
                     view.$el.find('[name=quantity]').val(1).trigger('change');
                     view.$el.find('[name=voucher_type]').val('Single use').trigger('change');
-                    expect(visible('[name=code]')).toBe(true);
+                    expect(SpecUtils.visibleElement(view, '[name=code]', '.form-group')).toBe(true);
 
                     view.$el.find('[name=voucher_type]').val('Once per customer').trigger('change');
-                    expect(visible('[name=code]')).toBe(true);
+                    expect(SpecUtils.visibleElement(view, '[name=code]', '.form-group')).toBe(true);
 
                     view.$el.find('[name=voucher_type]').val('Multi-use').trigger('change');
-                    expect(visible('[name=code]')).toBe(true);
+                    expect(SpecUtils.visibleElement(view, '[name=code]', '.form-group')).toBe(true);
                 });
 
                 it('should show prepaid invoice fields when changing to Prepaid invoice type.', function() {
                     view.$el.find('#already-invoiced').prop('checked', true).trigger('change');
                     _.each(prepaid_invoice_fields, function(field) {
-                        expect(visible(field)).toBe(true);
+                        expect(SpecUtils.visibleElement(view, field, '.form-group')).toBe(true);
                     });
-                    expect(visible('[name=invoice_discount_value]')).toBe(false);
+                    expect(SpecUtils.visibleElement(view, '[name=invoice_discount_value]', '.form-group')).toBe(false);
                 });
 
                 it('should show postpaid invoice fields when changing to Postpaid invoice type.', function() {
                     view.$el.find('#invoice-after-redemption').prop('checked', true).trigger('change');
                     _.each(prepaid_invoice_fields, function(field) {
-                        expect(visible(field)).toBe(false);
+                        expect(SpecUtils.visibleElement(view, field, '.form-group')).toBe(false);
                     });
-                    expect(visible('[name=invoice_discount_value]')).toBe(true);
+                    expect(SpecUtils.visibleElement(view, '[name=invoice_discount_value]', '.form-group')).toBe(true);
                 });
 
                 it('should hide all invoice fields when changing to Not applicable invoice type.', function() {
                     view.$el.find('#not-applicable').prop('checked', true).trigger('change');
                     _.each(prepaid_invoice_fields, function(field) {
-                        expect(visible(field)).toBe(false);
+                        expect(SpecUtils.visibleElement(view, field, '.form-group')).toBe(false);
                     });
-                    expect(visible('[name=invoice_discount_value]')).toBe(false);
+                    expect(SpecUtils.visibleElement(view, '[name=invoice_discount_value]', '.form-group')).toBe(false);
                 });
 
                 it('should show tax deduction source field when TSD is selected.', function() {
                     view.$el.find('#tax-deducted').prop('checked', true).trigger('change');
-                    expect(visible('[name=tax_deducted_source_value]')).toBe(true);
+                    expect(
+                        SpecUtils.visibleElement(view, '[name=tax_deducted_source_value]', '.form-group')
+                    ).toBe(true);
                     view.$el.find('#non-tax-deducted').prop('checked', true).trigger('change');
-                    expect(visible('[name=tax_deducted_source_value]')).toBe(false);
+                    expect(
+                        SpecUtils.visibleElement(view, '[name=tax_deducted_source_value]', '.form-group')
+                    ).toBe(false);
                 });
             });
 

--- a/ecommerce/static/js/test/specs/views/course_create_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/course_create_view_spec.js
@@ -2,11 +2,13 @@ define([
         'jquery',
         'views/course_create_edit_view',
         'views/alert_view',
+        'test/spec-utils',
         'models/course_model'
     ],
     function ($,
               CourseCreateEditView,
               AlertView,
+              SpecUtils,
               Course) {
         'use strict';
 
@@ -34,7 +36,25 @@ define([
                 expect(view.$el.find('.course-types input[type=radio]:checked').length).toEqual(1);
                 expect(view.$el.find('.course-seat.empty').hasClass('hidden')).toBe(true);
             });
+            it('should hide bulk enrollment checkbox if audit mode is selected', function() {
+                var bulk_enrollment_seat_types = ['verified', 'professional', 'credit'];
+                view.model.set('type', 'audit');
+                view.formView.toggleBulkEnrollmentField();
+                expect(SpecUtils.visibleElement(view, '[name=create_enrollment_code]', '.form-group')).toBe(false);
 
+                _.each(bulk_enrollment_seat_types, function(seat) {
+                    view.model.set('type', seat);
+                    view.formView.toggleBulkEnrollmentField();
+                    expect(SpecUtils.visibleElement(
+                        view, '[name=create_enrollment_code]', '.form-group')
+                    ).toBe(true);
+                }, this);
+            });
+
+            it('should set the bulk enrollment enabled if it is selected', function() {
+                view.$('[name=create_enrollment_code]').prop('checked', true).trigger('change');
+                expect(view.model.get('create_enrollment_code')).toBe('true');
+            });
         });
     }
 );

--- a/ecommerce/static/js/test/specs/views/course_form_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/course_form_view_spec.js
@@ -1,6 +1,6 @@
 define([
         'models/course_model',
-        'views/course_form_view'
+        'views/course_form_view',
     ],
     function (Course,
               CourseFormView) {
@@ -23,20 +23,35 @@ define([
 
             describe('getActiveCourseTypes', function () {
                 it('should return expected course types', function () {
+                    var mockAjaxData = {'results': [{
+                            'enable_enrollment_codes': true,
+                            'site': {
+                                'domain': 'test.site.domain'
+                            }
+                        }]
+                    };
+                    spyOn($, 'ajax').and.callFake(function(options) {
+                        options.success(mockAjaxData);
+                    });
                     view.model.set('type', 'audit');
                     expect(view.getActiveCourseTypes()).toEqual(['audit', 'verified', 'credit']);
+                    expect($.ajax).toHaveBeenCalled();
 
                     view.model.set('type', 'verified');
                     expect(view.getActiveCourseTypes()).toEqual(['verified', 'credit']);
+                    expect($.ajax).toHaveBeenCalled();
 
                     view.model.set('type', 'professional');
                     expect(view.getActiveCourseTypes()).toEqual(['professional']);
+                    expect($.ajax).toHaveBeenCalled();
 
                     view.model.set('type', 'credit');
                     expect(view.getActiveCourseTypes()).toEqual(['credit']);
+                    expect($.ajax).toHaveBeenCalled();
 
                     view.model.set('type', 'default');
                     expect(view.getActiveCourseTypes()).toEqual(['audit', 'verified', 'professional', 'credit']);
+                    expect($.ajax).toHaveBeenCalled();
                 });
             });
         });

--- a/ecommerce/static/templates/course_form.html
+++ b/ecommerce/static/templates/course_form.html
@@ -68,11 +68,21 @@
             <label class="radio-inline">
                 <input type="radio" name="honor_mode" value="false" aria-describedby="honorModeHelpBlock"> No
             </label>
-        <!-- NOTE: This help-block is here for validation messages. -->
+            <!-- NOTE: This help-block is here for validation messages. -->
+            <span class="help-block"></span>
+            <span id="honorModeHelpBlock" class="help-block">
+                <%- gettext('Include an Honor Seat with this course') %>
+            </span>
+        </div>
+    </div>
+</div>
+
+<div class="fields">
+    <div class="form-group create-enrollment-code hidden checkbox">
+        <label for="bulkEnrollment">
+        <input type="checkbox" id="bulkEnrollment" name="create_enrollment_code" value="true"> <%- gettext('Include Enrollment Code') %>
+        </label>
         <span class="help-block"></span>
-        <span id="honorModeHelpBlock" class="help-block">
-            <%- gettext('Include an Honor Seat with this course') %>
-        </span>
     </div>
 </div>
 


### PR DESCRIPTION
Enrollment code settings set in a white label site are re-used in the edX site which created enrollment codes for courses that it should not. 
This PR contains code that adds a new site configuration flag for enabling creating enrollment codes for toggling the enrollment codes for specific sites, and a checkbox in the CAT for toggling it for individual courses. 
Because the checkbox needs to be disabled for when creating enrollment codes is disabled, a new API endpoint for site configuration was implemented so that the Backbone application can get that information.

https://openedx.atlassian.net/browse/SOL-1938
- [ ] adjust documentation: https://github.com/edx/edx-documentation/pull/1125

Creating enabled:
![screenshot from 2016-07-18 14-41-11](https://cloud.githubusercontent.com/assets/2808092/16915043/d45708f6-4cf5-11e6-8ed1-2392cae0eceb.png)

Creating disabled:
![screenshot from 2016-07-18 14-41-44](https://cloud.githubusercontent.com/assets/2808092/16915130/6101b7ec-4cf6-11e6-8d46-aa5320c5bbc2.png)
