### PR TITLE
[SOL-2195] Add basket order details message

### DIFF
--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -147,7 +147,7 @@ class BasketSummaryView(BasketView):
         display_verification_message = False
         lines_data = []
         show_voucher_form = True
-        switch_link_text = partner_sku = ''
+        switch_link_text = partner_sku = order_details_msg = None
 
         for line in lines:
             product_class_name = line.product.get_product_class().name
@@ -156,9 +156,15 @@ class BasketSummaryView(BasketView):
                 if (getattr(line.product.attr, 'id_verification_required', False) and
                         line.product.attr.certificate_type != 'credit'):
                     display_verification_message = True
+                    order_details_msg = _(
+                        'You will be automatically enrolled in the course upon completing your order.'
+                    )
             elif product_class_name == 'Enrollment Code':
                 line_data = self._get_course_data(line.product)
                 show_voucher_form = False
+                order_details_msg = _(
+                    'You will receive an email at {user_email} with your enrollment code(s).'
+                ).format(user_email=self.request.user.email)
             else:
                 line_data = {
                     'product_title': line.product.title,
@@ -187,6 +193,7 @@ class BasketSummaryView(BasketView):
 
         context_updates = {
             'display_verification_message': display_verification_message,
+            'order_details_msg': order_details_msg,
             'partner_sku': partner_sku,
             'show_voucher_form': show_voucher_form,
             'switch_link_text': switch_link_text

--- a/ecommerce/static/sass/partials/views/_basket.scss
+++ b/ecommerce/static/sass/partials/views/_basket.scss
@@ -514,6 +514,10 @@
             .remove-voucher {
                 color: #337ab7;
             }
+
+            #order-details {
+                margin: 50px 0;
+            }
         }
     }
 }

--- a/ecommerce/templates/oscar/basket/partials/client_side_checkout_basket.html
+++ b/ecommerce/templates/oscar/basket/partials/client_side_checkout_basket.html
@@ -92,6 +92,12 @@
             <span class="price">{{ order_total.incl_tax|currency:basket.currency }}</span>
         </div>
     </fieldset>
+    {% if order_details_msg %}
+        <div id="order-details">
+            <p class="title">{% trans "ORDER DETAILS" %}</p>
+            <p>{{ order_details_msg }}</p>
+        </div>
+    {% endif %}
 </div>
 
 


### PR DESCRIPTION
Adding an order details section that contains more information about the basket item.

Order details for a seat product:
![screenshot from 2017-01-26 12-14-11](https://cloud.githubusercontent.com/assets/2808092/22329394/54a9e462-e3c1-11e6-8b54-0ec3b96ee80f.png)

Order details for an enrollment code product:
![screenshot from 2017-01-26 12-14-33](https://cloud.githubusercontent.com/assets/2808092/22329416/631c904e-e3c1-11e6-8a43-abc7d27c6dde.png)

https://openedx.atlassian.net/browse/SOL-2195