### PR TITLE
Upgrade gunicorn to 19.6.0

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,6 +4,8 @@
 django-ses==0.7.0
 MySQL-python==1.2.5
 PyYAML==3.11
-gunicorn==19.2.1
+gunicorn==19.6.0
+# Later versions of gevent wrap Python's __import__ in a way that breaks Oscar imports.
+# For more, see https://github.com/edx/ecommerce/pull/920.
 gevent==1.0.2
 nodeenv==0.13.6


### PR DESCRIPTION
Includes a note about why gevent has been left at 1.0.2. ECOM-5386.

I've confirmed that this upgrade won't break CI: http://jenkins.edx.org:8080/job/ansible-provision-continuous-integration/31475/.

@jibsheet @edx/ecommerce 
