### PR TITLE
[SOL-2162] Add Backend Validation for Client

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -499,10 +499,16 @@ class Client(User):
 class BusinessClient(models.Model):
     """The model for the business client."""
 
-    name = models.CharField(_('Name'), unique=True, max_length=255, blank=False, null=False)
+    name = models.CharField(_('Name'), unique=True, max_length=255)
 
     def __str__(self):
         return self.name
+
+    def save(self, *args, **kwargs):
+        if not self.name:
+            log.exception('Failed to create BusinessClient. BusinessClient name may not be empty.')
+            raise ValidationError(_('BusinessClient name must be set.'))
+        super(BusinessClient, self).save(*args, **kwargs)
 
 
 def validate_configuration():

--- a/ecommerce/core/tests/test_models.py
+++ b/ecommerce/core/tests/test_models.py
@@ -169,6 +169,10 @@ class BusinessClientTests(TestCase):
         client = BusinessClient.objects.create(name='TestClient')
         self.assertEquals(str(client), 'TestClient')
 
+    def test_creating_without_client_name_raises_exception(self):
+        with self.assertRaises(ValidationError):
+            BusinessClient.objects.create()
+
 
 @ddt.ddt
 class SiteConfigurationTests(TestCase):


### PR DESCRIPTION
@mjfrey @vkaracic @marjev The client model doesn't allow empty values for name field so if a post request without the name parameter is sent to our coupon api it will break. This ensures the error is handled properly.