### PR TITLE
Upgrade edx-auth-backends to 0.5.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ django-waffle==0.11.1
 djangorestframework==3.2.3
 djangorestframework-jwt==1.8.0
 drf-extensions==0.2.8
-edx-auth-backends==0.5.2
+edx-auth-backends==0.5.3
 edx-django-release-util==0.2.0
 edx-django-sites-extensions==1.0.0
 edx-drf-extensions==1.0.0


### PR DESCRIPTION
This version of the package limits the installed version of PSA to <0.3.0. 0.3.0 introduced a major breaking change, effectively gutting PSA and moving its Django components to a new social-auth-app-django package.

@edx/ecommerce @jibsheet FYI. This is follow-up to https://github.com/edx/auth-backends/pull/27 and should fix CI builds.