### PR TITLE
WL-862 Multi-source analytics event tracking

### DIFF
--- a/ecommerce/core/management/commands/create_or_update_site.py
+++ b/ecommerce/core/management/commands/create_or_update_site.py
@@ -1,13 +1,14 @@
 """ Creates or updates a Site including Partner and SiteConfiguration data. """
 
 from __future__ import unicode_literals
+from copy import deepcopy
 import logging
 
 from django.contrib.sites.models import Site
 from django.core.management import BaseCommand
 from oscar.core.loading import get_model
 
-from ecommerce.core.models import SiteConfiguration
+from ecommerce.core.models import DEFAULT_ANALYTICS_CONFIGURATION, SiteConfiguration
 
 logger = logging.getLogger(__name__)
 Partner = get_model('partner', 'Partner')
@@ -116,7 +117,8 @@ class Command(BaseCommand):
         lms_url_root = options.get('lms_url_root')
         client_id = options.get('client_id')
         client_secret = options.get('client_secret')
-        segment_key = options.get('segment_key')
+        analytics_configuration = deepcopy(DEFAULT_ANALYTICS_CONFIGURATION)
+        analytics_configuration['SEGMENT']['DEFAULT_WRITE_KEY'] = options.get('segment_key')
         from_email = options.get('from_email')
         enable_enrollment_codes = True if options.get('enable_enrollment_codes') else False
         payment_support_email = options.get('payment_support_email', '')
@@ -146,7 +148,7 @@ class Command(BaseCommand):
             'lms_url_root': lms_url_root,
             'theme_scss_path': options['theme_scss_path'],
             'payment_processors': options['payment_processors'],
-            'segment_key': segment_key,
+            'analytics_configuration': analytics_configuration,
             'from_email': from_email,
             'enable_enrollment_codes': enable_enrollment_codes,
             'oauth_settings': {

--- a/ecommerce/core/migrations/0023_siteconfiguration_analytics_configuration.py
+++ b/ecommerce/core/migrations/0023_siteconfiguration_analytics_configuration.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import jsonfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0022_auto_20161108_2101'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='siteconfiguration',
+            name='analytics_configuration',
+            field=jsonfield.fields.JSONField(default={b'GOOGLE_ANALYTICS': {b'TRACKING_IDS': []}, b'SEGMENT': {b'DEFAULT_WRITE_KEY': None, b'ADDITIONAL_WRITE_KEYS': []}}, help_text='JSON string containing settings related to analytics event tracking.', verbose_name='Analytics tracking configuration'),
+        ),
+    ]

--- a/ecommerce/core/tests/test_commands.py
+++ b/ecommerce/core/tests/test_commands.py
@@ -38,7 +38,7 @@ class CreateOrUpdateSiteCommandTests(TestCase):
         self.assertEqual(site_configuration.payment_processors, self.payment_processors)
         self.assertEqual(site_configuration.oauth_settings['SOCIAL_AUTH_EDX_OIDC_KEY'], self.client_id)
         self.assertEqual(site_configuration.oauth_settings['SOCIAL_AUTH_EDX_OIDC_SECRET'], self.client_secret)
