### PR TITLE
Fix checkout button analytics attribute.

### DIFF
--- a/ecommerce/templates/oscar/basket/partials/client_side_checkout_basket.html
+++ b/ecommerce/templates/oscar/basket/partials/client_side_checkout_basket.html
@@ -198,7 +198,7 @@
                             data-track-category="checkout"
                             data-processor-name="{{ client_side_payment_processor_name }}"
                             data-course-id="{{ course_key }}"
-                            data-checkout-type="client_side">
+                            data-track-checkout-type="client_side">
                       {% trans "Place Order" %}
                     </button>
                 {% endif %}

--- a/ecommerce/templates/oscar/basket/partials/hosted_checkout_basket.html
+++ b/ecommerce/templates/oscar/basket/partials/hosted_checkout_basket.html
@@ -154,7 +154,7 @@
                                 data-track-category="checkout"
                                 data-processor-name="{{ processor.NAME|lower }}"
                                 data-course-id="{{ course_key }}"
-                                data-checkout-type="hosted"
+                                data-track-checkout-type="hosted"
                                 class="btn payment-button"
                                 id="{{ processor.NAME|lower }}">
                             {% if processor.NAME == 'cybersource' %}


### PR DESCRIPTION
The new analytics attribute to track if a checkout happend on the hosted or client side basket wasn't working because of a mistake I did in naming the attribute. This PR fixes that.

Segment data before:
![screenshot from 2017-01-20 13-46-45](https://cloud.githubusercontent.com/assets/2808092/22149983/f11949be-df16-11e6-843b-040c1830e79f.png)

Segment data after update:
![screenshot from 2017-01-20 13-46-13](https://cloud.githubusercontent.com/assets/2808092/22149988/f52e96d0-df16-11e6-8fbe-4b6aea4b1488.png)
