### PR TITLE
Improved performance of order admin page

### DIFF
--- a/ecommerce/extensions/order/admin.py
+++ b/ecommerce/extensions/order/admin.py
@@ -3,10 +3,25 @@ from oscar.apps.order.admin import *  # noqa pylint: disable=wildcard-import,unu
 admin.site.unregister((Order, Line, LinePrice, PaymentEvent, OrderDiscount,))
 
 
+class LineInlineExtended(LineInline):
+    raw_id_fields = ['stockrecord', 'product', ]
+
+    def get_queryset(self, request):
+        queryset = super(LineInlineExtended, self).get_queryset(request)
+        queryset = queryset.select_related('partner', 'stockrecord', 'product', )
+        return queryset
+
+
 @admin.register(Order)
 class OrderAdminExtended(OrderAdmin):
+    inlines = [LineInlineExtended]
     readonly_fields = ('basket',) + OrderAdmin.readonly_fields
     show_full_result_count = False
+
+    def get_queryset(self, request):
+        queryset = super(OrderAdminExtended, self).get_queryset(request)
+        queryset = queryset.select_related('site', 'user', 'basket', )
+        return queryset
 
 
 @admin.register(Line)


### PR DESCRIPTION
- Using raw_id fields for order line stock records and products
- Added select_related to improve query performance

These changes greatly decrease the query count and load time of this page; but, the use of inlines poses a risk due to the fact that any choice field will result in query for each inline displaying that field. Some form of database query caching might help alleviate this issue.

ECOM-5767
