### PR TITLE
Fix design of credit card field.

### DIFF
--- a/ecommerce/static/sass/partials/views/_basket.scss
+++ b/ecommerce/static/sass/partials/views/_basket.scss
@@ -367,17 +367,17 @@
 
                     .fa-lock {
                         position: relative;
-                        float: left;
+                        float: right;
                         top: -25px;
-                        left: 92%;
+                        right: 10%;
                         margin-right: -5%;
                     }
 
                     .card-type-icon {
                         position: relative;
-                        float: left;
+                        float: right;
                         top: -30px;
-                        left: 70%;
+                        right: 28%;
                         margin-right: -15%;
                     }
                 }

--- a/ecommerce/templates/oscar/basket/partials/client_side_checkout_basket.html
+++ b/ecommerce/templates/oscar/basket/partials/client_side_checkout_basket.html
@@ -141,7 +141,7 @@
                 <img aria-hidden="true" class="credit-card-list" src="/static/images/credit_card_options.png" alt="Credit cards">
                 {% endif %}
                 <div class="pci-fields row">
-                    <div id="card-number" class="form-group col-sm-6">
+                    <div id="card-number" class="form-group col-md-6">
                         <label for="card-number-input" class="control-label">{% trans "Card Number (required)" %}<span class="sr">, {% trans "Secure" %}</span></label>
                         <input id="card-number-input" name="card_number" class="form-control pci-field" maxlength="20" required aria-required="true"/>
                         <i class="fa fa-lock" aria-hidden="true"></i>
@@ -149,7 +149,7 @@
                         <p class="help-block"></p>
                     </div>
                     <input type="hidden" name="card_type" class="pci-field">
-                    <div id="card-cvn" class="form-group col-sm-6">
+                    <div id="card-cvn" class="form-group col-md-6">
                         <label for="card-cvn-input" class="control-label">
                             {% trans "Security Code (required)" %}
                             <span class="sr">, {% trans "Secure" %}</span>


### PR DESCRIPTION
Changes the CSS of the credit card field on the
client-side basket checkout. The credit card
icon used to overlay the credit card numbers.
These changes fix that.

Screenshots are available here:
https://drive.google.com/drive/folders/0ByBQUYJ4LMyAVUFJeWE2UW1neTg?usp=sharing

https://openedx.atlassian.net/browse/ECOM-6707