### PR TITLE
Use Babel directly to format benefit value.

### DIFF
--- a/ecommerce/extensions/offer/tests/test_utils.py
+++ b/ecommerce/extensions/offer/tests/test_utils.py
@@ -1,8 +1,11 @@
 from decimal import Decimal
 import ddt
 
+from babel.numbers import format_currency
+
+from django.conf import settings
+from django.utils.translation import get_language, to_locale
 from oscar.core.loading import get_model
-from oscar.templatetags.currency_filters import currency
 from oscar.test.factories import *  # pylint:disable=wildcard-import,unused-wildcard-import
 
 from ecommerce.courses.tests.factories import CourseFactory
@@ -33,7 +36,10 @@ class UtilTests(CourseCatalogTestMixin, TestCase):
         self.assertEqual(benefit_value, '35%')
 
         benefit_value = format_benefit_value(self.value_benefit)
-        self.assertEqual(benefit_value, currency(self.seat_price - 10))
+        expected_benefit = format_currency(
+            Decimal((self.seat_price - 10)), settings.OSCAR_DEFAULT_CURRENCY, format=u'#,##0.00',
+            locale=to_locale(get_language()))
+        self.assertEqual(benefit_value, '${expected_benefit}'.format(expected_benefit=expected_benefit))
 
     @ddt.data(
         ('1.0', '1'),

--- a/ecommerce/extensions/offer/utils.py
+++ b/ecommerce/extensions/offer/utils.py
@@ -1,9 +1,11 @@
 """Offer Utility Methods. """
 from decimal import Decimal
 
-from django.utils.translation import ugettext_lazy as _
+from babel.numbers import format_currency
+
+from django.conf import settings
+from django.utils.translation import get_language, to_locale, ugettext_lazy as _
 from oscar.core.loading import get_model
-from oscar.templatetags.currency_filters import currency
 
 Benefit = get_model('offer', 'Benefit')
 
@@ -35,5 +37,8 @@ def format_benefit_value(benefit):
     if benefit.type == Benefit.PERCENTAGE:
         benefit_value = _('{benefit_value}%'.format(benefit_value=benefit_value))
     else:
-        benefit_value = _('{benefit_value}'.format(benefit_value=currency(benefit_value)))
+        converted_benefit = format_currency(
+            Decimal(benefit.value), settings.OSCAR_DEFAULT_CURRENCY, format=u'#,##0.00',
+            locale=to_locale(get_language()))
+        benefit_value = _('${benefit_value}'.format(benefit_value=converted_benefit))
     return benefit_value


### PR DESCRIPTION
Calling oscar's currency on the benefit value returns a format that contains line breaks.  This is not what we want and is broken for all locales but english.
Instead use Babel directly with our own format.