-        self.assertEqual(site_configuration.segment_key, self.segment_key)
+        self.assertEqual(site_configuration.default_segment_key, self.segment_key)
         self.assertEqual(site_configuration.from_email, self.from_email)
 
     def _call_command(self, site_domain, partner_code, lms_url_root, client_id, client_secret, from_email,

--- a/ecommerce/credit/views.py
+++ b/ecommerce/credit/views.py
@@ -82,7 +82,7 @@ class Checkout(TemplateView):
         context.update({
             'analytics_data': prepare_analytics_data(
                 self.request.user,
-                self.request.site.siteconfiguration.segment_key,
+                self.request.site.siteconfiguration,
                 course.id
             ),
             'course': course,

--- a/ecommerce/extensions/analytics/context_processors.py
+++ b/ecommerce/extensions/analytics/context_processors.py
@@ -2,7 +2,7 @@ from ecommerce.extensions.analytics.utils import prepare_analytics_data
 
 
 def analytics(request):
-    analytics_data = prepare_analytics_data(request.user, request.site.siteconfiguration.segment_key)
+    analytics_data = prepare_analytics_data(request.user, request.site.siteconfiguration)
 
     return {
         'analytics_data': analytics_data,

--- a/ecommerce/extensions/analytics/tests/test_context_processors.py
+++ b/ecommerce/extensions/analytics/tests/test_context_processors.py
@@ -9,7 +9,7 @@ class AnalyticsContextProcessorTests(TestCase):
         request = RequestFactory().get('/')
         request.user = self.create_user()
         request.site = self.site
-        analytics_data = prepare_analytics_data(request.user, request.site.siteconfiguration.segment_key)
+        analytics_data = prepare_analytics_data(request.user, request.site.siteconfiguration)
 
         self.assertDictEqual(
             analytics(request),

--- a/ecommerce/extensions/analytics/tests/test_utils.py
+++ b/ecommerce/extensions/analytics/tests/test_utils.py
@@ -17,19 +17,25 @@ class UtilsTest(TestCase):
             last_name='Doe',
             email='test@example.com'
         )
-        data = prepare_analytics_data(user, self.site.siteconfiguration.segment_key, 'a/b/c')
+        data = prepare_analytics_data(user, self.site.siteconfiguration, 'a/b/c')
         self.assertDictEqual(json.loads(data), {
             'course': {'courseId': 'a/b/c'},
-            'tracking': {'segmentApplicationId': self.site.siteconfiguration.segment_key},
+            'tracking': {
+                'googleAnalyticsTrackingIds': self.site.siteconfiguration.google_analytics_tracking_ids,
+                'segmentApplicationId': self.site.siteconfiguration.default_segment_key
+            },
             'user': {'username': 'Tester', 'name': 'John Doe', 'email': 'test@example.com'}
         })
 
     def test_anon_prepare_analytics_data(self):
         """ Verify the function returns correct analytics data for an anonymous user."""
         user = AnonymousUser()
-        data = prepare_analytics_data(user, self.site.siteconfiguration.segment_key, 'a/b/c')
+        data = prepare_analytics_data(user, self.site.siteconfiguration, 'a/b/c')
         self.assertDictEqual(json.loads(data), {
             'course': {'courseId': 'a/b/c'},
-            'tracking': {'segmentApplicationId': self.site.siteconfiguration.segment_key},
+            'tracking': {
+                'googleAnalyticsTrackingIds': self.site.siteconfiguration.google_analytics_tracking_ids,
+                'segmentApplicationId': self.site.siteconfiguration.default_segment_key
+            },
             'user': 'AnonymousUser'
         })

--- a/ecommerce/extensions/analytics/utils.py
+++ b/ecommerce/extensions/analytics/utils.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 def is_segment_configured():
     """Returns a Boolean indicating if Segment has been configured for use."""
-    return bool(get_current_request().site.siteconfiguration.segment_key)
+    return bool(get_current_request().site.siteconfiguration.default_segment_key)
 
 
 def parse_tracking_context(user):
@@ -88,12 +88,12 @@ def audit_log(name, **kwargs):
     logger.info(message)
 
 
-def prepare_analytics_data(user, segment_key, course_id=None):
+def prepare_analytics_data(user, site_config, course_id=None):
     """ Helper function for preparing necessary data for analytics.
 
     Arguments:
         user (User): The user making the request.
-        segment_key (str): Segment write/API key.
+        analytics_config (dict): Analytics configuration dict containing default Segment write/API key.
         course_id (str): The course ID.
 
     Returns:
@@ -104,7 +104,8 @@ def prepare_analytics_data(user, segment_key, course_id=None):
             'courseId': course_id
         },
         'tracking': {
-            'segmentApplicationId': segment_key
+            'googleAnalyticsTrackingIds': site_config.google_analytics_tracking_ids,
+            'segmentApplicationId': site_config.default_segment_key
         }
     }
 

--- a/ecommerce/extensions/api/v2/tests/views/test_siteconfiguration.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_siteconfiguration.py
@@ -16,6 +16,15 @@ class SiteConfigurationViewSetTests(TestCase):
             partner__name='TestX',
             site__domain='test.api.endpoint',
             segment_key='test_segment_key',
+            analytics_configuration=json.dumps({
+                'SEGMENT': {
+                    'DEFAULT_WRITE_KEY': 'test_segment_key2',
+                    'ADDITIONAL_WRITE_KEYS': ['test_segment_key3'],
+                },
+                'GOOGLE_ANALYTICS': {
+                    'TRACKING_IDS': ['test_tracking_id'],
+                },
+            }),
             enable_enrollment_codes=True
         )
         self.path = reverse('api:v2:siteconfiguration-list')

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -182,7 +182,7 @@ class BasketSummaryView(BasketView):
         context.update({
             'analytics_data': prepare_analytics_data(
                 user,
-                self.request.site.siteconfiguration.segment_key,
+                self.request.site.siteconfiguration,
                 unicode(course_key)
             ),
             'enable_client_side_checkout': False,

--- a/ecommerce/extensions/checkout/signals.py
+++ b/ecommerce/extensions/checkout/signals.py
@@ -26,7 +26,7 @@ def track_completed_order(sender, order=None, **kwargs):  # pylint: disable=unus
 
     user_tracking_id, lms_client_id, lms_ip = parse_tracking_context(order.user)
 
-    order.site.siteconfiguration.segment_client.track(
+    order.site.siteconfiguration.track_analytics_event(
         user_tracking_id,
         'Completed Order',
         {

--- a/ecommerce/extensions/refund/signals.py
+++ b/ecommerce/extensions/refund/signals.py
@@ -20,7 +20,7 @@ def track_completed_refund(sender, refund=None, **kwargs):  # pylint: disable=un
     # Ecommerce transaction reversal, performed by emitting an event which is the inverse of an
     # order completion event emitted previously.
     # See: https://support.google.com/analytics/answer/1037443?hl=en
-    refund.order.site.siteconfiguration.segment_client.track(
+    refund.order.site.siteconfiguration.track_analytics_event(
         user_tracking_id,
         'Completed Order',
         {

--- a/ecommerce/static/js/models/tracking_model.js
+++ b/ecommerce/static/js/models/tracking_model.js
@@ -6,13 +6,19 @@ define(['backbone', 'underscore'], function(Backbone, _) {
      */
     return Backbone.Model.extend({
 
-        /**
-         * Determine if the application is tracked.
-         */
-        isTracking: function() {
-            var self = this,
-                trackId = self.get('segmentApplicationId');
-            return !_(trackId).isUndefined() && !_(trackId).isNull();
+        isTrackingEnabled: function() {
+            return this.isGoogleAnalyticsTrackingEnabled() || this.isSegmentTrackingEnabled();
+        },
+
+        isGoogleAnalyticsTrackingEnabled: function() {
+            var trackingIds = this.get('googleAnalyticsTrackingIds');
+            return Boolean(!_(trackingIds).isUndefined() && trackingIds.length);
+        },
+
+        isSegmentTrackingEnabled: function() {
+            var trackId = this.get('segmentApplicationId');
+            return Boolean(!_(trackId).isUndefined() && trackId);
         }
+
     });
 });

--- a/ecommerce/static/js/test/mock_data/tracking.js
+++ b/ecommerce/static/js/test/mock_data/tracking.js
@@ -1,0 +1,21 @@
+define([], function () {
+    'use strict';
+
+    var courseData = {
+            courseId: 'test_course_id'
+        },
+        trackingData = {
+            googleAnalyticsTrackingIds: ['test_ga_tracking_id_1', 'test_ga_tracking_id_2'],
+            segmentApplicationId: 'test_segment_key'
+        },
+        userData = {
+            username: 'test_user',
+            name: 'test test',
+            email: 'test@example.com'
+        };
+    return {
+        'courseData': courseData,
+        'trackingData': trackingData,
+        'userData': userData
+    };
+});

--- a/ecommerce/static/js/test/specs/models/tracking_model_spec.js
+++ b/ecommerce/static/js/test/specs/models/tracking_model_spec.js
@@ -1,0 +1,82 @@
+define([
+        'underscore',
+        'models/tracking_model',
+        'test/mock_data/tracking'
+    ],
+    function (_,
+              TrackingModel,
+              Mock_Tracking
+    ) {
+        'use strict';
+
+        var trackingData = Mock_Tracking.trackingData;
+
+        describe('Tracking model', function () {
+            describe('isTrackingEnabled', function () {
+                it('should return true if Google Analytics tracking is enabled', function () {
+                    var model = new TrackingModel(),
+                        modelData = _.clone(trackingData);
+                    modelData.segmentApplicationId = null;
+                    model.set(modelData);
+
+                    expect(model.isTrackingEnabled()).toBe(true);
+                });
+
+                it('should return true if Segment tracking is enabled', function () {
+                    var model = new TrackingModel(),
+                        modelData = _.clone(trackingData);
+                    modelData.googleAnalyticsTrackingIds = [];
+                    model.set(modelData);
+
+                    expect(model.isTrackingEnabled()).toBe(true);
+                });
+
+                it('should return false if Google Analytics and Segment tracking are not enabled', function () {
+                    var model = new TrackingModel();
+                    model.set({
+                        googleAnalyticsTrackingIds: [],
+                        segmentApplicationId: null
+                    });
+
+                    expect(model.isTrackingEnabled()).toBe(false);
+                });
+            });
+
+            describe('isGoogleAnalyticsTrackingEnabled', function () {
+                it('should return true if Google Analytics tracking is enabled', function () {
+                    var model = new TrackingModel();
+                    model.set(trackingData);
+
+                    expect(model.isGoogleAnalyticsTrackingEnabled()).toBe(true);
+                });
+
+                it('should return false if Google Analytics tracking is not enabled', function () {
+                    var model = new TrackingModel();
+                    model.set({
+                        googleAnalyticsTrackingIds: []
+                    });
+
+                    expect(model.isGoogleAnalyticsTrackingEnabled()).toBe(false);
+                });
+            });
+
+            describe('isSegmentTrackingEnabled', function () {
+                it('should return true if Segment tracking is enabled', function () {
+                    var model = new TrackingModel();
+                    model.set(trackingData);
+
+                    expect(model.isSegmentTrackingEnabled()).toBe(true);
+                });
+
+                it('should return false if Segment tracking is not enabled', function () {
+                    var model = new TrackingModel();
+                    model.set({
+                        segmentApplicationId: null
+                    });
+
+                    expect(model.isSegmentTrackingEnabled()).toBe(false);
+                });
+            });
+        });
+    }
+);

--- a/ecommerce/static/js/test/specs/pages/basket_page_spec.js
+++ b/ecommerce/static/js/test/specs/pages/basket_page_spec.js
@@ -421,7 +421,7 @@ define([
 
             describe('Analytics', function() {
                 beforeEach(function () {
-                    spyOn(TrackingModel.prototype, 'isTracking').and.callFake(function() {
+                    spyOn(TrackingModel.prototype, 'isSegmentTrackingEnabled').and.callFake(function() {
                         return true;
                     });
                     spyOn(AnalyticsView.prototype, 'track');

--- a/ecommerce/static/js/test/specs/pages/coupon_offer_spec.js
+++ b/ecommerce/static/js/test/specs/pages/coupon_offer_spec.js
@@ -35,7 +35,7 @@ define([
 
             describe('Analytics', function() {
                 beforeEach(function () {
-                    spyOn(TrackingModel.prototype, 'isTracking').and.callFake(function() {
+                    spyOn(TrackingModel.prototype, 'isSegmentTrackingEnabled').and.callFake(function() {
                         return true;
                     });
                     spyOn(AnalyticsView.prototype, 'track');

--- a/ecommerce/static/js/test/specs/views/analytics_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/analytics_view_spec.js
@@ -1,0 +1,94 @@
+define([
+        'jquery',
+        'underscore',
+        'views/analytics_view',
+        'models/course_model',
+        'test/mock_data/tracking',
+        'models/tracking_model',
+        'models/user_model'
+    ],
+    function ($,
+              _,
+              AnalyticsView,
+              CourseModel,
+              Mock_Tracking,
+              TrackingModel,
+              UserModel
+    ) {
+        'use strict';
+
+        describe('analytics view', function() {
+            var view,
+                trackingModel,
+                courseModel = new CourseModel(Mock_Tracking.courseData),
+                userModel = new UserModel(Mock_Tracking.userData),
+                TEST_EVENT = {
+                    courseId: courseModel.get('courseId'),
+                    category: 'test_category'
+                },
+                EXPECTED_GA_CALLS= [];
+            for (var i = 0; i < Mock_Tracking.trackingData.googleAnalyticsTrackingIds.length; i++) {
+                EXPECTED_GA_CALLS.push({
+                    object: window,
+                    args: [
+                        'tracker' + i + '.send',
+                        {
+                            hitType: 'event',
+                            eventCategory: TEST_EVENT.category,
+                            eventAction: 'test'
+                        }
+                    ],
+                    returnValue: undefined
+                });
+            }
+
+            describe('track with Segment and GA configured', function() {
+                beforeEach(function() {
+                    trackingModel = new TrackingModel(Mock_Tracking.trackingData);
+                    view = new AnalyticsView({
+                        model: trackingModel,
+                        courseModel: courseModel,
+                        userModel: userModel
+                    });
+                    view.initialize(view.options);
+                    view.loadGoogleAnalytics(Mock_Tracking.trackingData.googleAnalyticsTrackingIds);
+
+                    spyOn(window.analytics, 'track');
+                    spyOn(window, 'ga');
+
+                    view.track('test', TEST_EVENT);
+                });
+
+                it('should send events to the configured segment source', function () {
+                    expect(window.analytics.track).toHaveBeenCalledWith('test', TEST_EVENT);
+                });
+
+                it('should send events to all configured ga tracking IDs', function () {
+                    expect(window.ga.calls.all()).toEqual(EXPECTED_GA_CALLS);
+                });
+            });
+
+            describe('track with only GA configured', function() {
+                beforeEach(function() {
+                    var trackingData = _.clone(Mock_Tracking.trackingData);
+                    delete trackingData.segmentApplicationId;
+                    trackingModel = new TrackingModel(trackingData);
+                    view = new AnalyticsView({
+                        model: trackingModel,
+                        courseModel: courseModel,
+                        userModel: userModel
+                    });
+                    view.initialize(view.options);
+
+                    spyOn(window, 'ga');
+
+                    view.track('test', TEST_EVENT);
+                });
+
+                it('should send events to all configured ga tracking IDs', function () {
+                    expect(window.ga.calls.all()).toEqual(EXPECTED_GA_CALLS);
+                });
+            });
+        });
+    }
+);

--- a/ecommerce/static/js/views/analytics_view.js
+++ b/ecommerce/static/js/views/analytics_view.js
@@ -1,3 +1,4 @@
+/* globals ga */
 define([
         'jquery',
         'backbone',
@@ -8,44 +9,91 @@ define([
 
         /**
          * This 'view' doesn't display anything, but rather sends tracking
-         * information in response to 'segment:track' events triggered by the
+         * information in response to 'analytics:track' events triggered by the
          * model.
          *
-         * Actions will only be tracked if segmentApplicationId is set in the
-         * model.
+         * Actions will only be tracked if analytics providers have been configured.
          */
         return Backbone.View.extend({
 
-            /**
-             * Reference to Segment analytics library.  This is set after
-             * loading.
-             */
-
             initialize: function (options) {
                 this.options = options || {};
+                this.googleAnalyticsTrackers = [];
 
                 // wait until you have a segment application ID before kicking
                 // up the script
-                if (this.model.isTracking()) {
-                    this.applicationIdSet();
+                if (this.model.isTrackingEnabled()) {
+                    this.initTracking();
                 } else {
-                    this.listenToOnce(this.model, 'change:segmentApplicationId',
-                        this.applicationIdSet);
+                    this.listenToOnce(this.model, 'change:segmentApplicationId', this.initTracking);
                 }
             },
 
-            applicationIdSet: function () {
-                var trackId = this.model.get('segmentApplicationId');
+            initTracking: function () {
+                var segmentKey = this.model.get('segmentApplicationId');
+                var googleAnalyticsTrackingIds = this.model.get('googleAnalyticsTrackingIds');
 
-                // if no ID is supplied, then don't track
-                if (this.model.isTracking()) {
-                    // kick off segment
-                    this.initSegment(trackId);
-                    this.logUser();
-
-                    // now segment has been loaded, we can track events
-                    this.listenTo(this.model, 'segment:track', this.track);
+                if (this.model.isSegmentTrackingEnabled()) {
+                    this.initSegment(segmentKey);
                 }
+                
+                if (this.model.isGoogleAnalyticsTrackingEnabled()) {
+                    this.initGoogleAnalytics(googleAnalyticsTrackingIds);
+                }
+                
+                if (this.model.isTrackingEnabled()) {
+                    this.listenTo(this.model, 'analytics:track', this.track);
+                    this.logUser();
+                    this.sendPageView();
+                }
+            },
+
+            /**
+             * Create a Google Analytics tracker for each configured tracking ID.
+             */
+            initGoogleAnalyticsTrackers: function(trackingIds) {
+                for (var t = 0; t < trackingIds.length; t++) {
+                    var trackingId = trackingIds[t],
+                        trackerName = 'tracker' + t;
+                    ga('create', trackingId, 'auto', trackerName);
+                    this.googleAnalyticsTrackers.push(trackerName);
+                }
+            },
+
+            /**
+             * This sets up Google Analytics tracking for the application.
+             */
+            initGoogleAnalytics: function (trackingIds) {
+                if (this.model.isSegmentTrackingEnabled()) {
+                    var self = this;
+                    analytics.ready(function(){
+                        self.loadGoogleAnalytics(trackingIds);
+                    });
+                } else {
+                    this.loadGoogleAnalytics(trackingIds);
+                }
+            },
+
+            /**
+             * This loads Google Analytics analytics.js library.
+             */
+            loadGoogleAnalytics: function (trackingIds) {
+                if (typeof ga === 'undefined') {
+                    // Load Google Analytics analytics.js library
+                    (function(i, s, o, g, r, a, m) {
+                        i.GoogleAnalyticsObject = r;
+                        i[r] = i[r] || function() {
+                            (i[r].q = i[r].q || []).push(arguments);
+                        };
+                        i[r].l = 1 * new Date();
+                        a = s.createElement(o);
+                        m = s.getElementsByTagName(o)[0];
+                        a.async = 1;
+                        a.src = g;
+                        m.parentNode.insertBefore(a, m);
+                    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+                }
+                this.initGoogleAnalyticsTrackers(trackingIds);
             },
 
             /**
@@ -55,19 +103,14 @@ define([
              * this.segment is set for convenience.
              */
             initSegment: function (applicationKey) {
-                var analytics, pageData;
-
                 /* jshint ignore:start */
                 // jscs:disable
-                analytics = window.analytics = window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.0.1";}
+                var analytics = window.analytics = window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.0.1";}
                 // jscs:enable
                 /* jshint ignore:end */
 
                 // provide our application key for logging
                 analytics.load(applicationKey);
-
-                pageData = this.getSegmentPageData();
-                analytics.page(pageData);
             },
 
             /**
@@ -84,23 +127,46 @@ define([
             /**
              * Log the user.
              */
-            logUser: function () {
+            logUser: function() {
                 var userModel = this.options.userModel;
-                analytics.identify(
-                    userModel.get('username'),
-                    {
-                        name: userModel.get('name'),
-                        email: userModel.get('email')
-                    },
-                    {
-                        integrations: {
-                            // Disable MailChimp because we don't want to update the user's email
-                            // and username in MailChimp based on this request. We only need to capture
-                            // this data in MailChimp on registration/activation.
-                            MailChimp: false
+                if (this.model.isSegmentTrackingEnabled()) {
+                    analytics.identify(
+                        userModel.get('username'),
+                        {
+                            name: userModel.get('name'),
+                            email: userModel.get('email')
+                        },
+                        {
+                            integrations: {
+                                // Disable MailChimp because we don't want to update the user's email
+                                // and username in MailChimp based on this request. We only need to capture
+                                // this data in MailChimp on registration/activation.
+                                MailChimp: false
+                            }
                         }
+                    );
+                }
+
+                if (this.model.isGoogleAnalyticsTrackingEnabled()) {
+                    for (var t = 0; t < this.googleAnalyticsTrackers.length; t++) {
+                        ga(this.googleAnalyticsTrackers[t] + '.set', 'userId', userModel.get('username'));
                     }
-                );
+                }
+            },
+
+            /**
+             * Send page view event.
+             */
+            sendPageView: function() {
+                if (this.model.isSegmentTrackingEnabled()) {
+                    analytics.page(this.getSegmentPageData());
+                }
+
+                if (this.model.isGoogleAnalyticsTrackingEnabled()) {
+                    for (var t = 0; t < this.googleAnalyticsTrackers.length; t++) {
+                        ga(this.googleAnalyticsTrackers[t] + '.send', 'pageview');
+                    }
+                }
             },
 
             buildCourseProperties: function() {
@@ -117,17 +183,34 @@ define([
                 return course;
             },
 
+            buildGoogleAnalyticsEventProperties: function(eventAction, properties) {
+                return {
+                    hitType: 'event',
+                    eventCategory: properties.category,
+                    eventAction: eventAction
+                };
+            },
+
             /**
-             * Catch 'segment:track' events and create events and send
-             * to Segment.
+             * Catch 'analytics:track' events and send them to analytics providers.
              *
              * @param eventType String event type.
              */
             track: function (eventType, properties) {
-                var course = this.buildCourseProperties();
+                if (this.model.isSegmentTrackingEnabled()) {
+                    // Send event to segment including the course ID
+                    analytics.track(eventType, _.extend(this.buildCourseProperties(), properties));
+                }
 
-                // send event to segment including the course ID
-                analytics.track(eventType, _.extend(course, properties));
+                if (this.model.isGoogleAnalyticsTrackingEnabled()) {
+                    // Send event to Google Analytics properties
+                    for (var t = 0; t < this.googleAnalyticsTrackers.length; t++) {
+                        ga(
+                            this.googleAnalyticsTrackers[t] + '.send',
+                            this.buildGoogleAnalyticsEventProperties(eventType, properties)
+                        );
+                    }
+                }
             }
         });
     }

--- a/ecommerce/static/js/views/clickable_view.js
+++ b/ecommerce/static/js/views/clickable_view.js
@@ -4,7 +4,7 @@ define(['underscore', 'backbone'],
 
         /**
          * Use this for triggering track events when an element is clicked.
-         * 'segment:track' and an event are fired when the element is clicked.
+         * 'analytics:track' and an event are fired when the element is clicked.
          */
         return Backbone.View.extend({
 
@@ -23,7 +23,7 @@ define(['underscore', 'backbone'],
                 // track the click
                 self.$el.click(function () {
                     // track this event type along with properties
-                    self.model.trigger('segment:track',
+                    self.model.trigger('analytics:track',
                         self.options.trackEventType,
                         self.options.trackProperties);
                 });


### PR DESCRIPTION
**Jira Story**:  https://openedx.atlassian.net/browse/WL-862
**Sandbox Testing**
https://edx.sandbox.edx.org
https://mitpe.sandbox.edx.org
See me for access to the Segment sources and GA properties that these sites are connected to.

This PR allows us to configure multiple Segment write keys for analytics tracking. Additionally, it allows us to configure zero or more GA property tracking IDs (this is needed to overcome a Segment limitation which prevents us from adding more than one GA integration per-segment source). Each site can have it's own analytics tracking configuration.

For server-side tracking, we send tracking events to each Segment source configured for the current site. For client-side tracking, we send tracking events to the default Segment source and any GA properties that are configured for the current site. This gives us the flexibility to set up Segment integrations with GA in such a way that we can send tracking events to multiple GA properties from both client and server.

A typical multi-GA property tracking setup would include the following:

- Segment Source A
- Segment Source B
- GA Property A
- GA Property B
- Add GA Property A as an integration under Segment Source A
- Add GA Property B as an integration under Segment Source B
- Configure Segment Source A's write key as the default write key in SiteConfiguration
- Configure Segment Source B's write key as an additional write key in SiteConfiguration
- Configure GA Property B's tracking ID in SiteConfiguration

Under this configuration, server-side tracking events will flow through Segment Source A/B to their respective GA Properties. Client-side tracking events will flow through Segment Source A to GA Property A and directly to GA Property B.

For now, I have left the deprecated `SiteConfiguration.segment_key` field so that we can deploy this change to production with no effect on edx.org, populate the new `SiteConfiguration.analytics_configuration` field for edx.org and WL sites, and then follow up with removal of the segment_key field. I have created a follow on [PR](https://github.com/edx/ecommerce/pull/1069) for this work.

The https://edx.sandbox.edx.org sandbox site referenced above is configured with the `segment_key` field populated only to verify the rollout plan.