### PR TITLE
Bump auth-backends to 0.5.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ django-waffle==0.11.1
 djangorestframework==3.2.3
 djangorestframework-jwt==1.8.0
 drf-extensions==0.2.8
-edx-auth-backends==0.5.0
+edx-auth-backends==0.5.1
 edx-django-release-util==0.1.0
 edx-django-sites-extensions==1.0.0
 edx-drf-extensions==1.0.0


### PR DESCRIPTION
Requires at least PSA 0.2.20, which includes an index on the Association model.

@clintonb @adampalay FYI. @jibsheet tagging you since you're familiar with the earlier truncation of this table, which we may want to do again before running the migration to add the index.
