### PR TITLE
[SOL-2170] Unable to change single to multi courses once course id entered

### DIFF
--- a/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
@@ -322,6 +322,16 @@ define([
                     expect(view.model.get('catalog_query')).toEqual(view._initAttributes.catalog_query);
                     expect(view.model.get('course_seat_types')).toEqual(view._initAttributes.course_seat_types);
                 });
+
+                it('should unset all single course attributes when multiple courses selected', function () {
+                    view.model.set('course_id', 'course id');
+                    view.model.set('seat_type', 'seat type');
+                    view.model.set('stock_record_ids', [1]);
+                    view.$('#multiple-courses').prop('checked', true).trigger('change');
+                    expect(view.model.get('course_id')).toEqual(undefined);
+                    expect(view.model.get('seat_type')).toEqual(undefined);
+                    expect(view.model.get('stock_record_ids')).toEqual(undefined);
+                });
             });
         });
     }

--- a/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
@@ -324,9 +324,11 @@ define([
                 });
 
                 it('should unset all single course attributes when multiple courses selected', function () {
-                    view.model.set('course_id', 'course id');
-                    view.model.set('seat_type', 'seat type');
-                    view.model.set('stock_record_ids', [1]);
+                    view.model.set({
+                        'course_id': 'course id',
+                        'seat_type': 'seat type',
+                        'stock_record_ids': [1]
+                    });
                     view.$('#multiple-courses').prop('checked', true).trigger('change');
                     expect(view.model.get('course_id')).toEqual(undefined);
                     expect(view.model.get('seat_type')).toEqual(undefined);

--- a/ecommerce/static/js/views/coupon_form_view.js
+++ b/ecommerce/static/js/views/coupon_form_view.js
@@ -429,8 +429,8 @@ define([
                     this.formGroup('[name=course_seat_types]').removeClass(this.hiddenClass);
                     this.formGroup('[name=course_id]').addClass(this.hiddenClass);
                     this.formGroup('[name=seat_type]').addClass(this.hiddenClass);
-                    this.model.unset('course_id');
                     this.$('[name=seat_type] option').remove();
+                    this.model.unset('course_id');
                     this.model.unset('seat_type');
                     this.model.unset('stock_record_ids');
 

--- a/ecommerce/static/js/views/coupon_form_view.js
+++ b/ecommerce/static/js/views/coupon_form_view.js
@@ -430,7 +430,9 @@ define([
                     this.formGroup('[name=course_id]').addClass(this.hiddenClass);
                     this.formGroup('[name=seat_type]').addClass(this.hiddenClass);
                     this.model.unset('course_id');
+                    this.$('[name=seat_type] option').remove();
                     this.model.unset('seat_type');
+                    this.model.unset('stock_record_ids');
 
                     if (!this.model.get('course_seat_types')) {
                         this.model.set('course_seat_types', []);


### PR DESCRIPTION
Fixed bug on coupon creation page when course id entered and then changed from single course to multiple courses an error would appear on save because stock_record_ids would be set and because of that our api would create a catalog. In this case the coupon would have catalog and dynamic catalog set this will cause our validation to fail.