### PR TITLE
Fix the receipt page style when the footer is displayed

### DIFF
--- a/ecommerce/static/sass/partials/views/_receipt.scss
+++ b/ecommerce/static/sass/partials/views/_receipt.scss
@@ -1,4 +1,6 @@
 .receipt {
+    margin-bottom: 20px;
+
     background-color: #ffffff;
     font-family: $font-family-sans-serif;
     line-height: 1em;


### PR DESCRIPTION
@mjfrey

Two following screenshots display the current state of the Receipt page on the staging server, when the footer is displayed, as well as the Verify now box:

![receipt-desktop](https://cloud.githubusercontent.com/assets/6833568/21356151/dd1c6f12-c6d0-11e6-8c09-956d1bb3a75f.png)

Mobile:
![receipt_mobile](https://cloud.githubusercontent.com/assets/6833568/21356160/e34685ee-c6d0-11e6-9f6f-9c3c5d87b0cc.png)

This PR should prevent overlapping by adding additional margin below the receipt page content.

What it looks like now:
![receipt-new-desktop](https://cloud.githubusercontent.com/assets/6833568/21356220/188f8dfe-c6d1-11e6-89d2-3df00f59925f.png)

Mobile:
![receipt-new-mobile](https://cloud.githubusercontent.com/assets/6833568/21356221/1c2fee86-c6d1-11e6-9dd4-d24321be9449.png)
