### PR TITLE
Fixes for coupon form.

### DIFF
--- a/ecommerce/static/js/views/coupon_form_view.js
+++ b/ecommerce/static/js/views/coupon_form_view.js
@@ -592,8 +592,12 @@ define([
                     this.$('.catalog-query').removeClass('editing');
                 }
 
-                this.setLimitToElement(this.$('[name=invoice_discount_value]'), 100, 1);
-                this.setLimitToElement(this.$('[name=benefit_value]'), 100, 1);
+                if (this.$('[name=invoice_discount_type]').val() === 'Percentage') {
+                    this.setLimitToElement(this.$('[name=invoice_discount_value]'), 100, 1);
+                }
+                if (this.$('[name=benefit_type]').val() === 'Percentage') {
+                    this.setLimitToElement(this.$('[name=benefit_value]'), 100, 1);
+                }
 
                 // Add date picker
                 Utils.addDatePicker(this);

--- a/ecommerce/static/templates/coupon_detail.html
+++ b/ecommerce/static/templates/coupon_detail.html
@@ -39,9 +39,11 @@
             <div class="heading"><%= gettext('Discount Value:') %></div>
             <div class="value"><%= discountValue %></div>
         </div>
+        <% if (coupon.seats) {%>
         <div class="info-item grid-item course-info">
             <div class="heading"><%= gettext('Valid for courses:') %></div>
         </div>
+        <%}%>
         <% if(coupon.catalog_query) {%>
         <div class="info-item grid-item catalog-query">
             <div class="heading"><%= gettext('Catalog Query:') %></div>


### PR DESCRIPTION
If you select discount as a fixed amount the upper limit is still there and you wouldn't be able to set more than $100 discount. Same in the postpaid invoice.
For the query coupons the field `Valid of courses:` appears even though there is no information for it.

@marjev @mjfrey 
