### PR TITLE
Refactor create coupon

### DIFF
--- a/ecommerce/coupons/tests/mixins.py
+++ b/ecommerce/coupons/tests/mixins.py
@@ -8,6 +8,7 @@ from django.test import RequestFactory
 from oscar.test import factories
 
 from ecommerce.core.models import BusinessClient
+from ecommerce.extensions.catalogue.utils import create_coupon_product
 from ecommerce.extensions.api.v2.views.coupons import CouponViewSet
 from ecommerce.extensions.basket.utils import prepare_basket
 from ecommerce.tests.factories import PartnerFactory
@@ -161,28 +162,25 @@ class CouponMixin(object):
             catalog = Catalog.objects.create(partner=partner)
         if code is not '':
             quantity = 1
-        data = {
-            'partner': partner,
-            'benefit_type': benefit_type,
-            'benefit_value': benefit_value,
-            'catalog': catalog,
-            'end_datetime': datetime.date(2020, 1, 1),
-            'code': code,
-            'quantity': quantity,
-            'start_datetime': datetime.date(2015, 1, 1),
-            'voucher_type': voucher_type,
-            'categories': [self.category],
-            'note': note,
-            'max_uses': max_uses,
-            'catalog_query': catalog_query,
-            'course_seat_types': course_seat_types,
-            'email_domains': email_domains,
-        }
 
