### PR TITLE
ENT-110: Add Catalog selection option to Coupon create/edit form

### DIFF
--- a/ecommerce/coupons/tests/mixins.py
+++ b/ecommerce/coupons/tests/mixins.py
@@ -149,7 +149,7 @@ class CouponMixin(object):
     def create_coupon(self, benefit_type=Benefit.PERCENTAGE, benefit_value=100, catalog=None,
                       catalog_query=None, client=None, code='', course_seat_types=None, email_domains=None,
                       max_uses=None, note=None, partner=None, price=100, quantity=5, title='Test coupon',
-                      voucher_type=Voucher.SINGLE_USE):
+                      voucher_type=Voucher.SINGLE_USE, course_catalog=None):
         """Helper method for creating a coupon.
 
         Arguments:
@@ -157,12 +157,18 @@ class CouponMixin(object):
             benefit_value(int): The voucher benefit value
             catalog(Catalog): Catalog of courses for which the coupon applies
             catalog_query(str): Course query string
+            client (BusinessClient):  Optional business client object
             code(str): Custom coupon code
+            course_catalog (int): Course catalog id from Catalog Service
             course_seat_types(str): A string of comma-separated list of seat types
             email_domains(str): A comma seperated list of email domains
+            max_uses (int): Number of Voucher max uses
+            note (str): Coupon note.
             partner(Partner): Partner used for creating a catalog
             price(int): Price of the coupon
+            quantity (int): Number of vouchers to be created and associated with the coupon
             title(str): Title of the coupon
+            voucher_type (str): Voucher type
 
         Returns:
             coupon (Coupon)
@@ -184,6 +190,7 @@ class CouponMixin(object):
             catalog_query=catalog_query,
             category=self.category,
             code=code,
+            course_catalog=course_catalog,
             course_seat_types=course_seat_types,
             email_domains=email_domains,
             end_datetime=datetime.datetime(2020, 1, 1),

--- a/ecommerce/courses/tests/mixins.py
+++ b/ecommerce/courses/tests/mixins.py
@@ -1,0 +1,143 @@
+import json
+
+import httpretty
+from django.conf import settings
+from django.core.cache import cache
+
+
+class CourseCatalogServiceMockMixin(object):
+    """
+    Mocks for the Open edX service 'Course Catalog Service' responses.
+    """
+    COURSE_DISCOVERY_CATALOGS_URL = '{}catalogs/'.format(
+        settings.COURSE_CATALOG_API_URL,
+    )
+
+    def setUp(self):
+        super(CourseCatalogServiceMockMixin, self).setUp()
+        cache.clear()
+
+    def mock_course_discovery_api_for_catalog_by_resource_id(self):
+        """
+        Helper function to register course catalog API endpoint for a
+        single catalog with its resource id.
+        """
+        catalog_id = 1
+        course_discovery_api_response = {
+            'count': 1,
+            'next': None,
+            'previous': None,
+            'results': [
+                {
+                    'id': catalog_id,
+                    'name': 'Catalog {}'.format(catalog_id),
+                    'query': 'title: *',
+                    'courses_count': 0,
+                    'viewers': []
+                }
+            ]
+        }
+        course_discovery_api_response_json = json.dumps(course_discovery_api_response)
+        single_catalog_uri = '{}{}/'.format(self.COURSE_DISCOVERY_CATALOGS_URL, catalog_id)
+
+        httpretty.register_uri(
+            method=httpretty.GET,
+            uri=single_catalog_uri,
+            body=course_discovery_api_response_json,
+            content_type='application/json'
+        )
+
+    def mock_course_discovery_api_for_catalogs(self, catalog_name_list):
+        """
+        Helper function to register course catalog API endpoint for a
+        single catalog or multiple catalogs response.
+        """
+        mocked_results = []
+        for catalog_index, catalog_name in enumerate(catalog_name_list):
+            catalog_id = catalog_index + 1
+            mocked_results.append(
+                {
+                    'id': catalog_id,
+                    'name': catalog_name,
+                    'query': 'title: *',
+                    'courses_count': 0,
+                    'viewers': []
+                }
+            )
+
+        course_discovery_api_response = {
+            'count': len(catalog_name_list),
+            'next': None,
+            'previous': None,
+            'results': mocked_results
+        }
+        course_discovery_api_response_json = json.dumps(course_discovery_api_response)
+
+        httpretty.register_uri(
+            method=httpretty.GET,
+            uri=self.COURSE_DISCOVERY_CATALOGS_URL,
+            body=course_discovery_api_response_json,
+            content_type='application/json'
+        )
+
+    def mock_course_discovery_api_for_paginated_catalogs(self, catalog_name_list):
+        """
+        Helper function to register course catalog API endpoint for multiple
+        catalogs with paginated response.
+        """
+        mocked_api_responses = []
+        for catalog_index, catalog_name in enumerate(catalog_name_list):
+            catalog_id = catalog_index + 1
+            mocked_result = {
+                'id': catalog_id,
+                'name': catalog_name,
+                'query': 'title: *',
+                'courses_count': 0,
+                'viewers': []
+            }
+
+            next_page_url = None
+            if catalog_id < len(catalog_name_list):
+                # Not a last page so there will be more catalogs for another page
+                next_page_url = '{}?limit=1&offset={}'.format(
+                    self.COURSE_DISCOVERY_CATALOGS_URL,
+                    catalog_id
+                )
+
+            previous_page_url = None
+            if catalog_index != 0:
+                # Not a first page so there will always be catalogs on previous page
+                previous_page_url = '{}?limit=1&offset={}'.format(
+                    self.COURSE_DISCOVERY_CATALOGS_URL,
+                    catalog_index
+                )
+
+            course_discovery_api_paginated_response = {
+                'count': len(catalog_name_list),
+                'next': next_page_url,
+                'previous': previous_page_url,
+                'results': [mocked_result]
+            }
+            course_discovery_api_paginated_response_json = json.dumps(course_discovery_api_paginated_response)
+            mocked_api_responses.append(
+                httpretty.Response(body=course_discovery_api_paginated_response_json, content_type='application/json')
+            )
+
+        httpretty.register_uri(
+            method=httpretty.GET,
+            uri=self.COURSE_DISCOVERY_CATALOGS_URL,
+            responses=mocked_api_responses
+        )
+
+    def mock_course_discovery_api_for_failure(self):
+        """
+        Helper function to register course catalog API endpoint for a
+        failure.
+        """
+        httpretty.register_uri(
+            method=httpretty.GET,
+            uri=self.COURSE_DISCOVERY_CATALOGS_URL,
+            responses=[
+                httpretty.Response(body='Clunk', content_type='application/json', status_code=500)
+            ]
+        )

--- a/ecommerce/courses/tests/test_utils.py
+++ b/ecommerce/courses/tests/test_utils.py
@@ -1,9 +1,8 @@
 import hashlib
 
 import ddt
-import httpretty
-
 from django.core.cache import cache
+import httpretty
 
 from ecommerce.core.constants import ENROLLMENT_CODE_SWITCH
 from ecommerce.core.tests import toggle_switch
@@ -11,8 +10,9 @@ from ecommerce.core.tests.decorators import mock_course_catalog_api_client
 from ecommerce.coupons.tests.mixins import CourseCatalogMockMixin
 from ecommerce.courses.models import Course
 from ecommerce.courses.tests.factories import CourseFactory
+from ecommerce.courses.tests.mixins import CourseCatalogServiceMockMixin
 from ecommerce.courses.utils import (
-    get_certificate_type_display_value, get_course_info_from_catalog, mode_for_seat
+    get_certificate_type_display_value, get_course_info_from_catalog, mode_for_seat, get_course_catalogs
 )
 from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
 from ecommerce.tests.testcases import TestCase
@@ -74,3 +74,110 @@ class UtilsTests(CourseCatalogTestMixin, CourseCatalogMockMixin, TestCase):
     def test_cert_display_assertion(self):
         """ Verify assertion for invalid cert type """
         self.assertRaises(ValueError, lambda: get_certificate_type_display_value('junk'))
+
+
+@ddt.ddt
+@httpretty.activate
+class GetCourseCatalogUtilTests(CourseCatalogServiceMockMixin, TestCase):
+
+    def tearDown(self):
+        # Reset HTTPretty state (clean up registered urls and request history)
+        httpretty.reset()
+
+    def _assert_num_requests(self, count):
+        """
+        DRY helper for verifying request counts.
+        """
+        self.assertEqual(len(httpretty.httpretty.latest_requests), count)
+
+    def _assert_get_course_catalogs(self, catalog_name_list):
+        """
+        Helper method to validate the response from the method
+        "get_course_catalogs".
+        """
+        cache_key = '{}.catalog.api.data'.format(self.request.site.domain)
+        cache_key = hashlib.md5(cache_key).hexdigest()
+        cached_course_catalogs = cache.get(cache_key)
+        self.assertIsNone(cached_course_catalogs)
+
+        response = get_course_catalogs(self.request.site)
+
+        self.assertEqual(len(response), len(catalog_name_list))
+        for catalog_index, catalog in enumerate(response):
+            self.assertEqual(catalog['name'], catalog_name_list[catalog_index])
+
+        cached_course = cache.get(cache_key)
+        self.assertEqual(cached_course, response)
+
+    @mock_course_catalog_api_client
+    def test_get_course_catalogs_for_single_catalog_with_id(self):
+        """
+        Verify that method "get_course_catalogs" returns proper response for a
+        single catalog by its id.
+        """
+        self.mock_course_discovery_api_for_catalog_by_resource_id()
+
+        catalog_id = 1
+        cache_key = '{}.catalog.api.data.{}'.format(self.request.site.domain, catalog_id)
+        cache_key = hashlib.md5(cache_key).hexdigest()
+        cached_course_catalog = cache.get(cache_key)
+        self.assertIsNone(cached_course_catalog)
+
+        response = get_course_catalogs(self.request.site, catalog_id)
+
+        self.assertEqual(response['count'], 1)
+        self.assertEqual(response['results'][0]['name'], 'Catalog {}'.format(catalog_id))
+
+        cached_course = cache.get(cache_key)
+        self.assertEqual(cached_course, response)
+
+        # Verify the API was actually hit (not the cache)
+        self._assert_num_requests(1)
+
+    @mock_course_catalog_api_client
+    @ddt.data(
+        ['Catalog 1'],
+        ['Catalog 1', 'Catalog 2'],
+    )
+    def test_get_course_catalogs_for_single_page_api_response(self, catalog_name_list):
+        """
+        Verify that method "get_course_catalogs" returns proper response for
+        single page Course Discovery API response and uses cache to return data
+        in case of same API request.
+        """
+        self.mock_course_discovery_api_for_catalogs(catalog_name_list)
+
+        self._assert_get_course_catalogs(catalog_name_list)
+
+        # Verify the API was hit once
+        self._assert_num_requests(1)
+
+        # Now fetch the catalogs again and there should be no more actual call
+        # to Course Discovery API as the data will be fetched from the cache
+        get_course_catalogs(self.request.site)
+        self._assert_num_requests(1)
+
+    @mock_course_catalog_api_client
+    def test_get_course_catalogs_for_paginated_api_response(self):
+        """
+        Verify that method "get_course_catalogs" returns all catalogs for
+        paginated Course Discovery API response for multiple catalogs.
+        """
+        catalog_name_list = ['Catalog 1', 'Catalog 2', 'Catalog 3']
+        self.mock_course_discovery_api_for_paginated_catalogs(catalog_name_list)
+
+        self._assert_get_course_catalogs(catalog_name_list)
+
+        # Verify the API was hit for each catalog page
+        self._assert_num_requests(len(catalog_name_list))
+
+    @mock_course_catalog_api_client
+    def test_get_course_catalogs_for_failure(self):
+        """
+        Verify that method "get_course_catalogs" raises exception in case
+        the Course Discovery API fails to return data.
+        """
+        self.mock_course_discovery_api_for_failure()
+
+        with self.assertRaises(Exception):
+            get_course_catalogs(self.request.site)

--- a/ecommerce/courses/utils.py
+++ b/ecommerce/courses/utils.py
@@ -1,4 +1,5 @@
 import hashlib
+from urlparse import parse_qs, urlparse
 
 from django.conf import settings
 from django.core.cache import cache
@@ -31,6 +32,67 @@ def get_course_info_from_catalog(site, course_key):
         course_run = api.course_runs(course_key).get(partner=partner_short_code)
         cache.set(cache_key, course_run, settings.COURSES_API_CACHE_TIMEOUT)
     return course_run
+
+
+def get_course_catalogs(site, resource_id=None):
+    """
+    Get details related to course catalogs from Catalog Service.
+
+    Arguments:
+        site (Site): Site object containing Site Configuration data
+        resource_id (int or str): Identifies a specific resource to be retrieved
+
+    Returns:
+        dict: Course catalogs received from Course Catalog API
+
+    """
+    resource = 'catalogs'
+    base_cache_key = '{}.catalog.api.data'.format(site.domain)
+
+    cache_key = '{}.{}'.format(base_cache_key, resource_id) if resource_id else base_cache_key
+    cache_key = hashlib.md5(cache_key).hexdigest()
+    cached = cache.get(cache_key)
+    if cached:
+        return cached
+
+    api = site.siteconfiguration.course_catalog_api_client
+    endpoint = getattr(api, resource)
+    response = endpoint(resource_id).get()
+
+    if resource_id:
+        results = response
+    else:
+        results = traverse_pagination(response, endpoint)
+
+    cache.set(cache_key, results, settings.COURSES_API_CACHE_TIMEOUT)
+    return results
+
+
+def traverse_pagination(response, endpoint):
+    """
+    Traverse a paginated API response.
+
+    Extracts and concatenates "results" (list of dict) returned by DRF-powered
+    APIs.
+
+    Arguments:
+        response (Dict): Current response dict from service API
+        endpoint (slumber Resource object): slumber Resource object from edx-rest-api-client
+
+    Returns:
+        list of dict.
+
+    """
+    results = response.get('results', [])
+
+    next_page = response.get('next')
+    while next_page:
+        querystring = parse_qs(urlparse(next_page).query, keep_blank_values=True)
+        response = endpoint.get(**querystring)
+        results += response.get('results', [])
+        next_page = response.get('next')
+
+    return results
 
 
 def get_certificate_type_display_value(certificate_type):

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -531,6 +531,7 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
     benefit_type = serializers.SerializerMethodField()
     benefit_value = serializers.SerializerMethodField()
     catalog_query = serializers.SerializerMethodField()
+    course_catalog = serializers.SerializerMethodField()
     category = serializers.SerializerMethodField()
     client = serializers.SerializerMethodField()
     code = serializers.SerializerMethodField()
@@ -557,6 +558,9 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
 
     def get_catalog_query(self, obj):
         return retrieve_offer(obj).condition.range.catalog_query
+
+    def get_course_catalog(self, obj):
+        return retrieve_offer(obj).condition.range.course_catalog
 
     def get_category(self, obj):
         category = ProductCategory.objects.filter(product=obj).first().category
@@ -645,7 +649,7 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
     class Meta(object):
         model = Product
         fields = (
-            'benefit_type', 'benefit_value', 'catalog_query', 'category',
+            'benefit_type', 'benefit_value', 'catalog_query', 'course_catalog', 'category',
             'client', 'code', 'code_status', 'coupon_type', 'course_seat_types',
             'email_domains', 'end_date', 'id', 'last_edited', 'max_uses',
             'note', 'num_uses', 'payment_information', 'price', 'quantity',

--- a/ecommerce/extensions/api/v2/tests/views/test_catalog.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_catalog.py
@@ -5,17 +5,20 @@ import httpretty
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test import RequestFactory
+import mock
 from oscar.core.loading import get_model
 from requests.exceptions import ConnectionError, Timeout
 from slumber.exceptions import SlumberBaseException
 
 from ecommerce.core.tests.decorators import mock_course_catalog_api_client
 from ecommerce.coupons.tests.mixins import CourseCatalogMockMixin
+from ecommerce.courses.tests.mixins import CourseCatalogServiceMockMixin
 from ecommerce.extensions.api.serializers import ProductSerializer
 from ecommerce.extensions.api.v2.tests.views.mixins import CatalogMixin
 from ecommerce.extensions.api.v2.views.catalog import CatalogViewSet
 from ecommerce.tests.mixins import ApiMockMixin
 from ecommerce.tests.testcases import TestCase
+
 
 Catalog = get_model('catalogue', 'Catalog')
 StockRecord = get_model('partner', 'StockRecord')
@@ -23,7 +26,7 @@ StockRecord = get_model('partner', 'StockRecord')
 
 @httpretty.activate
 @ddt.ddt
-class CatalogViewSetTest(CatalogMixin, CourseCatalogMockMixin, ApiMockMixin, TestCase):
+class CatalogViewSetTest(CatalogMixin, CourseCatalogMockMixin, CourseCatalogServiceMockMixin, ApiMockMixin, TestCase):
     """Test the Catalog and related products APIs."""
 
     catalog_list_path = reverse('api:v2:catalog-list')
@@ -129,6 +132,60 @@ class CatalogViewSetTest(CatalogMixin, CourseCatalogMockMixin, ApiMockMixin, Tes
 
         response = CatalogViewSet().preview(request)
         self.assertEqual(response.status_code, 400)
+
+    @ddt.data(
+        (
+            '/api/v2/coupons/course_catalogs/',
+            ['Catalog 1'],
+            ['Catalog 1']
+        ),
+        (
+            '/api/v2/coupons/course_catalogs/',
+            ['Clean Catalog', 'ABC Catalog', 'New Catalog', 'Edx Catalog'],
+            ['ABC Catalog', 'Clean Catalog', 'Edx Catalog', 'New Catalog']
+        ),
+    )
+    @ddt.unpack
+    @mock_course_catalog_api_client
+    def test_course_catalogs_for_single_page_api_response(self, url, catalog_name_list, sorted_catalog_name_list):
+        """
+        Test course catalogs list view "course_catalogs" for valid response
+        with catalogs in alphabetical order.
+        """
+        self.mock_course_discovery_api_for_catalogs(catalog_name_list)
+
+        request = self.prepare_request(url)
+        response = CatalogViewSet().course_catalogs(request)
+
+        self.assertEqual(response.status_code, 200)
+        # Validate that the catalogs are sorted by name in alphabetical order
+        self._assert_get_course_catalogs_response_with_order(response, sorted_catalog_name_list)
+
+    def _assert_get_course_catalogs_response_with_order(self, response, catalog_name_list):
+        """
+        Helper method to validate the response from the method
+        "course_catalogs".
+        """
+        response_results = response.data.get('results')
+        self.assertEqual(len(response_results), len(catalog_name_list))
+        for catalog_index, catalog in enumerate(response_results):
+            self.assertEqual(catalog['name'], catalog_name_list[catalog_index])
+
+    @mock_course_catalog_api_client
+    @mock.patch('ecommerce.extensions.api.v2.views.catalog.logger.exception')
+    def test_get_course_catalogs_for_failure(self, mock_exception):
+        """
+        Verify that the course catalogs list view "course_catalogs" returns
+        empty results list in case the Course Discovery API fails to return
+        data.
+        """
+        self.mock_course_discovery_api_for_failure()
+
+        request = self.prepare_request('/api/v2/coupons/course_catalogs/')
+        response = CatalogViewSet().course_catalogs(request)
+
+        self.assertTrue(mock_exception.called)
+        self.assertEqual(response.data.get('results'), [])
 
 
 class PartnerCatalogViewSetTest(CatalogMixin, TestCase):

--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -73,6 +73,7 @@ class CouponViewSetTest(CouponMixin, CourseCatalogTestMixin, TestCase):
             'catalog_query': None,
             'course_seat_types': None,
             'email_domains': None,
+            'course_catalog': {'id': '', 'name': ''},
         }
 
     def setup_site_configuration(self):
@@ -238,7 +239,8 @@ class CouponViewSetFunctionalTest(CouponMixin, CourseCatalogTestMixin, CourseCat
             'start_datetime': str(now() - datetime.timedelta(days=10)),
             'stock_record_ids': [1, 2],
             'title': 'Tešt čoupon',
-            'voucher_type': Voucher.SINGLE_USE
+            'voucher_type': Voucher.SINGLE_USE,
+            'course_catalog': {'id': '', 'name': ''},
         }
         self.response = self.client.post(COUPONS_LINK, json.dumps(self.data), 'application/json')
         self.coupon = Product.objects.get(title=self.data['title'])

--- a/ecommerce/extensions/api/v2/views/catalog.py
+++ b/ecommerce/extensions/api/v2/views/catalog.py
@@ -13,6 +13,7 @@ from slumber.exceptions import SlumberBaseException
 from ecommerce.core.constants import DEFAULT_CATALOG_PAGE_SIZE
 from ecommerce.coupons.utils import get_range_catalog_query_results
 from ecommerce.extensions.api import serializers
+from ecommerce.courses.utils import get_course_catalogs
 
 
 Catalog = get_model('catalogue', 'Catalog')
@@ -73,3 +74,20 @@ class CatalogViewSet(NestedViewSetMixin, ReadOnlyModelViewSet):
                 logger.error('Unable to connect to Course Catalog service.')
                 return Response(status=status.HTTP_400_BAD_REQUEST)
         return Response(status=status.HTTP_400_BAD_REQUEST)
+
+    @action(is_for_list=True, methods=['get'])
+    def course_catalogs(self, request):
+        """
+        Returns response with all course catalogs in the format:
+        ["results": {"id": 1, "name": "Dummy Catalog"}]
+        """
+        try:
+            results = get_course_catalogs(site=request.site)
+        except:  # pylint: disable=bare-except
+            logger.exception('Failed to retrieve course catalogs data from the Course Discovery API.')
+            results = []
+
+        # Create catalogs list with sorting by name
+        catalogs = [{'id': catalog['id'], 'name': catalog['name']} for catalog in results]
+        data = {'results': sorted(catalogs, key=lambda catalog: catalog.get('name', '').lower())}
+        return Response(data=data)

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -7,7 +7,6 @@ from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from django.http import Http404
 from django.shortcuts import get_object_or_404
-from django.utils.translation import ugettext as _
 from oscar.core.loading import get_model
 from rest_framework import filters, generics, serializers, status, viewsets
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
@@ -73,95 +72,34 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
             429 if the client has made requests at a rate exceeding that allowed by the configured rate limit.
             500 if an error occurs when attempting to create a coupon.
         """
