### PR TITLE
Ignore translations generated for test themes.

### DIFF
--- a/ecommerce/tests/themes-dir-2/test-theme-3/conf/locale/.gitignore
+++ b/ecommerce/tests/themes-dir-2/test-theme-3/conf/locale/.gitignore
@@ -1,1 +1,3 @@
-# this file is to add conf/local dir to git, currently there is no file to ignore.
+# this file is to add conf/local dir to git
+# it ignores translations generated for the test themes
+*


### PR DESCRIPTION
Files are generated under this directory when translations testing runs. They should be ignored.

@edx/ecommerce 