### PR TITLE
Remove vouchers when switching to bulk enrollment code basket.

### DIFF
--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -19,9 +19,9 @@ def prepare_basket(request, product, voucher=None):
     Create or get the basket, add the product, apply a voucher, and record referral data.
 
     Existing baskets are merged. The specified product will
-    be added to the remaining open basket. If a voucher is passed, all existing
-    ones added to the basket are removed because we allow only one voucher per
-    basket after the Voucher is applied to the basket.
+    be added to the remaining open basket. If voucher is passed, all existing
+    vouchers added to the basket are removed because we allow only one voucher per basket.
+    Vouchers are not applied if an enrollment code product is in the basket.
 
     Arguments:
         request (Request): The request object made to the view.
@@ -34,12 +34,13 @@ def prepare_basket(request, product, voucher=None):
     basket = Basket.get_basket(request.user, request.site)
     basket.flush()
     basket.add_product(product, 1)
-    if voucher:
+    if voucher or product.get_product_class().name == ENROLLMENT_CODE_PRODUCT_CLASS_NAME:
         for v in basket.vouchers.all():
             basket.vouchers.remove(v)
-        basket.vouchers.add(voucher)
-        Applicator().apply(basket, request.user, request)
-        logger.info('Applied Voucher [%s] to basket [%s].', voucher.code, basket.id)
+        if voucher:
+            basket.vouchers.add(voucher)
+            Applicator().apply(basket, request.user, request)
+            logger.info('Applied Voucher [%s] to basket [%s].', voucher.code, basket.id)
 
     affiliate_id = request.COOKIES.get(settings.AFFILIATE_COOKIE_KEY)
     if affiliate_id:


### PR DESCRIPTION
When switching to a basket that contains enrollment codes, applying a voucher to that product returns an error, and it shouldn't be possible to do that anyway. 
The code in this PR makes sure that no voucher is applied if an enrollment code is in the basket.

https://openedx.atlassian.net/browse/SOL-2003
