### PR TITLE
Upgrade Django to 1.8.15

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 analytics-python==1.1.0
-Django==1.8.14
+Django==1.8.15
 django-appconf==0.6
 django-compressor==2.0
 django_extensions==1.5.5


### PR DESCRIPTION
Django 1.8.15 fixes a security issue in 1.8.14. Release notes are at https://docs.djangoproject.com/en/1.10/releases/1.8.15.

@edx/ecommerce FYI.
