### PR TITLE
WL-895 Migration for removing SiteConfiguration.segment_key field

### DIFF
--- a/ecommerce/core/migrations/0024_remove_siteconfiguration_segment_key.py
+++ b/ecommerce/core/migrations/0024_remove_siteconfiguration_segment_key.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0023_siteconfiguration_analytics_configuration'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='siteconfiguration',
+            name='segment_key',
+        ),
+    ]


### PR DESCRIPTION
This is a follow on to https://github.com/edx/ecommerce/pull/1069 which adds the migration for removing the SiteConfiguration.segment_key column from the database.