### PR TITLE
[SOL-2038] Add a check if email_domains are in coupon update data before updating it

### DIFF
--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -360,11 +360,12 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
             coupon.attr.note = note
             coupon.save()
 
-        email_domains = request.data.get('email_domains')
-        # Need to update for individual vouchers because in case of multiple
-        # multi-use voucher each voucher will have individual offer.
-        for voucher in vouchers.all():
-            voucher.offers.update(email_domains=email_domains)
+        if 'email_domains' in request.data:
+            email_domains = request.data.get('email_domains')
+            # Need to update for individual vouchers because in case of multiple
+            # multi-use voucher each voucher will have individual offer.
+            for voucher in vouchers.all():
+                voucher.offers.update(email_domains=email_domains)
 
         self.update_invoice_data(coupon, request.data)
 


### PR DESCRIPTION
Email domains would get deleted if they are not altered during an update because Backbone would not send email domains as a parameter in the update.
This PR contains code that checks if the email domains are in the update request parameters before updating them.

https://openedx.atlassian.net/browse/SOL-2038
@mjfrey @marjev please review.
