### PR TITLE
Fix condition for multi-offer coupons.

### DIFF
--- a/ecommerce/coupons/tests/mixins.py
+++ b/ecommerce/coupons/tests/mixins.py
@@ -106,7 +106,7 @@ class CouponMixin(object):
 
     def create_coupon(self, title='Test coupon', price=100, client=None, partner=None, catalog=None, code='',
                       benefit_value=100, note=None, max_uses=None, quantity=5, catalog_query=None,
-                      course_seat_types=None, email_domains=None):
+                      course_seat_types=None, email_domains=None, voucher_type=Voucher.SINGLE_USE):
         """Helper method for creating a coupon.
 
         Arguments:
@@ -141,7 +141,7 @@ class CouponMixin(object):
             'code': code,
             'quantity': quantity,
             'start_datetime': datetime.date(2015, 1, 1),
-            'voucher_type': Voucher.SINGLE_USE,
+            'voucher_type': voucher_type,
             'categories': [self.category],
             'note': note,
             'max_uses': max_uses,

--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -135,22 +135,19 @@ class CouponViewSetTest(CouponMixin, CourseCatalogTestMixin, TestCase):
 
     def test_creating_multi_offer_coupon(self):
         """Test the creation of a multi-offer coupon."""
-        ordinary_max_uses = 1
-        ordinary_coupon = self.create_coupon(quantity=2, max_uses=ordinary_max_uses)
+        ordinary_coupon = self.create_coupon(quantity=2)
         ordinary_coupon_vouchers = ordinary_coupon.attr.coupon_vouchers.vouchers.all()
         self.assertEqual(
             ordinary_coupon_vouchers[0].offers.first(),
             ordinary_coupon_vouchers[1].offers.first()
         )
-        self.assertEqual(ordinary_coupon_vouchers[0].offers.first().max_global_applications, ordinary_max_uses)
 
-        multi_offer_coupon = self.create_coupon(quantity=2, max_uses=2)
+        multi_offer_coupon = self.create_coupon(quantity=2, voucher_type=Voucher.MULTI_USE)
         multi_offer_coupon_vouchers = multi_offer_coupon.attr.coupon_vouchers.vouchers.all()
         first_offer = multi_offer_coupon_vouchers[0].offers.first()
         second_offer = multi_offer_coupon_vouchers[1].offers.first()
 
         self.assertNotEqual(first_offer, second_offer)
-        self.assertEqual(first_offer.max_global_applications, second_offer.max_global_applications)
 
     def test_custom_code_string(self):
         """Test creating a coupon with custom voucher code."""

--- a/ecommerce/extensions/voucher/utils.py
+++ b/ecommerce/extensions/voucher/utils.py
@@ -423,7 +423,9 @@ def create_vouchers(
     # offer because the usage is tied to the offer so that a usage on one voucher would
     # mean all vouchers will have their usage decreased by one, hence each voucher needs
     # its own offer to keep track of its own usages without interfering with others.
-    multi_offer = True if quantity > 1 and max_uses > 1 else False
+    multi_offer = True if (
+        voucher_type == Voucher.MULTI_USE or voucher_type == Voucher.ONCE_PER_CUSTOMER
+    ) else False
     num_of_offers = quantity if multi_offer else 1
     for num in range(num_of_offers):
         offer = _get_or_create_offer(


### PR DESCRIPTION
Multi-usage coupons whos usage would be set to 1 wouldn't have individual offers created for each voucher, but instead it would have only one offer which, if a user uses the coupon, would render the coupon unusable for the rest of the users.
This PR contains changes that check the type of the coupon instead of the attributes, and creates individual offers for coupons regardless of their quantity or max_uses attribute.

@mjfrey 
