### PR TITLE
Updated payment processors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ override.cfg
 private.py
 docs/_build
 *.backup
+*.log

--- a/ecommerce/extensions/payment/processors/invoice.py
+++ b/ecommerce/extensions/payment/processors/invoice.py
@@ -46,5 +46,5 @@ class InvoicePayment(BasePaymentProcessor):
     def get_transaction_parameters(self, basket, request=None, use_client_side_checkout=False, **kwargs):
         return None
 
-    def issue_credit(self, source, amount, currency):
+    def issue_credit(self, order, reference_number, amount, currency):
         raise NotImplementedError

--- a/ecommerce/extensions/payment/tests/processors/__init__.py
+++ b/ecommerce/extensions/payment/tests/processors/__init__.py
@@ -1,20 +1,27 @@
-from ecommerce.extensions.payment.processors import BasePaymentProcessor
+from ecommerce.extensions.payment.processors import BasePaymentProcessor, HandledProcessorResponse
 
 
 class DummyProcessor(BasePaymentProcessor):
     NAME = 'dummy'
+    REFUND_TRANSACTION_ID = 'fake-refund'
 
     def get_transaction_parameters(self, basket, request=None, use_client_side_checkout=False, **kwargs):
         pass
 
     def handle_processor_response(self, response, basket=None):
-        pass
+        return HandledProcessorResponse(
+            transaction_id=basket.id,
+            total=basket.total_incl_tax,
+            currency=basket.currency,
+            card_number=basket.owner.username,
+            card_type=None
+        )
 
     def is_signature_valid(self, response):
         pass
 
-    def issue_credit(self, transaction_id, amount, currency):
-        pass
+    def issue_credit(self, order, reference_number, amount, currency):
+        return self.REFUND_TRANSACTION_ID
 
 
 class AnotherDummyProcessor(DummyProcessor):

--- a/ecommerce/extensions/payment/tests/processors/test_invoice.py
+++ b/ecommerce/extensions/payment/tests/processors/test_invoice.py
@@ -51,7 +51,7 @@ class InvoiceTests(PaymentProcessorTestCaseMixin, TestCase):
 
     def test_issue_credit(self):
         """Test issue credit"""
-        self.assertRaises(NotImplementedError, self.processor_class(self.site).issue_credit, None, 0, 'USD')
+        self.assertRaises(NotImplementedError, self.processor_class(self.site).issue_credit, None, None, 0, 'USD')
 
     def test_issue_credit_error(self):
         """ Tests that Invoice payment processor does not support issuing credit """

--- a/ecommerce/extensions/payment/tests/test_views.py
+++ b/ecommerce/extensions/payment/tests/test_views.py
@@ -62,13 +62,13 @@ class CybersourceNotifyViewTests(CybersourceMixin, PaymentEventsMixin, TestCase)
         """ Ensure PaymentEvent, PaymentProcessorResponse, and Source objects are created for the basket. """
 
         # Ensure the response is stored in the database
-        self.assert_processor_response_recorded(self.processor_name, notification[u'transaction_id'], notification,
+        self.assert_processor_response_recorded(self.processor_name, notification['transaction_id'], notification,
                                                 basket=self.basket)
 
         # Validate a payment Source was created
-        reference = notification[u'transaction_id']
+        reference = notification['transaction_id']
         source_type = SourceType.objects.get(code=self.processor_name)
-        label = notification[u'req_card_number']
+        label = notification['req_card_number']
         self.assert_payment_source_exists(self.basket, source_type, reference, label)
 
         # Validate that PaymentEvents exist


### PR DESCRIPTION
The creation/modification of Source and PaymentEvent objects has been moved to the locations in the code base responsible for triggering the processing of payment processor responses and issuing credits. This move ensures that payment processors are responsible solely for processing payments. All administrative work will be handled outside of the payment processor classes.

SOL-2125