### PR TITLE
Reduce impact store dashboard can have on site performance

### DIFF
--- a/ecommerce/extensions/dashboard/views.py
+++ b/ecommerce/extensions/dashboard/views.py
@@ -3,15 +3,43 @@ from oscar.apps.dashboard.views import *  # pylint: disable=wildcard-import, unu
 
 class ExtendedIndexView(IndexView):
     def get_stats(self):
-        stats = super(ExtendedIndexView, self).get_stats()
+        """
+        Statistics for the store dashboard.
 
+        To limit the impact this page can have on systems with millions of orders,
+        all queries against orders are limited to those placed in the last 24 hours;
+        Order's date_placed field is indexed for more efficient queries.
+        """
         datetime_24hrs_ago = now() - timedelta(hours=24)
+
         orders = Order.objects.filter()
+        orders_last_day = orders.filter(date_placed__gt=datetime_24hrs_ago)
         paid_orders_last_day = orders.filter(date_placed__gt=datetime_24hrs_ago, total_incl_tax__gt=0)
 
-        stats['average_paid_order_costs'] = paid_orders_last_day.aggregate(
-            Avg('total_incl_tax')
-        )['total_incl_tax__avg'] or D('0.00')
+        stats = {
+            'total_orders_last_day': orders_last_day.count(),
+
+            'average_order_costs': orders_last_day.aggregate(
+                Avg('total_incl_tax')
+            )['total_incl_tax__avg'] or D('0.00'),
+
+            'average_paid_order_costs': paid_orders_last_day.aggregate(
+                Avg('total_incl_tax')
+            )['total_incl_tax__avg'] or D('0.00'),
+
+            'total_revenue_last_day': orders_last_day.aggregate(
+                Sum('total_incl_tax')
+            )['total_incl_tax__sum'] or D('0.00'),
+
+            'hourly_report_dict': self.get_hourly_report(hours=24),
+            'total_customers_last_day': User.objects.filter(
+                date_joined__gt=datetime_24hrs_ago,
+            ).count(),
+
+            'total_products': Product.objects.count(),
+
+            'total_vouchers': self.get_active_vouchers().count(),
+        }
 
         return stats
 

--- a/ecommerce/templates/oscar/dashboard/index.html
+++ b/ecommerce/templates/oscar/dashboard/index.html
@@ -23,22 +23,22 @@
 {% endblock %}
 
 {% block dashboard_content %}
-
 <div class="table-header">
-    <i class="icon-signal icon-large"></i>{% trans "Your Store Statistics" %}
+    <i class="icon-signal icon-large"></i>{% trans "Store Statistics (Last 24 Hours)" %}
 </div>
 
 <div class="content-block">
     <div class="row">
         <aside class="col-md-3 order-graph-details">
-            <label><span><i class="icon-shopping-cart"></i>{{ total_orders_last_day }}</span>{% trans "Total Orders" %}</label>
+            <label><span><i class="icon-shopping-cart"></i>{{ total_orders_last_day }}</span>{% trans "Orders" %}</label>
             <label><span><i class="icon-hand-right"></i>{{ total_customers_last_day }}</span>{% trans "New Customers" %}</label>
-            <label><span><i class="icon-group"></i>{{ total_customers }}</span>{% trans "Total Customers" %}</label>
-            <label><span><i class="icon-briefcase"></i>{{ total_products }}</span>{% trans "Total Products" %}</label>
+            <label><span><i class="icon-money"></i>{{ total_revenue_last_day|currency }}</span>{% trans "Revenue" %}</label>
+            <label><span><i class="icon-credit-card"></i>{{ average_order_costs|currency }}</span>{% trans "Average order cost" %}</label>
+            <label><span><i class="icon-credit-card"></i>{{ average_paid_order_costs|currency }}</span>{% trans "Average (paid) order cost" %}</label>
         </aside>
         <div class="col-md-9">
             <div id="order_graph">
-                <div class="bar-caption"><h1>{% trans "Latest Orders (last 24 hours)" %}</h1></div>
+                <div class="bar-caption"><h1>{% trans "Revenue" %}</h1></div>
                 <div class="bar-y-axis">
                     <ul>
                     {% for y_value in hourly_report_dict.y_range %}
@@ -61,130 +61,19 @@
     </div>
 </div>
 
-
 <div class="row">
     <div class="col-md-4">
         <table class="table table-striped table-bordered table-hover">
