### PR TITLE
Handle null image for course info.

### DIFF
--- a/ecommerce/extensions/api/v2/views/vouchers.py
+++ b/ecommerce/extensions/api/v2/views/vouchers.py
@@ -193,7 +193,7 @@ class VoucherViewSet(NonDestroyableModelViewSet):
             'contains_verified': is_verified,
             'course_start_date': course_info['start'],
             'id': course.id,
-            'image_url': course_info['image']['src'],
+            'image_url': course_info['image'].get('src', ''),
             'organization': CourseKey.from_string(course.id).org,
             'seat_type': course.type,
             'stockrecords': serializers.StockRecordSerializer(stock_record).data,


### PR DESCRIPTION
In the case that there is not image in the course catalog for a course_run.  Do not break, just show the page without an image.