-        category_data = request.data.get('category')
-        code = request.data.get('code')
-        course_seat_types = request.data.get('course_seat_types')
-        max_uses = request.data.get('max_uses')
-        partner = request.site.siteconfiguration.partner
-        stock_record_ids = request.data.get('stock_record_ids')
-        voucher_type = request.data.get('voucher_type')
-
         try:
             with transaction.atomic():
-                if code:
-                    try:
-                        Voucher.objects.get(code=code)
-                        return Response(
-                            'A coupon with code {code} already exists.'.format(code=code),
-                            status=status.HTTP_400_BAD_REQUEST
-                        )
-                    except Voucher.DoesNotExist:
-                        pass
-
-                if course_seat_types:
-                    try:
-                        course_seat_types = prepare_course_seat_types(course_seat_types)
-                    except (AttributeError, TypeError) as e:
-                        logger.exception('Failed to create coupon. Invalid course seat types data: %s', e.message)
-                        return Response(
-                            _('Invalid course seat types data: {}').format(e.message),
-                            status=status.HTTP_400_BAD_REQUEST
-                        )
-
                 try:
-                    category = Category.objects.get(name=category_data['name'])
-                except Category.DoesNotExist:
-                    return Response(
-                        'Category {category_name} not found.'.format(category_name=category_data['name']),
-                        status=status.HTTP_404_NOT_FOUND
-                    )
-                except (KeyError, TypeError):
-                    return Response('Invalid Coupon Category data.', status=status.HTTP_400_BAD_REQUEST)
-
-                # Maximum number of uses can be set for each voucher type and disturb
-                # the predefined behaviours of the different voucher types. Therefor
-                # here we enforce that the max_uses variable can't be used for SINGLE_USE
-                # voucher types.
-                if max_uses and voucher_type != Voucher.SINGLE_USE:
-                    max_uses = int(max_uses)
-                else:
-                    max_uses = None
-
-                # When a black-listed course mode is received raise an exception.
-                # Audit modes do not have a certificate type and therefore will raise
-                # an AttributeError exception.
-                if stock_record_ids:
-                    seats = Product.objects.filter(stockrecords__id__in=stock_record_ids)
-                    for seat in seats:
-                        try:
-                            if seat.attr.certificate_type in settings.BLACK_LIST_COUPON_COURSE_MODES:
-                                return Response('Course mode not supported', status=status.HTTP_400_BAD_REQUEST)
-                        except AttributeError:
-                            return Response('Course mode not supported', status=status.HTTP_400_BAD_REQUEST)
-
-                    stock_records_string = ' '.join(str(id) for id in stock_record_ids)
-                    coupon_catalog, __ = get_or_create_catalog(
-                        name='Catalog for stock records: {}'.format(stock_records_string),
-                        partner=partner,
-                        stock_record_ids=stock_record_ids
-                    )
-                else:
-                    coupon_catalog = None
+                    cleaned_voucher_data = self.clean_voucher_request_data(request)
+                except ValidationError as error:
+                    logger.exception('Failed to create coupon. %s', error.message)
+                    return Response(error.message, status=error.code)
 
                 try:
                     coupon_product = create_coupon_product(
-                        benefit_type=request.data.get('benefit_type'),
-                        benefit_value=request.data.get('benefit_value'),
-                        catalog=coupon_catalog,
-                        catalog_query=request.data.get('catalog_query'),
-                        category=category,
-                        code=code,
-                        course_seat_types=course_seat_types,
-                        email_domains=request.data.get('email_domains'),
-                        end_datetime=request.data.get('end_datetime'),
-                        max_uses=max_uses,
-                        note=request.data.get('note'),
-                        partner=partner,
-                        price=request.data.get('price'),
-                        quantity=request.data.get('quantity'),
-                        start_datetime=request.data.get('start_datetime'),
-                        title=request.data.get('title'),
-                        voucher_type=voucher_type
+                        benefit_type=cleaned_voucher_data.get('benefit_type'),
+                        benefit_value=cleaned_voucher_data.get('benefit_value'),
+                        catalog=cleaned_voucher_data.get('coupon_catalog'),
+                        catalog_query=cleaned_voucher_data.get('catalog_query'),
+                        category=cleaned_voucher_data.get('category'),
+                        code=cleaned_voucher_data.get('code'),
+                        course_catalog=cleaned_voucher_data.get('course_catalog'),
+                        course_seat_types=cleaned_voucher_data.get('course_seat_types'),
+                        email_domains=cleaned_voucher_data.get('email_domains'),
+                        end_datetime=cleaned_voucher_data.get('end_datetime'),
+                        max_uses=cleaned_voucher_data.get('max_uses'),
+                        note=cleaned_voucher_data.get('note'),
+                        partner=cleaned_voucher_data.get('partner'),
+                        price=cleaned_voucher_data.get('price'),
+                        quantity=cleaned_voucher_data.get('quantity'),
+                        start_datetime=cleaned_voucher_data.get('start_datetime'),
+                        title=cleaned_voucher_data.get('title'),
+                        voucher_type=cleaned_voucher_data.get('voucher_type')
                     )
                 except IntegrityError as e:
                     return Response(str(e), status=status.HTTP_400_BAD_REQUEST)
