### PR TITLE
Catch exceptions during paypal payment creation and introduce retry

### DIFF
--- a/ecommerce/extensions/payment/admin.py
+++ b/ecommerce/extensions/payment/admin.py
@@ -3,8 +3,10 @@ from pprint import pformat
 from django.utils.html import format_html
 from oscar.apps.payment.admin import *  # noqa pylint: disable=wildcard-import,unused-wildcard-import,wrong-import-position
 from oscar.core.loading import get_model
+from solo.admin import SingletonModelAdmin
 
 PaymentProcessorResponse = get_model('payment', 'PaymentProcessorResponse')
+PaypalProcessorConfiguration = get_model('payment', 'PaypalProcessorConfiguration')
 
 
 @admin.register(PaymentProcessorResponse)
@@ -23,3 +25,6 @@ class PaymentProcessorResponseAdmin(admin.ModelAdmin):
         return format_html('<br><br><pre>{}</pre>', pretty_response)
 
     formatted_response.allow_tags = True
+
+
+admin.site.register(PaypalProcessorConfiguration, SingletonModelAdmin)

--- a/ecommerce/extensions/payment/migrations/0011_paypalprocessorconfiguration.py
+++ b/ecommerce/extensions/payment/migrations/0011_paypalprocessorconfiguration.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('payment', '0010_create_client_side_checkout_flag'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='PaypalProcessorConfiguration',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('retry_attempts', models.PositiveSmallIntegerField(default=0, verbose_name='Number of times to retry failing Paypal client actions')),
+            ],
+            options={
+                'verbose_name': 'Paypal Processor Configuration',
+            },
+        ),
+    ]

--- a/ecommerce/extensions/payment/models.py
+++ b/ecommerce/extensions/payment/models.py
@@ -2,6 +2,7 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from jsonfield import JSONField
 from oscar.apps.payment.abstract_models import AbstractSource
+from solo.models import SingletonModel
 
 from ecommerce.extensions.payment.constants import CARD_TYPE_CHOICES
 
@@ -32,5 +33,18 @@ class PaypalWebProfile(models.Model):
     name = models.CharField(max_length=255, unique=True)
 
 
+class PaypalProcessorConfiguration(SingletonModel):
+    """ This is a configuration model for PayPal Payment Processor"""
+    retry_attempts = models.PositiveSmallIntegerField(
+        default=0,
+        verbose_name=_(
+            'Number of times to retry failing Paypal client actions (e.g., payment creation, payment execution)'
+        )
+    )
+
+    class Meta(object):
+        verbose_name = "Paypal Processor Configuration"
+
+
 # noinspection PyUnresolvedReferences
-from oscar.apps.payment.models import *  # noqa pylint: disable=wildcard-import,unused-wildcard-import,wrong-import-position,wrong-import-order
+from oscar.apps.payment.models import *  # noqa pylint: disable=ungrouped-imports, wildcard-import,unused-wildcard-import,wrong-import-position,wrong-import-order

--- a/ecommerce/extensions/payment/tests/mixins.py
+++ b/ecommerce/extensions/payment/tests/mixins.py
@@ -282,21 +282,21 @@ class PaypalMixin(object):
             status=200
         )
 
-    def mock_api_responses(self, path, body_array, post=True):
+    def mock_api_responses(self, path, response_array, post=True):
         assert httpretty.is_enabled()
 
         url = self._create_api_url(path)
 
-        response_array = []
-        for body in body_array:
-            response_array.append(
-                httpretty.Response(body=json.dumps(body), status=200)
+        httpretty_response_array = []
+        for response in response_array:
+            httpretty_response_array.append(
+                httpretty.Response(body=json.dumps(response['body']), status=response['status'])
             )
 
         httpretty.register_uri(
             httpretty.POST if post else httpretty.GET,
             url,
-            responses=response_array,
+            responses=httpretty_response_array,
             status=200
         )
 

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -261,6 +261,7 @@ DJANGO_APPS = [
     'rest_framework_swagger',
     'release_util',
     'crispy_forms',
+    'solo',
 ]
 
 # Apps specific to this project go here.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,6 +9,7 @@ django-libsass==0.5
 django-oscar==1.1.1
 django-rest-swagger==0.3.5
 django_simple_history==1.6.3
+django-solo==1.1.2
 django-threadlocals==0.8
 django-waffle==0.11.1
 djangorestframework==3.2.3


### PR DESCRIPTION
ECOM-5891
@edx/ecommerce Please review
This is to take on @rlucioni's feedback on the same ticket. Introduced another test case as well