### PR TITLE
[SOL-1930] Add partner to query parameters for course discovery.

### DIFF
--- a/ecommerce/coupons/utils.py
+++ b/ecommerce/coupons/utils.py
@@ -31,6 +31,7 @@ def get_range_catalog_query_results(limit, query, site, offset=None):
             limit=limit,
             offset=offset,
             q=query,
+            partner=site.siteconfiguration.partner.short_code
         )
         cache.set(cache_hash, response, settings.COURSES_API_CACHE_TIMEOUT)
     return response

--- a/ecommerce/extensions/offer/models.py
+++ b/ecommerce/extensions/offer/models.py
@@ -27,7 +27,8 @@ class Range(AbstractRange):
             try:
                 response = request.site.siteconfiguration.course_catalog_api_client.course_runs.contains.get(
                     query=self.catalog_query,
-                    course_run_ids=product.course_id
+                    course_run_ids=product.course_id,
+                    partner=request.site.siteconfiguration.partner.short_code
                 )
                 cache.set(cache_hash, response, settings.COURSES_API_CACHE_TIMEOUT)
             except:  # pylint: disable=bare-except


### PR DESCRIPTION
Course discovery will filter our courses by the partner, so we need to send the current partner short code as a query parameter.

[tests]:
- [x] coupon creation preview
- [x] offer landing page
- [x] offer redemption
- [x] local [tests]
- [x] sandbox [tests]

https://openedx.atlassian.net/browse/SOL-1930
_once again, never mind the ticket number in the branch name_
