### PR TITLE
WL-895 Remove deprecated SiteConfiguration.segment_key field

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -81,14 +81,6 @@ class SiteConfiguration(models.Model):
         blank=False,
         default={}
     )
-    # TODO: WL-895 Remove the segment_key field after the analytics_configuration field has been deployed and configured
-    segment_key = models.CharField(
-        verbose_name=_('Segment key'),
-        help_text=_('Segment write/API key.'),
-        max_length=255,
-        null=True,
-        blank=True
-    )
     analytics_configuration = JSONField(
         verbose_name=_('Analytics tracking configuration'),
         help_text=_('JSON string containing settings related to analytics event tracking.'),
@@ -258,9 +250,7 @@ class SiteConfiguration(models.Model):
 
     @cached_property
     def default_segment_key(self):
-        # TODO: WL-895 Remove self.segment_key from this statement once the segment_key field is removed from this model
-        return self.analytics_configuration.get('SEGMENT', {}).get('DEFAULT_WRITE_KEY') or \
-            self.segment_key
+        return self.analytics_configuration.get('SEGMENT', {}).get('DEFAULT_WRITE_KEY')
 
     @cached_property
     def segment_clients(self):

--- a/ecommerce/extensions/api/v2/tests/views/test_siteconfiguration.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_siteconfiguration.py
@@ -15,7 +15,6 @@ class SiteConfigurationViewSetTests(TestCase):
         self.site_configuration = SiteConfigurationFactory(
             partner__name='TestX',
             site__domain='test.api.endpoint',
-            segment_key='test_segment_key',
             analytics_configuration=json.dumps({
                 'SEGMENT': {
                     'DEFAULT_WRITE_KEY': 'test_segment_key2',

--- a/ecommerce/extensions/checkout/tests/test_mixins.py
+++ b/ecommerce/extensions/checkout/tests/test_mixins.py
@@ -158,7 +158,7 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin,
         Ensure that tracking events do not fire when there is no Segment key
         configured.
         """
-        self.site.siteconfiguration.segment_key = None
+        self.site.siteconfiguration.analytics_configuration['SEGMENT']['DEFAULT_WRITE_KEY'] = None
         EdxOrderPlacementMixin().handle_successful_order(self.order)
         # ensure no event was fired
         self.assertFalse(mock_track.called)

--- a/ecommerce/extensions/refund/tests/mixins.py
+++ b/ecommerce/extensions/refund/tests/mixins.py
@@ -5,7 +5,7 @@ from django.test import override_settings
 import mock
 from mock_django import mock_signal_receiver
 from oscar.core.loading import get_model, get_class
-from oscar.test.factories import create_order
+from oscar.test.factories import create_order, UserFactory
 from oscar.test.newfactories import BasketFactory
 
 from ecommerce.courses.models import Course
@@ -71,7 +71,7 @@ class RefundTestMixin(CourseCatalogTestMixin):
             self.assertEqual(refund_line.quantity, order_line.quantity)
 
     def create_refund(self, processor_name=DummyProcessor.NAME):
-        refund = RefundFactory()
+        refund = RefundFactory(order=self.create_order(UserFactory()))
         order = refund.order
         source_type, __ = SourceType.objects.get_or_create(name=processor_name)
         Source.objects.create(source_type=source_type, order=order, currency=refund.currency,

--- a/ecommerce/extensions/refund/tests/test_models.py
+++ b/ecommerce/extensions/refund/tests/test_models.py
@@ -212,7 +212,6 @@ class RefundTests(RefundTestMixin, StatusTestsMixin, TestCase):
         If payment refund and fulfillment revocation succeed, the method should update the status of the Refund and
         RefundLine objects to Complete, and return True.
         """
-        self.site.siteconfiguration.segment_key = None
         refund = self.create_refund()
         source = refund.order.sources.first()
         with LogCapture(LOGGER_NAME) as l:

--- a/ecommerce/extensions/refund/tests/test_signals.py
+++ b/ecommerce/extensions/refund/tests/test_signals.py
@@ -77,9 +77,8 @@ class RefundTrackingTests(BusinessIntelligenceMixin, RefundTestMixin, TestCase):
 
     def test_successful_refund_no_segment_key(self, mock_track):
         """Verify that a successfully placed refund is not tracked when Segment is disabled."""
-        self.site.siteconfiguration.segment_key = None
-
         # Approve the refund.
+        self.site.siteconfiguration.analytics_configuration['SEGMENT']['DEFAULT_WRITE_KEY'] = None
         self.approve(self.refund)
 
         # Verify that no business intelligence event was emitted.

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -259,11 +259,11 @@ class SiteMixin(object):
                 'SOCIAL_AUTH_EDX_OIDC_SECRET': 'secret'
             },
             partner__name='edX',
-            segment_key='fake_segment_key',
             site__domain=domain,
             site__id=settings.SITE_ID,
             client_side_payment_processor='cybersource'
         )
+        site_configuration.analytics_configuration['SEGMENT']['DEFAULT_WRITE_KEY'] = 'fake_segment_key'
         self.partner = site_configuration.partner
         self.site = site_configuration.site
 


### PR DESCRIPTION
This is a post-deployment follow up to https://github.com/edx/ecommerce/pull/1053 which removes the deprecated segment_key field from the SiteConfiguration model. Once this change is deployed, we can follow up with https://github.com/edx/ecommerce/pull/1075 to remove the column from the database.