### PR TITLE
Created view to generate signed CyberSource parameters

### DIFF
--- a/ecommerce/core/migrations/0021_siteconfiguration_client_side_payment_processor.py
+++ b/ecommerce/core/migrations/0021_siteconfiguration_client_side_payment_processor.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0020_siteconfiguration_enable_otto_receipt_page'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='siteconfiguration',
+            name='client_side_payment_processor',
+            field=models.CharField(help_text='Processor that will be used for client-side payments', max_length=255, null=True, verbose_name='Payment processors', blank=True),
+        ),
+    ]

--- a/ecommerce/extensions/api/v2/tests/views/test_checkout.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_checkout.py
@@ -18,7 +18,7 @@ class DummyProcessorWithUrl(DummyProcessor):
     """ Dummy payment processor class that has a test payment page url. """
     NAME = 'dummy_with_url'
 
-    def get_transaction_parameters(self, basket, request=None):
+    def get_transaction_parameters(self, basket, request=None, use_client_side_checkout=False, **kwargs):
         dummy_values = {
             'payment_page_url': 'test_processor.edx',
             'transaction_param': 'test_trans_param'

--- a/ecommerce/extensions/payment/constants.py
+++ b/ecommerce/extensions/payment/constants.py
@@ -1,4 +1,7 @@
 """Payment processor constants."""
+from __future__ import unicode_literals
+
+import six
 
 CARD_TYPES = {
     'american_express': {
@@ -19,7 +22,9 @@ CARD_TYPES = {
     },
 }
 
-CARD_TYPE_CHOICES = ((key, value['display_name']) for key, value in CARD_TYPES.iteritems())
+CARD_TYPE_CHOICES = ((key, value['display_name']) for key, value in six.iteritems(CARD_TYPES))
 CYBERSOURCE_CARD_TYPE_MAP = {
-    value['cybersource_code']: key for key, value in CARD_TYPES.iteritems() if 'cybersource_code' in value
+    value['cybersource_code']: key for key, value in six.iteritems(CARD_TYPES) if 'cybersource_code' in value
 }
+
+CLIENT_SIDE_CHECKOUT_FLAG_NAME = 'enable_client_side_checkout'

--- a/ecommerce/extensions/payment/exceptions.py
+++ b/ecommerce/extensions/payment/exceptions.py
@@ -1,10 +1,16 @@
 """Exceptions and error messages used by payment processors."""
+from __future__ import unicode_literals
+
 from django.utils.translation import ugettext_lazy as _
 from oscar.apps.payment.exceptions import GatewayError, PaymentError
 
-
-PROCESSOR_NOT_FOUND_DEVELOPER_MESSAGE = u"Lookup for a payment processor with name [{name}] failed"
+PROCESSOR_NOT_FOUND_DEVELOPER_MESSAGE = "Lookup for a payment processor with name [{name}] failed"
 PROCESSOR_NOT_FOUND_USER_MESSAGE = _("We don't support the payment option you selected.")
+
+
+class ProcessorMisconfiguredError(Exception):
+    """ Raised when a payment processor has invalid/missing settings. """
+    pass
 
 
 class ProcessorNotFoundError(Exception):
@@ -24,4 +30,12 @@ class InvalidCybersourceDecision(GatewayError):
 
 class PartialAuthorizationError(PaymentError):
     """The amount authorized by the payment processor differs from the requested amount."""
+    pass
+
+
+class PCIViolation(PaymentError):
+    """ Raised when a payment request violates PCI compliance.
+
+    If we are raising this exception BAD things are happening, and the service MUST be taken offline IMMEDIATELY!
+    """
     pass

--- a/ecommerce/extensions/payment/forms.py
+++ b/ecommerce/extensions/payment/forms.py
@@ -1,0 +1,73 @@
+from __future__ import unicode_literals
+
+import logging
+
+import pycountry
+from django import forms
+from django.core.exceptions import ValidationError
+from django.utils.translation import ugettext as _
+from oscar.core.loading import get_model
+
+logger = logging.getLogger(__name__)
+Basket = get_model('basket', 'Basket')
+
+
+def country_choices():
+    """ Returns a tuple of tuples, each containing an ISO 3166 country code. """
+    return ((country.alpha2, country.name) for country in pycountry.countries)
+
+
+class PaymentForm(forms.Form):
+    """
+    Payment form with billing details.
+
+    This form captures the data necessary to complete a payment transaction. The current field constraints pertain
+    to CyberSource Silent Order POST, but should work nicely with other payment providers.
+    """
+
+    def __init__(self, user, *args, **kwargs):
+        super(PaymentForm, self).__init__(*args, **kwargs)
+        self.fields['basket'].queryset = self.fields['basket'].queryset.filter(owner=user)
+
+    basket = forms.ModelChoiceField(queryset=Basket.objects.all(), widget=forms.HiddenInput())
+    first_name = forms.CharField(max_length=60, label=_('First Name'))
+    last_name = forms.CharField(max_length=60, label=_('Last Name'))
+    address_line1 = forms.CharField(max_length=29, label=_('Address'))
+    address_line2 = forms.CharField(max_length=29, required=False, label=_('Address (continued)'))
+    city = forms.CharField(max_length=32, label=_('City'))
+    state = forms.CharField(max_length=60, required=False, label=_('State/Province'))
+    postal_code = forms.CharField(max_length=10, required=False, label=_('Zip/Postal Code'))
+    country = forms.ChoiceField(choices=country_choices, label=_('Country'))
+
+    def clean(self):
+        cleaned_data = super(PaymentForm, self).clean()
+
+        # Perform specific validation for the United States and Canada
+        country = cleaned_data.get('country')
+        if country in ('US', 'CA'):
+            state = cleaned_data.get('state')
+
+            # Ensure that a valid 2-character state/province code is specified.
+            if not state:
+                raise ValidationError({'state': _('This field is required.')})
+
+            code = '{country}-{state}'.format(country=country, state=state)
+
+            try:
+                pycountry.subdivisions.get(code=code)
+            except KeyError:
+                msg = _('{state} is not a valid state/province in {country}.').format(state=state, country=country)
+                logger.debug(msg)
+                raise ValidationError({'state': msg})
+
+            # Ensure the postal code is present, and limited to 9 characters
+            postal_code = cleaned_data.get('postal_code')
+            if not postal_code:
+                raise ValidationError({'postal_code': _('This field is required.')})
+
+            if len(postal_code) > 9:
+                raise ValidationError(
+                    {'postal_code': _(
+                        'Postal codes for the U.S. and Canada are limited to nine (9) characters.')})
+
+        return cleaned_data

--- a/ecommerce/extensions/payment/migrations/0010_create_client_side_checkout_flag.py
+++ b/ecommerce/extensions/payment/migrations/0010_create_client_side_checkout_flag.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+from ecommerce.extensions.payment.constants import CLIENT_SIDE_CHECKOUT_FLAG_NAME
+
+
+def create_flag(apps, schema_editor):
+    Flag = apps.get_model('waffle', 'Flag')
+    note = 'This flag determines if the integrated/client-side checkout flow should be enabled.'
+    Flag.objects.get_or_create(name=CLIENT_SIDE_CHECKOUT_FLAG_NAME, defaults={'note': note})
+
+
+def delete_flag(apps, schema_editor):
+    Flag = apps.get_model('waffle', 'Flag')
+    Flag.objects.filter(name=CLIENT_SIDE_CHECKOUT_FLAG_NAME).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('payment', '0009_auto_20161025_1446'),
+        ('waffle', '0001_initial'),
+
+    ]
+
+    operations = [
+        migrations.RunPython(create_flag, reverse_code=delete_flag),
+
+    ]

--- a/ecommerce/extensions/payment/processors/invoice.py
+++ b/ecommerce/extensions/payment/processors/invoice.py
@@ -43,7 +43,7 @@ class InvoicePayment(BasePaymentProcessor):
             invoice.save()
         return source, event
 
-    def get_transaction_parameters(self, basket, request=None):
+    def get_transaction_parameters(self, basket, request=None, use_client_side_checkout=False, **kwargs):
         return None
 
     def issue_credit(self, source, amount, currency):

--- a/ecommerce/extensions/payment/processors/paypal.py
+++ b/ecommerce/extensions/payment/processors/paypal.py
@@ -70,15 +70,15 @@ class Paypal(BasePaymentProcessor):
     def error_url(self):
         return get_ecommerce_url(self.configuration['error_path'])
 
-    def get_transaction_parameters(self, basket, request=None):
+    def get_transaction_parameters(self, basket, request=None, use_client_side_checkout=False, **kwargs):
         """
         Create a new PayPal payment.
 
         Arguments:
             basket (Basket): The basket of products being purchased.
-
-        Keyword Arguments:
-            request (Request): A Request object which is used to construct PayPal's `return_url`.
+            request (Request, optional): A Request object which is used to construct PayPal's `return_url`.
+            use_client_side_checkout (bool, optional): This value is not used.
+            **kwargs: Additional parameters; not used by this method.
 
         Returns:
             dict: PayPal-specific parameters required to complete a transaction. Must contain a URL

--- a/ecommerce/extensions/payment/tests/processors/__init__.py
+++ b/ecommerce/extensions/payment/tests/processors/__init__.py
@@ -4,7 +4,7 @@ from ecommerce.extensions.payment.processors import BasePaymentProcessor
 class DummyProcessor(BasePaymentProcessor):
     NAME = 'dummy'
 
-    def get_transaction_parameters(self, basket, request=None):
+    def get_transaction_parameters(self, basket, request=None, use_client_side_checkout=False, **kwargs):
         pass
 
     def handle_processor_response(self, response, basket=None):

--- a/ecommerce/extensions/payment/tests/processors/mixins.py
+++ b/ecommerce/extensions/payment/tests/processors/mixins.py
@@ -58,6 +58,10 @@ class PaymentProcessorTestCaseMixin(RefundTestMixin, CourseCatalogTestMixin, Pay
         """Test that the name constant on the processor class is correct."""
         self.assertEqual(self.processor.NAME, self.processor_name)
 
+    def test_client_side_payment_url(self):
+        """ Verify the property returns the client-side payment URL. """
+        self.assertIsNone(self.processor.client_side_payment_url)
+
     def test_get_transaction_parameters(self):
         """ Verify the processor returns the appropriate parameters required to complete a transaction. """
         raise NotImplementedError

--- a/ecommerce/extensions/payment/tests/test_forms.py
+++ b/ecommerce/extensions/payment/tests/test_forms.py
@@ -1,0 +1,94 @@
+from __future__ import unicode_literals
+
+import ddt
+from oscar.test import factories
+
+from ecommerce.extensions.payment.forms import PaymentForm
+from ecommerce.tests.testcases import TestCase
+
+
+@ddt.ddt
+class CyberSourceSubmitFormTests(TestCase):
+    def setUp(self):
+        super(CyberSourceSubmitFormTests, self).setUp()
+        self.user = self.create_user()
+        self.basket = factories.create_basket()
+        self.basket.owner = self.user
+        self.basket.save()
+
+    def _generate_data(self, **kwargs):
+        data = {
+            'basket': self.basket.id,
+            'first_name': 'Test',
+            'last_name': 'User',
+            'address_line1': '141 Portland Ave.',
+            'address_line2': 'Floor 9',
+            'city': 'Cambridge',
+            'state': 'MA',
+            'postal_code': '02139',
+            'country': 'US',
+        }
+        data.update(**kwargs)
+        return data
+
+    def _assert_form_validity(self, is_valid, **kwargs):
+        data = self._generate_data(**kwargs)
+        self.assertEqual(PaymentForm(user=self.user, data=data).is_valid(), is_valid)
+
+    def assert_form_valid(self, **kwargs):
+        self._assert_form_validity(True, **kwargs)
+
+    def assert_form_not_valid(self, **kwargs):
+        self._assert_form_validity(False, **kwargs)
+
+    def test_country_validation(self):
+        """ Verify the country field is limited to valid ISO 3166 2-character country codes. """
+        self.assert_form_valid(country='US')
+        self.assert_form_not_valid(country='ZZ')
+        self.assert_form_not_valid(country='ABC')
+
+    @ddt.unpack
+    @ddt.data(
+        ('US', 'TX'),
+        ('CA', 'QC')
+    )
+    def test_state_validation_for_north_america(self, country, valid_state):
+        """ Verify the state field is limited to 2 characters when the country is set to the U.S. or Canada. """
+        self.assert_form_valid(country=country, state=valid_state)
+        self.assert_form_not_valid(country=country, state='ZZ')
+        self.assert_form_not_valid(country=country, state=None)
+        self.assert_form_not_valid(country=country, state='')
+
+        data = self._generate_data(country=country)
+        data.pop('state', None)
+        self.assertFalse(PaymentForm(user=self.user, data=data).is_valid())
+
+    def test_state_validation_outside_north_america(self):
+        """ Verify the state field is limited to 60 characters when the country is NOT set to the U.S. or Canada. """
+        self.assert_form_valid(country='GH', state=None)
+        self.assert_form_valid(country='GH', state='Brong-Ahafo')
+
+        invalid_state = ''.join(['a' for __ in range(0, 61)])
+        self.assert_form_not_valid(country='GH', state=invalid_state)
+
+    @ddt.unpack
+    @ddt.data(
+        ('US', 'CA'),
+        ('CA', 'QC')
+    )
+    def test_postal_code_validation_for_north_america(self, country, valid_state):
+        """ Verify the postal code is limited to 9 characters when the country is set to the U.S. or Canada. """
+        self.assert_form_valid(country=country, state=valid_state, postal_code='90210')
+        self.assert_form_valid(country=country, state=valid_state, postal_code='902102938')
+        self.assert_form_not_valid(country=country, state=valid_state, postal_code='1234567890')
+        self.assert_form_not_valid(country=country, state=valid_state, postal_code='')
+        self.assert_form_not_valid(country=country, state=valid_state, postal_code=None)
+
+    def test_postal_code_validation_outside_north_america(self):
+        """ Verify the postal code field is limited to 10 characters when the country is
+        NOT set to the U.S. or Canada. """
+        self.assert_form_valid(country='IN', postal_code=None)
+        self.assert_form_valid(country='IN', postal_code='1947')
+
+        invalid_postal_code = ''.join(['a' for __ in range(0, 11)])
+        self.assert_form_not_valid(country='IN', postal_code=invalid_postal_code)

--- a/ecommerce/extensions/payment/tests/test_views.py
+++ b/ecommerce/extensions/payment/tests/test_views.py
@@ -1,9 +1,15 @@
 """ Tests of the Payment Views. """
+from __future__ import unicode_literals
+
+import json
+
 import ddt
+import mock
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 from factory.django import mute_signals
-import mock
+from freezegun import freeze_time
 from oscar.apps.order.exceptions import UnableToPlaceOrder
 from oscar.apps.payment.exceptions import PaymentError, UserCancelled, TransactionDeclined
 from oscar.core.loading import get_class, get_model
@@ -11,20 +17,23 @@ from oscar.test import factories
 from oscar.test.contextmanagers import mock_signal_receiver
 from testfixtures import LogCapture
 
+from ecommerce.core.tests.patched_httpretty import httpretty
 from ecommerce.extensions.checkout.utils import get_receipt_page_url
 from ecommerce.extensions.fulfillment.status import ORDER
 from ecommerce.extensions.payment.processors.cybersource import Cybersource
 from ecommerce.extensions.payment.processors.paypal import Paypal
 from ecommerce.extensions.payment.tests.mixins import PaymentEventsMixin, CybersourceMixin, PaypalMixin
 from ecommerce.extensions.payment.views import CybersourceNotifyView, PaypalPaymentExecutionView
-from ecommerce.core.tests.patched_httpretty import httpretty
 from ecommerce.tests.testcases import TestCase
+
+JSON = 'application/json'
 
 Basket = get_model('basket', 'Basket')
 Order = get_model('order', 'Order')
 PaymentEvent = get_model('order', 'PaymentEvent')
 PaymentEventType = get_model('order', 'PaymentEventType')
 PaymentProcessorResponse = get_model('payment', 'PaymentProcessorResponse')
+Selector = get_class('partner.strategy', 'Selector')
 SourceType = get_model('payment', 'SourceType')
 
 post_checkout = get_class('checkout.signals', 'post_checkout')
@@ -107,11 +116,7 @@ class CybersourceNotifyViewTests(CybersourceMixin, PaymentEventsMixin, TestCase)
         # The basket should not have an associated order if no payment was made.
         self.assertFalse(Order.objects.filter(basket=self.basket).exists())
 
-        notification = self.generate_notification(
-            self.processor.secret_key,
-            self.basket,
-            billing_address=self.billing_address,
-        )
+        notification = self.generate_notification(self.basket, billing_address=self.billing_address)
 
         with mock_signal_receiver(post_checkout) as receiver:
             response = self.client.post(reverse('cybersource_notify'), notification)
@@ -148,7 +153,7 @@ class CybersourceNotifyViewTests(CybersourceMixin, PaymentEventsMixin, TestCase)
         be created.
         """
 
-        notification = self.generate_notification(self.processor.secret_key, self.basket, decision=decision)
+        notification = self.generate_notification(self.basket, decision=decision)
         response = self.client.post(reverse('cybersource_notify'), notification)
 
         # The view should always return 200
@@ -177,15 +182,10 @@ class CybersourceNotifyViewTests(CybersourceMixin, PaymentEventsMixin, TestCase)
         Verify that CyberSource's merchant notification is saved to the database despite an error handling payment.
         """
         notification = self.generate_notification(
-            self.processor.secret_key,
             self.basket,
             billing_address=self.billing_address,
         )
-        with mock.patch.object(
-            CybersourceNotifyView,
-            'handle_payment',
-            side_effect=error_class
-        ) as fake_handle_payment:
+        with mock.patch.object(CybersourceNotifyView, 'handle_payment', side_effect=error_class) as fake_handle_payment:
             self._assert_processing_failure(
                 notification,
                 status_code,
@@ -198,7 +198,6 @@ class CybersourceNotifyViewTests(CybersourceMixin, PaymentEventsMixin, TestCase)
         """ When payment is accepted, but an order cannot be placed, log an error and return HTTP 200. """
 
         notification = self.generate_notification(
-            self.processor.secret_key,
             self.basket,
             billing_address=self.billing_address,
         )
@@ -226,7 +225,6 @@ class CybersourceNotifyViewTests(CybersourceMixin, PaymentEventsMixin, TestCase)
         order_number = '{}-{}'.format(self.partner.short_code.upper(), 101986)
 
         notification = self.generate_notification(
-            self.processor.secret_key,
             self.basket,
             billing_address=self.billing_address,
             req_reference_number=order_number,
@@ -256,7 +254,6 @@ class CybersourceNotifyViewTests(CybersourceMixin, PaymentEventsMixin, TestCase)
         # and that the address our endpoint parses from the notification is
         # equivalent to the original.
         notification = self.generate_notification(
-            self.processor.secret_key,
             self.basket,
             billing_address=self.billing_address,
         )
@@ -268,7 +265,6 @@ class CybersourceNotifyViewTests(CybersourceMixin, PaymentEventsMixin, TestCase)
         # recognizes and parses it correctly.
         billing_address = self.make_billing_address({field_name: field_value})
         notification = self.generate_notification(
-            self.processor.secret_key,
             self.basket,
             billing_address=billing_address,
         )
@@ -280,7 +276,7 @@ class CybersourceNotifyViewTests(CybersourceMixin, PaymentEventsMixin, TestCase)
         If the response signature is invalid, the view should return a 400. The response should be recorded, but an
         order should NOT be created.
         """
-        notification = self.generate_notification(self.processor.secret_key, self.basket)
+        notification = self.generate_notification(self.basket)
         notification[u'signature'] = u'Tampered'
         response = self.client.post(reverse('cybersource_notify'), notification)
 
@@ -600,3 +596,132 @@ class PaypalProfileAdminViewTests(TestCase):
         mock_call_command.side_effect = Exception("oof")
         self.get_response(True, 500, {"action": "list"})
         self.assertTrue(mock_call_command.called)
+
+
+@ddt.ddt
+class CybersourceSubmitViewTests(CybersourceMixin, TestCase):
+    path = reverse('cybersource_submit')
+
+    def setUp(self):
+        super(CybersourceSubmitViewTests, self).setUp()
+        self.user = self.create_user()
+        self.client.login(username=self.user.username, password=self.password)
+
+    def _generate_data(self, basket_id):
+        return {
+            'basket': basket_id,
+            'first_name': 'Test',
+            'last_name': 'User',
+            'address_line1': '141 Portland Ave.',
+            'address_line2': 'Floor 9',
+            'city': 'Cambridge',
+            'state': 'MA',
+            'postal_code': '02139',
+            'country': 'US',
+        }
+
+    def _create_valid_basket(self):
+        """ Creates a Basket ready for checkout. """
+        basket = factories.create_basket()
+        basket.owner = self.user
+        basket.strategy = Selector().strategy()
+        basket.site = self.site
+        basket.thaw()
+        return basket
+
+    def assert_basket_retrieval_error(self, basket_id):
+        error_msg = 'There was a problem retrieving your basket. Refresh the page to try again.'
+        return self._assert_basket_error(basket_id, error_msg)
+
+    def test_login_required(self):
+        """ Verify the view redirects anonymous users to the login page. """
+        self.client.logout()
+        response = self.client.post(self.path)
+        expected_url = '{base}?next={path}'.format(base=self.get_full_url(path=reverse(settings.LOGIN_URL)),
+                                                   path=self.path)
+        self.assertRedirects(response, expected_url, fetch_redirect_response=False)
+
+    @ddt.data('get', 'put', 'patch', 'head')
+    def test_invalid_methods(self, method):
+        """ Verify the view only supports the POST and OPTION HTTP methods."""
+        response = getattr(self.client, method)(self.path)
+        self.assertEqual(response.status_code, 405)
+
+    def _assert_basket_error(self, basket_id, error_msg):
+        response = self.client.post(self.path, self._generate_data(basket_id))
+        self.assertEqual(response.status_code, 400)
+        expected = {'error': error_msg}
+        self.assertDictEqual(json.loads(response.content), expected)
+
+    def test_missing_basket(self):
+        """ Verify the view returns an HTTP 400 status if the basket is missing. """
+        self.assert_basket_retrieval_error(1234)
+
+    def test_mismatched_basket_owner(self):
+        """ Verify the view returns an HTTP 400 status if the posted basket does not belong to the requesting user. """
+        basket = factories.BasketFactory()
+        self.assert_basket_retrieval_error(basket.id)
+
+        basket = factories.BasketFactory(owner=self.create_user())
+        self.assert_basket_retrieval_error(basket.id)
+
+    @ddt.data(Basket.MERGED, Basket.SAVED, Basket.FROZEN, Basket.SUBMITTED)
+    def test_invalid_basket_status(self, status):
+        """ Verify the view returns an HTTP 400 status if the basket is in an invalid state. """
+        basket = factories.BasketFactory(owner=self.user, status=status)
+        error_msg = 'Your basket may have been modified or already purchased. Refresh the page to try again.'
+        self._assert_basket_error(basket.id, error_msg)
+
+    @freeze_time('2016-01-01')
+    def test_valid_request(self):
+        """ Verify the view returns the CyberSource parameters if the request is valid. """
+        basket = self._create_valid_basket()
+        data = self._generate_data(basket.id)
+        response = self.client.post(self.path, data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['content-type'], JSON)
+
+        actual = json.loads(response.content)['form_fields']
+        transaction_uuid = actual['transaction_uuid']
+        extra_parameters = {
+            'payment_method': 'card',
+            'unsigned_field_names': 'card_cvn,card_expiry_date,card_number,card_type',
+            'bill_to_email': self.user.email,
+            'device_fingerprint_id': self.client.session.session_key,
+            'bill_to_address_city': data['city'],
+            'bill_to_address_country': data['country'],
+            'bill_to_address_line1': data['address_line1'],
+            'bill_to_address_line2': data['address_line2'],
+            'bill_to_address_postal_code': data['postal_code'],
+            'bill_to_address_state': data['state'],
+            'bill_to_forename': data['first_name'],
+            'bill_to_surname': data['last_name'],
+        }
+
+        expected = self.get_expected_transaction_parameters(
+            basket,
+            transaction_uuid,
+            use_sop_profile=True,
+            extra_parameters=extra_parameters
+        )
+        self.assertDictEqual(actual, expected)
+
+        # Ensure the basket is frozen
+        basket = Basket.objects.get(pk=basket.pk)
+        self.assertEqual(basket.status, Basket.FROZEN)
+
+    def test_field_error(self):
+        """ Verify the view responds with a JSON object containing fields with errors, when input is invalid. """
+        basket = self._create_valid_basket()
+        data = self._generate_data(basket.id)
+        field = 'first_name'
+        del data[field]
+
+        response = self.client.post(self.path, data)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response['content-type'], JSON)
+
+        errors = json.loads(response.content)['field_errors']
+        self.assertIn(field, errors)

