### PR TITLE
[SOL-1975] Code | Offer Page - Display in order of Course Launch Date

### DIFF
--- a/ecommerce/coupons/utils.py
+++ b/ecommerce/coupons/utils.py
@@ -8,7 +8,7 @@ from oscar.core.loading import get_model
 Product = get_model('catalogue', 'Product')
 
 
-def get_range_catalog_query_results(limit, query, site, offset=None):
+def get_range_catalog_query_results(limit, query, site, offset=None, ordering=None):
     """
     Get catalog query results
 
@@ -17,20 +17,22 @@ def get_range_catalog_query_results(limit, query, site, offset=None):
         query (str): ElasticSearch Query
         site (Site): Site object containing Site Configuration data
         offset (int): Page offset
+        ordering (str): Course Discovery results ordering (only start is enabled for now)
 
     Returns:
-        dict: Query seach results received from Course Catalog API
+        dict: Query search results received from Course Catalog API
     """
     partner_code = site.siteconfiguration.partner.short_code
-    cache_key = 'course_runs_{}_{}_{}_{}'.format(query, limit, offset, partner_code)
+    cache_key = 'course_runs_{}_{}_{}_{}_{}'.format(query, limit, offset, partner_code, ordering)
     cache_hash = hashlib.md5(cache_key).hexdigest()
     response = cache.get(cache_hash)
     if not response:
         response = site.siteconfiguration.course_catalog_api_client.course_runs.get(
             limit=limit,
             offset=offset,
+            ordering=ordering,
+            partner=partner_code,
             q=query,
-            partner=partner_code
         )
         cache.set(cache_hash, response, settings.COURSES_API_CACHE_TIMEOUT)
     return response

--- a/ecommerce/extensions/api/v2/tests/views/test_vouchers.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_vouchers.py
@@ -82,28 +82,29 @@ class VoucherViewSetTests(CourseCatalogMockMixin, CourseCatalogTestMixin, LmsApi
             'next': 'path/to/the/next/page',
             'results': []
         }
+        dates = ['2015-05-01T00:00:00Z', '2016-05-01T00:00:00Z', '2014-05-01T00:00:00Z']
         products = []
         new_range, __ = Range.objects.get_or_create(catalog_query='*:*', course_seat_types=seat_type)
         if seats:
-            for seat in seats:
+            for i, seat in enumerate(seats):
                 course_run_info['results'].append({
                     'image': {
                         'src': 'path/to/the/course/image'
                     },
                     'key': seat.course_id,
-                    'start': '2016-05-01T00:00:00Z',
+                    'start': dates[i % 3],
                     'title': seat.title,
                 })
                 new_range.add_product(seat)
         else:
-            for _ in range(quantity):
+            for i in range(quantity):
                 course, seat = self.create_course_and_seat(seat_type=seat_type)
                 course_run_info['results'].append({
                     'image': {
                         'src': 'path/to/the/course/image'
                     },
                     'key': course.id,
-                    'start': '2016-05-01T00:00:00Z',
+                    'start': dates[i % 3],
                     'title': course.name,
                 })
                 new_range.add_product(seat)
@@ -119,6 +120,16 @@ class VoucherViewSetTests(CourseCatalogMockMixin, CourseCatalogTestMixin, LmsApi
         request.strategy = DefaultStrategy()
 
         return products, request, voucher
+
+    @httpretty.activate
+    @mock_course_catalog_api_client
+    def test_get_offers_return_sorted_offers(self):
+        """ Verify get_offers sorts the offers returned by start date """
+        __, request, voucher = self.prepare_get_offers_response(quantity=3)
+        offers = VoucherViewSet().get_offers(request=request, voucher=voucher)['results']
+        self.assertTrue(
+            offers[0]['course_start_date'] < offers[1]['course_start_date'] < offers[2]['course_start_date']
+        )
 
     @httpretty.activate
     @mock_course_catalog_api_client

--- a/ecommerce/extensions/api/v2/views/vouchers.py
+++ b/ecommerce/extensions/api/v2/views/vouchers.py
@@ -109,13 +109,14 @@ class VoucherViewSet(NonDestroyableModelViewSet):
         stock_records = StockRecord.objects.filter(product__in=products)
         return products, stock_records
 
-    def get_offers_from_query(self, request, voucher, catalog_query):
+    def get_offers_from_query(self, request, voucher, catalog_query, ordering=None):
         """ Helper method for collecting offers from catalog query.
 
         Args:
             request (WSGIRequest): Request data.
             voucher (Voucher): Oscar Voucher for which the offers are returned.
             catalog_query (str): The query for the Course Discovery.
+            ordering (str): Course Discovery results ordering (only start is enabled for now)
 
         Returns:
             A list of dictionaries with retrieved offers and a link to the next
@@ -130,8 +131,9 @@ class VoucherViewSet(NonDestroyableModelViewSet):
         response = get_range_catalog_query_results(
             limit=request.GET.get('limit', DEFAULT_CATALOG_PAGE_SIZE),
             offset=request.GET.get('offset'),
+            ordering=ordering,
             query=catalog_query,
-            site=request.site
+            site=request.site,
         )
         next_page = response['next']
         products, stock_records = self.retrieve_course_objects(response['results'], course_seat_types)
@@ -189,7 +191,7 @@ class VoucherViewSet(NonDestroyableModelViewSet):
                     voucher=voucher
                 ))
 
-        return offers, next_page
+        return sorted(offers, key=lambda offer: offer['course_start_date']), next_page
 
     def get_offers(self, request, voucher):
         """
@@ -207,7 +209,7 @@ class VoucherViewSet(NonDestroyableModelViewSet):
         offers = []
 
         if catalog_query:
-            offers, next_page = self.get_offers_from_query(request, voucher, catalog_query)
+            offers, next_page = self.get_offers_from_query(request, voucher, catalog_query, ordering='start')
         else:
             product_range = voucher.offers.first().benefit.range
             products = product_range.all_products()


### PR DESCRIPTION
This PR sorts the offers by the course start date but we limited the api call to 50 results from the course discovery service so additional work is required on that side. Once I've done the sorting on course discovery I'll propose a PR in the course discovery repo.
@mjfrey @vkaracic @marjev 

https://openedx.atlassian.net/browse/SOL-1975
