### PR TITLE
[SOL-2169] Add Backend Validation for Category

### DIFF
--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -103,7 +103,7 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
                         'Category {category_name} not found.'.format(category_name=category_data['name']),
                         status=status.HTTP_404_NOT_FOUND
                     )
-                except KeyError:
+                except (KeyError, TypeError):
                     return Response('Invalid Coupon Category data.', status=status.HTTP_400_BAD_REQUEST)
 
                 # Maximum number of uses can be set for each voucher type and disturb


### PR DESCRIPTION
I covered the case when no category or category with wrong value type (must be dict) is sent to the api.