### PR TITLE
WL-499 Remove duplicate analytics initialization code

### DIFF
--- a/ecommerce/static/js/pages/basket_page.js
+++ b/ecommerce/static/js/pages/basket_page.js
@@ -7,14 +7,12 @@ define([
         'underscore',
         'underscore.string',
         'utils/utils',
-        'utils/analytics_utils',
         'js-cookie'
     ],
     function ($,
               _,
               _s,
               Utils,
-              AnalyticsUtils,
               Cookies
     ) {
         'use strict';
@@ -120,8 +118,6 @@ define([
                     btn.prev('disabled', true);
                 }
             });
-
-            AnalyticsUtils.analyticsSetUp();
         },
         showVoucherForm = function() {
             $('#voucher_form_container').show();

--- a/ecommerce/static/js/pages/coupon_offer_page.js
+++ b/ecommerce/static/js/pages/coupon_offer_page.js
@@ -1,14 +1,11 @@
 define([
-        'utils/analytics_utils',
         'pages/page'
     ],
-    function (AnalyticsUtils,
-              Page) {
+    function (Page) {
         'use strict';
 
         return Page.extend({
             initialize: function () {
-                AnalyticsUtils.analyticsSetUp();
             }
         });
     }

--- a/ecommerce/static/js/pages/credit_checkout.js
+++ b/ecommerce/static/js/pages/credit_checkout.js
@@ -3,7 +3,6 @@ define([
         'backbone',
         'views/payment_button_view',
         'utils/utils',
-        'utils/analytics_utils',
         'views/provider_selection_view',
         'pages/page'
     ],
@@ -11,7 +10,6 @@ define([
               Backbone,
               PaymentButtonView,
               Utils,
-              AnalyticsUtils,
               ProviderSelectionView,
               Page) {
         'use strict';
@@ -33,8 +31,6 @@ define([
                 // select the first available product.
                 paymentButtonView.render();
                 providerSelectionView.render();
-
-                AnalyticsUtils.analyticsSetUp();
             }
         });
     }

--- a/ecommerce/static/js/test/specs/pages/basket_page_spec.js
+++ b/ecommerce/static/js/test/specs/pages/basket_page_spec.js
@@ -199,6 +199,7 @@ define([
                         return true;
                     });
                     spyOn(AnalyticsView.prototype, 'track');
+                    AnalyticsUtils.analyticsSetUp();
                     BasketPage.onReady();
                     spyOn(window.analytics, 'page');
                 });

--- a/ecommerce/static/js/test/specs/pages/coupon_offer_spec.js
+++ b/ecommerce/static/js/test/specs/pages/coupon_offer_spec.js
@@ -1,11 +1,13 @@
 define([
         'jquery',
+        'utils/analytics_utils',
         'pages/coupon_offer_page',
         'models/tracking_model',
         'models/user_model',
         'views/analytics_view',
     ],
     function($,
+             AnalyticsUtils,
              CouponOfferPage,
              TrackingModel,
              UserModel,
@@ -32,12 +34,16 @@ define([
             });
 
             describe('Analytics', function() {
-                it('should trigger purchase certificate event', function() {
+                beforeEach(function () {
                     spyOn(TrackingModel.prototype, 'isTracking').and.callFake(function() {
                         return true;
                     });
                     spyOn(AnalyticsView.prototype, 'track');
+                    AnalyticsUtils.analyticsSetUp();
                     new CouponOfferPage();
+                });
+
+                it('should trigger purchase certificate event', function() {
                     $('a#PurchaseCertificate').trigger('click');
                     expect(AnalyticsView.prototype.track).toHaveBeenCalledWith(
                         'edx.bi.ecommerce.coupons.accept_offer',
@@ -45,5 +51,5 @@ define([
                     );
                 });
             });
-    });
+        });
 });

--- a/ecommerce/templates/edx/credit/checkout.html
+++ b/ecommerce/templates/edx/credit/checkout.html
@@ -115,12 +115,6 @@
         </div>
 
         <form id="payment-processor-form"></form>
-
-        {% if analytics_data %}
-            <script type="text/javascript">
-                var initModelData = {{ analytics_data|safe }};
-            </script>
-        {% endif %}
     </div>
 {% endblock content %}
 

--- a/ecommerce/templates/oscar/basket/basket.html
+++ b/ecommerce/templates/oscar/basket/basket.html
@@ -22,10 +22,4 @@
             {% include 'basket/partials/basket_content.html' %}
         </div>
     </div>
-
-    {% if analytics_data %}
-        <script type="text/javascript">
-            var initModelData = {{ analytics_data|safe }};
-        </script>
-    {% endif %}
 {% endblock content %}


### PR DESCRIPTION
This PR eliminates a JS console error ("Segment snippet included twice.") that was being thrown on several page renders. The issue was that we were calling `AnalyticsUtils.analyticsSetUp();` from both the [common module](https://github.com/edx/ecommerce/blob/master/ecommerce/static/js/common.js#L25) which is loaded on every page and from page specific modules. I have removed the duplicate calls from the page specific modules.

I have also removed duplicate definitions of backbone model data that is rendered within script tags in templates.

@vkaracic @mjfrey @hasnain-naveed 
