### PR TITLE
Fixes the CSS of the error page.

### DIFF
--- a/ecommerce/static/sass/partials/utilities/_variables.scss
+++ b/ecommerce/static/sass/partials/utilities/_variables.scss
@@ -56,4 +56,3 @@ $input-addon-width: 40px;
 $coupon-grid-item-height: 75px;
 
 $container-padding-top: 60px;
-$container-padding-bottom: spacing-vertical(small);

--- a/ecommerce/static/sass/partials/views/_coupon_offer.scss
+++ b/ecommerce/static/sass/partials/views/_coupon_offer.scss
@@ -1,7 +1,7 @@
 #offer {
     .container {
         padding-top: $container-padding-top;
-        padding-bottom: $container-padding-bottom;
+        padding-bottom: spacing-vertical(small);
 
         .row {
             .pagination-block {

--- a/ecommerce/static/sass/partials/views/_error.scss
+++ b/ecommerce/static/sass/partials/views/_error.scss
@@ -1,10 +1,11 @@
-#error-message {
+#error-message .container {
   padding-top: $container-padding-top;
-  padding-bottom: $container-padding-bottom;
+  padding-bottom: spacing-vertical(small);
 }
 
 .message-error-content {
   border-top: 4px solid #B20610;
+
   h3 {
     margin-bottom: 10px;
     font-weight: bold;

--- a/ecommerce/templates/edx/error.html
+++ b/ecommerce/templates/edx/error.html
@@ -1,5 +1,6 @@
 {% extends 'edx/base.html' %}
 {% load i18n %}
+{% load staticfiles %}
 
 {% block title %}{% endblock %}
 


### PR DESCRIPTION
The padding was applied to the wrong selector. Basically now we have this:
![screenshot from 2016-11-15 15-40-27](https://cloud.githubusercontent.com/assets/2808092/20309890/1254cdb6-ab4a-11e6-860f-9b4ff762c060.png)

And we want this:
![screenshot from 2016-11-15 15-39-20](https://cloud.githubusercontent.com/assets/2808092/20309882/08d3aff0-ab4a-11e6-9727-9f7e78a5d4d9.png)

@iivic please review.