### PR TITLE
Fix CC expired month JS test.

### DIFF
--- a/ecommerce/static/js/test/specs/pages/basket_page_spec.js
+++ b/ecommerce/static/js/test/specs/pages/basket_page_spec.js
@@ -7,8 +7,7 @@ define([
         'models/tracking_model',
         'models/user_model',
         'views/analytics_view',
-        'js-cookie',
-        'moment'
+        'js-cookie'
     ],
     function ($,
               _,
@@ -18,8 +17,7 @@ define([
               TrackingModel,
               UserModel,
               AnalyticsView,
-              Cookies,
-              moment) {
+              Cookies) {
         'use strict';
 
         describe('Basket Page', function () {
@@ -185,8 +183,8 @@ define([
             });
 
             describe('clientSideCheckoutValidation', function() {
-                    var currentYear = moment().year(),
-                        lastMonth = moment().subtract(1, 'month').month();
+                    var currentYear = 2016,
+                        lastMonth = 11;
 
                 beforeEach(function() {
                     $(
@@ -233,6 +231,10 @@ define([
                     $('input[name=address_line1]').val('Central Perk');
                     $('input[name=city]').val('New York City');
                     $('select[name=country]').val('US');
+
+                    // Freeze time to 12-2016.
+                    spyOn(Date.prototype, 'getFullYear').and.returnValue(currentYear);
+                    spyOn(Date.prototype, 'getMonth').and.returnValue(lastMonth + 1);
 
                     BasketPage.onReady();
                 });


### PR DESCRIPTION
@saleem-latif @mattdrayer this should fix the failing JS test in a similar way that we freeze time in python tests. I know you wanted to include this in one of your PR's but this needs to be merged ASAP as it causes all the CI builds to fail and blocks any work on ecomm.
