### PR TITLE
Display messages for Enrollment codes basket items.

### DIFF
--- a/ecommerce/static/sass/partials/views/_basket.scss
+++ b/ecommerce/static/sass/partials/views/_basket.scss
@@ -1,6 +1,6 @@
 .basket {
-    .close {
-        margin-top: -20px;
+    .alertinner {
+        display: inline-block;
     }
 
     .container {
@@ -53,7 +53,7 @@
                        width: 35%;
                        padding: 3px;
                    }
- 
+
                    button.update-button {
                        display: inline-block;
                        vertical-align:top;
@@ -235,10 +235,6 @@
 }
 
 .basket-client-side {
-    .close {
-        margin-top: -20px;
-    }
-
     legend, p.title {
         color: #337ab7;
         font-size: 16px;

--- a/ecommerce/templates/oscar/basket/partials/client_side_checkout_basket.html
+++ b/ecommerce/templates/oscar/basket/partials/client_side_checkout_basket.html
@@ -4,9 +4,7 @@
 {% load widget_tweaks %}
 {% load staticfiles %}
 
-{% if show_voucher_form %}
-    {% include 'partials/alert_messages.html' %}
-{% endif %}
+{% include 'partials/alert_messages.html' %}
 
 <div id="summary" class="col-sm-5">
     <form action="." method="post" class="row">


### PR DESCRIPTION
Notification messages when updating the quantity of bulk enrollment code basket items weren't displaying at all, but all of them would display when switched to a seat basket item (screenshot in ticket). This PR allows the update notification messages to be displayed where they are suppose to be.

https://openedx.atlassian.net/browse/SOL-2177