### PR TITLE
Change the logic for when to display an empty offer error.

### DIFF
--- a/ecommerce/static/js/collections/offer_collection.js
+++ b/ecommerce/static/js/collections/offer_collection.js
@@ -8,22 +8,24 @@ define([
               OfferModel) {
         'use strict';
 
-        return PaginatedCollection.extend({
+        return Backbone.Collection.extend({
             model: OfferModel,
             url: '/api/v2/vouchers/offers/',
 
             initialize: function() {
-                this.empty = false;
                 this.page = 1;
                 this.perPage = 6;
+                this.populated = false;
                 this.updateLimits();
                 this.on('update', this.updateNumberOfPages);
             },
 
             parse: function(response) {
-                this._super(response);
-                if (response.results.length === 0) {
-                    this.empty = true;
+                if (response.next) {
+                    this.url = response.next;
+                    this.fetch({remove: false});
+                } else {
+                    this.populated = true;
                 }
                 return response.results;
             },

--- a/ecommerce/static/js/test/specs/collections/offer_collection_spec.js
+++ b/ecommerce/static/js/test/specs/collections/offer_collection_spec.js
@@ -8,7 +8,6 @@ define([
             response = {
                 count: 4,
                 page: 1,
-                empty: false,
                 next: null,
                 previous: null,
                 results: [
@@ -33,10 +32,19 @@ define([
                 expect(collection.parse(response)).toEqual(response.results);
             });
 
-            it('should set the collection is empty when no results are fetched', function() {
-                response.results = [];
+            it('should set collection to be populated after it is populated', function() {
                 collection.parse(response);
-                expect(collection.empty).toBeTruthy();
+                expect(collection.populated).toBeTruthy();
+            });
+
+            it('should fetch the next page.', function() {
+                var test_url = 'example.com';
+                response.next = test_url;
+                spyOn(collection, 'fetch');
+
+                collection.parse(response);
+                expect(collection.fetch).toHaveBeenCalled();
+                expect(collection.url).toBe(test_url);
             });
 
             it('should fetch the next page of results', function() {

--- a/ecommerce/static/js/test/specs/views/offer_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/offer_view_spec.js
@@ -249,9 +249,10 @@ define([
                 expect(view.changePage).toHaveBeenCalled();
             });
 
-            it('should call emptyOffer when a collection is empty.', function() {
+            it('should call showEmptyOfferErrorMessage when a collection is empty and populated.', function() {
                 spyOn(view, 'showEmptyOfferErrorMessage').and.callThrough();
-                collection.empty = true;
+                collection.reset();
+                collection.populated = true;
                 view.render();
                 expect(view.showEmptyOfferErrorMessage).toHaveBeenCalled();
             });

--- a/ecommerce/static/js/views/offer_view.js
+++ b/ecommerce/static/js/views/offer_view.js
@@ -47,7 +47,7 @@ define([
             },
 
             render: function() {
-                if (this.collection.empty) {
+                if (this.collection.populated && this.collection.length === 0) {
                     this.showEmptyOfferErrorMessage();
                 } else if (this.collection.length > 0) {
                     this.showVerifiedCertificate();


### PR DESCRIPTION
Since we are populating a collection asynchronously, there needs to be a label when the populating process is over and there are no more pages to fetch from. That way it's possible to determine if an error page for no offers should be displayed or not.
