### PR TITLE
Using edX Python Social Auth strategy

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -409,37 +409,6 @@ AUTHENTICATION_BACKENDS = ('auth_backends.backends.EdXOpenIdConnect',) + AUTHENT
 
 SOCIAL_AUTH_STRATEGY = 'ecommerce.social_auth.strategies.CurrentSiteDjangoStrategy'
 
-# Set to true if using SSL and running behind a proxy
-SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
-
-# https://github.com/omab/python-social-auth/blob/master/docs/configuration/django.rst#django-admin
-SOCIAL_AUTH_ADMIN_USER_SEARCH_FIELDS = ['username', 'email']
-
-SOCIAL_AUTH_PIPELINE = (
-    'social.pipeline.social_auth.social_details',
-    'social.pipeline.social_auth.social_uid',
-    'social.pipeline.social_auth.auth_allowed',
-    'social.pipeline.social_auth.social_user',
-
-    # By default python-social-auth will simply create a new user/username if the username
-    # from the provider conflicts with an existing username in this system. This custom pipeline function
-    # loads existing users instead of creating new ones.
-    'auth_backends.pipeline.get_user_if_exists',
-    'social.pipeline.user.get_username',
-    'social.pipeline.user.create_user',
-    'social.pipeline.social_auth.associate_user',
-    'social.pipeline.social_auth.load_extra_data',
-    'social.pipeline.user.user_details'
-)
-
-# Fields passed to the custom ecommerce user model when creating a new user
-SOCIAL_AUTH_USER_FIELDS = ['username', 'email', 'first_name', 'last_name']
-
-# Always raise auth exceptions so that they are properly logged. Otherwise, the PSA middleware will redirect to an
-# auth error page and attempt to display the error message to the user (via Django's message framework). We do not
-# want the uer to see the message; but, we do want our downstream exception handlers to log the message.
-SOCIAL_AUTH_RAISE_EXCEPTIONS = True
-
 # Set these to the correct values for your OAuth2/OpenID Connect provider
 SOCIAL_AUTH_EDX_OIDC_KEY = None
 SOCIAL_AUTH_EDX_OIDC_SECRET = None

--- a/ecommerce/settings/devstack.py
+++ b/ecommerce/settings/devstack.py
@@ -12,6 +12,8 @@ LOGGING['handlers']['local'] = {
 # Determine which requests should render Django Debug Toolbar
 INTERNAL_IPS = ('127.0.0.1',)
 
+SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
+
 # PAYMENT PROCESSING
 PAYMENT_PROCESSOR_CONFIG = {
     'edx': {

--- a/ecommerce/settings/local.py
+++ b/ecommerce/settings/local.py
@@ -62,6 +62,8 @@ INTERNAL_IPS = ('127.0.0.1',)
 
 
 # AUTHENTICATION
+SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
+
 JWT_AUTH.update({
     'JWT_SECRET_KEY': 'insecure-secret-key',
     'JWT_ISSUERS': (

--- a/ecommerce/social_auth/strategies.py
+++ b/ecommerce/social_auth/strategies.py
@@ -1,18 +1,17 @@
-from django.conf import settings
-
-from social.strategies.django_strategy import DjangoStrategy
+from auth_backends.strategies import EdxDjangoStrategy
 
 
-class CurrentSiteDjangoStrategy(DjangoStrategy):
+class CurrentSiteDjangoStrategy(EdxDjangoStrategy):
     """
     Python Social Auth strategy which accounts for the current
     Site when enabling third party authentication.
     """
 
     def get_setting(self, name):
-        # First check the current SiteConfiguration for the setting
-        setting = self.request.site.siteconfiguration.oauth_settings.get(name)
-        if not setting:
-            # Then check Django settings for the setting
-            setting = getattr(settings, name)
-        return setting
+        # Check the request's associated SiteConfiguration for the setting
+        value = self.request.site.siteconfiguration.oauth_settings.get(name)
+
+        if not value:
+            value = super(CurrentSiteDjangoStrategy, self).get_setting(name)
+
+        return value

--- a/ecommerce/social_auth/tests/test_strategies.py
+++ b/ecommerce/social_auth/tests/test_strategies.py
@@ -1,6 +1,6 @@
 """Tests of social auth strategies."""
 from django.conf import settings
-from threadlocals.threadlocals import get_current_request
+from social.apps.django_app.default.models import DjangoStorage
 
 from ecommerce.social_auth.strategies import CurrentSiteDjangoStrategy
 from ecommerce.tests.testcases import TestCase
@@ -14,7 +14,7 @@ class CurrentSiteDjangoStrategyTests(TestCase):
         self.site.siteconfiguration.oauth_settings = {
             'SOCIAL_AUTH_EDX_OIDC_KEY': 'test-key'
         }
-        self.strategy = CurrentSiteDjangoStrategy(None, get_current_request())
+        self.strategy = CurrentSiteDjangoStrategy(DjangoStorage, self.request)
 
     def test_get_setting_from_siteconfiguration(self):
         """Test that a setting can be retrieved from the site configuration."""
@@ -34,5 +34,5 @@ class CurrentSiteDjangoStrategyTests(TestCase):
 
     def test_get_setting_raises_exception_on_missing_setting(self):
         """Test that a setting that does not exist raises exception."""
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(KeyError):
             self.strategy.get_setting('FAKE_SETTING')

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ django-waffle==0.11.1
 djangorestframework==3.2.3
 djangorestframework-jwt==1.8.0
 drf-extensions==0.2.8
-edx-auth-backends==0.5.3
+edx-auth-backends==0.6.0
 edx-django-release-util==0.2.0
 edx-django-sites-extensions==1.0.0
 edx-drf-extensions==1.0.0


### PR DESCRIPTION
This strategy incorporates all of our custom settings into a single, shared, location rather than duplicating them in every IDA.

ECOM-6842