### PR TITLE
This prevents errors in attribute_cookie_data from rolling back all basket-related transactions.

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,7 +2,7 @@
 -r base.txt
 
 bok-choy==0.4.7
-coverage==4.0.2
+coverage==4.2
 ddt==1.0.0
 django-nose==1.4.2
 freezegun==0.3.7


### PR DESCRIPTION
@edx/ecommerce Please review
This is to fix the issue in ECOM-6366 for the long term