### PR TITLE
[SOL-2033] Change voucher list to raw ID list in basket details admin page.

### DIFF
--- a/ecommerce/extensions/basket/admin.py
+++ b/ecommerce/extensions/basket/admin.py
@@ -19,6 +19,7 @@ class PaymentProcessorResponseInline(admin.TabularInline):
 
 @admin.register(Basket)
 class BasketAdminExtended(BasketAdmin):
+    raw_id_fields = ('vouchers', )
     inlines = (LineInline, PaymentProcessorResponseInline,)
     show_full_result_count = False
 


### PR DESCRIPTION
The basket details page in Django admin was displaying all the vouchers in a list, where the selected one meant it was the one applied, which caused a large load-time because of the large number of vouchers.
The code in this PR changes the `vouchers` field to a `raw_id_field`, changing the list of all vouchers to a list of ID's of only the applied vouchers effectively speeding up the load.

https://openedx.atlassian.net/browse/SOL-2033
@clintonb (thanks for tip)
