### PR TITLE
Add a list of email domains to an offer for validation at redemption.

### DIFF
--- a/ecommerce/coupons/tests/mixins.py
+++ b/ecommerce/coupons/tests/mixins.py
@@ -106,7 +106,7 @@ class CouponMixin(object):
 
     def create_coupon(self, title='Test coupon', price=100, client=None, partner=None, catalog=None, code='',
                       benefit_value=100, note=None, max_uses=None, quantity=5, catalog_query=None,
-                      course_seat_types=None):
+                      course_seat_types=None, email_domains=None):
         """Helper method for creating a coupon.
 
         Arguments:
@@ -118,6 +118,7 @@ class CouponMixin(object):
             benefit_value(int): The voucher benefit value
             catalog_query(str): Course query string
             course_seat_types(str): A string of comma-separated list of seat types
+            email_domains(str): A comma seperated list of email domains
 
         Returns:
             coupon (Coupon)
@@ -146,6 +147,7 @@ class CouponMixin(object):
             'max_uses': max_uses,
             'catalog_query': catalog_query,
             'course_seat_types': course_seat_types,
+            'email_domains': email_domains,
         }
 
         coupon = CouponViewSet().create_coupon_product(

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -177,6 +177,9 @@ class CouponRedeemView(EdxOrderPlacementMixin, View):
         if not valid_voucher:
             return render(request, template_name, {'error': msg})
 
+        if not voucher.offers.first().is_email_valid(request.user.email):
+            return render(request, template_name, {'error': _('You are not eligible to use this coupon.')})
+
         if request.user.is_user_already_enrolled(request, product):
             return render(request, template_name, {'error': _('You are already enrolled in the course.')})
 

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -448,6 +448,7 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
     start_date = serializers.SerializerMethodField()
     voucher_type = serializers.SerializerMethodField()
     seats = serializers.SerializerMethodField()
+    email_domains = serializers.SerializerMethodField()
 
     def retrieve_benefit(self, obj):
         """Helper method to retrieve the benefit from voucher. """
@@ -533,6 +534,10 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
         offer = self.retrieve_offer(obj)
         return offer.num_applications
 
+    def get_email_domains(self, obj):
+        offer = self.retrieve_offer(obj)
+        return offer.email_domains
+
     def get_payment_information(self, obj):
         """
         Retrieve the payment information.
@@ -571,7 +576,7 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
             'categories', 'client', 'code', 'code_status', 'coupon_type',
             'course_seat_types', 'end_date', 'id', 'last_edited', 'max_uses',
             'note', 'num_uses', 'payment_information', 'price', 'quantity',
-            'start_date', 'title', 'voucher_type', 'seats'
+            'start_date', 'title', 'voucher_type', 'seats', 'email_domains'
         )
 
 

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -42,6 +42,7 @@ Voucher = get_model('voucher', 'Voucher')
 CATALOG_QUERY = 'catalog_query'
 CLIENT = 'client'
 COURSE_SEAT_TYPES = 'course_seat_types'
+EMAIL_DOMAINS = 'email_domains'
 INVOICE_DISCOUNT_TYPE = 'invoice_discount_type'
 INVOICE_DISCOUNT_VALUE = 'invoice_discount_value'
 INVOICE_NUMBER = 'invoice_number'
@@ -130,6 +131,7 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
             max_uses = request.data.get('max_uses')
             catalog_query = request.data.get(CATALOG_QUERY)
             course_seat_types = request.data.get(COURSE_SEAT_TYPES)
+            email_domains = request.data.get(EMAIL_DOMAINS)
 
             if code:
                 try:
@@ -191,7 +193,8 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
                 'note': note,
                 'max_uses': max_uses,
                 'catalog_query': catalog_query,
-                'course_seat_types': course_seat_types
+                'course_seat_types': course_seat_types,
+                'email_domains': email_domains
             }
 
             coupon_product = self.create_coupon_product(title, price, data)
@@ -226,6 +229,7 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
                 - max_uses (int)
                 - catalog_query (str)
                 - course_seat_types (str)
+                - email_domains (str)
 
         Returns:
             A coupon product object.
@@ -251,7 +255,8 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
             voucher_type=data['voucher_type'],
             max_uses=data['max_uses'],
             catalog_query=data['catalog_query'],
-            course_seat_types=data['course_seat_types']
+            course_seat_types=data['course_seat_types'],
+            email_domains=data['email_domains']
         )
 
         coupon_vouchers = CouponVouchers.objects.get(coupon=coupon_product)
@@ -380,6 +385,12 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
         if note is not None:
             coupon.attr.note = note
             coupon.save()
