### PR TITLE
[SOL-2175] Add util for cleaning CyberSource fields.

### DIFF
--- a/ecommerce/extensions/payment/processors/cybersource.py
+++ b/ecommerce/extensions/payment/processors/cybersource.py
@@ -25,6 +25,7 @@ from ecommerce.extensions.payment.exceptions import (
 from ecommerce.extensions.payment.helpers import sign
 from ecommerce.extensions.payment.processors import BasePaymentProcessor, HandledProcessorResponse
 from ecommerce.extensions.payment.transport import RequestsTransport
+from ecommerce.extensions.payment.utils import clean_field_value
 
 logger = logging.getLogger(__name__)
 
@@ -176,7 +177,7 @@ class Cybersource(BasePaymentProcessor):
                 parameters['item_{}_discount_amount '.format(index)] = str(line.discount_value)
                 # Note (CCB): This indicates that the total_amount field below includes tax.
                 parameters['item_{}_gross_net_indicator'.format(index)] = 'Y'
-                parameters['item_{}_name'.format(index)] = line.product.title.replace('"', '')
+                parameters['item_{}_name'.format(index)] = clean_field_value(line.product.title)
                 parameters['item_{}_quantity'.format(index)] = line.quantity
                 parameters['item_{}_sku'.format(index)] = line.stockrecord.partner_sku
                 parameters['item_{}_tax_amount'.format(index)] = str(line.line_tax)

--- a/ecommerce/extensions/payment/tests/test_utils.py
+++ b/ecommerce/extensions/payment/tests/test_utils.py
@@ -1,4 +1,4 @@
-from ecommerce.extensions.payment.utils import middle_truncate
+from ecommerce.extensions.payment.utils import clean_field_value, middle_truncate
 from ecommerce.tests.testcases import TestCase
 
 
@@ -17,3 +17,8 @@ class UtilsTests(TestCase):
         self.assertEqual('xx...xx', middle_truncate(string, length - 2))
 
         self.assertRaises(ValueError, middle_truncate, string, 0)
+
+    def test_clean_field_value(self):
+        """ Verify the passed value is cleaned of specific special characters. """
+        value = 'Some^text:\'test-value'
+        self.assertEqual(clean_field_value(value), 'Sometexttest-value')

--- a/ecommerce/extensions/payment/utils.py
+++ b/ecommerce/extensions/payment/utils.py
@@ -1,3 +1,5 @@
+import re
+
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -37,3 +39,17 @@ def middle_truncate(string, chars):
     truncated = u'{start}{indicator}{end}'.format(start=start, indicator=indicator, end=end)
 
     return truncated
+
+
+def clean_field_value(value):
+    """Strip the value of any special characters.
+
+    Currently strips caret(^), colon(:) and quote(" ') characters from the value.
+
+    Args:
+        value (str): The original value.
+
+    Returns:
+        A cleaned string.
+    """
+    return re.sub(r'[\^:"\']', '', value)

--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -23,6 +23,7 @@ from ecommerce.extensions.checkout.utils import get_receipt_page_url
 from ecommerce.extensions.payment.exceptions import InvalidSignatureError, InvalidBasketError
 from ecommerce.extensions.payment.forms import PaymentForm
 from ecommerce.extensions.payment.processors.cybersource import Cybersource
+from ecommerce.extensions.payment.utils import clean_field_value
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +107,7 @@ class CybersourceSubmitView(FormView):
         }
 
         for source, destination in six.iteritems(self.FIELD_MAPPINGS):
-            extra_parameters[destination] = data[source]
+            extra_parameters[destination] = clean_field_value(data[source])
 
         parameters = Cybersource(self.request.site).get_transaction_parameters(
             basket,


### PR DESCRIPTION
As per http://apps.cybersource.com/library/documentation/dev_guides/Getting_Started_SO/Getting_Started_SO_API.pdf?searchid=1468415087832 (page 19), colons and carets are not allowed in ``item_#`` fields. The same cleanup is added for ``bill_to`` fields.

https://openedx.atlassian.net/browse/SOL-2175