### PR TITLE
Revert "Upgrade gunicorn and gevent"

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,6 +4,6 @@
 django-ses==0.7.0
 MySQL-python==1.2.5
 PyYAML==3.11
-gunicorn==19.6.0
-gevent==1.1.2
+gunicorn==19.2.1
+gevent==1.0.2
 nodeenv==0.13.6


### PR DESCRIPTION
This reverts commit 20eec8e0714136f3c6d3593e819463a42c61dad6, undoing https://github.com/edx/ecommerce/pull/920. I'm backing this out because of a problem with the way gevent wraps Python's __import__ functionality.

FYI @jibsheet @edx/ecommerce.
