### PR TITLE
Change edx-django-release-util version.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ djangorestframework==3.2.3
 djangorestframework-jwt==1.8.0
 drf-extensions==0.2.8
 edx-auth-backends==0.5.0
-edx-django-release-util==0.0.3
+edx-django-release-util==0.1.0
 edx-django-sites-extensions==1.0.0
 edx-drf-extensions==1.0.0
 edx-ecommerce-worker==0.5.0


### PR DESCRIPTION
Change the required version of edx-django-release-util to 0.1.0.

@edx/pipeline-team  Please review and tag appropriate parties.
