### PR TITLE
Prevent dashboard from reloading on its own

### DIFF
--- a/ecommerce/templates/oscar/dashboard/index.html
+++ b/ecommerce/templates/oscar/dashboard/index.html
@@ -6,7 +6,6 @@
 
 {% block extrahead %}
     {{ block.super }}
-    <meta http-equiv="refresh" content="300">
 {% endblock %}
 
 {% block extrascripts %}


### PR DESCRIPTION
This page makes an expensive query and shouldn't reload unless it's necessary.

@edx/ecommerce @jibsheet @fredsmith 