-            <caption><i class="icon-shopping-cart icon-large"></i>{% trans "Orders - Last 24 Hours" %}</caption>
-            </tr>
-                <tr>
-                    <th class="col-md-10">{% trans "Total orders" %}</th>
-                    <td class="col-md-2" >{{ total_orders_last_day }}</td>
-                </tr>
-                <tr>
-                    <th class="col-md-10">{% trans "Total lines" %}</th>
-                    <td class="col-md-2" >{{ total_lines_last_day }}</td>
-                </tr>
-                <tr>
-                    <th class="col-md-10">{% trans "Total revenue" %}</th>
-                    <td class="col-md-2" >{{ total_revenue_last_day|currency }}</td>
-                </tr>
-                <tr>
-                    <th class="col-md-10">{% trans "Average order costs" %}</th>
-                    <td class="col-md-2" >{{ average_order_costs|currency }}</td>
-                </tr>
-                <tr>
-                    <th class="col-md-10">{% trans "Average (paid) order costs" %}</th>
-                    <td class="col-md-2" >{{ average_paid_order_costs|currency }}</td>
-                </tr>
-        </table>
-    </div>
-
-    <div class="col-md-4">
-        <table class="table table-striped table-bordered table-hover">
-            <caption>
-                <a href="{% url 'dashboard:order-list' %}" class="btn btn-default pull-right">
-                    <i class="icon-shopping-cart"></i> {% trans "Manage" %}
-                </a>
-                <i class="icon-shopping-cart icon-large"></i>{% trans "Orders - All Time" %}
-            </caption>
-            <tr>
-                <th class="col-md-10">{% trans "Total orders" %}</th>
-                <td class="col-md-2" >{{ total_orders }}</td>
-            </tr>
-            <tr>
-                <th class="col-md-10">{% trans "Total lines" %}</th>
-                <td class="col-md-2" >{{ total_lines }}</td>
-            </tr>
-            <tr>
-                <th class="col-md-10">{% trans "Total revenue" %}</th>
-                <td class="col-md-2" >{{ total_revenue|currency }}</td>
-            </tr>
-            <tr>
-                <th class="col-md-10">{% trans "Total <em>open</em> baskets" %}</th>
-                <td class="col-md-2" >{{ total_open_baskets }}</td>
-            </tr>
-        </table>
-    </div>
-
-    <div class="col-md-4">
-        <table class="table table-striped table-bordered table-hover">
-            <caption><i class="icon-group icon-large"></i>{% trans "Customers" %}</caption>
-            <tr>
-                <th class="col-md-10">{% trans "Total customers" %}</th>
-                <td class="col-md-2" >{{ total_customers }}</td>
-            </tr>
-            <tr>
-                <th class="col-md-10">{% trans "New customers" %}</th>
-                <td class="col-md-2" >{{ total_customers_last_day }}</td>
-            </tr>
-            <tr>
-                <th class="col-md-10">{% trans "Total <em>open</em> baskets" %}</th>
-                <td class="col-md-2" >{{ total_open_baskets_last_day }}</td>
-            </tr>
-        </table>
-    </div>
-</div>
-
-<div class="row">
-    <div class="col-md-6">
-        <table class="table table-striped table-bordered table-hover">
-            <caption>
-                <div class="btn-toolbar pull-right">
-                  <div class="btn-group">
-                    <a href="{% url 'dashboard:catalogue-product-list' %}" class="btn btn-default">
-                        <i class="icon-sitemap"></i> {% trans "Manage" %}
-                    </a>
-                  </div>
-                  <div class="btn-group">
-                    <a href="{% url 'dashboard:stock-alert-list' %}" class="btn btn-default">
-                        <i class="icon-sitemap"></i> {% trans "View Stock Alerts" %}
-                    </a>
-                  </div>
-                </div>
-                <i class="icon-sitemap icon-large"></i>{% trans "Catalogue and stock" %}
-            </caption>
+            <caption><i class="icon-gift icon-large"></i>{% trans "Products and vouchers" %}</caption>
             <tr>
                 <th class="col-md-10">{% trans "Total products" %}</th>
                     <td class="col-md-2" >{{ total_products }}</td>
             </tr>
             <tr>
-                <th class="col-md-10">{% trans "<em>Open</em> stock alerts" %}</th>
-                    <td class="col-md-2" >{{ total_open_stock_alerts }}</td>
-            </tr>
-            <tr>
-                <th class="col-md-10">{% trans "<em>Closed</em> stock alerts" %}</th>
-                    <td class="col-md-2" >{{ total_closed_stock_alerts }}</td>
-            </tr>
-        </table>
-    </div>
-    <div class="col-md-6">
-
-        <table class="table table-striped table-bordered table-hover">
-            <caption><i class="icon-gift icon-large"></i>{% trans "Offers, vouchers and promotions" %}</caption>
-            <tr>
-                <th class="col-md-10">{% trans "Active <em>Site</em> Offers" %}</th>
-                <td class="col-md-2" >{{ total_site_offers }}</td>
-            </tr>
-            <tr>
-                <th class="col-md-10">{% trans "Active <em>Vouchers</em>" %}</th>
+                <th class="col-md-10">{% trans "Active Vouchers" %}</th>
                 <td class="col-md-2" >{{ total_vouchers }}</td>
-            </tr>
-            <th class="col-md-10">{% trans "Promotions" %}</th>
-                <td class="col-md-2" >{{ total_promotions }}</td>
             </tr>
         </table>
     </div>
 </div>
-
 {% endblock %}


### PR DESCRIPTION
Oscar's default store dashboard doesn't scale well for sites with millions of orders. To limit the impact this page can have on large systems, all queries against orders are now limited to those placed in the last 24 hours. Order's date_placed field is indexed for more efficient queries. I've also removed fields that aren't useful to us (e.g., stock alerts).

@edx/ecommerce