### PR TITLE
Disallow showing the note about verified certificate in baskets with credit seats.

### DIFF
--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -151,7 +151,8 @@ class BasketSummaryView(BasketView):
 
             # Check product attributes to determine if ID verification is required for this basket
             try:
-                is_verification_required = is_verification_required or line.product.attr.id_verification_required
+                is_verification_required = line.product.attr.id_verification_required \
+                    and line.product.attr.certificate_type != 'credit'
             except AttributeError:
                 pass
 


### PR DESCRIPTION
This PR sets the `is_verification_required` to `False` if the product is a credit seat, and subsequently, the basket does not show the verification message in that case.

https://openedx.atlassian.net/browse/SOL-2093
