### PR TITLE
Added verbosity to pip requirements installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
     - node_modules
     - ecommerce/static/bower_components
 addons:
+    firefox: latest
     apt:
         packages:
             - lcov

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ validate_js:
 	$(NODE_BIN)/gulp jscs
 
 validate_python: clean
-	REUSE_DB=1 coverage run --branch --source=ecommerce ./manage.py test ecommerce \
+	PATH=$$PATH:$(NODE_BIN) REUSE_DB=1 coverage run --branch --source=ecommerce ./manage.py test ecommerce \
 	--settings=ecommerce.settings.test --with-ignore-docstrings --logging-level=DEBUG
 	coverage report
 	make quality

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ requirements.js:
 	$(NODE_BIN)/bower install
 
 requirements: requirements.js
-	pip install -qr requirements/local.txt --exists-action w
+	pip install -r requirements/local.txt --exists-action w
 
 migrate:
 	python manage.py migrate

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "requirejs": "^2.1.18"
   },
   "devDependencies": {
+    "geckodriver": "^1.1.3",
     "gulp": "^3.9.0",
     "gulp-jscs": "3.0.0",
     "gulp-jshint": "1.12.0",

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,6 +11,6 @@ mock-django==0.6.9
 nose-ignore-docstring==0.2
 pep8==1.6.2
 pylint==1.5.0
-selenium>=2.53.1
+selenium>=3.0.1
 testfixtures==4.5.0
 diff-cover==0.9.6


### PR DESCRIPTION
I have removed the quiet argument so that we can see exactly what is installed when this command is called. This is primarily useful for knowing what is installed by Travis.
