### PR TITLE
Updated payment processor switch signal receiver

### DIFF
--- a/ecommerce/extensions/api/v2/views/payments.py
+++ b/ecommerce/extensions/api/v2/views/payments.py
@@ -11,7 +11,13 @@ PAYMENT_PROCESSOR_CACHE_TIMEOUT = 60 * 30
 
 
 class PaymentProcessorListView(generics.ListAPIView):
-    """List the available payment processors"""
+    """List the available payment processors
+
+    Note:
+        This endpoint is *deprecated*. There is no use case for this given that the payment page
+        is served by this service (rather than LMS), and the new page loads payment processors
+        via server-side rendering (rather than client-side).
+    """
     pagination_class = None
     permission_classes = (IsAuthenticated,)
     serializer_class = serializers.PaymentProcessorSerializer

--- a/ecommerce/extensions/payment/signals.py
+++ b/ecommerce/extensions/payment/signals.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.conf import settings
-from django.core.cache import caches
+from django.core.cache import cache
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from waffle.models import Switch
@@ -23,5 +23,5 @@ def invalidate_processor_cache(*_args, **kwargs):
     if len(parts) == 2:
         processor = parts[1]
         logger.info('Switched payment processor [%s] %s.', processor, 'on' if switch.active else 'off')
-        caches['default'].delete(PAYMENT_PROCESSOR_CACHE_KEY)
+        cache.delete(PAYMENT_PROCESSOR_CACHE_KEY)
         logger.info('Invalidated payment processor cache after toggling [%s].', switch.name)

--- a/ecommerce/extensions/payment/tests/processors/test_signals.py
+++ b/ecommerce/extensions/payment/tests/processors/test_signals.py
@@ -1,0 +1,23 @@
+from django.conf import settings
+from django.core.cache import cache
+from django.core.urlresolvers import reverse
+from waffle.models import Switch
+
+from ecommerce.extensions.api.v2.views.payments import PAYMENT_PROCESSOR_CACHE_KEY
+from ecommerce.tests.testcases import TestCase
+
+
+class SignalTests(TestCase):
+    def test_invalidate_processor_cache(self):
+        """ Verify the payment processor cache is invalidated when payment processor switches are toggled. """
+        user = self.create_user()
+        self.client.login(username=user.username, password=self.password)
+
+        # Make a call that triggers cache creation
+        response = self.client.get(reverse('api:v2:payment:list_processors'))
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(cache.get(PAYMENT_PROCESSOR_CACHE_KEY))
+
+        # Toggle a switch to trigger cache deletion
+        Switch.objects.get_or_create(name=settings.PAYMENT_PROCESSOR_SWITCH_PREFIX + 'dummy')
+        self.assertIsNone(cache.get(PAYMENT_PROCESSOR_CACHE_KEY))


### PR DESCRIPTION
- Using `cache.delete` rather than `caches['default']`
- Added tests