### PR TITLE
Set an upper limit of number of coupon codes to 1000.

### DIFF
--- a/ecommerce/static/templates/coupon_form.html
+++ b/ecommerce/static/templates/coupon_form.html
@@ -51,7 +51,7 @@
 
         <div class="form-group">
             <label for="quantity"><%= gettext('Number of Codes') %> *</label>
-            <input id="quantity" type="number" step="1" class="form-control non-editable" name="quantity" value="1" min="1">
+            <input id="quantity" type="number" step="1" class="form-control non-editable" name="quantity" value="1" min="1" max="1000">
             <p class="help-block"></p>
         </div>
 


### PR DESCRIPTION
Because of performance reasons there needs to be an upper limit of the number of vouchers that can be created for one coupon.

https://openedx.atlassian.net/browse/SOL-1908
