### PR TITLE
Fixes

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -447,6 +447,7 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
     quantity = serializers.SerializerMethodField()
     start_date = serializers.SerializerMethodField()
     voucher_type = serializers.SerializerMethodField()
+    seats = serializers.SerializerMethodField()
 
     def retrieve_benefit(self, obj):
         """Helper method to retrieve the benefit from voucher. """
@@ -551,6 +552,18 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
     def get_voucher_type(self, obj):
         return self.retrieve_voucher_usage(obj)
 
+    def get_seats(self, obj):
+        offer = self.retrieve_offer(obj)
+        _range = offer.condition.range
+        request = self.context['request']
+        if _range.catalog:
+            stockrecords = _range.catalog.stock_records.all()
+            seats = Product.objects.filter(id__in=[sr.product.id for sr in stockrecords])
+            serializer = ProductSerializer(seats, many=True, context={'request': request})
+            return serializer.data
+        else:
+            return None
+
     class Meta(object):
         model = Product
         fields = (
@@ -558,7 +571,7 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
             'categories', 'client', 'code', 'code_status', 'coupon_type',
             'course_seat_types', 'end_date', 'id', 'last_edited', 'max_uses',
             'note', 'num_uses', 'payment_information', 'price', 'quantity',
-            'start_date', 'title', 'voucher_type'
+            'start_date', 'title', 'voucher_type', 'seats'
         )
 
 

--- a/ecommerce/extensions/basket/models.py
+++ b/ecommerce/extensions/basket/models.py
@@ -45,6 +45,11 @@ class Basket(AbstractBasket):
 
         return basket
 
+    def clear_vouchers(self):
+        """Remove all vouchers applied to the basket."""
+        for v in self.vouchers.all():
+            self.vouchers.remove(v)
+
     def __unicode__(self):
         return _(u"{id} - {status} basket (owner: {owner}, lines: {num_lines})").format(
             id=self.id,

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -34,13 +34,13 @@ def prepare_basket(request, product, voucher=None):
     basket = Basket.get_basket(request.user, request.site)
     basket.flush()
     basket.add_product(product, 1)
-    if voucher or product.get_product_class().name == ENROLLMENT_CODE_PRODUCT_CLASS_NAME:
-        for v in basket.vouchers.all():
-            basket.vouchers.remove(v)
-        if voucher:
-            basket.vouchers.add(voucher)
-            Applicator().apply(basket, request.user, request)
-            logger.info('Applied Voucher [%s] to basket [%s].', voucher.code, basket.id)
+    if product.get_product_class().name == ENROLLMENT_CODE_PRODUCT_CLASS_NAME:
+        basket.clear_vouchers()
+    elif voucher:
+        basket.clear_vouchers()
+        basket.vouchers.add(voucher)
+        Applicator().apply(basket, request.user, request)
+        logger.info('Applied Voucher [%s] to basket [%s].', voucher.code, basket.id)
 
     affiliate_id = request.COOKIES.get(settings.AFFILIATE_COOKIE_KEY)
     if affiliate_id:


### PR DESCRIPTION
Instead of creating two separate PR's I'm doing this in one with two separate commits. This PR contains:
- adding seats back only for single course coupons, because that seat is displayed in the details page
- a couple of fixes to the https://github.com/edx/ecommerce/commit/877e7b4ad3aa918645c5d4a14a8478447a23aca2 changes:
  - changes to the test, because the current one won't work for running tests with `DISABLE_MIGRATIONS`
  - changes to the `prepare_basket` logic, now if a product that is an enrollment code and a voucher are passed to that function, the voucher is not applied.

@mjfrey @mattdrayer 
(sorry for not finishing this yesterday, but I didn't have any more time to work on it)
