### PR TITLE
[SOL-2151] Allow max number of uses to be increased on a multi-use coupon

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -696,6 +696,17 @@ class CouponViewSetFunctionalTest(CouponMixin, CourseCatalogTestMixin, CourseCat
         self.get_response_json('PUT', path, self.data)
         self.assertEqual(offer.email_domains, email_domains)
 
+    def test_update_max_uses_field(self):
+        """Verify max_uses field can be updated."""
+        path = reverse('api:v2:coupons-detail', args=[self.coupon.id])
+        details = self.get_response_json('GET', path)
+        self.assertIsNone(details['max_uses'])
+
+        max_uses = 3
+        self.data.update({'max_uses': max_uses})
+        response = self.get_response_json('PUT', path, self.data)
+        self.assertEqual(response['max_uses'], max_uses)
+
 
 class CouponCategoriesListViewTests(TestCase):
     """ Tests for the coupon category list view. """

--- a/ecommerce/extensions/offer/models.py
+++ b/ecommerce/extensions/offer/models.py
@@ -12,10 +12,11 @@ from oscar.apps.offer.abstract_models import AbstractBenefit, AbstractConditiona
 from threadlocals.threadlocals import get_current_request
 
 logger = logging.getLogger(__name__)
-VALID_BENEFIT_TYPES = [AbstractBenefit.PERCENTAGE, AbstractBenefit.FIXED]
 
 
 class Benefit(AbstractBenefit):
+    VALID_BENEFIT_TYPES = [AbstractBenefit.PERCENTAGE, AbstractBenefit.FIXED]
+
     def save(self, *args, **kwargs):
         self.clean()
         super(Benefit, self).save(*args, **kwargs)  # pylint: disable=bad-super-call
@@ -26,9 +27,9 @@ class Benefit(AbstractBenefit):
         super(Benefit, self).clean()  # pylint: disable=bad-super-call
 
     def clean_type(self):
-        if self.type not in VALID_BENEFIT_TYPES:
+        if self.type not in self.VALID_BENEFIT_TYPES:
             logger.exception(
-                'Failed to create Benefit. Benefit type must be one of the following %s.', VALID_BENEFIT_TYPES
+                'Failed to create Benefit. Benefit type must be one of the following %s.', self.VALID_BENEFIT_TYPES
             )
             raise ValidationError(_('Unrecognised benefit type {type}'.format(type=self.type)))
 
@@ -39,6 +40,7 @@ class Benefit(AbstractBenefit):
 
 
 class ConditionalOffer(AbstractConditionalOffer):
+    UPDATABLE_OFFER_FIELDS = ['email_domains', 'max_uses']
     email_domains = models.CharField(max_length=255, blank=True, null=True)
 
     def is_email_valid(self, email):

--- a/ecommerce/static/js/test/specs/views/coupon_edit_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/coupon_edit_view_spec.js
@@ -46,6 +46,10 @@ define([
                     expect(view.$el.find('[name=price]').val()).toEqual(model.get('price'));
                     expect(view.$el.find('[name=course_id]').val()).toEqual(model.get('course_id'));
                 });
+
+                it('should verify single-use voucher max_uses field min attribute is empty string', function () {
+                    expect(view.$('[name=max_uses]').attr('min')).toBe('');
+                });
             });
 
             describe('edit discount code', function () {
@@ -170,12 +174,23 @@ define([
                     expect(view.model.get('course_id')).toBe(formView._initAttributes.course_id);
                     expect(view.model.get('seat_type')).toBe(formView._initAttributes.seat_type);
                 });
-
+                
                 it('should not update price when editing coupon', function() {
                     var formView = view.formView;
                     spyOn(formView, 'updateTotalValue');
                     formView.changeSeatType();
                     expect(formView.updateTotalValue).not.toHaveBeenCalled();
+                });
+
+                it('should verify multi-use max_uses field min attribute is set to model value', function () {
+                    expect(view.$('[name=max_uses]').attr('min')).toBe(view.model.get('max_uses'));
+                });
+
+                it('should verify once-per-customer max_uses field min attribute is set to model value', function () {
+                    view.model.set('voucher_type', 'Once per customer');
+                    view.model.set('max_uses', '3');
+                    view.render();
+                    expect(view.$('[name=max_uses]').attr('min')).toBe(view.model.get('max_uses'));
                 });
             });
         });

--- a/ecommerce/static/js/views/coupon_form_view.js
+++ b/ecommerce/static/js/views/coupon_form_view.js
@@ -258,6 +258,7 @@ define([
                         'invoice_number',
                         'invoice_payment_date',
                         'invoice_type',
+                        'max_uses',
                         'note',
                         'price',
                         'start_date',
@@ -447,7 +448,8 @@ define([
 
             toggleVoucherTypeField: function () {
                 var maxUsesFieldSelector = '[name=max_uses]',
-                    multiUseMaxUsesValue = this.editing ? this.model.get('max_uses') : null,
+                    maxUsesModelValue = this.model.get('max_uses'),
+                    multiUseMaxUsesValue = this.editing ? maxUsesModelValue : null,
                     voucherType = this.model.get('voucher_type');
                 if (!this.editing) {
                     this.emptyCodeField();
@@ -457,6 +459,7 @@ define([
                 *  integrity issues.
                 */
                 if (voucherType === 'Single use') {
+                    this.setLimitToElement(this.$(maxUsesFieldSelector), '', '');
                     this.hideField(maxUsesFieldSelector, 1);
                 } else {
                     if (this.model.get('coupon_type') === 'Discount code' && this.$('[name=quantity]').val() === 1) {
@@ -468,10 +471,18 @@ define([
                      */
                     if (voucherType === 'Multi-use') {
                         this.model.set('max_uses', multiUseMaxUsesValue);
-                        this.$(maxUsesFieldSelector).attr('min', 2);
+                        if (this.editing) {
+                            this.setLimitToElement(this.$(maxUsesFieldSelector), '', multiUseMaxUsesValue);
+                        } else {
+                            this.setLimitToElement(this.$(maxUsesFieldSelector), '', 2);
+                        }
                     } else {
-                        this.model.set('max_uses', 1);
-                        this.$(maxUsesFieldSelector).attr('min', 1);
+                        if (this.editing) {
+                            this.setLimitToElement(this.$(maxUsesFieldSelector), '', maxUsesModelValue);
+                        } else {
+                            this.model.set('max_uses', 1);
+                            this.setLimitToElement(this.$(maxUsesFieldSelector), '', 1);
+                        }
                     }
                 }
             },

--- a/ecommerce/static/templates/coupon_form.html
+++ b/ecommerce/static/templates/coupon_form.html
@@ -55,7 +55,7 @@
 
         <div class="form-group">
             <label for="max-uses"><%= gettext('Maximum Number of Uses') %></label>
-            <input id="max-uses" type="number" step="1" class="form-control non-editable" name="max_uses" value="1" min="1" placeholder="Defaults to 10000">
+            <input id="max-uses" type="number" step="1" class="form-control" name="max_uses" value="1" min="1" placeholder="Defaults to 10000">
             <p class="help-block"></p>
         </div>
 


### PR DESCRIPTION
@vkaracic @marjev @mjfrey While enabling this feature I noticed a bug: on editing once per customer coupon the max_uses field value was always 1. Now this is fixed. The max_uses field editing is only enabled for multi-use and not for once per customer coupons. Please review. 