### PR TITLE
ENT-127: Fix JS test failure for basket page tests

### DIFF
--- a/ecommerce/static/js/pages/basket_page.js
+++ b/ecommerce/static/js/pages/basket_page.js
@@ -102,7 +102,10 @@ define([
 
         cardInfoValidation = function (event) {
             var cardType,
-                currentMonth = new Date().getMonth(),
+                // We are adding 1 here because month in js style date-time starts with 0
+                // i.e. 0 for JAN, 1 for FEB etc. However, credit card expiry months start with 1
+                // i.e 1 for JAN, 2 for FEB etc.
+                currentMonth = new Date().getMonth() + 1,
                 currentYear = new Date().getFullYear(),
                 cardNumber = $('input[name=card_number]').val(),
                 cvnNumber = $('input[name=card_cvn]').val(),


### PR DESCRIPTION
Hi @mattdrayer , @asadiqbal08 , @vkaracic , @zubair-arbi 

Kindly take a look at this PR, it contains changes for ENT-127.

__Description of Changes:__
Months in Javascript start from 0 (i.e. JAN is 0, FEB is 1 etc.) however months displayed in the dropdown for credit card expiry months start from 1 (i.e. JAN is 1, FEB is 0 etc.). So, we get an off by 1 error if we compare months coming dropdown and month accessed from js `Date` type. In order to resolve the issue we must add 1 to the month number accessed via js `Date` type.
