### PR TITLE
prototype for enterprise entitlements flow

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -329,6 +329,17 @@ class SiteConfiguration(models.Model):
 
         return EdxRestApiClient(settings.COURSE_CATALOG_API_URL, jwt=self.access_token)
 
+    @cached_property
+    def enterprise_api_client(self):
+        """
+        Returns an API client to access the Enterprise service.
+
+        Returns:
+            EdxRestApiClient: The client to access the Enterprise service.
+        """
+
+        return EdxRestApiClient(settings.ENTERPRISE_API_URL, jwt=self.access_token)
+
 
 class User(AbstractUser):
     """Custom user model for use with OIDC."""

--- a/ecommerce/coupons/enterprise_utils.py
+++ b/ecommerce/coupons/enterprise_utils.py
@@ -1,0 +1,46 @@
+"""
+Enterprise related utility functions.
+"""
+import logging
+
+from django.conf import settings
+from django.core.cache import cache
+
+
+log = logging.getLogger(__name__)
+
+
+def get_user_enterprise_info(user, site):
+    """
+    Get the Enterprise for the given learner along with the entitlement info.
+
+    Arguments:
+        user (django.contrib.auth.User): django auth user
+        site (django.contrib.sites.Site): site instance
+    """
+    # TODO: Fetch learner related enterprise info from Enterprise API against a specific site
+    # response = {}
+    # try:
+    #     response = site.siteconfiguration.enterprise_api_client.course_runs.get(user.username, site.domain)
+    # except (ConnectionError, SlumberBaseException, Timeout):
+    #     log.exception(
+    #         'Failed to retrieve enterprise info for the learner [%s]',
+    #         user.username
+    #     )
+    #     raise
+
+    # create dummy data for testing
+    response = {
+        'username': user.username,
+        'enterprise': {
+            'name': 'Arbisoft',
+            'catalog': 1,
+            'site_domain': site.domain,
+            'enable_data_sharing_consent': True,
+            'enforce_data_sharing_consent': 'At Enrollment',
+            'logo': 'https://www.edx.org/sites/default/files/homepage/banner/promo/bkg/onethird-539x290-csedweek.jpg',
+            'user_data_sharing_consent': True
+        }
+    }
+    # TODO: Cache the response from enterprise API in case of 200 status
+    return response

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -18,6 +18,7 @@ from oscar.core.loading import get_class, get_model
 from ecommerce.core.url_utils import get_ecommerce_url
 from ecommerce.core.views import StaffOnlyMixin
 from ecommerce.coupons.decorators import login_required_for_credit
+from ecommerce.coupons.enterprise_utils import get_user_enterprise_info
 from ecommerce.extensions.api import exceptions
 from ecommerce.extensions.basket.utils import prepare_basket
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
@@ -100,6 +101,9 @@ class CouponOfferView(TemplateView):
                 return {'error': _('Coupon does not exist')}
             except exceptions.ProductNotFoundError:
                 return {'error': _('The voucher is not applicable to your current basket.')}
+
+            # TODO: Add Enterprise related entitlements code here
+
             valid_voucher, msg = voucher_is_valid(voucher, products, self.request)
             if valid_voucher:
                 self.template_name = 'coupons/offer.html'

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -511,6 +511,9 @@ RECEIPT_PAGE_PATH = '/checkout/receipt/'
 # URL for Course Catalog service
 COURSE_CATALOG_API_URL = 'http://localhost:8008/api/v1/'
 
+# URL for Enterprise service
+ENTERPRISE_API_URL = 'http://localhost:8000/enterprise/api/v1/'
+
 # Black-listed course modes not allowed to create coupons with
 BLACK_LIST_COUPON_COURSE_MODES = [u'audit', u'honor']
 

--- a/ecommerce/templates/oscar/basket/partials/basket_content.html
+++ b/ecommerce/templates/oscar/basket/partials/basket_content.html
@@ -11,6 +11,20 @@
 
 {% if not basket.is_empty %}
     <div id="content-inner">
+        {% if enterprise_customer %}
+            <h3>
+                <span class="pull-left">
+                    <img class="thumbnail" height="50px" width="50px" src="{{ enterprise_customer.logo }}"/>
+                </span>
+                <span class="pull-left">
+                     {% blocktrans with enterprise_name=enterprise_customer.name %}
+                        You are eligible for the enterprise entitlements from {{ enterprise_name }}.
+                    {% endblocktrans %}
+                </span>
+            </h3>
+        {% endif %}
+        <br><br><br>
+
         {% block basket_form_main %}
             <form action="." method="post" class="basket_summary" id="basket_formset">
                 {% csrf_token %}


### PR DESCRIPTION
ENT-84

This is a **sample code** for the prototype of enterprise entitlements.
Please ignore the print statements or commented code.
@asadiqbal08 @saleem-latif @mattdrayer @kashifch

* add settings variable `ENTERPRISE_API_URL` to locate enterprise service API
* add method `enterprise_api_client` in `core/models.py`
* add enterprise utils file to fetch data for enterprises
* update basket view to display enterprise name and logo

**Related edx-enterprise PR for enterprise entitlements:** https://github.com/edx/edx-enterprise/pull/21

### Not Added (pending)
* validate the coupon record in Ecom
* add flow in case learner hasn't signed consent
* apply enterprise coupon in basket view before rendering in case of valid and eligible enterprise learner

### Basket page Screen shots
<img width="1209" alt="screen shot 2016-12-09 at 2 50 28 pm" src="https://cloud.githubusercontent.com/assets/5072991/21044673/f541d65a-be1e-11e6-8534-9ce0e877b76c.png">
