### PR TITLE
Display error message when no offers exist for a coupon.

### DIFF
--- a/ecommerce/static/js/collections/offer_collection.js
+++ b/ecommerce/static/js/collections/offer_collection.js
@@ -13,10 +13,19 @@ define([
             url: '/api/v2/vouchers/offers/',
 
             initialize: function() {
+                this.empty = false;
                 this.page = 1;
                 this.perPage = 6;
                 this.updateLimits();
                 this.on('update', this.updateNumberOfPages);
+            },
+
+            parse: function(response) {
+                this._super(response);
+                if (response.results.length === 0) {
+                    this.empty = true;
+                }
+                return response.results;
             },
 
             updateNumberOfPages: function() {

--- a/ecommerce/static/js/pages/offer_page.js
+++ b/ecommerce/static/js/pages/offer_page.js
@@ -16,8 +16,8 @@ define([
             initialize: function(options) {
                 this.collection = new OfferCollection();
                 this.view = new OfferView({code: options.code, collection: this.collection});
-                this.render();
                 this.collection.fetch({remove: false, data: {code: options.code, limit: 50}});
+                this.render();
             }
         });
     }

--- a/ecommerce/static/js/test/specs/collections/offer_collection_spec.js
+++ b/ecommerce/static/js/test/specs/collections/offer_collection_spec.js
@@ -1,5 +1,6 @@
 define([
-        'collections/offer_collection'
+        'collections/offer_collection',
+        'backbone.super'
     ],
     function(OfferCollection) {
         'use strict';
@@ -7,6 +8,7 @@ define([
             response = {
                 count: 4,
                 page: 1,
+                empty: false,
                 next: null,
                 previous: null,
                 results: [
@@ -29,6 +31,12 @@ define([
 
             it('should return the results list in the response', function() {
                 expect(collection.parse(response)).toEqual(response.results);
+            });
+
+            it('should set the collection is empty when no results are fetched', function() {
+                response.results = [];
+                collection.parse(response);
+                expect(collection.empty).toBeTruthy();
             });
 
             it('should fetch the next page of results', function() {

--- a/ecommerce/static/js/test/specs/views/form_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/form_view_spec.js
@@ -47,7 +47,7 @@ define([
             });
 
             it('should validate if course id is duplicate', function () {
-                 var courseDataSuccess =  {
+                 var courseDataSuccess = {
                         id: courseId,
                         name: 'Demo Course',
                         type: 'audit'

--- a/ecommerce/static/js/test/specs/views/offer_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/offer_view_spec.js
@@ -249,6 +249,12 @@ define([
                 expect(view.changePage).toHaveBeenCalled();
             });
 
+            it('should call emptyOffer when a collection is empty.', function() {
+                spyOn(view, 'showEmptyOfferErrorMessage').and.callThrough();
+                collection.empty = true;
+                view.render();
+                expect(view.showEmptyOfferErrorMessage).toHaveBeenCalled();
+            });
         });
     }
 );

--- a/ecommerce/static/js/views/offer_view.js
+++ b/ecommerce/static/js/views/offer_view.js
@@ -4,19 +4,22 @@ define([
         'underscore',
         'underscore.string',
         'moment',
-        'text!templates/_offer_course_list.html'
+        'text!templates/_offer_course_list.html',
+        'text!templates/_offer_error.html'
     ],
     function ($,
               Backbone,
               _,
               _s,
               moment,
-              OfferCourseListTemplate) {
+              OfferCourseListTemplate,
+              OfferErrorTemplate) {
 
         'use strict';
 
         return Backbone.View.extend({
             template: _.template(OfferCourseListTemplate),
+            errorTemplate: _.template(OfferErrorTemplate),
 
             events: {
                 'click .prev': 'previous',
@@ -25,7 +28,7 @@ define([
             },
 
             initialize: function (options) {
-                this.listenTo(this.collection, 'update', this.render);
+                this.listenTo(this.collection, 'sync', this.render);
                 this.code = options.code;
             },
 
@@ -44,7 +47,9 @@ define([
             },
 
             render: function() {
-                if (this.collection.length > 0) {
+                if (this.collection.empty) {
+                    this.showEmptyOfferErrorMessage();
+                } else if (this.collection.length > 0) {
                     this.showVerifiedCertificate();
                     this.refreshData();
                     this.$el.html(
@@ -60,6 +65,12 @@ define([
                     this.delegateEvents();
                 }
                 return this;
+            },
+
+            showEmptyOfferErrorMessage: function() {
+                this.$el.html(this.errorTemplate(
+                    {error_msg: 'This coupon is not valid for any currently available course seats.'}
+                ));
             },
 
             refreshData: function() {

--- a/ecommerce/static/sass/partials/views/_coupon_offer.scss
+++ b/ecommerce/static/sass/partials/views/_coupon_offer.scss
@@ -209,6 +209,10 @@
                 }
             }
         }
+
+        .offer-error {
+            margin: 0 15px;
+        }
     }
 
     .course_name {

--- a/ecommerce/static/templates/_offer_error.html
+++ b/ecommerce/static/templates/_offer_error.html
@@ -1,0 +1,4 @@
+<div class="depth depth-2 message-error offer-error">
+    <h3><%= error_msg %></h3>
+    <%- gettext('If you need assistance, contact edX support.') %>
+</div>


### PR DESCRIPTION
The offer landing page for a dynamic coupon that has no offers (no seats to display) would display an empty page. This PR contains changes that make the offer landing page display an error message instead of the empty page.
![screenshot from 2016-09-28 12-39-47](https://cloud.githubusercontent.com/assets/2808092/18910515/abf0c666-8578-11e6-9fe3-38b08ef24ad2.png)

https://openedx.atlassian.net/browse/SOL-2090
