### PR TITLE
[SOL-2004] Display seats instead of courses in catalog preview API endpoint.

### DIFF
--- a/ecommerce/static/js/test/specs/views/dynamic_catalog_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/dynamic_catalog_view_spec.js
@@ -1,12 +1,14 @@
 define([
         'jquery',
         'underscore',
+        'underscore.string',
         'collections/course_collection',
         'models/course_model',
         'views/dynamic_catalog_view'
     ],
     function ($,
               _,
+              _s,
               Courses,
               Course,
               DynamicCatalogView) {
@@ -32,17 +34,25 @@ define([
             });
 
             it('should format row data for dynamic catalog preview', function () {
-                var course = {
-                    'id': 'a/b/c',
-                    'name': 'ABC Course',
-                    'type': 'verified'
+                var course_key = 'a/b/c',
+                    certificate_type = 'verified',
+                    seat = {
+                    'title': 'Seat in ABC Course',
+                    'attribute_values': [{
+                        'name': 'course_key',
+                        'value': course_key
+                    }, {
+                        'name': 'certificate_type',
+                        'value': certificate_type
+                    }
+                    ]
                 },
-                row_data = view.getRowData(course);
+                row_data = view.getRowData(seat);
 
                 expect(row_data).toEqual({
-                    'id': course.id,
-                    'name': course.name,
-                    'type': 'Verified'
+                    'id': course_key,
+                    'name': seat.title,
+                    'type': _s(certificate_type).capitalize().value()
                 });
             });
 
@@ -73,8 +83,8 @@ define([
                         sTitle: 'Course ID', mData: 'id'
                     },
                     {
-                        title: 'Course name', data: 'name',
-                        sTitle: 'Course name', mData: 'name',
+                        title: 'Seat title', data: 'name',
+                        sTitle: 'Seat title', mData: 'name',
                     },
                     {
                         title: 'Seat type', data: 'type',
@@ -95,25 +105,37 @@ define([
             it('should fill datatable on successful AJAX call to Course Catalog API', function () {
                 var API_data = {
                     'next': 'test.link',
-                    'courses': [{
-                            id: 'a/b/c',
-                            name: 'Test course 1',
-                            type: 'verified'
+                    'seats': [{
+                        'title': 'Seat in ABC Course',
+                        'attribute_values': [{
+                            'name': 'course_key',
+                            'value': 'a/b/c'
                         }, {
-                            id: 'd/e/f',
-                            name: 'Test course 2',
-                            type: 'professional'
+                            'name': 'certificate_type',
+                            'value': 'verified'
+                        }
+                        ]
+                    },{
+                        'title': 'Seat in DEF Course',
+                        'attribute_values': [{
+                            'name': 'course_key',
+                            'value': 'd/e/f'
+                        }, {
+                            'name': 'certificate_type',
+                            'value': 'professional'
+                        }
+                        ]
                     }]
                 };
                 view.previewCatalog($.Event('click'));
-                this.table = view.$('#coursesTable').DataTable();
+                this.table = view.$('#seatsTable').DataTable();
                 _.bind(view.onSuccess, this);
                 spyOn(window, 'setTimeout');
 
                 view.onSuccess(API_data);
                 expect(window.setTimeout).toHaveBeenCalled();
-                expect(this.table.row(0).data()).toEqual(view.getRowData(API_data.courses[0]));
-                expect(this.table.row(1).data()).toEqual(view.getRowData(API_data.courses[1]));
+                expect(this.table.row(0).data()).toEqual(view.getRowData(API_data.seats[0]));
+                expect(this.table.row(1).data()).toEqual(view.getRowData(API_data.seats[1]));
             });
 
             it('should call stopEventPropagation when disabled or active button pressed', function () {

--- a/ecommerce/static/js/views/dynamic_catalog_view.js
+++ b/ecommerce/static/js/views/dynamic_catalog_view.js
@@ -29,11 +29,21 @@ define(['jquery',
                 event.stopPropagation();
             },
 
-            getRowData: function (course) {
+            getRowData: function (seat) {
+                var course_key_attr = _.find(seat.attribute_values, function(attr) {
+                    if (attr.name === 'course_key'){
+                        return attr;
+                    }
+                });
+                var certificate_type = _.find(seat.attribute_values, function(attr) {
+                    if (attr.name === 'certificate_type'){
+                        return attr;
+                    }
+                });
                 return {
-                    id: course.id,
-                    name: course.name,
-                    type: _s(course.type).capitalize().value()
+                    id: course_key_attr.value,
+                    name: seat.title,
+                    type: _s(certificate_type.value).capitalize().value()
                 };
             },
 
@@ -41,10 +51,10 @@ define(['jquery',
                 this.limit = 10;
                 this.offset = 0;
                 event.preventDefault();
-                if (!$.fn.dataTable.isDataTable('#coursesTable') || 
+                if (!$.fn.dataTable.isDataTable('#seatsTable') ||
                     (this.used_query !== this.query || this.used_seat_types !== this.seat_types)
                 ) {
-                    this.table = this.$('#coursesTable').DataTable({
+                    this.table = this.$('#seatsTable').DataTable({
                         autoWidth: false,
                         destroy: true,
                         info: true,
@@ -57,7 +67,7 @@ define(['jquery',
                                 data: 'id'
                             },
                             {
-                                title: gettext('Course name'),
+                                title: gettext('Seat title'),
                                 data: 'name'
                             },
                             {
@@ -88,7 +98,7 @@ define(['jquery',
             },
 
             onSuccess: function(data) {
-                var tableData = data.courses.map(this.getRowData, this);
+                var tableData = data.seats.map(this.getRowData, this);
                 this.table.rows.add(tableData).draw();
                 if (data.next) {
                     this.offset += this.limit;

--- a/ecommerce/static/templates/dynamic_catalog_buttons.html
+++ b/ecommerce/static/templates/dynamic_catalog_buttons.html
@@ -10,7 +10,7 @@
             <h4 class="modal-title" id="catalogModalLabel"><%= gettext('Catalog Details') %></h4>
           </div>
           <div class="modal-body">
-            <table id="coursesTable" class="copy copy-base table table-striped table-bordered" cellspacing="0">
+            <table id="seatsTable" class="copy copy-base table table-striped table-bordered" cellspacing="0">
             </table>
           </div>
       </div>


### PR DESCRIPTION
The dynamic catalog preview in the coupon form would display courses instead of seats which means that it would not display a credit course which has a verified seat so there would be a discrepancy between the seats displayed in the offer landing page (with the verified seat from credit course) and the preview window (without that seat).
This PR contains code that changes the preview to show those seats instead of courses.

https://openedx.atlassian.net/browse/SOL-2004
_Yet again don't mind the name of the branch_
