### PR TITLE
[SOL-2074] Omit expired professional courses from offer landing page.

### DIFF
--- a/ecommerce/coupons/tests/mixins.py
+++ b/ecommerce/coupons/tests/mixins.py
@@ -34,6 +34,7 @@ class CourseCatalogMockMixin(object):
                 "image": {
                     "src": "/path/to/image.jpg",
                 },
+                'enrollment_end': None
             }
 
         course_run_info_json = json.dumps(course_run_info)
@@ -61,10 +62,12 @@ class CourseCatalogMockMixin(object):
                     'start': '2016-05-01T00:00:00Z',
                     'image': {
                         'src': 'path/to/the/course/image'
-                    }
+                    },
+                    'enrollment_end': None
                 }] if course_run else [{
                     'key': 'test',
                     'title': 'Test course',
+                    'enrollment_end': None
                 }],
             }
         course_run_info_json = json.dumps(course_run_info)


### PR DESCRIPTION
In the coupon offer landing page omit the professional courses which
have a set enrollment end datetime which has passed.

https://openedx.atlassian.net/browse/SOL-2074

According to @griffresch in the ticket:

> edX and Partners often change the enrollment end-date of a course (any type, not just ProfEd).

This might cause problems in the following scenario:
1. Course discovery service (CDS) picks up the enrollment end date metadata for a course.
2. Course enrollment end date is edited to a passed date, to prematurely close the enrollment for example, and because of that the course is no longer listed in the courses API from which the CDS retrieves the course data which means CDS has the old date stored.
3. Even though the course enrollment date has passed, we still get the old date from CDS and show that course is the offer landing page.

I don't know what settings are for the course discovery on stage and production, but that described issue happens to me locally.

Upon further investigation, setting this value (https://github.com/edx/edx-platform/blob/master/lms/envs/common.py#L2696) to `see_in_catalog` displays the course who's enrollment end date has passed. So if that setting is set so on stage and production, I could change the code to check directly on the LMS API the enrollment end date instead of CDS. @mjfrey who can ask for the values of these settings?
