### PR TITLE
Add ability to create coupons for credit seats.

### DIFF
--- a/ecommerce/static/js/test/custom-matchers.js
+++ b/ecommerce/static/js/test/custom-matchers.js
@@ -1,0 +1,30 @@
+define(function() {
+    'use strict';
+
+    beforeEach(function() {
+        jasmine.addMatchers({
+            /**
+             * Returns a Boolean value that indicates whether an element is visible,
+             * which it can't be if it's not in the DOM or is hidden.
+             */
+            toBeVisible: function () {
+                return {
+                    compare: function (actual) {
+                        return {pass: ($(actual).length > 0 && !$(actual).hasClass('hidden'))};
+                    }
+                };
+            },
+
+            /**
+             * Returns a Boolean value that indicates whether a DOM element has a specific class.
+             */
+            toHaveClass: function () {
+                return {
+                    compare: function (actual, className) {
+                        return { pass: $(actual).hasClass(className) };
+                    }
+                };
+            },
+        });
+    });
+});

--- a/ecommerce/static/js/test/mock_data/coupons.js
+++ b/ecommerce/static/js/test/mock_data/coupons.js
@@ -248,6 +248,31 @@ define([], function(){
             }
         ]
     },
+    dynamicCouponData = {
+        'id': 12,
+        'title': 'Test Dynamic Code',
+        'coupon_type': 'Enrollment code',
+        'last_edited': lastEditData,
+        'seats': [],
+        'client': 'Client Name',
+        'price': '100.00',
+        'categories': [
+            {
+                'id': 4,
+                'name': 'TESTCAT'
+            }
+        ],
+        'start_date': '2015-01-01T00:00:00Z',
+        'end_date': '2017-01-01T00:00:00Z',
+        'voucher_type': 'Single use',
+        'benefit_type': 'Percentage',
+        'benefit_value': 10,
+        'catalog_type': 'Multiple courses',
+        'catalog_query': 'org:edX',
+        'course_seat_types': [
+            'verified', 'professional'
+        ]
+    },
     couponWithInvoiceData = {
         id: 2,
         title: 'Test Enrollment',
@@ -286,9 +311,11 @@ define([], function(){
     };
     return {
         'couponAPIResponseData': couponAPIResponseData,
+        'couponWithInvoiceData': couponWithInvoiceData,
         'courseData': courseData,
         'discountCodeCouponData': discountCodeCouponData,
         'discountCodeCouponModelData': discountCodeCouponModelData,
+        'dynamicCouponData': dynamicCouponData,
         'enrollmentCodeCouponData': enrollmentCodeCouponData,
         'enrollmentCodeCouponModelData': enrollmentCodeCouponModelData,
         'enrollmentCodeVoucher': enrollmentCodeVoucher,
@@ -296,6 +323,5 @@ define([], function(){
         'percentageDiscountCodeVoucher': percentageDiscountCodeVoucher,
         'valueDiscountCodeVoucher': valueDiscountCodeVoucher,
         'verifiedSeat': verifiedSeat,
-        'couponWithInvoiceData': couponWithInvoiceData
     };
 });

--- a/ecommerce/static/js/test/spec-utils.js
+++ b/ecommerce/static/js/test/spec-utils.js
@@ -31,26 +31,10 @@ define([
             },
 
             /**
-             * Returns a Boolean value that indicates whether a DOM element has a specific class.
+             * Helper function to return the closest form group.
              */
-            toHaveClass: function () {
-                return {
-                    compare: function (actual, className) {
-                        return { pass: $(actual).hasClass(className) };
-                    }
-                };
-            },
-
-            /**
-              * Helper function to check if a form field is visible.
-              */
-            visibleElement: function(view, selector, groupSelector) {
-                var formGroup = view.$(selector).closest(groupSelector);
-                if (formGroup.length > 0) {
-                    return !formGroup.hasClass('hidden');
-                } else {
-                    return false;
-                }
+            formGroup: function(view, selector) {
+                return view.$(selector).closest('.form-group');
             }
         };
     }

--- a/ecommerce/static/js/test/specs/utils/utils_spec.js
+++ b/ecommerce/static/js/test/specs/utils/utils_spec.js
@@ -64,9 +64,6 @@ define([
             describe('disableElementWhileRunning', function () {
 
                 beforeEach(function () {
-                    jasmine.addMatchers({
-                        toHaveClass: SpecUtils.toHaveClass
-                    });
                     ecommerce.coupons = {
                         categories: Mock_Categories
                     };

--- a/ecommerce/static/js/test/specs/views/coupon_detail_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/coupon_detail_view_spec.js
@@ -5,7 +5,8 @@ define([
         'utils/alert_utils',
         'views/coupon_detail_view',
         'test/mock_data/coupons',
-        'test/spec-utils'
+        'test/spec-utils',
+        'test/custom-matchers'
     ],
     function ($,
               _s,
@@ -35,16 +36,6 @@ define([
                 percentageDiscountCodeVoucher = Mock_Coupons.percentageDiscountCodeVoucher;
                 valueDiscountCodeVoucher = Mock_Coupons.valueDiscountCodeVoucher;
                 verifiedSeat = Mock_Coupons.verifiedSeat;
-
-                jasmine.addMatchers({      
-                    toExist: function () {
-                        return {
-                            compare: function (actual) {
-                                return { pass: $.contains(document.documentElement, $(actual)[0]) };
-                            }
-                        };
-                    }
-                });
             });
 
             it('should compare view.model with model sent', function () {
@@ -193,8 +184,8 @@ define([
                 expect(view.$('.invoice-payment-date .value').text()).toEqual(
                     view.formatDateTime(model.get('invoice_payment_date'))
                 );
-                expect(view.$('.invoice_discount_type')).not.toExist();
-                expect(view.$('.invoice_discount_value')).not.toExist();
+                expect(view.$('.invoice_discount_type')).not.toBeVisible();
+                expect(view.$('.invoice_discount_value')).not.toBeVisible();
             });
 
             it('should render postpaid invoice data.', function() {
@@ -210,28 +201,27 @@ define([
                         model.get('invoice_discount_value')
                     )
                 );
-                expect(view.$('.invoice-number')).not.toExist();
-                expect(view.$('.invoiced-amount')).not.toExist();
-                expect(view.$('.invoice-payment-date')).not.toExist();
+                expect(SpecUtils.formGroup(view, '.invoice-number')).not.toBeVisible();
+                expect(SpecUtils.formGroup(view, '.invoiced-amount')).not.toBeVisible();
+                expect(SpecUtils.formGroup(view, '.invoice-payment-date')).not.toBeVisible();
             });
 
             it('should render not-applicable invoice data.', function() {
                 view.model.set('invoice_type', 'Not-Applicable');
                 view.render();
-                expect(view.$('.invoice_discount_type')).not.toExist();
-                expect(view.$('.invoice-number')).not.toExist();
-                expect(view.$('.invoiced-amount')).not.toExist();
-                expect(view.$('.invoice-payment-date')).not.toExist();
+                expect(SpecUtils.formGroup(view, '.invoice_discount_type')).not.toBeVisible();
+                expect(SpecUtils.formGroup(view, '.invoice-number')).not.toBeVisible();
+                expect(SpecUtils.formGroup(view, '.invoiced-amount')).not.toBeVisible();
+                expect(SpecUtils.formGroup(view, '.invoice-payment-date')).not.toBeVisible();
             });
 
             it('should display tax deducted source input field.', function() {
                 view.model.set('tax_deduction', 'Yes');
                 view.render();
-                expect(SpecUtils.visibleElement(view, '.tax-deducted-source-value', '.info-item')).toBe(true);
-
+                expect(view.$('.tax-deducted-source-value').closest('.info-item')).toBeVisible();
                 view.model.set('tax_deduction', 'No');
                 view.render();
-                expect(view.$('.tax-deducted-source-value')).not.toExist();
+                expect(SpecUtils.formGroup(view, '.tax-deducted-source-value')).not.toBeVisible();
             });
 
             it('should download voucher report in the new tab', function () {

--- a/ecommerce/static/js/test/specs/views/coupon_edit_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/coupon_edit_view_spec.js
@@ -4,7 +4,7 @@ define([
         'views/coupon_create_edit_view',
         'models/coupon_model',
         'test/mock_data/coupons',
-
+        'test/custom-matchers'
     ],
     function (_s,
               Utils,
@@ -19,7 +19,8 @@ define([
                 model,
                 enrollment_code_data = Mock_Coupons.enrollmentCodeCouponData,
                 discount_code_data = Mock_Coupons.discountCodeCouponData,
-                invoice_coupon_data = Mock_Coupons.couponWithInvoiceData;
+                invoice_coupon_data = Mock_Coupons.couponWithInvoiceData,
+                dynamic_coupon = Mock_Coupons.dynamicCouponData;
 
             describe('edit enrollment code', function () {
                 beforeEach(function () {
@@ -69,6 +70,26 @@ define([
                     expect(view.$el.find('[name=benefit_type]').val()).toEqual(model.get('benefit_type'));
                     expect(view.$el.find('[name=benefit_value]').val()).toEqual(model.get('benefit_value').toString());
                     expect(view.$el.find('[name=code]').val()).toEqual(model.get('code'));
+                });
+            });
+
+            describe('Editing dynamic coupon', function() {
+                beforeEach(function() {
+                    model = Coupon.findOrCreate(dynamic_coupon);
+                    model.updateSeatData();
+                    view = new CouponCreateEditView({model: model, editing: true}).render();
+                });
+
+                it('should display dynamic catalog information.', function() {
+                    expect(view.$('#catalog-query').val()).toEqual(model.get('catalog_query'));
+                    expect(view.$('#non-credit, #verified, #professional').is(':checked')).toEqual(true);
+                });
+
+                it('should hide checkboxes if credit seat type.', function() {
+                    var credit_seat_type = ['credit'];
+                    model.set('course_seat_types', credit_seat_type);
+                    view.render();
+                    expect(view.$('.non-credit-seats')).not.toBeVisible();
                 });
             });
 

--- a/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
@@ -7,7 +7,8 @@ define([
         'test/mock_data/categories',
         'test/mock_data/coupons',
         'test/spec-utils',
-        'ecommerce'
+        'ecommerce',
+        'test/custom-matchers'
     ],
     function ($,
               _,
@@ -82,16 +83,33 @@ define([
                 });
 
                 it('should show the price field', function () {
-                    expect(SpecUtils.visibleElement(view, '[name=price]', '.form-group')).toBe(true);
+                    expect(SpecUtils.formGroup(view, '[name=price]')).toBeVisible();
                 });
 
                 it('should hide discount and code fields', function () {
-                    expect(SpecUtils.visibleElement(view, '[name=benefit_value]', '.form-group')).toBe(false);
-                    expect(SpecUtils.visibleElement(view, '[name=code]', '.form-group')).toBe(false);
+                    expect(SpecUtils.formGroup(view, '[name=benefit_value]')).not.toBeVisible();
+                    expect(SpecUtils.formGroup(view, '[name=code]')).not.toBeVisible();
                 });
 
                 it('should set model attribute category_ids on render', function () {
                     expect(view.model.get('category_ids')[0]).toBe(4);
+                });
+            });
+
+            describe('toggle credit seats', function() {
+                it('should hide non-credit seats and uncheck them.', function() {
+                    view.$('#credit').prop('checked', true).trigger('change');
+                    expect(view.$('input[id=verified], input[id=professional]').is(':checked')).toBe(false);
+                    expect(view.$('.non-credit-seats')).not.toBeVisible();
+                    expect(view.model.get('course_seat_types')[0]).toBe('credit');
+                });
+
+                it('should show non-credit seats.', function() {
+                    view.$('#non-credit').prop('checked', true).trigger('change');
+                    expect(view.$('.non-credit-seats')).toBeVisible();
+
+                    view.$('input[id=verified]').prop('checked', true).trigger('change');
+                    expect(view.model.get('course_seat_types')[0]).toBe('verified');
                 });
             });
 
@@ -117,7 +135,7 @@ define([
                 });
 
                 it('should show the discount field', function () {
-                    expect(SpecUtils.visibleElement(view, '[name=benefit_value]', '.form-group')).toBe(true);
+                    expect(SpecUtils.formGroup(view, '[name=benefit_value]')).toBeVisible();
                 });
 
                 it('should indicate the benefit type', function () {
@@ -153,89 +171,85 @@ define([
 
                 it('should show the code field for once-per-customer and singe-use vouchers', function () {
                     view.$el.find('[name=voucher_type]').val('Single use').trigger('change');
-                    expect(SpecUtils.visibleElement(view, '[name=code]', '.form-group')).toBe(true);
+                    expect(SpecUtils.formGroup(view, '[name=code]')).toBeVisible();
                     view.$el.find('[name=voucher_type]').val('Once per customer').trigger('change');
-                    expect(SpecUtils.visibleElement(view, '[name=code]', '.form-group')).toBe(true);
+                    expect(SpecUtils.formGroup(view, '[name=code]')).toBeVisible();
                 });
 
                 it('should show the usage number field only for once-per-customer vouchers', function () {
                     view.$el.find('[name=voucher_type]').val('Single use').trigger('change');
-                    expect(SpecUtils.visibleElement(view, '[name=max_uses]', '.form-group')).toBe(false);
+                    expect(SpecUtils.formGroup(view, '[name=max_uses]')).not.toBeVisible();
                     view.$el.find('[name=voucher_type]').val('Once per customer').trigger('change');
-                    expect(SpecUtils.visibleElement(view, '[name=max_uses]', '.form-group')).toBe(true);
+                    expect(SpecUtils.formGroup(view, '[name=max_uses]')).toBeVisible();
                 });
 
                 it('should hide quantity field when code entered', function () {
                     view.$el.find('[name=code]').val('E34T4GR342').trigger('input');
-                    expect(SpecUtils.visibleElement(view, '[name=quantity]', '.form-group')).toBe(false);
+                    expect(SpecUtils.formGroup(view, '[name=quantity]')).not.toBeVisible();
                     view.$el.find('[name=code]').val('').trigger('input');
-                    expect(SpecUtils.visibleElement(view, '[name=quantity]', '.form-group')).toBe(true);
+                    expect(SpecUtils.formGroup(view, '[name=quantity]')).toBeVisible();
                 });
 
                 it('should hide code field when quantity not 1', function () {
                     view.$el.find('[name=quantity]').val(21).trigger('change');
-                    expect(SpecUtils.visibleElement(view, '[name=code]', '.form-group')).toBe(false);
+                    expect(SpecUtils.formGroup(view, '[name=code]')).not.toBeVisible();
                     view.$el.find('[name=quantity]').val(1).trigger('change');
-                    expect(SpecUtils.visibleElement(view, '[name=code]', '.form-group')).toBe(true);
+                    expect(SpecUtils.formGroup(view, '[name=code]')).toBeVisible();
                 });
 
                 it('should hide code field for every voucher type if quantity is not 1.', function() {
                     view.$el.find('[name=quantity]').val(2).trigger('change');
                     view.$el.find('[name=voucher_type]').val('Single use').trigger('change');
-                    expect(SpecUtils.visibleElement(view, '[name=code]', '.form-group')).toBe(false);
+                    expect(SpecUtils.formGroup(view, '[name=code]')).not.toBeVisible();
 
                     view.$el.find('[name=voucher_type]').val('Once per customer').trigger('change');
-                    expect(SpecUtils.visibleElement(view, '[name=code]', '.form-group')).toBe(false);
+                    expect(SpecUtils.formGroup(view, '[name=code]')).not.toBeVisible();
 
                     view.$el.find('[name=voucher_type]').val('Multi-use').trigger('change');
-                    expect(SpecUtils.visibleElement(view, '[name=code]', '.form-group')).toBe(false);
+                    expect(SpecUtils.formGroup(view, '[name=code]')).not.toBeVisible();
                 });
 
                 it('should show the code field for every voucher type if quantity is 1.', function() {
                     view.$el.find('[name=quantity]').val(1).trigger('change');
                     view.$el.find('[name=voucher_type]').val('Single use').trigger('change');
-                    expect(SpecUtils.visibleElement(view, '[name=code]', '.form-group')).toBe(true);
+                    expect(SpecUtils.formGroup(view, '[name=code]')).toBeVisible();
 
                     view.$el.find('[name=voucher_type]').val('Once per customer').trigger('change');
-                    expect(SpecUtils.visibleElement(view, '[name=code]', '.form-group')).toBe(true);
+                    expect(SpecUtils.formGroup(view, '[name=code]')).toBeVisible();
 
                     view.$el.find('[name=voucher_type]').val('Multi-use').trigger('change');
-                    expect(SpecUtils.visibleElement(view, '[name=code]', '.form-group')).toBe(true);
+                    expect(SpecUtils.formGroup(view, '[name=code]')).toBeVisible();
                 });
 
                 it('should show prepaid invoice fields when changing to Prepaid invoice type.', function() {
                     view.$el.find('#already-invoiced').prop('checked', true).trigger('change');
                     _.each(prepaid_invoice_fields, function(field) {
-                        expect(SpecUtils.visibleElement(view, field, '.form-group')).toBe(true);
+                        expect(SpecUtils.formGroup(view, field)).toBeVisible();
                     });
-                    expect(SpecUtils.visibleElement(view, '[name=invoice_discount_value]', '.form-group')).toBe(false);
+                    expect(SpecUtils.formGroup(view, '[name=invoice_discount_value]')).not.toBeVisible();
                 });
 
                 it('should show postpaid invoice fields when changing to Postpaid invoice type.', function() {
                     view.$el.find('#invoice-after-redemption').prop('checked', true).trigger('change');
                     _.each(prepaid_invoice_fields, function(field) {
-                        expect(SpecUtils.visibleElement(view, field, '.form-group')).toBe(false);
+                        expect(SpecUtils.formGroup(view, field)).not.toBeVisible();
                     });
-                    expect(SpecUtils.visibleElement(view, '[name=invoice_discount_value]', '.form-group')).toBe(true);
+                    expect(SpecUtils.formGroup(view, '[name=invoice_discount_value]')).toBeVisible();
                 });
 
                 it('should hide all invoice fields when changing to Not applicable invoice type.', function() {
                     view.$el.find('#not-applicable').prop('checked', true).trigger('change');
                     _.each(prepaid_invoice_fields, function(field) {
-                        expect(SpecUtils.visibleElement(view, field, '.form-group')).toBe(false);
+                        expect(SpecUtils.formGroup(view, field)).not.toBeVisible();
                     });
-                    expect(SpecUtils.visibleElement(view, '[name=invoice_discount_value]', '.form-group')).toBe(false);
+                    expect(SpecUtils.formGroup(view, '[name=invoice_discount_value]')).not.toBeVisible();
                 });
 
                 it('should show tax deduction source field when TSD is selected.', function() {
                     view.$el.find('#tax-deducted').prop('checked', true).trigger('change');
-                    expect(
-                        SpecUtils.visibleElement(view, '[name=tax_deducted_source_value]', '.form-group')
-                    ).toBe(true);
+                    expect(SpecUtils.formGroup(view, '[name=tax_deducted_source_value]')).toBeVisible();
                     view.$el.find('#non-tax-deducted').prop('checked', true).trigger('change');
-                    expect(
-                        SpecUtils.visibleElement(view, '[name=tax_deducted_source_value]', '.form-group')
-                    ).toBe(false);
+                    expect(SpecUtils.formGroup(view, '[name=tax_deducted_source_value]')).not.toBeVisible();
                 });
             });
 

--- a/ecommerce/static/js/test/specs/views/course_create_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/course_create_view_spec.js
@@ -3,7 +3,8 @@ define([
         'views/course_create_edit_view',
         'views/alert_view',
         'test/spec-utils',
-        'models/course_model'
+        'models/course_model',
+        'test/custom-matchers'
     ],
     function ($,
               CourseCreateEditView,
@@ -40,14 +41,12 @@ define([
                 var bulk_enrollment_seat_types = ['verified', 'professional', 'credit'];
                 view.model.set('type', 'audit');
                 view.formView.toggleBulkEnrollmentField();
-                expect(SpecUtils.visibleElement(view, '[name=create_enrollment_code]', '.form-group')).toBe(false);
+                expect(SpecUtils.formGroup(view, '[name=create_enrollment_code]')).not.toBeVisible();
 
                 _.each(bulk_enrollment_seat_types, function(seat) {
                     view.model.set('type', seat);
                     view.formView.toggleBulkEnrollmentField();
-                    expect(SpecUtils.visibleElement(
-                        view, '[name=create_enrollment_code]', '.form-group')
-                    ).toBe(true);
+                    expect(SpecUtils.formGroup(view, '[name=create_enrollment_code]')).toBeVisible();
                 }, this);
             });
 

--- a/ecommerce/static/js/views/coupon_form_view.js
+++ b/ecommerce/static/js/views/coupon_form_view.js
@@ -227,6 +227,7 @@ define([
                 'change [name=invoice_discount_type]': 'changeLimitForInvoiceDiscountValue',
                 'change [name=invoice_type]': 'toggleInvoiceFields',
                 'change [name=tax_deduction]': 'toggleTaxDeductedSourceField',
+                'change [name=credit_radio]': 'toggleCreditSeats',
                 'click .external-link': 'routeToLink'
             },
 
@@ -271,6 +272,17 @@ define([
                 this.listenTo(this.model, 'change:course_seat_types', this.updateCourseSeatTypes);
 
                 this._super();
+            },
+
+            toggleCreditSeats: function() {
+                var nonCreditSeatsField = this.$('.non-credit-seats');
+                if (this.$('#credit').is(':checked')) {
+                    this.$('input[id=verified], input[id=professional]').attr('checked', false);
+                    nonCreditSeatsField.addClass(this.hiddenClass);
+                    this.model.set('course_seat_types', ['credit']);
+                } else if (this.$('#non-credit').is(':checked')) {
+                    nonCreditSeatsField.removeClass(this.hiddenClass);
+                }
             },
 
             setLimitToElement: function(element, max_value, min_value) {
@@ -463,13 +475,15 @@ define([
                 course.listenTo(course, 'sync', _.bind(function () {
                     this.seatTypes = _.map(course.seats(), function (seat) {
                         var name = seat.getSeatTypeDisplayName();
-                        return $('<option></option>')
-                            .text(name)
-                            .val(name)
-                            .data({
-                                price: seat.get('price'),
-                                stockrecords: _.map(seat.get('stockrecords'), parseId)
-                            });
+                        if (name !== 'Credit') {
+                            return $('<option></option>')
+                                .text(name)
+                                .val(name)
+                                .data({
+                                    price: seat.get('price'),
+                                    stockrecords: _.map(seat.get('stockrecords'), parseId)
+                                });
+                        }
                     });
                     // update field
                     this.$('[name=seat_type]')
@@ -554,6 +568,12 @@ define([
                 this.$('.row:first').before(AlertDivTemplate);
 
                 if (this.editing) {
+                    if (this.model.get('course_seat_types')[0] === 'credit') {
+                        this.$('#credit').attr('checked', true);
+                        this.$('.non-credit-seats').addClass(this.hiddenClass);
+                    } else {
+                        this.$('#non-credit').attr('checked', true);
+                    }
                     this.disableNonEditableFields();
                     this.toggleCouponTypeField();
                     this.toggleVoucherTypeField();
@@ -578,6 +598,7 @@ define([
                         'invoice_type': 'Prepaid',
                         'tax_deduction': 'No',
                     });
+                    this.$('#non-credit').attr('checked', true);
                     this.$('button[type=submit]').html(gettext('Create Coupon'));
                     this.$('.catalog-query').removeClass('editing');
                 }

--- a/ecommerce/static/sass/partials/views/_coupon_admin.scss
+++ b/ecommerce/static/sass/partials/views/_coupon_admin.scss
@@ -66,10 +66,10 @@
                 margin-bottom: 10px;
                 padding-right: 10px;
             }
+        }
 
-            .checkboxes {
-                margin-bottom: 55px;
-            }
+        .credit-radio {
+            width: 100%;
         }
     }
 }

--- a/ecommerce/static/templates/coupon_form.html
+++ b/ecommerce/static/templates/coupon_form.html
@@ -185,10 +185,20 @@
         <div class="form-group course-seat-types">
             <label for="course-seat-types"><%= gettext('Seat Types:') %> *</label>
             <div class="checkboxes">
-                <input id="verified" type="checkbox" name="course_seat_types" value="verified">
-                <label for="verified"><%= gettext('Verified') %></label>
-                <input id="professional" type="checkbox" name="course_seat_types" value="professional">
-                <label for="professional"><%= gettext('Professional') %></label>
+                <div class="credit-radio">
+                    <input id="non-credit" type="radio" name="credit_radio" value="non-credit">
+                    <label for="non-credit"><%= gettext('Non-credit') %></label>
+                </div>
+                <div class="non-credit-seats">
+                    <input id="verified" type="checkbox" name="course_seat_types" value="verified">
+                    <label for="verified"><%= gettext('Verified') %></label>
+                    <input id="professional" type="checkbox" name="course_seat_types" value="professional">
+                    <label for="professional"><%= gettext('Professional') %></label>
+                </div>
+                <div class="credit-radio">
+                    <input id="credit" type="radio" name="credit_radio" value="credit">
+                    <label for="credit"><%= gettext('Credit') %></label>
+                </div>
                 <p class="help-block"></p>
             </div>
             <div class="catalog_buttons"></div>


### PR DESCRIPTION
This PR contains changes that allow the creation of coupons for credit seats.
![screenshot from 2016-09-21 14-45-42](https://cloud.githubusercontent.com/assets/2808092/18711400/1b5057ac-800a-11e6-8ea1-03f1ccde5b8c.png)
![screenshot from 2016-09-21 14-45-47](https://cloud.githubusercontent.com/assets/2808092/18711405/20515c2e-800a-11e6-8814-317f01c5c8e4.png)

Also additional custom jasmine matches are added and test updated accordingly.