@@ -178,6 +116,106 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
                 return Response(response_data, status=status.HTTP_200_OK)
         except ValidationError as e:
             raise serializers.ValidationError(e.message)
+
+    @classmethod
+    def clean_voucher_request_data(cls, request):
+        """
+        Helper method to return cleaned request data for voucher creation or
+        raise validation error with error code.
+
+        Arguments:
+            request (HttpRequest): request with voucher data
+
+        """
+        category_data = request.data.get('category')
+        code = request.data.get('code')
+        course_catalog_data = request.data.get('course_catalog')
+        course_seat_types = request.data.get('course_seat_types')
+        max_uses = request.data.get('max_uses')
+        partner = request.site.siteconfiguration.partner
+        stock_record_ids = request.data.get('stock_record_ids')
+        voucher_type = request.data.get('voucher_type')
+
+        if code and Voucher.does_exist(code):
+            return Response(
+                'A coupon with code {code} already exists.'.format(code=code),
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        if course_seat_types:
+            try:
+                course_seat_types = prepare_course_seat_types(course_seat_types)
+            except (AttributeError, TypeError) as exception:
+                validation_message = 'Invalid course seat types data: {}'.format(exception.message)
+                raise ValidationError(validation_message, code=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            category = Category.objects.get(name=category_data['name'])
+        except Category.DoesNotExist:
+            validation_message = 'Category "{category_name}" not found.'.format(category_name=category_data['name'])
+            raise ValidationError(validation_message, code=status.HTTP_404_NOT_FOUND)
+        except (KeyError, TypeError):
+            validation_message = 'Invalid Coupon Category data.'
+            raise ValidationError(validation_message, code=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            course_catalog = course_catalog_data['id']
+        except (KeyError, TypeError):
+            validation_message = 'Unexpected catalog data format received for coupon.'
+            raise ValidationError(validation_message, code=status.HTTP_400_BAD_REQUEST)
+
+        # Maximum number of uses can be set for each voucher type and disturb
+        # the predefined behaviours of the different voucher types. Therefor
+        # here we enforce that the max_uses variable can't be used for SINGLE_USE
+        # voucher types.
+        if max_uses and voucher_type != Voucher.SINGLE_USE:
+            max_uses = int(max_uses)
+        else:
+            max_uses = None
+
+        # When a black-listed course mode is received raise an exception.
+        # Audit modes do not have a certificate type and therefore will raise
+        # an AttributeError exception.
+        if stock_record_ids:
+            seats = Product.objects.filter(stockrecords__id__in=stock_record_ids)
+            for seat in seats:
+                try:
+                    if seat.attr.certificate_type in settings.BLACK_LIST_COUPON_COURSE_MODES:
+                        validation_message = 'Course mode not supported'
+                        raise ValidationError(validation_message, code=status.HTTP_400_BAD_REQUEST)
+                except AttributeError:
+                    validation_message = 'Course mode not supported'
+                    raise ValidationError(validation_message, code=status.HTTP_400_BAD_REQUEST)
+
+            stock_records_string = ' '.join(str(id) for id in stock_record_ids)
+            coupon_catalog, __ = get_or_create_catalog(
+                name='Catalog for stock records: {}'.format(stock_records_string),
+                partner=partner,
+                stock_record_ids=stock_record_ids
+            )
+        else:
+            coupon_catalog = None
+
+        return {
+            'benefit_type': request.data.get('benefit_type'),
+            'benefit_value': request.data.get('benefit_value'),
+            'catalog': coupon_catalog,
+            'catalog_query': request.data.get('catalog_query'),
+            'category': category,
+            'code': code,
+            'course_catalog': course_catalog,
+            'course_seat_types': course_seat_types,
+            'email_domains': request.data.get('email_domains'),
+            'end_datetime': request.data.get('end_datetime'),
+            'max_uses': max_uses,
+            'note': request.data.get('note'),
+            'partner': partner,
+            'price': request.data.get('price'),
+            'quantity': request.data.get('quantity'),
+            'start_datetime': request.data.get('start_datetime'),
+            'title': request.data.get('title'),
+            'voucher_type': voucher_type,
+        }
 
     def create_order_for_invoice(self, basket, coupon_id, client, invoice_data=None):
         """Creates an order from the basket and invokes the invoice payment processor."""
@@ -240,6 +278,13 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
             # Remove catalog if switching from single course to dynamic query
             if voucher_range.catalog:
                 range_data['catalog'] = None
+
+            course_catalog_data = request.data.get('course_catalog')
+            if course_catalog_data:
+                # make sure course catalog is None if its empty
+                course_catalog = course_catalog_data.get('id') if course_catalog_data.get('id') else None
+                range_data['course_catalog'] = course_catalog
+
             Range.objects.filter(id=voucher_range.id).update(**range_data)
 
         benefit_value = request.data.get('benefit_value')

--- a/ecommerce/extensions/catalogue/tests/test_utils.py
+++ b/ecommerce/extensions/catalogue/tests/test_utils.py
@@ -122,6 +122,7 @@ class CouponCreationTests(CouponMixin, TestCase):
             catalog_query=None,
             category=self.category,
             code=code,
+            course_catalog=None,
             course_seat_types=None,
             email_domains=None,
             end_datetime='2020-1-1',

--- a/ecommerce/extensions/catalogue/utils.py
+++ b/ecommerce/extensions/catalogue/utils.py
@@ -36,7 +36,8 @@ def create_coupon_product(
         quantity,
         start_datetime,
         title,
-        voucher_type
+        voucher_type,
+        course_catalog,
 ):
     """
     Creates a coupon product and a stock record for it.
@@ -49,6 +50,7 @@ def create_coupon_product(
         category (dict): Contains category ID and name.
         code (str): Voucher code.
         course_seat_types (str): Comma-separated list of course seat types.
+        course_catalog (int): Course catalog id from Catalog Service
         email_domains (str): Comma-separated list of email domains.
         end_datetime (Datetime): Voucher end Datetime.
         max_uses (int): Number of Voucher max uses.
@@ -82,6 +84,7 @@ def create_coupon_product(
             catalog_query=catalog_query,
             code=code or None,
             coupon=coupon_product,
+            course_catalog=course_catalog,
             course_seat_types=course_seat_types,
             email_domains=email_domains,
             end_datetime=end_datetime,

--- a/ecommerce/extensions/offer/admin.py
+++ b/ecommerce/extensions/offer/admin.py
@@ -2,8 +2,9 @@ from oscar.apps.offer.admin import *  # pylint: disable=unused-import,wildcard-i
 
 
 class RangeAdminExtended(admin.ModelAdmin):
-    list_display = ('name', 'catalog',)
+    list_display = ('name', 'catalog', 'course_catalog',)
     raw_id_fields = ('catalog',)
+    search_fields = ['name', 'course_catalog']
 
 
 admin.site.unregister(Range)

--- a/ecommerce/extensions/offer/migrations/0008_range_course_catalog.py
+++ b/ecommerce/extensions/offer/migrations/0008_range_course_catalog.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('offer', '0007_auto_20161026_0856'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='range',
+            name='course_catalog',
+            field=models.PositiveIntegerField(help_text='Course catalog id from the Catalog Service.', null=True, blank=True),
+        ),
+    ]

--- a/ecommerce/extensions/offer/models.py
+++ b/ecommerce/extensions/offer/models.py
@@ -119,10 +119,16 @@ class Range(AbstractRange):
     UPDATABLE_RANGE_FIELDS = [
         'catalog_query',
         'course_seat_types',
+        'course_catalog',
     ]
     ALLOWED_SEAT_TYPES = ['credit', 'professional', 'verified']
     catalog = models.ForeignKey('catalogue.Catalog', blank=True, null=True, related_name='ranges')
     catalog_query = models.TextField(blank=True, null=True)
+    course_catalog = models.PositiveIntegerField(
+        help_text=_('Course catalog id from the Catalog Service.'),
+        null=True,
+        blank=True
+    )
     course_seat_types = models.CharField(
         max_length=255,
         validators=[validate_credit_seat_type],

--- a/ecommerce/extensions/voucher/models.py
+++ b/ecommerce/extensions/voucher/models.py
@@ -52,5 +52,13 @@ class Voucher(AbstractVoucher):
             logger.exception('Failed to create Voucher. Voucher start and end datetime fields must be type datetime.')
             raise ValidationError(_('Voucher start and end datetime fields must be type datetime.'))
 
+    @classmethod
+    def does_exist(cls, code):
+        try:
+            Voucher.objects.get(code=code)
+            return True
+        except Voucher.DoesNotExist:
+            return False
+
 
 from oscar.apps.voucher.models import *  # noqa pylint: disable=wildcard-import,unused-wildcard-import,wrong-import-position

--- a/ecommerce/extensions/voucher/tests/test_utils.py
+++ b/ecommerce/extensions/voucher/tests/test_utils.py
@@ -137,6 +137,13 @@ class UtilTests(CouponMixin, CourseCatalogMockMixin, CourseCatalogTestMixin, Lms
             course_seat_types=course_seat_types
         )
 
+    def create_course_catalog_coupon(self, coupon_title, quantity, course_catalog):
+        return self.create_coupon(
+            title=coupon_title,
+            quantity=quantity,
+            course_catalog=course_catalog,
+        )
+
     def use_voucher(self, order_num, voucher, user):
         """
         Mark voucher as used by provided users
@@ -239,6 +246,39 @@ class UtilTests(CouponMixin, CourseCatalogMockMixin, CourseCatalogTestMixin, Lms
         self.assertEqual(len(discount_vouchers), 1)
         self.assertEqual(discount_vouchers[0].code, VOUCHER_CODE)
 
+        with self.assertRaises(IntegrityError):
+            create_vouchers(**self.data)
+
+    def test_create_course_catalog_coupon(self):
+        """
+        Test course catalog coupon voucher creation with specified catalog id.
+        """
+        coupon_title = 'Course catalog coupon'
+        quantity = 1
+        course_catalog = 1
+
+        course_catalog_coupon = self.create_course_catalog_coupon(
+            coupon_title=coupon_title,
+            quantity=quantity,
+            course_catalog=course_catalog,
+        )
+        self.assertEqual(course_catalog_coupon.title, coupon_title)
+
+        course_catalog_vouchers = course_catalog_coupon.attr.coupon_vouchers.vouchers.all()
+        self.assertEqual(course_catalog_vouchers.count(), quantity)
+
+        course_catalog_voucher_range = course_catalog_vouchers.first().offers.first().benefit.range
+        self.assertEqual(course_catalog_voucher_range.course_catalog, course_catalog)
+
+        self.data.update({
+            'name': coupon_title,
+            'benefit_value': course_catalog_vouchers.first().offers.first().benefit.value,
+            'code': course_catalog_vouchers.first().code,
+            'quantity': quantity,
+            'course_catalog': course_catalog,
+            'catalog': None,
+            'course_seat_types': None
+        })
         with self.assertRaises(IntegrityError):
             create_vouchers(**self.data)
 

--- a/ecommerce/extensions/voucher/utils.py
+++ b/ecommerce/extensions/voucher/utils.py
@@ -418,26 +418,33 @@ def create_vouchers(
         _range=None,
         catalog_query=None,
         course_seat_types=None,
-        email_domains=None):
+        email_domains=None,
+        course_catalog=None,
+):
     """
     Create vouchers.
 
-    Args:
-            benefit_type (str): Type of benefit associated with vouchers.
-            benefit_value (Decimal): Value of benefit associated with vouchers.
-            catalog (Catalog): Catalog associated with range of products
-                               to which a voucher can be applied to.
-            coupon (Coupon): Coupon entity associated with vouchers.
-            end_datetime (datetime): End date for voucher offer.
-            name (str): Voucher name.
-            quantity (int): Number of vouchers to be created.
-            start_datetime (datetime): Start date for voucher offer.
-            voucher_type (str): Type of voucher.
-            code (str): Code associated with vouchers. Defaults to None.
-            email_domains (str): List of email domains to restrict coupons. Defaults to None.
+    Arguments:
+        benefit_type (str): Type of benefit associated with vouchers.
+        benefit_value (Decimal): Value of benefit associated with vouchers.
+        catalog (Catalog): Catalog associated with range of products
+                           to which a voucher can be applied to.
+        catalog_query (str): ElasticSearch query used by dynamic coupons. Defaults to None.
+        code (str): Code associated with vouchers. Defaults to None.
+        coupon (Coupon): Coupon entity associated with vouchers.
+        course_catalog (int): Course catalog id from Catalog Service. Defaults to None.
+        course_seat_types (str): Comma-separated list of course seat types.
+        email_domains (str): List of email domains to restrict coupons. Defaults to None.
+        end_datetime (datetime): End date for voucher offer.
+        max_uses (int): Number of Voucher max uses. Defaults to None.
+        name (str): Voucher name.
+        quantity (int): Number of vouchers to be created.
+        start_datetime (datetime): Start date for voucher offer.
+        voucher_type (str): Type of voucher.
+        _range (Range): Product range. Defaults to None.
 
     Returns:
-            List[Voucher]
+        List[Voucher]
     """
     logger.info("Creating [%d] vouchers product [%s]", quantity, coupon.id)
     vouchers = []
@@ -450,10 +457,13 @@ def create_vouchers(
     else:
         logger.info("Creating [%d] vouchers for coupon [%s]", quantity, coupon.id)
         range_name = (_('Range for coupon [{coupon_id}]').format(coupon_id=coupon.id))
+        # make sure course catalog is None if its empty
+        course_catalog = course_catalog if course_catalog else None
         product_range, __ = Range.objects.get_or_create(
             name=range_name,
             catalog=catalog,
             catalog_query=catalog_query,
+            course_catalog=course_catalog,
             course_seat_types=course_seat_types,
         )
 

--- a/ecommerce/static/js/apps/coupon_admin_app.js
+++ b/ecommerce/static/js/apps/coupon_admin_app.js
@@ -1,12 +1,14 @@
 require([
         'backbone',
         'collections/category_collection',
+        'collections/catalog_collection',
         'ecommerce',
         'routers/coupon_router',
         'utils/navigate',
     ],
     function (Backbone,
               CategoryCollection,
+              CatalogCollection,
               ecommerce,
               CouponRouter,
               navigate) {
@@ -20,6 +22,10 @@ require([
             ecommerce.coupons.categories = new CategoryCollection();
             ecommerce.coupons.categories.url = '/api/v2/coupons/categories/';
             ecommerce.coupons.categories.fetch({ async: false });
+
+            ecommerce.coupons.catalogs = new CatalogCollection();
+            ecommerce.coupons.catalogs.fetch({ async: false });
+
             couponApp.start();
 
             // Handle navbar clicks.

--- a/ecommerce/static/js/collections/catalog_collection.js
+++ b/ecommerce/static/js/collections/catalog_collection.js
@@ -1,0 +1,15 @@
+define([
+        'collections/paginated_collection',
+        'models/catalog_model'
+    ],
+    function (PaginatedCollection,
+              Catalog) {
+        'use strict';
+
+        return PaginatedCollection.extend({
+                model: Catalog,
+                url: '/api/v2/catalogs/course_catalogs/'
+            }
+        );
+    }
+);

--- a/ecommerce/static/js/models/catalog_model.js
+++ b/ecommerce/static/js/models/catalog_model.js
@@ -1,0 +1,11 @@
+define([
+        'backbone.relational'
+    ],
+    function () {
+        'use strict';
+
+        return Backbone.RelationalModel.extend({
+            urlRoot: '/api/v2/catalogs/course_catalogs/'
+        });
+    }
+);

--- a/ecommerce/static/js/models/coupon_model.js
+++ b/ecommerce/static/js/models/coupon_model.js
@@ -7,7 +7,9 @@ define([
         'underscore',
         'moment',
         'collections/category_collection',
+        'collections/catalog_collection',
         'models/category',
+        'models/catalog_model',
         'utils/validation_patterns'
     ],
     function (Backbone,
@@ -24,15 +26,23 @@ define([
             required: gettext('This field is required.'),
             number: gettext('This value must be a number.'),
             date: gettext('This value must be a date.'),
-            seat_types: gettext('At least one seat type must be selected.'),
+            seat_types: gettext('At least one seat type must be selected.')
         });
         _.extend(Backbone.Model.prototype, Backbone.Validation.mixin);
+
+        /* jshint esnext: true */
+        var CATALOG_TYPES = {
+            single_course: 'Single course',
+            multiple_courses: 'Multiple courses',
+            catalog: 'Catalog'
+        };
 
         return Backbone.RelationalModel.extend({
             urlRoot: '/api/v2/coupons/',
 
             defaults: {
                 category: {id: 3, name: 'Affiliate Promotion'},
+                course_catalog: {id: '', name: ''},
                 code: '',
                 course_seats: [],
                 course_seat_types: [],
@@ -42,8 +52,10 @@ define([
                 quantity: 1,
                 seats: [],
                 stock_record_ids: [],
-                total_value: 0,
+                total_value: 0
             },
+
+            catalogTypes: CATALOG_TYPES,
 
             validation: {
                 benefit_value: {
@@ -54,7 +66,12 @@ define([
                 },
                 catalog_query: {
                     required: function () {
-                        return this.get('catalog_type') === 'Multiple courses';
+                        return this.get('catalog_type') === CATALOG_TYPES.multiple_courses;
+                    }
+                },
+                course_catalog: {
+                    required: function () {
+                        return this.get('catalog_type') === CATALOG_TYPES.catalog;
                     }
                 },
                 category: {required: true},
@@ -69,11 +86,11 @@ define([
                     pattern: 'courseId',
                     msg: gettext('A valid course ID is required'),
                     required: function () {
-                        return this.get('catalog_type') === 'Single course';
+                        return this.get('catalog_type') === CATALOG_TYPES.single_course;
                     }
                 },
                 course_seat_types: function (val) {
-                    if (this.get('catalog_type') === 'Multiple courses' && val.length === 0) {
+                    if (this.get('catalog_type') === CATALOG_TYPES.multiple_courses && val.length === 0) {
                         return Backbone.Validation.messages.seat_types;
                     }
                 },
@@ -133,7 +150,7 @@ define([
                 // seat_type is for validation only, stock_record_ids holds the values
                 seat_type: {
                     required: function () {
-                        return this.get('catalog_type') === 'Single course';
+                        return this.get('catalog_type') === CATALOG_TYPES.single_course;
                     }
                 },
                 start_date: function (val) {
@@ -151,7 +168,7 @@ define([
                         return gettext('Must occur before end date');
                     }
                 },
-                title: {required: true},
+                title: {required: true}
             },
 
             initialize: function () {
@@ -185,11 +202,29 @@ define([
 
             updateSeatData: function () {
                 var seat_data,
-                    seats = this.get('seats');
+                    seats = this.get('seats'),
+                    catalogId,
+                    catalogType;
 
-                this.set('catalog_type', this.has('catalog_query') ? 'Multiple courses': 'Single course');
+                catalogId = '';
+                if (this.has('course_catalog')) {
+                    if (typeof this.get('course_catalog') === 'number') {
+                        catalogId = this.get('course_catalog');
+                    } else if (!$.isEmptyObject(this.get('course_catalog'))) {
+                        catalogId = this.get('course_catalog').id;
+                    }
+                }
 
-                if (this.get('catalog_type') === 'Single course') {
+                if (this.has('catalog_query') && this.get('catalog_query') !== '') {
+                    catalogType = this.catalogTypes.multiple_courses;
+                } else if (catalogId !== '') {
+                    catalogType = this.catalogTypes.catalog;
+                } else {
+                    catalogType = this.catalogTypes.single_course;
+                }
+                this.set('catalog_type', catalogType);
+
+                if (this.get('catalog_type') === this.catalogTypes.single_course) {
                     if (seats[0]) {
                         seat_data = seats[0].attribute_values;
 
@@ -197,6 +232,7 @@ define([
                         this.set('course_id', this.getCourseID(seat_data));
                         this.updateTotalValue(this.getSeatPrice());
                     }
+                    this.set('course_catalog', this.defaults.course_catalog);
                 }
             },
 
@@ -211,7 +247,7 @@ define([
                     'invoice_number': invoice.number,
                     'invoice_payment_date': invoice.payment_date,
                     'tax_deducted_source': invoice.tax_deducted_source,
-                    'tax_deduction': tax_deducted,
+                    'tax_deduction': tax_deducted
                 });
             },
 

--- a/ecommerce/static/js/test/mock_data/catalogs.js
+++ b/ecommerce/static/js/test/mock_data/catalogs.js
@@ -1,0 +1,36 @@
+define([], function(){
+	'use strict';
+
+    var catalogs = [
+        {
+            'id': 1,
+            'name': 'All Courses Catalog'
+        },
+        {
+            'id': 2,
+            'name': 'No Courses Catalog'
+        },
+        {
+            'id': 3,
+            'name': 'edX Catalog'
+        },
+        {
+            'id': 4,
+            'name': 'Test Catalog 1'
+        },
+        {
+            'id': 5,
+            'name': 'Enterprise Catalog'
+        },
+        {
+            'id': 6,
+            'name': 'Test 2 Catalog'
+        },
+        {
+            'id': 7,
+            'name': 'Empty Catalog'
+        }
+     ];
+
+    return catalogs;
+});

--- a/ecommerce/static/js/test/mock_data/coupons.js
+++ b/ecommerce/static/js/test/mock_data/coupons.js
@@ -194,6 +194,7 @@ define([], function () {
                 'id': 4,
                 'name': 'TESTCAT'
             },
+            course_catalog: {},
             'price': '100.00',
             'invoice_type': 'Prepaid',
             'invoice_discount_type': 'Percentage',

--- a/ecommerce/static/js/test/mock_data/selected_catalogs.js
+++ b/ecommerce/static/js/test/mock_data/selected_catalogs.js
@@ -1,0 +1,17 @@
+define([], function(){
+	'use strict';
+
+    var selected_catalog =  {
+        1 : {
+            'id': 1,
+            'name': 'Courses Catalog 1'
+        },
+
+        2 : {
+            'id': 2,
+            'name': 'Courses Catalog 2'
+        }
+    };
+
+    return selected_catalog;
+});

--- a/ecommerce/static/js/test/spec-runner.js
+++ b/ecommerce/static/js/test/spec-runner.js
@@ -20,6 +20,8 @@ if (!window.gettext) {
 // Establish the global namespace
 window.ecommerce = window.ecommerce || {};
 window.ecommerce.coupons = window.ecommerce.coupons || {};
+window.ecommerce.catalogs = window.ecommerce.catalogs || {};
+window.ecommerce.categories = window.ecommerce.categories || {};
 window.ecommerce.credit = window.ecommerce.credit || {};
 
 // you can automatically get the test files using karma's configs

--- a/ecommerce/static/js/test/spec-utils.js
+++ b/ecommerce/static/js/test/spec-utils.js
@@ -14,7 +14,13 @@ define([
                 return Backbone.Model.extend({
                     defaults: {
                         id: null,
-                        category: {}
+                        category: {},
+                        course_catalog: {}
+                    },
+                    catalogTypes: {
+                        single_course: 'Single course',
+                        multiple_courses: 'Multiple courses',
+                        catalog: 'Catalog'
                     },
 
                     isValid: function () {

--- a/ecommerce/static/js/test/specs/collections/catalog_collection_spec.js
+++ b/ecommerce/static/js/test/specs/collections/catalog_collection_spec.js
@@ -1,0 +1,29 @@
+define([
+        'collections/catalog_collection',
+        'test/mock_data/catalogs'
+    ],
+    function (CatalogCollection,
+              Mock_Catalogs) {
+        'use strict';
+        var collection,
+            response = Mock_Catalogs;
+
+        beforeEach(function () {
+            collection = new CatalogCollection();
+        });
+
+        describe('Catalog collection', function () {
+            describe('parse', function () {
+                it('should fetch the next page of results', function () {
+                    spyOn(collection, 'fetch').and.returnValue(null);
+                    response.next = '/api/v2/catalogs/course_catalogs/?page=2';
+
+                    collection.parse(response);
+                    expect(collection.url).toEqual(response.next);
+                    expect(collection.fetch).toHaveBeenCalledWith({remove: false});
+                });
+
+            });
+        });
+    }
+);

--- a/ecommerce/static/js/test/specs/models/coupon_model_spec.js
+++ b/ecommerce/static/js/test/specs/models/coupon_model_spec.js
@@ -81,10 +81,30 @@ define([
                     model.validate();
                     expect(model.isValid()).toBeFalsy();
 
+                    model.set('catalog_query', '');
+                    model.set('course_seat_types', ['verified']);
+                    model.validate();
+                    expect(model.isValid()).toBe(false);
+
                     model.set('catalog_query', '*:*');
                     model.set('course_seat_types', ['verified']);
                     model.validate();
                     expect(model.isValid()).toBeTruthy();
+                });
+
+                it('should validate course catalog for type Catalog', function () {
+                    model.set('catalog_type', 'Catalog');
+                    model.set('course_catalog', '');
+                    model.validate();
+                    expect(model.isValid()).toBe(false);
+
+                    model.set('course_catalog', '');
+                    model.validate();
+                    expect(model.isValid()).toBe(false);
+
+                    model.set('course_catalog', '1');
+                    model.validate();
+                    expect(model.isValid()).toBe(true);
                 });
 
                 it('should validate invoice data.', function() {
@@ -170,6 +190,36 @@ define([
 
                     model.set('seats', [{'price': 100}]);
                     expect(model.getSeatPrice()).toEqual(100);
+                });
+            });
+
+            describe('Should Update Seat Data Correctly.', function () {
+                it('should set correct catalog type for each seat.', function () {
+
+                    // Test single course catalog type when a single course is selected for coupon creation.
+                    var model = new Coupon({});
+                    model.updateSeatData();
+                    expect(model.get('catalog_type')).toEqual(model.catalogTypes.single_course);
+
+                    // Test course catalog type when an existing course catalog is selected for coupon creation.
+                    model = new Coupon({
+                        course_catalog: {id: 1, name: 'Test Catalog'}
+                    });
+                    model.updateSeatData();
+                    expect(model.get('catalog_type')).toEqual(model.catalogTypes.catalog);
+
+                    model = new Coupon({
+                        course_catalog: 1
+                    });
+                    model.updateSeatData();
+                    expect(model.get('catalog_type')).toEqual(model.catalogTypes.catalog);
+
+                    // Test multiple course type when an catalog query is given for coupon creation.
+                    model = new Coupon({
+                        catalog_query: '*:*'
+                    });
+                    model.updateSeatData();
+                    expect(model.get('catalog_type')).toEqual(model.catalogTypes.multiple_courses);
                 });
             });
 

--- a/ecommerce/static/js/test/specs/utils/utils_spec.js
+++ b/ecommerce/static/js/test/specs/utils/utils_spec.js
@@ -4,6 +4,7 @@ define([
         'utils/utils',
         'views/coupon_form_view',
         'test/mock_data/categories',
+        'test/mock_data/catalogs',
         'ecommerce'
     ],
     function (Backbone,
@@ -11,6 +12,7 @@ define([
               Utils,
               CouponFormView,
               Mock_Categories,
+              Mock_Catalogs,
               ecommerce) {
         'use strict';
 
@@ -65,7 +67,8 @@ define([
 
                 beforeEach(function () {
                     ecommerce.coupons = {
-                        categories: Mock_Categories
+                        categories: Mock_Categories,
+                        catalogs: Mock_Catalogs
                     };
                 });
 

--- a/ecommerce/static/js/test/specs/views/coupon_create_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/coupon_create_view_spec.js
@@ -4,6 +4,7 @@ define([
         'views/alert_view',
         'models/coupon_model',
         'test/mock_data/categories',
+        'test/mock_data/catalogs',
         'ecommerce'
     ],
     function ($,
@@ -11,6 +12,7 @@ define([
               AlertView,
               Coupon,
               Mock_Categories,
+              Mock_Catalogs,
               ecommerce) {
         'use strict';
 
@@ -20,7 +22,8 @@ define([
 
             beforeEach(function () {
                 ecommerce.coupons = {
-                    categories: Mock_Categories
+                    categories: Mock_Categories,
+                    catalogs: Mock_Catalogs
                 };
                 model = new Coupon();
                 view = new CouponCreateEditView({ model: model, editing: false }).render();

--- a/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
@@ -6,6 +6,8 @@ define([
         'models/coupon_model',
         'test/mock_data/categories',
         'test/mock_data/coupons',
+        'test/mock_data/catalogs',
+        'test/mock_data/selected_catalogs',
         'test/spec-utils',
         'ecommerce',
         'test/custom-matchers'
@@ -17,6 +19,8 @@ define([
               Coupon,
               Mock_Categories,
               Mock_Coupons,
+              Mock_Catalogs,
+              Mock_Selected_Catalogs,
               SpecUtils,
               ecommerce) {
         'use strict';
@@ -28,9 +32,10 @@ define([
 
             beforeEach(function () {
                 ecommerce.coupons = {
-                    categories: Mock_Categories
+                    categories: Mock_Categories,
+                    catalogs: Mock_Catalogs
                 };
-                model = new Coupon();
+                model = new Coupon({course_catalog: Mock_Catalogs});
                 view = new CouponFormView({ editing: false, model: model }).render();
             });
 
@@ -121,6 +126,50 @@ define([
                     view.$el.append('<a href="' + href + '" class="test external-link">Google</a>');
                     view.$('.test.external-link').click();
                     expect(window.open).toHaveBeenCalledWith(href);
+                });
+            });
+
+            describe('course catalogs', function() {
+                it('course catalog drop down should be hidden when catalog is not selected', function() {
+                    view.$('#single-course').prop('checked', true).trigger('change');
+                    expect(SpecUtils.formGroup(view, '[name=course_catalog]')).not.toBeVisible();
+
+                    view.$('#multiple-courses').prop('checked', true).trigger('change');
+                    expect(SpecUtils.formGroup(view, '[name=course_catalog]')).not.toBeVisible();
+
+                    view.$('#catalog').prop('checked', true).trigger('change');
+                    expect(SpecUtils.formGroup(view, '[name=course_catalog]')).toBeVisible();
+                });
+
+                it('course catalog is setting properly', function() {
+                    view.$('#catalog').prop('checked', true).trigger('change');
+
+                    view.$('[name=course_catalog]').val(1).trigger('change');
+                    expect(view.$('select[name=course_catalog] option:selected').text()).toEqual(Mock_Catalogs[0].name);
+                    expect(view.$('[name=course_catalog]').val()).toEqual('1');
+
+                    view.$('[name=course_catalog]').val(2).trigger('change');
+                    expect(view.$('select[name=course_catalog] option:selected').text()).toEqual(Mock_Catalogs[1].name);
+                    expect(view.$('[name=course_catalog]').val()).toEqual('2');
+
+                    view.$('[name=course_catalog]').val(3).trigger('change');
+                    expect(view.$('select[name=course_catalog] option:selected').text()).toEqual(Mock_Catalogs[2].name);
+                    expect(view.$('[name=course_catalog]').val()).toEqual('3');
+                });
+
+                it('returning right course catalog when selected catalog is number', function() {
+                    ecommerce.coupons = {
+                        categories: Mock_Categories,
+                        catalogs: Mock_Selected_Catalogs
+                    };
+                    var coupon_model = new Coupon({course_catalog: 1});
+                    var coupon_form_view = new CouponFormView({ editing: true, model: coupon_model }).render();
+                    expect(coupon_model.get('course_catalog')).toEqual({id: 1,'name': 'Courses Catalog 1'});
+
+                    coupon_model.set({course_catalog: 2});
+                    coupon_form_view.render();
+                    expect(coupon_model.get('course_catalog')).toEqual({id: 2,'name': 'Courses Catalog 2'});
+
                 });
             });
 

--- a/ecommerce/static/js/views/coupon_detail_view.js
+++ b/ecommerce/static/js/views/coupon_detail_view.js
@@ -1,6 +1,7 @@
 define([
         'jquery',
         'backbone',
+        'ecommerce',
         'underscore',
         'underscore.string',
         'moment',
@@ -11,6 +12,7 @@ define([
     ],
     function ($,
               Backbone,
+              ecommerce,
               _,
               _s,
               moment,
@@ -114,6 +116,8 @@ define([
             render: function () {
                 var html,
                     category = this.model.get('category').name,
+                    courseCatalog = this.model.get('course_catalog'),
+                    courseCatalogName = '',
                     invoice_data = this.formatInvoiceData(),
                     emailDomains = this.model.get('email_domains'),
                     template_data,
@@ -123,9 +127,16 @@ define([
                     price = _s.sprintf('$%s', this.model.get('price'));
                 }
 
+                if (typeof courseCatalog === 'number') {
+                    courseCatalogName = ecommerce.coupons.catalogs.get(courseCatalog).get('name');
+                } else if (!$.isEmptyObject(courseCatalog)) {
+                    courseCatalogName = courseCatalog.name;
+                }
+
                 template_data = {
                     category: category,
                     coupon: this.model.toJSON(),
+                    courseCatalogName: courseCatalogName,
                     courseSeatType: this.formatSeatTypes(),
                     discountValue: this.discountValue(),
                     endDateTime: this.formatDateTime(this.model.get('end_date')),

--- a/ecommerce/static/templates/coupon_detail.html
+++ b/ecommerce/static/templates/coupon_detail.html
@@ -50,6 +50,12 @@
             <div class="value"><%= coupon.catalog_query %></div>
         </div>
         <%}%>
+        <% if(courseCatalogName) {%>
+        <div class="info-item grid-item catalog-name">
+            <div class="heading"><%= gettext('Catalog:') %></div>
+            <div class="value"><%= courseCatalogName %></div>
+        </div>
+        <%}%>
         <div class="info-item grid-item date-info">
             <div class="start-date-info">
                 <div class="heading"><%= gettext('Valid from:') %></div>

--- a/ecommerce/static/templates/coupon_form.html
+++ b/ecommerce/static/templates/coupon_form.html
@@ -164,6 +164,8 @@
                 <label for="single-course"><%= gettext('Single course') %></label>
                 <input id="multiple-courses" type="radio" name="catalog_type" value="Multiple courses">
                 <label for="multiple-courses"><%= gettext('Multiple courses') %></label>
+                <input id="catalog" type="radio" name="catalog_type" value="Catalog">
+                <label for="catalog"><%= gettext('Catalog') %></label>
             </div>
             <p class="help-block"></p>
         </div>
@@ -203,6 +205,11 @@
                 <p class="help-block"></p>
             </div>
             <div class="catalog_buttons"></div>
+        </div>
+        <div class="form-group course-catalog">
+            <label for="course-catalog"><%= gettext('Select from course catalogs:') %> *</label>
+            <select id="course-catalog" class="form-control" name="course_catalog"></select>
+            <p class="help-block"></p>
         </div>
         <div class="form-group email-domains">
             <label for="email-domains"><%= gettext('Email domains:') %> </label>


### PR DESCRIPTION
ENT-110
@asadiqbal08 @saleem-latif @mattdrayer 

There were two ways to add catalogs selection functionality:

1. Provide catalogs lists from view and pass the list as an argument all the way to `coupon_form_view.js` from `coupon_app.js`
2. Get catalogs list through `ajax` while rendering the page `coupon_form.html`.

I followed second approach which is currently being used for populating the `catagories` field and also seems more suitable for our current requirement.

We also needed a new field to save the catalog id returned from the discovery service to display the selected catalog on edit coupon view and also to display catalog courses on offer redeem page. Saving the catalog id on our end will abstract us away from any changes (name, query etc) being made in the service `discovery`. 

> _**Note:** We will need to create a follow up story to update the `Redeem` coupon page to use the new field `course_catalog` for displaying the courses against some coupon._

## Completed tasks:
* Add new field `course_catalog` to save the id for the related catalog in coupon range model
* Add migration for the `offer` model `Range`
* Update coupon form to display the new course type selection `Catalog`
* Update coupon form to add a new field `course_catalog` to allow catalogs selection while creating coupons
* Update backend code to save the `course_catalog` value in the model `Range`
* Add method `get_course_catalogs` to recursively get all catalogs or a single course catalog from the service `discovery`
* Update serializer `CouponSerializer` to include `course_catalog` field
* Display course catalog name on the coupon detail page in case of `Catalog`
* Update the `Coupon edit page` for course catalogs
* Use existing settings variable `COURSES_API_CACHE_TIMEOUT` for caching the Course Catalogs API response which has default value of `3600  # Value is in seconds`.
* Refactor the method `create` of class `CouponViewSet` and move all cleaning/validation logic to separate class method `clean_voucher_request_data`.
* Add unit tests
* Add js tests (https://github.com/edx/ecommerce/pull/1071)

### Coupon create page
<img width="609" alt="screen shot 2016-12-30 at 4 15 46 pm" src="https://cloud.githubusercontent.com/assets/5072991/21564125/879db70c-ceab-11e6-9a54-ef86ed5809ac.png">

### Coupon detail page
<img width="605" alt="screen shot 2016-12-30 at 4 16 07 pm" src="https://cloud.githubusercontent.com/assets/5072991/21564129/8ff0cb06-ceab-11e6-8b15-8b73c59fa021.png">

### Coupon edit page
<img width="605" alt="screen shot 2016-12-30 at 4 16 33 pm" src="https://cloud.githubusercontent.com/assets/5072991/21564133/97fac694-ceab-11e6-9f94-67e3f0ff9d04.png">

## Related stories to this feature (future):
* Update coupon redemption logic to handle course runs based on the catalog fetched on the basis of new `Range` model field `course_catalog`
* Update coupon report generation method to include course catalogs