+
+        email_domains = request.data.get(EMAIL_DOMAINS)
+        # Need to update for individual vouchers because in case of multiple
+        # multi-use voucher each voucher will have individual offer.
+        for voucher in vouchers.all():
+            voucher.offers.update(email_domains=email_domains)
 
         self.update_invoice_data(coupon, request.data)
 

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -59,7 +59,7 @@ class EnrollmentFulfillmentModuleTests(CourseCatalogTestMixin, FulfillmentTestMi
 
         self.seat = self.course.create_or_update_seat(self.certificate_type, False, 100, self.partner, self.provider)
 
-        basket = BasketFactory()
+        basket = BasketFactory(owner=self.user)
         basket.add_product(self.seat, 1)
         self.order = factories.create_order(number=1, basket=basket, user=self.user)
 

--- a/ecommerce/extensions/offer/migrations/0005_conditionaloffer_email_domains.py
+++ b/ecommerce/extensions/offer/migrations/0005_conditionaloffer_email_domains.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('offer', '0004_auto_20160530_0944'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='conditionaloffer',
+            name='email_domains',
+            field=models.CharField(max_length=255, null=True, blank=True),
+        ),
+    ]

--- a/ecommerce/extensions/voucher/tests/test_utils.py
+++ b/ecommerce/extensions/voucher/tests/test_utils.py
@@ -153,6 +153,7 @@ class UtilTests(CouponMixin, CourseCatalogMockMixin, CourseCatalogTestMixin, Lms
         """
         Test voucher creation
         """
+        email_domains = 'edx.org,example.com'
         vouchers = create_vouchers(
             benefit_type=Benefit.PERCENTAGE,
             benefit_value=100.00,
@@ -162,7 +163,8 @@ class UtilTests(CouponMixin, CourseCatalogMockMixin, CourseCatalogTestMixin, Lms
             name="Tešt voučher",
             quantity=10,
             start_datetime=datetime.date(2015, 10, 1),
-            voucher_type=Voucher.SINGLE_USE
+            voucher_type=Voucher.SINGLE_USE,
+            email_domains=email_domains
         )
 
         self.assertEqual(len(vouchers), 10)
@@ -174,6 +176,7 @@ class UtilTests(CouponMixin, CourseCatalogMockMixin, CourseCatalogTestMixin, Lms
         self.assertEqual(voucher_offer.benefit.type, Benefit.PERCENTAGE)
         self.assertEqual(voucher_offer.benefit.value, 100.00)
         self.assertEqual(voucher_offer.benefit.range.catalog, self.catalog)
+        self.assertEqual(voucher_offer.email_domains, email_domains)
         self.assertEqual(len(coupon_voucher.vouchers.all()), 11)
         self.assertEqual(voucher.end_datetime, datetime.date(2015, 10, 30))
         self.assertEqual(voucher.start_datetime, datetime.date(2015, 10, 1))
@@ -356,6 +359,7 @@ class UtilTests(CouponMixin, CourseCatalogMockMixin, CourseCatalogTestMixin, Lms
             'Create Date',
             'Coupon Start Date',
             'Coupon Expiry Date',
+            'Email Domains',
         ])
 
         voucher = Voucher.objects.get(name=rows[0]['Coupon Name'])
@@ -517,6 +521,7 @@ class UtilTests(CouponMixin, CourseCatalogMockMixin, CourseCatalogTestMixin, Lms
         self.assertEqual(rows[-1]['Redeemed For Course ID'], self.course.id)
 
     def test_update_voucher_offer(self):
+        """Test updating a voucher."""
         vouchers = create_vouchers(
             benefit_type=Benefit.PERCENTAGE,
             benefit_value=100.00,
@@ -526,7 +531,8 @@ class UtilTests(CouponMixin, CourseCatalogMockMixin, CourseCatalogTestMixin, Lms
             name="Test voucher",
             quantity=10,
             start_datetime=datetime.date(2015, 10, 1),
-            voucher_type=Voucher.SINGLE_USE
+            voucher_type=Voucher.SINGLE_USE,
+            email_domains='example.com'
         )
 
         voucher = vouchers[0]
@@ -535,7 +541,12 @@ class UtilTests(CouponMixin, CourseCatalogMockMixin, CourseCatalogTestMixin, Lms
         self.assertEqual(voucher_offer.benefit.value, 100.00)
         self.assertEqual(voucher_offer.benefit.range.catalog, self.catalog)
 
-        new_offer = update_voucher_offer(voucher_offer, 50.00, Benefit.PERCENTAGE, self.coupon)
+        new_email_domains = 'example.org'
+        new_offer = update_voucher_offer(
+            voucher_offer, 50.00, Benefit.PERCENTAGE,
+            self.coupon, email_domains=new_email_domains
+        )
         self.assertEqual(new_offer.benefit.type, Benefit.PERCENTAGE)
         self.assertEqual(new_offer.benefit.value, 50.00)
         self.assertEqual(new_offer.benefit.range.catalog, self.catalog)
+        self.assertEqual(new_offer.email_domains, new_email_domains)

--- a/ecommerce/static/js/models/coupon_model.js
+++ b/ecommerce/static/js/models/coupon_model.js
@@ -107,6 +107,7 @@ define([
                         return Backbone.Validation.messages.seat_types;
                     }
                 },
+                email_domains: {required: false},
                 start_date: function (val) {
                     var startDate,
                         endDate;

--- a/ecommerce/static/js/views/coupon_detail_view.js
+++ b/ecommerce/static/js/views/coupon_detail_view.js
@@ -56,7 +56,7 @@ define([
                     invoice_discount_type = this.model.get('invoice_discount_type'),
                     invoice_discount_value = this.model.get('invoice_discount_value'),
                     tax_deducted_source = this.model.get('tax_deducted_source');
-                
+
                 if (invoice_discount_value === null) {
                     invoice_discount_type = null;
                 } else  {
@@ -107,6 +107,7 @@ define([
                 var html,
                     category = this.model.get('categories')[0].name,
                     invoice_data = this.formatInvoiceData(),
+                    emailDomains = this.model.get('email_domains'),
                     template_data,
                     price = null;
 
@@ -123,7 +124,8 @@ define([
                     lastEdited: this.formatLastEditedData(this.model.get('last_edited')),
                     price: price,
                     startDateTime: this.formatDateTime(this.model.get('start_date')),
-                    usage: this.usageLimitation()
+                    usage: this.usageLimitation(),
+                    emailDomains: emailDomains
                 };
 
                 $.extend(template_data, invoice_data);

--- a/ecommerce/static/js/views/coupon_form_view.js
+++ b/ecommerce/static/js/views/coupon_form_view.js
@@ -161,6 +161,9 @@ define([
                 'input[name=course_seat_types]': {
                     observe: 'course_seat_types'
                 },
+                'input[name=email_domains]': {
+                    observe: 'email_domains'
+                },
                 'input[name=invoice_type]': {
                     observe: 'invoice_type'
                 },
@@ -248,6 +251,7 @@ define([
                         'start_date',
                         'tax_deducted_source',
                         'title',
+                        'email_domains'
                     ];
                 }
 

--- a/ecommerce/static/templates/coupon_detail.html
+++ b/ecommerce/static/templates/coupon_detail.html
@@ -65,6 +65,12 @@
             <div class="catalog_buttons"></div>
         </div>
         <%}%>
+        <% if(emailDomains) {%>
+        <div class="info-item grid-item email-domains">
+            <div class="heading"><%= gettext('Email Domains:') %></div>
+            <div class="value"><%= emailDomains %></div>
+        </div>
+        <%}%>
         <div class="info-item grid-item usage-limitations">
             <div class="heading"><%= gettext('Usage Limitations:') %></div>
             <div class="value"><%= usage %></div>

--- a/ecommerce/static/templates/coupon_form.html
+++ b/ecommerce/static/templates/coupon_form.html
@@ -81,7 +81,6 @@
             <input id="client" type="text" class="form-control" name="client" maxlength="50">
             <p class="help-block"></p>
         </div>
- 
         <hr>
 
         <div class="form-group">
@@ -146,7 +145,7 @@
             <div class="form-inline tax-deduction">
                 <input id="tax-deducted" type="radio" name="tax_deduction" value="Yes">
                 <label for="tax-deducted" class="normal-font-weight"><%= gettext('Yes') %></label>
-                <input id="non-tax-deducted" type="radio" name="tax_deduction" value="No" checked> 
+                <input id="non-tax-deducted" type="radio" name="tax_deduction" value="No" checked>
                 <label for="non-tax-deducted" class="normal-font-weight"><%= gettext('No') %></label>
             </div>
         </div>
@@ -195,6 +194,11 @@
                 <p class="help-block"></p>
             </div>
             <div class="catalog_buttons"></div>
+        </div>
+        <div class="form-group email-domains">
+            <label for="email-domains"><%= gettext('Email domains:') %> </label>
+            <input id="email-domains" class="form-control" name="email_domains" maxlength="255">
+            <p class="help-block"></p>
         </div>
         <div class="form-group">
             <label for="note"><%= gettext('Note') %></label>


### PR DESCRIPTION
This PR introduces a new way of restricting coupons by email domains of users. A new input field is added in the coupon creation form:
![screenshot from 2016-08-12 15-19-25](https://cloud.githubusercontent.com/assets/2808092/17623420/38d38242-60a0-11e6-82cb-01b8207cf28f.png)

`ConditionalOffer` model has been extended to add the `email_domain` character field, and to extend the `is_condition_satisfied` method to check if the basket owners email domain is in the email domain list for the offer. This is usually done by proxying the `Condition` model and extending its `is_satisfied` method, but, for some reason, the proxy needs to be unique: https://github.com/django-oscar/django-oscar/blob/1.1.1/src/oscar/apps/offer/abstract_models.py#L640-L641 and we can't have a unique proxy because every condition is different for coupons (different range or products.) Therefor I decided on doing it this way.

https://openedx.atlassian.net/browse/SOL-1967