-        coupon = CouponViewSet().create_coupon_product(
-            title=title,
+        coupon = create_coupon_product(
+            benefit_type=benefit_type,
+            benefit_value=benefit_value,
+            catalog=catalog,
+            catalog_query=catalog_query,
+            category=self.category,
+            code=code,
+            course_seat_types=course_seat_types,
+            email_domains=email_domains,
+            end_datetime=datetime.date(2020, 1, 1),
+            max_uses=max_uses,
+            note=note,
+            partner=partner,
             price=price,
-            data=data
+            quantity=quantity,
+            start_datetime=datetime.date(2015, 1, 1),
+            title=title,
+            voucher_type=voucher_type
         )
 
         request = RequestFactory()

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -32,6 +32,7 @@ Order = get_model('order', 'Order')
 Product = get_model('catalogue', 'Product')
 Partner = get_model('partner', 'Partner')
 ProductAttributeValue = get_model('catalogue', 'ProductAttributeValue')
+ProductCategory = get_model('catalogue', 'ProductCategory')
 Refund = get_model('refund', 'Refund')
 Selector = get_class('partner.strategy', 'Selector')
 StockRecord = get_model('partner', 'StockRecord')
@@ -419,6 +420,7 @@ class CategorySerializer(serializers.ModelSerializer):
 
     class Meta(object):
         model = Category
+        fields = ('id', 'name',)
 
 
 class CouponListSerializer(serializers.ModelSerializer):
@@ -431,12 +433,12 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
     """ Serializer for Coupons. """
     benefit_type = serializers.SerializerMethodField()
     benefit_value = serializers.SerializerMethodField()
-    coupon_type = serializers.SerializerMethodField()
     catalog_query = serializers.SerializerMethodField()
-    categories = CategorySerializer(many=True, read_only=True)
+    category = serializers.SerializerMethodField()
     client = serializers.SerializerMethodField()
     code = serializers.SerializerMethodField()
     code_status = serializers.SerializerMethodField()
+    coupon_type = serializers.SerializerMethodField()
     course_seat_types = serializers.SerializerMethodField()
     end_date = serializers.SerializerMethodField()
     last_edited = serializers.SerializerMethodField()
@@ -569,14 +571,18 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
         else:
             return None
 
+    def get_category(self, obj):
+        category = ProductCategory.objects.filter(product=obj).first().category
+        return CategorySerializer(category).data
+
     class Meta(object):
         model = Product
         fields = (
-            'benefit_type', 'benefit_value', 'catalog_query',
-            'categories', 'client', 'code', 'code_status', 'coupon_type',
-            'course_seat_types', 'end_date', 'id', 'last_edited', 'max_uses',
+            'benefit_type', 'benefit_value', 'catalog_query', 'category',
+            'client', 'code', 'code_status', 'coupon_type', 'course_seat_types',
+            'email_domains', 'end_date', 'id', 'last_edited', 'max_uses',
             'note', 'num_uses', 'payment_information', 'price', 'quantity',
-            'start_date', 'title', 'voucher_type', 'seats', 'email_domains'
+            'seats', 'start_date', 'title', 'voucher_type'
         )
 
 

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 import logging
-from decimal import Decimal
 
 import dateutil.parser
 from django.conf import settings
@@ -19,11 +18,11 @@ from ecommerce.extensions.api import data as data_api
 from ecommerce.extensions.api.filters import ProductFilter
 from ecommerce.extensions.api.serializers import CategorySerializer, CouponSerializer, CouponListSerializer
 from ecommerce.extensions.basket.utils import prepare_basket
-from ecommerce.extensions.catalogue.utils import generate_sku, get_or_create_catalog
+from ecommerce.extensions.catalogue.utils import create_coupon_product, get_or_create_catalog
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
 from ecommerce.extensions.payment.processors.invoice import InvoicePayment
 from ecommerce.extensions.voucher.models import CouponVouchers
-from ecommerce.extensions.voucher.utils import create_vouchers, update_voucher_offer
+from ecommerce.extensions.voucher.utils import update_voucher_offer
 from ecommerce.invoice.models import Invoice
 
 Basket = get_model('basket', 'Basket')
@@ -73,25 +72,26 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
             500 if an error occurs when attempting to create a coupon.
         """
         with transaction.atomic():
-            title = request.data.get('title')
-            client_username = request.data.get('client')
-            stock_record_ids = request.data.get('stock_record_ids')
-            start_datetime = dateutil.parser.parse(request.data.get('start_datetime'))
-            end_datetime = dateutil.parser.parse(request.data.get('end_datetime'))
-            code = request.data.get('code')
             benefit_type = request.data.get('benefit_type')
             benefit_value = request.data.get('benefit_value')
-            voucher_type = request.data.get('voucher_type')
-            quantity = request.data.get('quantity')
-            price = request.data.get('price')
-            partner = request.site.siteconfiguration.partner
-            categories = Category.objects.filter(id__in=request.data.get('category_ids'))
-            client, __ = BusinessClient.objects.get_or_create(name=client_username)
-            note = request.data.get('note')
-            max_uses = request.data.get('max_uses')
             catalog_query = request.data.get('catalog_query')
+            category_data = request.data.get('category')
+            client_username = request.data.get('client')
+            code = request.data.get('code')
             course_seat_types = request.data.get('course_seat_types')
             email_domains = request.data.get('email_domains')
+            end_datetime = dateutil.parser.parse(request.data.get('end_datetime'))
+            max_uses = request.data.get('max_uses')
+            note = request.data.get('note')
+            partner = request.site.siteconfiguration.partner
+            price = request.data.get('price')
+            quantity = request.data.get('quantity')
+            start_datetime = dateutil.parser.parse(request.data.get('start_datetime'))
+            stock_record_ids = request.data.get('stock_record_ids')
+            title = request.data.get('title')
+            voucher_type = request.data.get('voucher_type')
+
+            client, __ = BusinessClient.objects.get_or_create(name=client_username)
 
             if code:
                 try:
@@ -107,6 +107,16 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
 
             if course_seat_types:
                 course_seat_types = prepare_course_seat_types(course_seat_types)
+
+            try:
+                category = Category.objects.get(name=category_data['name'])
+            except Category.DoesNotExist:
+                return Response(
+                    'Category {category_name} not found.'.format(category_name=category_data['name']),
+                    status=status.HTTP_404_NOT_FOUND
+                )
+            except KeyError:
+                return Response('Invalid Coupon Category data.', status=status.HTTP_400_BAD_REQUEST)
 
             # Maximum number of uses can be set for each voucher type and disturb
             # the predefined behaviours of the different voucher types. Therefor
@@ -138,25 +148,25 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
             else:
                 coupon_catalog = None
 
-            data = {
-                'benefit_type': benefit_type,
-                'benefit_value': benefit_value,
-                'catalog': coupon_catalog,
-                'catalog_query': catalog_query,
-                'categories': categories,
-                'code': code,
-                'course_seat_types': course_seat_types,
-                'email_domains': email_domains,
-                'end_datetime': end_datetime,
-                'max_uses': max_uses,
-                'note': note,
-                'partner': partner,
-                'quantity': quantity,
-                'start_datetime': start_datetime,
-                'voucher_type': voucher_type
-            }
-
-            coupon_product = self.create_coupon_product(title, price, data)
+            coupon_product = create_coupon_product(
+                benefit_type=benefit_type,
+                benefit_value=benefit_value,
+                catalog=coupon_catalog,
+                catalog_query=catalog_query,
+                category=category,
+                code=code,
+                course_seat_types=course_seat_types,
+                email_domains=email_domains,
+                end_datetime=end_datetime,
+                max_uses=max_uses,
+                note=note,
+                partner=partner,
+                price=price,
+                quantity=quantity,
+                start_datetime=start_datetime,
+                title=title,
+                voucher_type=voucher_type
+            )
 
             basket = prepare_basket(request, coupon_product)
 
@@ -166,87 +176,6 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
             )
 
             return Response(response_data, status=status.HTTP_200_OK)
-
-    def create_coupon_product(self, title, price, data):
-        """Creates a coupon product and a stock record for it.
-
-        Arguments:
-            title (str): The name of the coupon.
-            price (int): The price of the coupon(s).
-            data (dict): Contains data needed to create vouchers,SKU and UPC:
-                - partner (User)
-                - benefit_type (str)
-                - benefit_value (int)
-                - catalog (Catalog)
-                - end_date (Datetime)
-                - code (str)
-                - quantity (int)
-                - start_date (Datetime)
-                - voucher_type (str)
-                - categories (list of Category objects)
-                - note (str)
-                - max_uses (int)
-                - catalog_query (str)
-                - course_seat_types (str)
-                - email_domains (str)
-
-        Returns:
-            A coupon product object.
-        """
-
-        product_class = ProductClass.objects.get(slug='coupon')
-        coupon_product = Product.objects.create(title=title, product_class=product_class)
-
-        self.assign_categories_to_coupon(coupon=coupon_product, categories=data['categories'])
-
-        # Vouchers are created during order and not fulfillment like usual
-        # because we want vouchers to be part of the line in the order.
-        create_vouchers(
-            name=title,
-            benefit_type=data['benefit_type'],
-            benefit_value=Decimal(data['benefit_value']),
-            catalog=data['catalog'],
-            coupon=coupon_product,
-            end_datetime=data['end_datetime'],
-            code=data['code'] or None,
-            quantity=int(data['quantity']),
-            start_datetime=data['start_datetime'],
-            voucher_type=data['voucher_type'],
-            max_uses=data['max_uses'],
-            catalog_query=data['catalog_query'],
-            course_seat_types=data['course_seat_types'],
-            email_domains=data['email_domains']
-        )
-
-        coupon_vouchers = CouponVouchers.objects.get(coupon=coupon_product)
-
-        coupon_product.attr.coupon_vouchers = coupon_vouchers
-        coupon_product.attr.note = data['note']
-        coupon_product.save()
-
-        sku = generate_sku(product=coupon_product, partner=data['partner'])
-        StockRecord.objects.update_or_create(
-            product=coupon_product,
-            partner=data['partner'],
-            partner_sku=sku,
-            defaults={
-                'price_currency': 'USD',
-                'price_excl_tax': price
-            }
-        )
-
-        return coupon_product
-
-    def assign_categories_to_coupon(self, coupon, categories):
-        """
-        Assigns categories to a coupon.
-
-        Arguments:
-            coupon (Product): Coupon product
-            categories (list): List of Category instances
-        """
-        for category in categories:
-            ProductCategory.objects.get_or_create(product=coupon, category=category)
 
     def create_order_for_invoice(self, basket, coupon_id, client, invoice_data=None, request=None):
         """Creates an order from the basket and invokes the invoice payment processor."""
@@ -312,9 +241,10 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
         if benefit_value:
             self.update_coupon_benefit_value(benefit_value=benefit_value, vouchers=vouchers, coupon=coupon)
 
-        category_ids = request.data.get('category_ids')
-        if category_ids:
-            self.update_coupon_category(category_ids=category_ids, coupon=coupon)
+        category_data = request.data.get('category')
+        if category_data:
+            category = Category.objects.get(name=category_data['name'])
+            ProductCategory.objects.filter(product=coupon).update(category=category)
 
         client_username = request.data.get('client')
         if client_username:
@@ -382,19 +312,6 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
         for voucher in vouchers.all():
             voucher.offers.clear()
             voucher.offers.add(new_offer)
-
-    def update_coupon_category(self, category_ids, coupon):
-        """
-        Remove categories currently assigned to a coupon and assigned new categories
-        Arguments:
-            category_ids (list): List of category IDs
-            coupon (Product): Coupon product to be updated
-        """
-        new_categories = Category.objects.filter(id__in=category_ids)
-
-        ProductCategory.objects.filter(product=coupon).exclude(category__in=new_categories).delete()
-
-        self.assign_categories_to_coupon(coupon=coupon, categories=new_categories)
 
     def update_coupon_client(self, baskets, client_username):
         """

--- a/ecommerce/extensions/catalogue/tests/test_utils.py
+++ b/ecommerce/extensions/catalogue/tests/test_utils.py
@@ -1,12 +1,14 @@
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 from hashlib import md5
 
+from django.db.utils import IntegrityError
 from oscar.core.loading import get_model
 
 from ecommerce.coupons.tests.mixins import CouponMixin
 from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
-from ecommerce.extensions.catalogue.utils import generate_sku, get_or_create_catalog
+from ecommerce.extensions.catalogue.utils import create_coupon_product, generate_sku, get_or_create_catalog
 from ecommerce.tests.factories import ProductFactory
 from ecommerce.tests.testcases import TestCase
 
@@ -102,3 +104,72 @@ class CouponUtilsTests(CouponMixin, CourseCatalogTestMixin, TestCase):
         expected = digest.upper()
         actual = generate_sku(coupon, self.partner)
         self.assertEqual(actual, expected)
+
+
+class CouponCreationTests(CouponMixin, TestCase):
+    def setUp(self):
+        super(CouponCreationTests, self).setUp()
+        self.catalog = Catalog.objects.create(partner=self.partner)
+
+    def create_custom_coupon(self, code='', max_uses=None, note=None, quantity=1, title='Tešt Čoupon'):
+        """Create a custom test coupon product."""
+
+        return create_coupon_product(
+            benefit_type=Benefit.PERCENTAGE,
+            benefit_value=100,
+            catalog=self.catalog,
+            catalog_query=None,
+            category=self.category,
+            code=code,
+            course_seat_types=None,
+            email_domains=None,
+            end_datetime='2020-1-1',
+            max_uses=max_uses,
+            note=note,
+            partner=self.partner,
+            price=100,
+            quantity=quantity,
+            start_datetime='2015-1-1',
+            title=title,
+            voucher_type=Voucher.ONCE_PER_CUSTOMER,
+        )
+
+    def test_custom_code_integrity_error(self):
+        """Test custom coupon code duplication."""
+        self.create_custom_coupon(
+            code='CUSTOMCODE',
+            title='Custom coupon',
+        )
+
+        with self.assertRaises(IntegrityError):
+            self.create_custom_coupon(
+                code='CUSTOMCODE',
+                title='Coupon with integrity issue',
+            )
+
+    def test_coupon_note(self):
+        """Test creating a coupon with a note."""
+        note_coupon = self.create_custom_coupon(
+            note='𝑵𝑶𝑻𝑬',
+            title='Coupon',
+        )
+        self.assertEqual(note_coupon.attr.note, '𝑵𝑶𝑻𝑬')
+        self.assertEqual(note_coupon.title, 'Coupon')
+
+    def test_custom_code_string(self):
+        """Test creating a coupon with custom voucher code."""
+        custom_code = 'ČUSTOMĆODE'
+        custom_coupon = self.create_custom_coupon(
+            code=custom_code,
+            quantity=1,
+            title='Custom coupon',
+        )
+        self.assertEqual(custom_coupon.attr.coupon_vouchers.vouchers.count(), 1)
+        self.assertEqual(custom_coupon.attr.coupon_vouchers.vouchers.first().code, custom_code)
+
+    def test_multi_use_coupon_creation(self):
+        """Test that the endpoint supports the creation of multi-usage coupons."""
+        max_uses_number = 2
+        coupon = self.create_custom_coupon(max_uses=max_uses_number)
+        voucher = coupon.attr.coupon_vouchers.vouchers.first()
+        self.assertEqual(voucher.offers.first().max_global_applications, max_uses_number)

--- a/ecommerce/extensions/catalogue/utils.py
+++ b/ecommerce/extensions/catalogue/utils.py
@@ -1,12 +1,22 @@
 from __future__ import unicode_literals
 
+from decimal import Decimal
 from hashlib import md5
+import logging
 
+from django.conf import settings
+from django.db.utils import IntegrityError
 from oscar.core.loading import get_model
 
 from ecommerce.core.constants import ENROLLMENT_CODE_PRODUCT_CLASS_NAME, SEAT_PRODUCT_CLASS_NAME
+from ecommerce.extensions.voucher.models import CouponVouchers
+from ecommerce.extensions.voucher.utils import create_vouchers
 
 Catalog = get_model('catalogue', 'Catalog')
+logger = logging.getLogger(__name__)
+Product = get_model('catalogue', 'Product')
+ProductCategory = get_model('catalogue', 'ProductCategory')
+ProductClass = get_model('catalogue', 'ProductClass')
 StockRecord = get_model('partner', 'StockRecord')
 
 
@@ -66,3 +76,98 @@ def get_or_create_catalog(name, partner, stock_record_ids):
     for stock_record in stock_records:
         catalog.stock_records.add(stock_record)
     return catalog, True
+
+
+def create_coupon_product(
+        benefit_type,
+        benefit_value,
+        catalog,
+        catalog_query,
+        category,
+        code,
+        course_seat_types,
+        email_domains,
+        end_datetime,
+        max_uses,
+        note,
+        partner,
+        price,
+        quantity,
+        start_datetime,
+        title,
+        voucher_type
+):
+    """
+    Creates a coupon product and a stock record for it.
+
+    Arguments:
+        benefit_type (str): Voucher Benefit type.
+        benefit_value (int): Voucher Benefit value.
+        catalog (Catalog): Catalog used to create a range of products.
+        catalog_query (str): ElasticSearch query used by dynamic coupons.
+        category (dict): Contains category ID and name.
+        code (str): Voucher code.
+        course_seat_types (str): Comma-separated list of course seat types.
+        email_domains (str): Comma-separated list of email domains.
+        end_datetime (Datetime): Voucher end Datetime.
+        max_uses (int): Number of Voucher max uses.
+        note (str): Coupon note.
+        partner (User): Partner associated with coupon Stock Record.
+        price (int): The price of the coupon.
+        quantity (int): Number of vouchers to be created and associated with the coupon.
+        start_datetime (Datetime): Voucher start Datetime.
+        title (str): The name of the coupon.
+        voucher_type (str): Voucher type
+
+    Returns:
+        A coupon Product object.
+
+    Raises:
+        IntegrityError: An error occured when create_vouchers method returns
+                        an IntegrityError exception
+    """
+    product_class = ProductClass.objects.get(slug='coupon')
+    coupon_product = Product.objects.create(title=title, product_class=product_class)
+    ProductCategory.objects.get_or_create(product=coupon_product, category=category)
+
+    # Vouchers are created during order and not fulfillment like usual
+    # because we want vouchers to be part of the line in the order.
+
+    try:
+        create_vouchers(
+            benefit_type=benefit_type,
+            benefit_value=Decimal(benefit_value),
+            catalog=catalog,
+            catalog_query=catalog_query,
+            code=code or None,
+            coupon=coupon_product,
+            course_seat_types=course_seat_types,
+            email_domains=email_domains,
+            end_datetime=end_datetime,
+            max_uses=max_uses,
+            name=title,
+            quantity=int(quantity),
+            start_datetime=start_datetime,
+            voucher_type=voucher_type
+        )
+    except IntegrityError:
+        logger.exception('Failed to create vouchers for [%s] coupon.', coupon_product.title)
+        raise
+
+    coupon_vouchers = CouponVouchers.objects.get(coupon=coupon_product)
+    coupon_product.attr.coupon_vouchers = coupon_vouchers
+    coupon_product.attr.note = note
+    coupon_product.save()
+
+    sku = generate_sku(product=coupon_product, partner=partner)
+    StockRecord.objects.update_or_create(
+        defaults={
+            'price_currency': settings.OSCAR_DEFAULT_CURRENCY,
+            'price_excl_tax': price
+        },
+        partner=partner,
+        partner_sku=sku,
+        product=coupon_product
+    )
+
+    return coupon_product

--- a/ecommerce/static/js/models/coupon_model.js
+++ b/ecommerce/static/js/models/coupon_model.js
@@ -32,16 +32,17 @@ define([
             urlRoot: '/api/v2/coupons/',
 
             defaults: {
-                id: null,
-                quantity: 1,
-                stock_record_ids: [],
+                category: {id: 3, name: 'Affiliate Promotion'},
                 code: '',
-                price: 0,
-                total_value: 0,
-                max_uses: 1,
-                seats: [],
                 course_seats: [],
-                course_seat_types: []
+                course_seat_types: [],
+                id: null,
+                max_uses: 1,
+                price: 0,
+                quantity: 1,
+                seats: [],
+                stock_record_ids: [],
+                total_value: 0,
             },
 
             validation: {
@@ -141,7 +142,6 @@ define([
             },
 
             initialize: function () {
-                this.on('change:categories', this.updateCategory, this);
                 this.on('change:voucher_type', this.changeVoucherType, this);
                 this.on('change:seats', this.updateSeatData);
                 this.on('change:quantity', this.updateTotalValue(this.getSeatPrice));
@@ -178,12 +178,6 @@ define([
             getCourseID: function(seat_data) {
                 var course_id = _.findWhere(seat_data, {'name': 'course_key'});
                 return course_id ? course_id.value : '';
-            },
-
-            updateCategory: function() {
-                var categoryID = this.get('categories')[0].id;
-                this.set('category', categoryID);
-                this.set('category_ids', [categoryID]);
             },
 
             updateSeatData: function () {

--- a/ecommerce/static/js/test/mock_data/coupons.js
+++ b/ecommerce/static/js/test/mock_data/coupons.js
@@ -190,12 +190,10 @@ define([], function(){
         'last_edited': lastEditData,
         'seats': [verifiedSeat],
         'client': 'Client Name',
-        'categories': [
-            {
-                'id': 4,
-                'name': 'TESTCAT'
-            }
-        ],
+        'category': {
+            'id': 4,
+            'name': 'TESTCAT'
+        },
         'price': '100.00',
         'invoice_type': 'Prepaid',
         'invoice_discount_type': 'Percentage',

--- a/ecommerce/static/js/test/spec-utils.js
+++ b/ecommerce/static/js/test/spec-utils.js
@@ -13,7 +13,8 @@ define([
             getModelForValidation: function (valid) {
                 return Backbone.Model.extend({
                     defaults: {
-                        id: null
+                        id: null,
+                        category: {}
                     },
 
                     isValid: function () {

--- a/ecommerce/static/js/test/specs/views/coupon_detail_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/coupon_detail_view_spec.js
@@ -75,7 +75,7 @@ define([
             });
 
             it('should display correct data upon rendering', function () {
-                var category = model.get('categories')[0].name;
+                var category = model.get('category').name;
 
                 view.render();
                 expect(view.$('.coupon-title').text()).toEqual(model.get('title'));

--- a/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
@@ -90,10 +90,6 @@ define([
                     expect(SpecUtils.formGroup(view, '[name=benefit_value]')).not.toBeVisible();
                     expect(SpecUtils.formGroup(view, '[name=code]')).not.toBeVisible();
                 });
-
-                it('should set model attribute category_ids on render', function () {
-                    expect(view.model.get('category_ids')[0]).toBe(4);
-                });
             });
 
             describe('toggle credit seats', function() {

--- a/ecommerce/static/js/views/coupon_detail_view.js
+++ b/ecommerce/static/js/views/coupon_detail_view.js
@@ -113,7 +113,7 @@ define([
 
             render: function () {
                 var html,
-                    category = this.model.get('categories')[0].name,
+                    category = this.model.get('category').name,
                     invoice_data = this.formatInvoiceData(),
                     emailDomains = this.model.get('email_domains'),
                     template_data,

--- a/ecommerce/static/js/views/coupon_form_view.js
+++ b/ecommerce/static/js/views/coupon_form_view.js
@@ -82,9 +82,14 @@ define([
                     setOptions: {
                         validate: true
                     },
-                    onSet: function(val) {
-                        this.model.set('category_ids', [val]);
-                        return val;
+                    onGet: function (val) {
+                        return val.id;
+                    },
+                    onSet: function (val) {
+                        return {
+                            id: val,
+                            name: $('select[name=category] option:selected').text()
+                        };
                     }
                 },
                 'input[name=title]': {
@@ -240,7 +245,7 @@ define([
                     this.editableAttributes = [
                         'benefit_value',
                         'catalog_query',
-                        'category_ids',
+                        'category',
                         'client',
                         'course_seat_types',
                         'end_date',
@@ -585,13 +590,9 @@ define([
                     this.$('[name=tax_deduction]').trigger('change');
                     this.fillFromCourse();
                 } else {
-                    var firstEntry = function(obj, i){ return i === 0 ? obj : null; },
-                        defaultCategory = ecommerce.coupons.categories.filter(firstEntry);
                     this.model.set({
                         'coupon_type': this.codeTypes[0].value,
                         'voucher_type': this.voucherTypes[0].value,
-                        'category': defaultCategory[0].id,
-                        'category_ids': [defaultCategory[0].id],
                         'benefit_type': 'Percentage',
                         'catalog_type': 'Single course',
                         'invoice_discount_type': 'Percentage',


### PR DESCRIPTION
@mjfrey, @vkaracic, @iivic: Here's the 3rd cleanup PR, so please take a look when you get the time. I've refactored the Coupon API code to release the tension that was building up there.

Since the Coupon UI only allows the end user to assign a single Category to a Coupon, I've cleaned up Backend/API code so that it reflects that use case. Otherwise, we're doing additional work in Backbone instead of simply reading the value returned by Coupon API endpoint.
