### PR TITLE
Remove duplicate invoices for coupons.

### DIFF
--- a/ecommerce/invoice/management/commands/squash_duplicate_invoices.py
+++ b/ecommerce/invoice/management/commands/squash_duplicate_invoices.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         for coupon in Product.objects.filter(product_class__name='Coupon'):
-            qs = Invoice.objects.filter(order__basket__lines__product=coupon).order_by('created')
+            qs = Invoice.objects.filter(order__lines__product=coupon).order_by('created')
             if qs.count() > 1:
                 qs.exclude(pk=qs.first().id).delete()
                 logger.info('Deleted douplicate invoices of coupon %s', coupon.id)

--- a/ecommerce/invoice/tests.py
+++ b/ecommerce/invoice/tests.py
@@ -113,20 +113,20 @@ class SquashDuplicateInvoicesCommandTests(TestCase):
 
     def assert_unique_invoice(self, product, invoice):
         """Helper method for asserting there is only one invoice for given product."""
-        invoice_qs = Invoice.objects.filter(order__basket__lines__product=product)
+        invoice_qs = Invoice.objects.filter(order__lines__product=product)
         self.assertEqual(invoice_qs.count(), 1)
         self.assertEqual(invoice_qs.first(), invoice)
 
     def test_squashing_invoices(self):
         """Verify after calling the command the duplicate invoices are squashed."""
         Invoice.objects.create(order=self.order)
-        self.assertEqual(Invoice.objects.filter(order__basket__lines__product=self.product).count(), 2)
+        self.assertEqual(Invoice.objects.filter(order__lines__product=self.product).count(), 2)
 
         call_command('squash_duplicate_invoices')
         self.assert_unique_invoice(self.product, self.invoice)
 
     def test_not_squashing_invoices(self):
         """Verify the non-duplicate invoices are left the same."""
-        self.assertEqual(Invoice.objects.filter(order__basket__lines__product=self.product).count(), 1)
+        self.assertEqual(Invoice.objects.filter(order__lines__product=self.product).count(), 1)
         call_command('squash_duplicate_invoices')
         self.assert_unique_invoice(self.product, self.invoice)


### PR DESCRIPTION
There were still some duplicate invoices left after running #994.
This will remove invoices that have more than one same coupon in
it's order lines instead of only it's order basket lines.

@mjfrey 