--- a/ecommerce/extensions/payment/urls.py
+++ b/ecommerce/extensions/payment/urls.py
@@ -5,6 +5,7 @@ from ecommerce.extensions.payment import views
 
 urlpatterns = [
     url(r'^cybersource/notify/$', views.CybersourceNotifyView.as_view(), name='cybersource_notify'),
+    url(r'^cybersource/submit/$', views.CybersourceSubmitView.as_view(), name='cybersource_submit'),
     url(r'^paypal/execute/$', views.PaypalPaymentExecutionView.as_view(), name='paypal_execute'),
     url(r'^paypal/profiles/$', views.PaypalProfileAdminView.as_view(), name='paypal_profiles'),
 ]

--- a/ecommerce/settings/test.py
+++ b/ecommerce/settings/test.py
@@ -80,6 +80,10 @@ PAYMENT_PROCESSOR_CONFIG = {
             'receipt_path': PAYMENT_PROCESSOR_RECEIPT_PATH,
             'cancel_checkout_path': PAYMENT_PROCESSOR_CANCEL_PATH,
             'send_level_2_3_details': True,
+            'sop_profile_id': 'sop-fake-profile-id',
+            'sop_access_key': 'sop-fake-access-key',
+            'sop_secret_key': 'sop-fake-secret-key',
+            'sop_payment_page_url': 'https://sop-replace-me/',
         },
         'paypal': {
             'mode': 'sandbox',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,4 +31,5 @@ python-dateutil==2.4.2
 pytz==2015.7
 requests==2.9.1
 sailthru-client==2.2.3
+six==1.10.0
 suds==0.4

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,6 +5,7 @@ bok-choy==0.4.7
 coverage==4.0.2
 ddt==1.0.0
 django-nose==1.4.2
+freezegun==0.3.7
 httpretty==0.8.14
 mock==1.3.0
 mock-django==0.6.9


### PR DESCRIPTION
This view signs the user-input billing details along with the server-generated basket details, and returns the complete parameter JSON object. The resulting data can be forwarded to CyberSource to complete a transaction.

SOL-2116
