### PR TITLE
[ECOM-6698] Add padding between header and receipt page content

### DIFF
--- a/ecommerce/static/sass/partials/views/_receipt.scss
+++ b/ecommerce/static/sass/partials/views/_receipt.scss
@@ -1,6 +1,8 @@
 .receipt {
     margin-bottom: 20px;
 
+    padding-top: 20px;
+
     background-color: #ffffff;
     font-family: $font-family-sans-serif;
     line-height: 1em;


### PR DESCRIPTION
Reviewers:
@douglashall 
@mjfrey 
Please take a look. Thanks!
Below is the screenshot showing the change.

JIRA ticket:
https://openedx.atlassian.net/browse/ECOM-6698

Screenshot:
![image](https://cloud.githubusercontent.com/assets/6833568/21540722/80c297b8-cdb1-11e6-816a-05e09610d532.png)
