### PR TITLE
ECOM-5835 Otto no longer able to refund an order after a refund denial

### DIFF
--- a/ecommerce/extensions/refund/models.py
+++ b/ecommerce/extensions/refund/models.py
@@ -98,7 +98,8 @@ class Refund(StatusMixin, TimeStampedModel):
             None: If no unrefunded order lines have been provided.
             Refund: With RefundLines corresponding to each given unrefunded order line.
         """
-        unrefunded_lines = [line for line in lines if not line.refund_lines.exists()]
+        unrefunded_lines = [line for line in lines if not line.refund_lines.exclude(status=REFUND_LINE.DENIED).exists()]
+
         if unrefunded_lines:
             status = getattr(settings, 'OSCAR_INITIAL_REFUND_STATUS', REFUND.OPEN)
             total_credit_excl_tax = sum([line.line_price_excl_tax for line in unrefunded_lines])


### PR DESCRIPTION
**ECOM-5835 :**
Otto no longer able to refund an order after a refund denial
**Description :**
*Updated the Refund model's create_with_lines method's code to check for refunded lines status too.
*Added tests

**Reviewers :** 
- [x]  @awaisdar001 
- [x]  @clintonb  
