### PR TITLE
Set Selenium version to 2.53.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
     - node_modules
     - ecommerce/static/bower_components
 addons:
+    firefox: latest
     apt:
         packages:
             - lcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
     - "export DISPLAY=:99.0"
     - "sh -e /etc/init.d/xvfb start"
     - "export DJANGO_SETTINGS_MODULE=ecommerce.settings.test"
+    - "export PATH=$PATH:$(which firefox)"
 install:
     - pip install -U codecov
     - pip install -U pip wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,19 @@ before_install:
     - "export DISPLAY=:99.0"
     - "sh -e /etc/init.d/xvfb start"
     - "export DJANGO_SETTINGS_MODULE=ecommerce.settings.test"
-    - "export PATH=$PATH:/usr/bin"
 install:
     - pip install -U codecov
     - pip install -U pip wheel
     - make requirements
+    - "mkdir /root/bin"
+    - "cd /root/bin"
+    - "wget https://github.com/mozilla/geckodriver/releases/download/v0.9.0/geckodriver-v0.9.0-linux64.tar.gz"
+    - "tar -xvzf geckodriver-v0.9.0-linux64.tar.gz"
+    - "rm geckodriver-v0.9.0-linux64.tar.gz"
+    - "chmod +x geckodriver"
+    - "cp geckodriver wires"
+    - "export PATH=$PATH:/root/bin/wires"
+    - "export PATH=$PATH:/root/bin/geckodriver"
 script:
     # Ensure documentation can be compiled
     - cd docs && make html

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
     - "export DISPLAY=:99.0"
     - "sh -e /etc/init.d/xvfb start"
     - "export DJANGO_SETTINGS_MODULE=ecommerce.settings.test"
-    - "export PATH=$PATH:$(which firefox)"
+    - "export PATH=$PATH:/usr/bin"
 install:
     - pip install -U codecov
     - pip install -U pip wheel

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ requirements.js:
 	$(NODE_BIN)/bower install
 
 requirements: requirements.js
-	pip install -qr requirements/local.txt --exists-action w
+	pip install -r requirements/local.txt --exists-action w
 
 migrate:
 	python manage.py migrate

--- a/ecommerce/extensions/dashboard/orders/tests.py
+++ b/ecommerce/extensions/dashboard/orders/tests.py
@@ -6,9 +6,8 @@ from django.test import override_settings
 from nose.plugins.skip import SkipTest
 from oscar.core.loading import get_model
 from oscar.test import factories
-from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+from selenium.webdriver.firefox.webdriver import WebDriver
 from selenium.webdriver.support.wait import WebDriverWait
 
 from ecommerce.extensions.dashboard.orders.views import queryset_orders_for_user
@@ -50,10 +49,7 @@ class OrderListViewTests(OrderViewTestsMixin, RefundTestMixin, LiveServerTestCas
         if os.environ.get('DISABLE_ACCEPTANCE_TESTS') == 'True':
             raise SkipTest
 
-        caps = DesiredCapabilities.FIREFOX
-        caps['marionette'] = True
-        caps['binary'] = '/usr/bin/firefox'
-        cls.selenium = webdriver.Firefox(capabilities=caps)
+        cls.selenium = WebDriver()
         super(OrderListViewTests, cls).setUpClass()
 
     @classmethod

--- a/ecommerce/extensions/dashboard/orders/tests.py
+++ b/ecommerce/extensions/dashboard/orders/tests.py
@@ -6,8 +6,9 @@ from django.test import override_settings
 from nose.plugins.skip import SkipTest
 from oscar.core.loading import get_model
 from oscar.test import factories
+from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
-from selenium.webdriver.firefox.webdriver import WebDriver
+from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.support.wait import WebDriverWait
 
 from ecommerce.extensions.dashboard.orders.views import queryset_orders_for_user
@@ -49,7 +50,10 @@ class OrderListViewTests(OrderViewTestsMixin, RefundTestMixin, LiveServerTestCas
         if os.environ.get('DISABLE_ACCEPTANCE_TESTS') == 'True':
             raise SkipTest
 
-        cls.selenium = WebDriver()
+        caps = DesiredCapabilities.FIREFOX
+        caps['marionette'] = True
+        caps['binary'] = '/usr/bin/firefox'
+        cls.selenium = webdriver.Firefox(capabilities=caps)
         super(OrderListViewTests, cls).setUpClass()
 
     @classmethod

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,6 +11,6 @@ mock-django==0.6.9
 nose-ignore-docstring==0.2
 pep8==1.6.2
 pylint==1.5.0
-selenium==2.53.1
+selenium>=3.0.1
 testfixtures==4.5.0
 diff-cover==0.9.6

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,6 +11,6 @@ mock-django==0.6.9
 nose-ignore-docstring==0.2
 pep8==1.6.2
 pylint==1.5.0
-selenium>=2.53.1
+selenium==2.53.1
 testfixtures==4.5.0
 diff-cover==0.9.6


### PR DESCRIPTION
Here's a proposed fix for recent test failures that I've been experiencing on ecommerce PRs. See #965 and #970 for Travis build failure info.

This PR is influenced by this [comment](http://stackoverflow.com/a/38164528/5859065).
Also, I noticed that in edx-platform repo, Selenium is set to `2.53.1`.

@edx/ecommerce Can someone please take a look?
