### PR TITLE
[WL-554] Error creating new coupon code

### DIFF
--- a/ecommerce/static/js/views/form_view.js
+++ b/ecommerce/static/js/views/form_view.js
@@ -222,6 +222,8 @@ define([
                         }
                     );
                 } else {
+                    // Remove all saved models from store, which prevents Duplicate id errors
+                    Backbone.Relational.store.reset();
                     this.model.save(
                         null,
                         {


### PR DESCRIPTION
I noticed when I try to save but the form has a validation error and on the second save attempt the error occurs.
My guess is that backbone saves the model in its store space and can't save it a second time (the second time save is pressed).
I fixed the issue by deleting everything from the store space before backbone tries to save the model so that this error can't occur.
The coupon and course views inherit the same form view and this fix should handle the problem with both forms.
@mjfrey  @vkaracic  Please review.
