### PR TITLE
ENT-121: Automated entitlements applied for enterprise learners

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -330,6 +330,20 @@ class SiteConfiguration(models.Model):
 
         return EdxRestApiClient(settings.COURSE_CATALOG_API_URL, jwt=self.access_token)
 
+    @cached_property
+    def enterprise_api_client(self):
+        """
+        Constructs a Slumber-based REST API client for the provided site.
+
+        Example:
+            site.siteconfiguration.enterprise_api_client.enterprise-learner(learner.username).get()
+
+        Returns:
+            EdxRestApiClient: The client to access the Enterprise service.
+
+        """
+        return EdxRestApiClient(settings.ENTERPRISE_API_URL, jwt=self.access_token)
+
 
 class User(AbstractUser):
     """Custom user model for use with OIDC."""

--- a/ecommerce/core/tests/decorators.py
+++ b/ecommerce/core/tests/decorators.py
@@ -41,3 +41,42 @@ def mock_course_catalog_api_client(test):
     if isinstance(test, type):
         return decorate_class(test)
     return decorate_callable(test)
+
+
+def mock_enterprise_api_client(test):
+    """
+    Custom decorator for mocking the property "enterprise_api_client" of
+    siteconfiguration to construct a new instance of EdxRestApiClient with a
+    dummy jwt value.
+    """
+    def decorate_class(klass):
+        for attr in dir(klass):
+            # Decorate only callable unit tests.
+            if not attr.startswith('test_'):
+                continue
+
+            attr_value = getattr(klass, attr)
+            if not hasattr(attr_value, '__call__'):
+                continue
+
+            setattr(klass, attr, decorate_callable(attr_value))
+        return klass
+
+    def decorate_callable(test):
+        @functools.wraps(test)
+        def wrapper(*args, **kw):
+            with mock.patch(
+                'ecommerce.core.models.SiteConfiguration.enterprise_api_client',
+                mock.PropertyMock(
+                    return_value=EdxRestApiClient(
+                        settings.ENTERPRISE_API_URL,
+                        jwt='auth-token'
+                    )
+                )
+            ):
+                return test(*args, **kw)
+        return wrapper
+
+    if isinstance(test, type):
+        return decorate_class(test)
+    return decorate_callable(test)

--- a/ecommerce/core/tests/test_models.py
+++ b/ecommerce/core/tests/test_models.py
@@ -18,6 +18,7 @@ from ecommerce.tests.mixins import LmsApiMockMixin
 from ecommerce.tests.testcases import TestCase
 
 COURSE_CATALOG_API_URL = 'https://catalog.example.com/api/v1/'
+ENTERPRISE_API_URL = 'https://enterprise.example.com/api/v1/'
 
 
 def _make_site_config(payment_processors_str, site_id=1):
@@ -362,6 +363,22 @@ class SiteConfigurationTests(TestCase):
         client_auth = client_store['session'].auth
 
         self.assertEqual(client_store['base_url'], COURSE_CATALOG_API_URL)
+        self.assertIsInstance(client_auth, SuppliedJwtAuth)
+        self.assertEqual(client_auth.token, token)
+
+    @httpretty.activate
+    @override_settings(ENTERPRISE_API_URL=ENTERPRISE_API_URL)
+    def test_enterprise_api_client(self):
+        """
+        Verify the property "enterprise_api_client" returns a Slumber-based
+        REST API client for enterprise service API.
+        """
+        token = self.mock_access_token_response()
+        client = self.site.siteconfiguration.enterprise_api_client
+        client_store = client._store    # pylint: disable=protected-access
+        client_auth = client_store['session'].auth
+
+        self.assertEqual(client_store['base_url'], ENTERPRISE_API_URL)
         self.assertIsInstance(client_auth, SuppliedJwtAuth)
         self.assertEqual(client_auth.token, token)
 

--- a/ecommerce/coupons/tests/mixins.py
+++ b/ecommerce/coupons/tests/mixins.py
@@ -50,12 +50,17 @@ class CourseCatalogMockMixin(object):
             content_type='application/json'
         )
 
-    def mock_dynamic_catalog_course_runs_api(self, course_run=None, query=None, course_run_info=None):
-        """ Helper function to register a dynamic course catalog API endpoint for the course run information. """
+    def mock_dynamic_catalog_course_runs_api(self, course_run=None, partner_code=None, query=None,
+                                             course_run_info=None):
+        """
+        Helper function to register a course catalog API endpoint for getting
+        course runs information.
+        """
         if not course_run_info:
             course_run_info = {
                 'count': 1,
-                'next': 'path/to/next/page',
+                'next': None,
+                'previous': None,
                 'results': [{
                     'key': course_run.id,
                     'title': course_run.name,
@@ -78,6 +83,18 @@ class CourseCatalogMockMixin(object):
         httpretty.register_uri(
             httpretty.GET,
             course_run_url_with_query,
+            body=course_run_info_json,
+            content_type='application/json'
+        )
+
+        course_run_url_with_query_and_partner_code = '{}course_runs/?q={}&partner={}'.format(
+            settings.COURSE_CATALOG_API_URL,
+            partner_code if partner_code else 'edx',
+            query if query else 'id:course*'
+        )
+        httpretty.register_uri(
+            httpretty.GET,
+            course_run_url_with_query_and_partner_code,
             body=course_run_info_json,
             content_type='application/json'
         )

--- a/ecommerce/coupons/utils.py
+++ b/ecommerce/coupons/utils.py
@@ -5,34 +5,91 @@ from django.conf import settings
 from django.core.cache import cache
 from oscar.core.loading import get_model
 
+from ecommerce.courses.utils import traverse_pagination
+
+
 Product = get_model('catalogue', 'Product')
 
 
-def get_range_catalog_query_results(limit, query, site, offset=None):
+def get_catalog_course_runs(site, query, limit=None, offset=None):
     """
-    Get catalog query results
+    Get course runs for a site on the basis of provided query from the Course
+    Catalog API.
+
+    This method will get all course runs by recursively retrieving API
+    next urls in the API response if no limit is provided.
 
     Arguments:
         limit (int): Number of results per page
+        offset (int): Page offset
         query (str): ElasticSearch Query
         site (Site): Site object containing Site Configuration data
-        offset (int): Page offset
 
+    Example:
+        >>> get_catalog_course_runs(site, query, limit=1)
+        {
+            "count": 1,
+            "next": "None",
+            "previous": "None",
+            "results": [{
+                "key": "course-v1:edX+DemoX+Demo_Course",
+                "title": edX Demonstration Course,
+                "start": "2016-05-01T00:00:00Z",
+                "image": {
+                    "src": "path/to/the/course/image"
+                },
+                "enrollment_end": None
+            }],
+        }
     Returns:
-        dict: Query seach results received from Course Catalog API
+        dict: Query search results for course runs received from Course
+            Catalog API
+
+    Raises:
+        ConnectionError: requests exception "ConnectionError"
+        SlumberBaseException: slumber exception "SlumberBaseException"
+        Timeout: requests exception "Timeout"
+
     """
+    api_resource_name = 'course_runs'
     partner_code = site.siteconfiguration.partner.short_code
-    cache_key = 'course_runs_{}_{}_{}_{}'.format(query, limit, offset, partner_code)
+    cache_key = '{site_domain}_{partner_code}_{resource}_{query}_{limit}_{offset}'.format(
+        site_domain=site.domain,
+        partner_code=partner_code,
+        resource=api_resource_name,
+        query=query,
+        limit=limit,
+        offset=offset
+    )
     cache_key = hashlib.md5(cache_key).hexdigest()
+
     response = cache.get(cache_key)
     if not response:
-        response = site.siteconfiguration.course_catalog_api_client.course_runs.get(
-            limit=limit,
-            offset=offset,
-            q=query,
-            partner=partner_code
-        )
+        api = site.siteconfiguration.course_catalog_api_client
+        endpoint = getattr(api, api_resource_name)
+
+        if limit:
+            response = endpoint().get(
+                partner=partner_code,
+                q=query,
+                limit=limit,
+                offset=offset
+            )
+        else:
+            response = endpoint().get(
+                partner=partner_code,
+                q=query
+            )
+            all_response_results = traverse_pagination(response, endpoint)
+            response = {
+                'count': len(all_response_results),
+                'next': 'None',
+                'previous': 'None',
+                'results': all_response_results,
+            }
+
         cache.set(cache_key, response, settings.COURSES_API_CACHE_TIMEOUT)
+
     return response
 
 

--- a/ecommerce/courses/tests/mixins.py
+++ b/ecommerce/courses/tests/mixins.py
@@ -17,25 +17,18 @@ class CourseCatalogServiceMockMixin(object):
         super(CourseCatalogServiceMockMixin, self).setUp()
         cache.clear()
 
-    def mock_course_discovery_api_for_catalog_by_resource_id(self):
+    def mock_course_discovery_api_for_catalog_by_resource_id(self, catalog_query='title: *'):
         """
         Helper function to register course catalog API endpoint for a
         single catalog with its resource id.
         """
         catalog_id = 1
         course_discovery_api_response = {
-            'count': 1,
-            'next': None,
-            'previous': None,
-            'results': [
-                {
-                    'id': catalog_id,
-                    'name': 'Catalog {}'.format(catalog_id),
-                    'query': 'title: *',
-                    'courses_count': 0,
-                    'viewers': []
-                }
-            ]
+            'id': catalog_id,
+            'name': 'Catalog {}'.format(catalog_id),
+            'query': catalog_query,
+            'courses_count': 0,
+            'viewers': []
         }
         course_discovery_api_response_json = json.dumps(course_discovery_api_response)
         single_catalog_uri = '{}{}/'.format(self.COURSE_DISCOVERY_CATALOGS_URL, catalog_id)

--- a/ecommerce/courses/tests/test_utils.py
+++ b/ecommerce/courses/tests/test_utils.py
@@ -124,9 +124,7 @@ class GetCourseCatalogUtilTests(CourseCatalogServiceMockMixin, TestCase):
         self.assertIsNone(cached_course_catalog)
 
         response = get_course_catalogs(self.request.site, catalog_id)
-
-        self.assertEqual(response['count'], 1)
-        self.assertEqual(response['results'][0]['name'], 'Catalog {}'.format(catalog_id))
+        self.assertEqual(response['name'], 'Catalog {}'.format(catalog_id))
 
         cached_course = cache.get(cache_key)
         self.assertEqual(cached_course, response)

--- a/ecommerce/courses/utils.py
+++ b/ecommerce/courses/utils.py
@@ -45,6 +45,11 @@ def get_course_catalogs(site, resource_id=None):
     Returns:
         dict: Course catalogs received from Course Catalog API
 
+    Raises:
+        ConnectionError: requests exception "ConnectionError"
+        SlumberBaseException: slumber exception "SlumberBaseException"
+        Timeout: requests exception "Timeout"
+
     """
     resource = 'catalogs'
     base_cache_key = '{}.catalog.api.data'.format(site.domain)

--- a/ecommerce/enterprise/__init__.py
+++ b/ecommerce/enterprise/__init__.py
@@ -1,0 +1,4 @@
+"""
+This package contains all workflows and communications related to the Open edX
+Enterprise service.
+"""

--- a/ecommerce/enterprise/entitlements.py
+++ b/ecommerce/enterprise/entitlements.py
@@ -1,0 +1,278 @@
+"""
+Helper methods for getting site based enterprise entitlements against the
+learners.
+
+Enterprise learners can get coupons, offered by their respective Enterprise
+customers with which they are affiliated. The coupon product id's for the
+enterprise entitlements are provided by the Enterprise Service on the basis
+of the learner's enterprise eligibility criterion.
+"""
+import hashlib
+import logging
+
+from django.conf import settings
+from django.core.cache import cache
+from oscar.core.loading import get_model
+from requests.exceptions import ConnectionError, Timeout
+from slumber.exceptions import SlumberBaseException
+
+from ecommerce.coupons.utils import get_catalog_course_runs
+from ecommerce.coupons.views import voucher_is_valid
+from ecommerce.courses.utils import get_course_catalogs
+from ecommerce.enterprise.utils import is_enterprise_feature_enabled
+from ecommerce.extensions.api.serializers import retrieve_voucher
+
+
+logger = logging.getLogger(__name__)
+Product = get_model('catalogue', 'Product')
+Voucher = get_model('voucher', 'Voucher')
+
+
+def get_entitlement_voucher(request, product):
+    """
+    Returns entitlement voucher for the given product against an enterprise
+    learner.
+
+    Arguments:
+        request (HttpRequest): request with voucher data
+        product (Product): A product that has course_key as attribute (seat or
+            bulk enrollment coupon)
+
+    """
+    if not is_enterprise_feature_enabled():
+        return None
+
+    vouchers = get_vouchers_for_learner(request.site, request.user)
+    if vouchers:
+        entitlement_voucher = get_available_voucher_for_product(request, product, vouchers)
+        return entitlement_voucher
+
+    return None
+
+
+def get_vouchers_for_learner(site, user):
+    """
+    Get vouchers against the list of all enterprise entitlements for the
+    provided learner.
+
+    Arguments:
+        site: (django.contrib.sites.Site) site instance
+        user: (django.contrib.auth.User) django auth user
+
+    Returns:
+        list of Voucher class objects
+
+    """
+    entitlements = get_entitlements_for_learner(site, user)
+    if not entitlements:
+        return None
+
+    vouchers = []
+    for entitlement in entitlements:
+        try:
+            coupon_product = Product.objects.filter(product_class__name='Coupon').get(id=entitlement['entitlement_id'])
+        except Product.DoesNotExist:
+            logger.exception(
+                'There was an error getting coupon product with the entitlement id %s',
+                entitlement['entitlement_id']
+            )
+            return None
+
+        entitlement_voucher = retrieve_voucher(coupon_product)
+        vouchers.append(entitlement_voucher)
+
+    return vouchers
+
+
+def get_entitlements_for_learner(site, user):
+    """
+    Get entitlements for the provided learner if the provided learner is
+    affiliated with an enterprise.
+
+    Arguments:
+        site: (django.contrib.sites.Site) site instance
+        user: (django.contrib.auth.User) django auth user
+
+    """
+    try:
+        enterprise_learner_data = get_enterprise_learner_data(site, user)['results']
+    except (ConnectionError, SlumberBaseException, Timeout, KeyError, TypeError):
+        logger.exception(
+            'Failed to retrieve enterprise info for the learner [%s]',
+            user.username
+        )
+        return None
+
+    if not enterprise_learner_data:
+        logger.info('Learner with username [%s] in not affiliated with any enterprise', user.username)
+        return None
+
+    try:
+        entitlements = enterprise_learner_data[0]['enterprise_customer']['enterprise_customer_entitlements']
+    except KeyError:
+        logger.error('Invalid structure for enterprise learner API response for the learner [%s]', user.username)
+        return None
+
+    return entitlements
+
+
+def get_enterprise_learner_data(site, user):
+    """
+    Fetch information related to enterprise and its entitlements according to
+    the eligibility criterion for the provided learners from the Enterprise
+    Service.
+
+    Example:
+        get_enterprise_learner_data(site, user)
+
+    Arguments:
+        site: (django.contrib.sites.Site) site instance
+        user: (django.contrib.auth.User) django auth user
+
+    Returns:
+        dict: {
+            "enterprise_api_response_for_learner": {
+                "count": 1,
+                "num_pages": 1,
+                "current_page": 1,
+                "results": [
+                    {
+                        "enterprise_customer": {
+                            "uuid": "cf246b88-d5f6-4908-a522-fc307e0b0c59",
+                            "name": "TestShib",
+                            "catalog": 2,
+                            "active": true,
+                            "site": {
+                                "domain": "example.com",
+                                "name": "example.com"
+                            },
+                            "enable_data_sharing_consent": true,
+                            "enforce_data_sharing_consent": "at_login",
+                            "enterprise_customer_users": [
+                                1
+                            ],
+                            "branding_configuration": {
+                                "enterprise_customer": "cf246b88-d5f6-4908-a522-fc307e0b0c59",
+                                "logo": "https://open.edx.org/sites/all/themes/edx_open/logo.png"
+                            },
+                            "enterprise_customer_entitlements": [
+                                {
+                                    "enterprise_customer": "cf246b88-d5f6-4908-a522-fc307e0b0c59",
+                                    "entitlement_id": 69
+                                }
+                            ]
+                        },
+                        "user_id": 5,
+                        "user": {
+                            "username": "staff",
+                            "first_name": "",
+                            "last_name": "",
+                            "email": "staff@example.com",
+                            "is_staff": true,
+                            "is_active": true,
+                            "date_joined": "2016-09-01T19:18:26.026495Z"
+                        },
+                        "data_sharing_consent": [
+                            {
+                                "user": 1,
+                                "state": "enabled",
+                                "enabled": true
+                            }
+                        ]
+                    }
+                ],
+                "next": null,
+                "start": 0,
+                "previous": null
+            }
+        }
+
+    Raises:
+        ConnectionError: requests exception "ConnectionError"
+        SlumberBaseException: slumber exception "SlumberBaseException"
+        Timeout: requests exception "Timeout"
+
+    """
+    api_resource_name = 'enterprise-learner'
+    partner_code = site.siteconfiguration.partner.short_code
+    cache_key = '{site_domain}_{partner_code}_{resource}_{username}'.format(
+        site_domain=site.domain,
+        partner_code=partner_code,
+        resource=api_resource_name,
+        username=user.username
+    )
+    cache_key = hashlib.md5(cache_key).hexdigest()
+
+    response = cache.get(cache_key)
+    if not response:
+        api = site.siteconfiguration.enterprise_api_client
+        endpoint = getattr(api, api_resource_name)
+        querystring = {'username': user.username}
+        response = endpoint().get(**querystring)
+        cache.set(cache_key, response, settings.ENTERPRISE_API_CACHE_TIMEOUT)
+
+    return response
+
+
+def get_available_voucher_for_product(request, product, vouchers):
+    """
+    Get first active entitlement from a list of vouchers for the given
+    product.
+
+    Arguments:
+        product (Product): A product that has course_key as attribute (seat or
+            bulk enrollment coupon)
+        request (HttpRequest): request with voucher data
+        vouchers: (List) List of voucher class objects for an enterprise
+
+    """
+    for voucher in vouchers:
+        is_valid_voucher, __ = voucher_is_valid(voucher, [product], request)
+        if is_valid_voucher:
+            voucher_course_ids = get_course_ids_from_voucher(request.site, voucher)
+            if product.course_id in voucher_course_ids:
+                return voucher
+
+
+def get_course_ids_from_voucher(site, voucher):
+    """
+    Get site base list of course run keys from the provided voucher object.
+
+    Arguments:
+        site: (django.contrib.sites.Site) site instance
+        voucher (Voucher): voucher class object
+
+    Returns:
+        list of course ids
+
+    """
+    voucher_offer = voucher.offers.first()
+    offer_range = voucher_offer.condition.range
+    if offer_range.course_catalog:
+        try:
+            course_catalog = get_course_catalogs(site=site, resource_id=offer_range.course_catalog)
+        except (ConnectionError, SlumberBaseException, Timeout):
+            logger.error('Unable to connect to Course Catalog service for course catalogs.')
+            return None
+
+        try:
+            course_runs = get_catalog_course_runs(site, course_catalog.get('query'))['results']
+        except (ConnectionError, SlumberBaseException, Timeout, KeyError):
+            logger.error('Unable to get course runs from Course Catalog service.')
+            return None
+
+        voucher_course_ids = [course_run.get('key') for course_run in course_runs if course_run.get('key')]
+    elif offer_range.catalog_query:
+        try:
+            course_runs = get_catalog_course_runs(site, offer_range.catalog_query)['results']
+        except (ConnectionError, SlumberBaseException, Timeout, KeyError):
+            logger.error('Unable to get course runs from Course Catalog service.')
+            return None
+
+        voucher_course_ids = [course_run.get('key') for course_run in course_runs if course_run.get('key')]
+    else:
+        stock_records = offer_range.catalog.stock_records.all()
+        seats = Product.objects.filter(id__in=[sr.product.id for sr in stock_records])
+        voucher_course_ids = [seat.course_id for seat in seats]
+
+    return voucher_course_ids

--- a/ecommerce/enterprise/tests/mixins.py
+++ b/ecommerce/enterprise/tests/mixins.py
@@ -1,0 +1,165 @@
+import json
+
+import httpretty
+from django.conf import settings
+from django.core.cache import cache
+
+
+class EnterpriseServiceMockMixin(object):
+    """
+    Mocks for the Open edX service 'Enterprise Service' responses.
+    """
+    ENTERPRISE_LEARNER_URL = '{}enterprise-learner/'.format(
+        settings.ENTERPRISE_API_URL,
+    )
+
+    def setUp(self):
+        super(EnterpriseServiceMockMixin, self).setUp()
+        cache.clear()
+
+    def mock_enterprise_learner_api(self, catalog_id=1, entitlement_id=1):
+        """
+        Helper function to register enterprise learner API endpoint.
+        """
+        enterprise_learner_api_response = {
+            'count': 1,
+            'num_pages': 1,
+            'current_page': 1,
+            'results': [
+                {
+                    'enterprise_customer': {
+                        'uuid': 'cf246b88-d5f6-4908-a522-fc307e0b0c59',
+                        'name': 'TestShib',
+                        'catalog': catalog_id,
+                        'active': True,
+                        'site': {
+                            'domain': 'example.com',
+                            'name': 'example.com'
+                        },
+                        'enable_data_sharing_consent': True,
+                        'enforce_data_sharing_consent': 'at_login',
+                        'enterprise_customer_users': [
+                            1
+                        ],
+                        'branding_configuration': {
+                            'enterprise_customer': 'cf246b88-d5f6-4908-a522-fc307e0b0c59',
+                            'logo': 'https://open.edx.org/sites/all/themes/edx_open/logo.png'
+                        },
+                        'enterprise_customer_entitlements': [
+                            {
+                                'enterprise_customer': 'cf246b88-d5f6-4908-a522-fc307e0b0c59',
+                                'entitlement_id': entitlement_id
+                            }
+                        ]
+                    },
+                    'user_id': 5,
+                    'user': {
+                        'username': 'verified',
+                        'first_name': '',
+                        'last_name': '',
+                        'email': 'verified@example.com',
+                        'is_staff': True,
+                        'is_active': True,
+                        'date_joined': '2016-09-01T19:18:26.026495Z'
+                    },
+                    'data_sharing_consent': [
+                        {
+                            'user': 1,
+                            'state': 'enabled',
+                            'enabled': True
+                        }
+                    ]
+                }
+            ],
+            'next': None,
+            'start': 0,
+            'previous': None
+        }
+        enterprise_learner_api_response_json = json.dumps(enterprise_learner_api_response)
+
+        httpretty.register_uri(
+            method=httpretty.GET,
+            uri=self.ENTERPRISE_LEARNER_URL,
+            body=enterprise_learner_api_response_json,
+            content_type='application/json'
+        )
+
+    def mock_enterprise_learner_api_for_learner_with_no_enterprise(self):
+        """
+        Helper function to register enterprise learner API endpoint for a
+        learner which is not associated with any enterprise.
+        """
+        enterprise_learner_api_response = {
+            'count': 0,
+            'num_pages': 1,
+            'current_page': 1,
+            'results': [],
+            'next': None,
+            'start': 0,
+            'previous': None
+        }
+        enterprise_learner_api_response_json = json.dumps(enterprise_learner_api_response)
+
+        httpretty.register_uri(
+            method=httpretty.GET,
+            uri=self.ENTERPRISE_LEARNER_URL,
+            body=enterprise_learner_api_response_json,
+            content_type='application/json'
+        )
+
+    def mock_enterprise_learner_api_for_learner_with_invalid_response(self):
+        """
+        Helper function to register enterprise learner API endpoint for a
+        learner with invalid API reponse structure.
+        """
+        enterprise_learner_api_response = {
+            'count': 0,
+            'num_pages': 1,
+            'current_page': 1,
+            'results': [
+                {
+                    'invalid-unexpected-key': {
+                        'enterprise_customer': {
+                            'uuid': 'cf246b88-d5f6-4908-a522-fc307e0b0c59',
+                            'name': 'TestShib',
+                            'catalog': 1,
+                            'active': True,
+                            'site': {
+                                'domain': 'example.com',
+                                'name': 'example.com'
+                            },
+                            'enterprise_customer_entitlements': [
+                                {
+                                    'enterprise_customer': 'cf246b88-d5f6-4908-a522-fc307e0b0c59',
+                                    'entitlement_id': 1
+                                }
+                            ]
+                        },
+                    }
+                }
+            ],
+            'next': None,
+            'start': 0,
+            'previous': None
+        }
+        enterprise_learner_api_response_json = json.dumps(enterprise_learner_api_response)
+
+        httpretty.register_uri(
+            method=httpretty.GET,
+            uri=self.ENTERPRISE_LEARNER_URL,
+            body=enterprise_learner_api_response_json,
+            content_type='application/json'
+        )
+
+    def mock_enterprise_learner_api_for_failure(self):
+        """
+        Helper function to register enterprise learner API endpoint for a
+        failure.
+        """
+        httpretty.register_uri(
+            method=httpretty.GET,
+            uri=self.ENTERPRISE_LEARNER_URL,
+            responses=[
+                httpretty.Response(body='{}', content_type='application/json', status_code=500)
+            ]
+        )

--- a/ecommerce/enterprise/tests/test_entitlements.py
+++ b/ecommerce/enterprise/tests/test_entitlements.py
@@ -1,0 +1,405 @@
+import hashlib
+
+import ddt
+from django.core.cache import cache
+from django.conf import settings
+import httpretty
+from oscar.core.loading import get_model
+from testfixtures import LogCapture
+
+from ecommerce.core.tests import toggle_switch
+from ecommerce.core.tests.decorators import mock_enterprise_api_client
+from ecommerce.core.tests.decorators import mock_course_catalog_api_client
+from ecommerce.coupons.tests.mixins import CouponMixin, CourseCatalogMockMixin
+from ecommerce.courses.tests.factories import CourseFactory
+from ecommerce.courses.tests.mixins import CourseCatalogServiceMockMixin
+from ecommerce.enterprise.entitlements import (
+    get_enterprise_learner_data, get_entitlement_voucher, get_entitlements_for_learner,
+    get_course_ids_from_voucher
+)
+from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
+from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
+from ecommerce.extensions.partner.strategy import DefaultStrategy
+from ecommerce.tests.testcases import TestCase
+
+
+COURSE_CATALOG_API_URL = 'https://catalog.example.com/api/v1/'
+Catalog = get_model('catalogue', 'Catalog')
+StockRecord = get_model('partner', 'StockRecord')
+
+
+@ddt.ddt
+@httpretty.activate
+class EntitlementsTests(EnterpriseServiceMockMixin, CourseCatalogServiceMockMixin, CourseCatalogTestMixin,
+                        CourseCatalogMockMixin, CouponMixin, TestCase):
+    def setUp(self):
+        super(EntitlementsTests, self).setUp()
+        self.learner = self.create_user(is_staff=True)
+        self.client.login(username=self.learner.username, password=self.password)
+
+        # Enable enterprise functionality
+        toggle_switch(settings.ENABLE_ENTERPRISE_ON_RUNTIME_SWITCH, True)
+
+        self.course = CourseFactory(id='edx/Demo_Course/DemoX')
+        course_seat = self.course.create_or_update_seat('verified', False, 100, partner=self.partner)
+        stock_record = StockRecord.objects.get(product=course_seat)
+        self.catalog = Catalog.objects.create(partner=self.partner)
+        self.catalog.stock_records.add(stock_record)
+
+        self.request.user = self.learner
+        self.request.site = self.site
+        self.request.strategy = DefaultStrategy()
+
+    def tearDown(self):
+        # Reset HTTPretty state (clean up registered urls and request history)
+        httpretty.reset()
+
+    def _assert_num_requests(self, count):
+        """
+        DRY helper for verifying request counts.
+        """
+        self.assertEqual(len(httpretty.httpretty.latest_requests), count)
+
+    def _create_course_catalog_coupon(self):
+        """
+        Helper method to create course catalog coupon.
+        """
+        coupon_title = 'Course catalog coupon'
+        quantity = 1
+        course_catalog_id = 1
+
+        course_catalog_coupon = self.create_coupon(
+            title=coupon_title,
+            quantity=quantity,
+            course_catalog=course_catalog_id,
+        )
+        course_catalog_coupon_voucher = course_catalog_coupon.attr.coupon_vouchers.vouchers.first()
+        self.assertEqual(course_catalog_coupon.title, coupon_title)
+
+        course_catalog_vouchers = course_catalog_coupon.attr.coupon_vouchers.vouchers.all()
+        self.assertEqual(course_catalog_vouchers.count(), quantity)
+
+        course_catalog_voucher_range = course_catalog_vouchers.first().offers.first().benefit.range
+        self.assertEqual(course_catalog_voucher_range.course_catalog, course_catalog_id)
+
+        return course_catalog_coupon_voucher
+
+    def _create_multiple_course_coupon(self):
+        """
+        Helper method to multiple course (dynamic) coupon.
+        """
+        coupon_title = 'Multiple courses coupon'
+        quantity = 1
+        catalog_query = '*:*',
+        course_seat_types = 'verified'
+
+        course_catalog_coupon = self.create_coupon(
+            title=coupon_title,
+            quantity=quantity,
+            catalog_query=catalog_query,
+            course_seat_types=course_seat_types,
+        )
+        course_catalog_coupon_voucher = course_catalog_coupon.attr.coupon_vouchers.vouchers.first()
+        self.assertEqual(course_catalog_coupon.title, coupon_title)
+
+        course_catalog_vouchers = course_catalog_coupon.attr.coupon_vouchers.vouchers.all()
+        self.assertEqual(course_catalog_vouchers.count(), quantity)
+
+        course_catalog_voucher_range = course_catalog_vouchers.first().offers.first().benefit.range
+        self.assertEqual(str(course_catalog_voucher_range.catalog_query), str(catalog_query))
+        self.assertEqual(course_catalog_voucher_range.course_seat_types, course_seat_types)
+
+        return course_catalog_coupon_voucher
+
+    def _assert_get_enterprise_learner_data(self):
+        """
+        Helper method to validate the response from the method
+        "get_enterprise_learner_data".
+        """
+        api_resource_name = 'enterprise-learner'
+        partner_code = self.request.site.siteconfiguration.partner.short_code
+        cache_key = '{site_domain}_{partner_code}_{resource}_{username}'.format(
+            site_domain=self.request.site.domain,
+            partner_code=partner_code,
+            resource=api_resource_name,
+            username=self.learner.username
+        )
+        cache_key = hashlib.md5(cache_key).hexdigest()
+
+        cached_enterprise_learner_response = cache.get(cache_key)
+        self.assertIsNone(cached_enterprise_learner_response)
+
+        response = get_enterprise_learner_data(self.request.site, self.learner)
+        self.assertEqual(len(response['results']), 1)
+
+        cached_course = cache.get(cache_key)
+        self.assertEqual(cached_course, response)
+
+    def _assert_get_entitlements_for_learner_log_and_response(self, expected_entitlements, log_level, log_message):
+        """
+        Helper method to validate the response from the method
+        "get_entitlements_for_learner" and verify the logged message.
+        """
+        logger_name = 'ecommerce.enterprise.entitlements'
+        with LogCapture(logger_name) as logger:
+            entitlements = get_entitlements_for_learner(self.request.site, self.request.user)
+            self._assert_num_requests(1)
+
+            logger.check(
+                (
+                    logger_name,
+                    log_level,
+                    log_message
+                )
+            )
+            self.assertEqual(expected_entitlements, entitlements)
+
+    def _assert_get_course_ids_from_voucher_for_failure(self, voucher, expected_requests, log_message):
+        """
+        Helper method to validate the response from the method
+        "get_course_ids_from_voucher" and verify the logged message.
+        """
+        logger_name = 'ecommerce.enterprise.entitlements'
+        with LogCapture(logger_name) as logger:
+            voucher_course_ids = get_course_ids_from_voucher(self.request.site, voucher)
+            self._assert_num_requests(expected_requests)
+            logger.check(
+                (
+                    logger_name,
+                    'ERROR',
+                    log_message
+                )
+            )
+            self.assertEqual(None, voucher_course_ids)
+
+    @mock_enterprise_api_client
+    def test_get_enterprise_learner_data(self):
+        """
+        Verify that method "get_enterprise_learner_data" returns a proper
+        response for the enterprise learner.
+        """
+        self.mock_enterprise_learner_api()
+        self._assert_get_enterprise_learner_data()
+
+        # Verify the API was hit once
+        self._assert_num_requests(1)
+
+        # Now fetch the enterprise learner data again and verify that was no
+        # actual call to Enterprise API, as the data will be fetched from the
+        # cache
+        get_enterprise_learner_data(self.request.site, self.learner)
+        self._assert_num_requests(1)
+
+    @mock_enterprise_api_client
+    def test_get_entitlement_voucher_with_enterprise_feature_disabled(self):
+        """
+        Verify that method "get_entitlement_voucher" doesn't call the
+        enterprise service API and returns no voucher if the enterprise
+        feature is disabled.
+        """
+        self.mock_enterprise_learner_api()
+        toggle_switch(settings.ENABLE_ENTERPRISE_ON_RUNTIME_SWITCH, False)
+
+        entitlement_voucher = get_entitlement_voucher(self.request, self.course.products.first())
+        self._assert_num_requests(0)
+        self.assertIsNone(entitlement_voucher)
+
+    @mock_enterprise_api_client
+    def test_get_entitlement_voucher_with_enterprise_feature_enabled(self):
+        """
+        Verify that method "get_entitlement_voucher" returns a voucher if
+        the enterprise feature is enabled.
+        """
+        coupon = self.create_coupon(catalog=self.catalog)
+        expected_voucher = coupon.attr.coupon_vouchers.vouchers.first()
+
+        self.mock_enterprise_learner_api(entitlement_id=coupon.id)
+
+        entitlement_voucher = get_entitlement_voucher(self.request, self.course.products.first())
+        self._assert_num_requests(1)
+        self.assertEqual(expected_voucher, entitlement_voucher)
+
+    @mock_enterprise_api_client
+    def test_get_entitlement_voucher_with_invalid_entitlement_id(self):
+        """
+        Verify that method "get_entitlement_voucher" logs exception if there
+        is no coupon against the provided entitlement id in the enterprise
+        learner API response.
+        """
+        non_existing_coupon_id = 99
+        self.mock_enterprise_learner_api(entitlement_id=non_existing_coupon_id)
+
+        logger_name = 'ecommerce.enterprise.entitlements'
+        with LogCapture(logger_name) as logger:
+            entitlement_voucher = get_entitlement_voucher(self.request, self.course.products.first())
+            self._assert_num_requests(1)
+
+            logger.check(
+                (
+                    logger_name,
+                    'ERROR',
+                    'There was an error getting coupon product with the entitlement id %s' % non_existing_coupon_id
+                )
+            )
+            self.assertIsNone(entitlement_voucher)
+
+    @mock_enterprise_api_client
+    def test_get_entitlements_for_learner_with_exception(self):
+        """
+        Verify that method "get_entitlements_for_learner" logs exception if
+        there is an error while accessing the enterprise learner API.
+        """
+        self.mock_enterprise_learner_api_for_failure()
+
+        self._assert_get_entitlements_for_learner_log_and_response(
+            expected_entitlements=None,
+            log_level='ERROR',
+            log_message='Failed to retrieve enterprise info for the learner [%s]' % self.learner.username,
+        )
+
+    @mock_enterprise_api_client
+    def test_get_entitlements_for_learner_with_no_enterprise(self):
+        """
+        Verify that method "get_entitlements_for_learner" logs and returns
+        empty list if the learner is not affiliated with any enterprise.
+        """
+        self.mock_enterprise_learner_api_for_learner_with_no_enterprise()
+
+        self._assert_get_entitlements_for_learner_log_and_response(
+            expected_entitlements=None,
+            log_level='INFO',
+            log_message='Learner with username [%s] in not affiliated with any enterprise' % self.learner.username,
+        )
+
+    @mock_enterprise_api_client
+    def test_get_entitlements_for_learner_with_invalid_response(self):
+        """
+        Verify that method "get_entitlements_for_learner" logs and returns
+        empty list for entitlements if the enterprise learner API response has
+        invalid/unexpected structure.
+        """
+        self.mock_enterprise_learner_api_for_learner_with_invalid_response()
+
+        message = 'Invalid structure for enterprise learner API response for the learner [%s]' % self.learner.username
+        self._assert_get_entitlements_for_learner_log_and_response(
+            expected_entitlements=None,
+            log_level='ERROR',
+            log_message=message
+        )
+
+    @mock_course_catalog_api_client
+    def test_get_course_ids_from_voucher_for_catalog_voucher(self):
+        """
+        Verify that method "get_course_ids_from_voucher" returns course ids
+        related to a course catalog voucher.
+        """
+        course_catalog_coupon_voucher = self._create_course_catalog_coupon()
+
+        catalog_query = '*:*'
+        self.mock_course_discovery_api_for_catalog_by_resource_id(catalog_query=catalog_query)
+        partner_code = self.request.site.siteconfiguration.partner.short_code
+        self.mock_dynamic_catalog_course_runs_api(
+            course_run=self.course, partner_code=partner_code, query=catalog_query
+        )
+
+        voucher_course_ids = get_course_ids_from_voucher(self.request.site, course_catalog_coupon_voucher)
+        # Verify that there were two calls for the course discovery API, one
+        # for getting all course_catalogs and the other for getting course
+        # runs against the course catalog query
+        self._assert_num_requests(2)
+
+        expected_voucher_course_ids = [self.course.id]
+        self.assertEqual(expected_voucher_course_ids, voucher_course_ids)
+
+    @mock_course_catalog_api_client
+    def test_get_course_ids_from_voucher_for_error_in_get_course_catalogs(self):
+        """
+        Verify that method "get_course_ids_from_voucher" returns empty course ids
+        if get_course_catalogs raises exception.
+        """
+        course_catalog_coupon_voucher = self._create_course_catalog_coupon()
+
+        self.mock_course_discovery_api_for_failure()
+        # Verify that there was only one call to the course discovery API and
+        # it fails with error
+        self._assert_get_course_ids_from_voucher_for_failure(
+            voucher=course_catalog_coupon_voucher,
+            expected_requests=1,
+            log_message='Unable to connect to Course Catalog service for course catalogs.'
+        )
+
+    @mock_course_catalog_api_client
+    def test_get_course_ids_from_voucher_for_error_in_get_catalog_course_runs(self):
+        """
+        Verify that method "get_course_ids_from_voucher" returns empty course ids
+        if get_catalog_course_runs raises exception.
+        """
+        course_catalog_coupon_voucher = self._create_course_catalog_coupon()
+
+        self.mock_course_discovery_api_for_catalog_by_resource_id()
+        self.mock_course_discovery_api_for_failure()
+        # Verify that there was two calls to the course discovery API, one for
+        # getting details of course catalog and other for getting course run
+        # against the catalog query and it fails with error
+        self._assert_get_course_ids_from_voucher_for_failure(
+            voucher=course_catalog_coupon_voucher,
+            expected_requests=2,
+            log_message='Unable to get course runs from Course Catalog service.'
+        )
+
+    @mock_course_catalog_api_client
+    def test_get_course_ids_from_voucher_for_dynamic_voucher(self):
+        """
+        Verify that method "get_course_ids_from_voucher" returns course ids
+        related to a dynamic catalog voucher query.
+        """
+        coupon_title = 'Multiple courses coupon'
+        quantity = 1
+        catalog_query = '*:*',
+        course_seat_types = 'verified'
+
+        course_catalog_coupon = self.create_coupon(
+            title=coupon_title,
+            quantity=quantity,
+            catalog_query=catalog_query,
+            course_seat_types=course_seat_types,
+        )
+        course_catalog_coupon_voucher = course_catalog_coupon.attr.coupon_vouchers.vouchers.first()
+        self.assertEqual(course_catalog_coupon.title, coupon_title)
+
+        course_catalog_vouchers = course_catalog_coupon.attr.coupon_vouchers.vouchers.all()
+        self.assertEqual(course_catalog_vouchers.count(), quantity)
+
+        course_catalog_voucher_range = course_catalog_vouchers.first().offers.first().benefit.range
+        self.assertEqual(str(course_catalog_voucher_range.catalog_query), str(catalog_query))
+        self.assertEqual(course_catalog_voucher_range.course_seat_types, course_seat_types)
+
+        partner_code = self.request.site.siteconfiguration.partner.short_code
+        self.mock_dynamic_catalog_course_runs_api(
+            course_run=self.course, partner_code=partner_code, query=catalog_query
+        )
+
+        voucher_course_ids = get_course_ids_from_voucher(self.request.site, course_catalog_coupon_voucher)
+        # Verify that there was only one call to the course discovery API for
+        # getting course runs against the catalog query from dynamic coupon.
+        self._assert_num_requests(1)
+
+        expected_voucher_course_ids = [self.course.id]
+        self.assertEqual(expected_voucher_course_ids, voucher_course_ids)
+
+    @mock_course_catalog_api_client
+    def test_get_course_ids_from_dynamic_voucher_for_error_in_get_catalog_course_runs(self):
+        """
+        Verify that method "get_course_ids_from_voucher" returns empty course
+        ids if get_course_ids_from_voucher raises exception for getting course
+        runs from course discovery service.
+        """
+        course_catalog_coupon_voucher = self._create_multiple_course_coupon()
+        self.mock_course_discovery_api_for_failure()
+        # Verify that there was only one call to the course discovery API for
+        # course runs and it fails with error
+        self._assert_get_course_ids_from_voucher_for_failure(
+            voucher=course_catalog_coupon_voucher,
+            expected_requests=1,
+            log_message='Unable to get course runs from Course Catalog service.'
+        )

--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -1,0 +1,22 @@
+"""
+Helper methods for enterprise app.
+"""
+from django.conf import settings
+import waffle
+
+
+def is_enterprise_feature_enabled():
+    """
+    Returns boolean indicating whether enterprise feature is enabled or
+    disabled.
+
+    Example:
+        >> is_enterprise_feature_enabled()
+        True
+
+    Returns:
+         (bool): True if enterprise feature is enabled else False
+
+    """
+    is_enterprise_enabled = waffle.switch_is_active(settings.ENABLE_ENTERPRISE_ON_RUNTIME_SWITCH)
+    return is_enterprise_enabled

--- a/ecommerce/extensions/api/v2/views/catalog.py
+++ b/ecommerce/extensions/api/v2/views/catalog.py
@@ -11,7 +11,7 @@ from rest_framework_extensions.mixins import NestedViewSetMixin
 from slumber.exceptions import SlumberBaseException
 
 from ecommerce.core.constants import DEFAULT_CATALOG_PAGE_SIZE
-from ecommerce.coupons.utils import get_range_catalog_query_results
+from ecommerce.coupons.utils import get_catalog_course_runs
 from ecommerce.extensions.api import serializers
 from ecommerce.courses.utils import get_course_catalogs
 
@@ -48,10 +48,10 @@ class CatalogViewSet(NestedViewSetMixin, ReadOnlyModelViewSet):
         if query and seat_types:
             seat_types = seat_types.split(',')
             try:
-                response = get_range_catalog_query_results(
-                    limit=limit,
-                    query=query,
+                response = get_catalog_course_runs(
                     site=request.site,
+                    query=query,
+                    limit=limit,
                     offset=offset
                 )
                 results = response['results']

--- a/ecommerce/extensions/api/v2/views/vouchers.py
+++ b/ecommerce/extensions/api/v2/views/vouchers.py
@@ -17,7 +17,7 @@ from slumber.exceptions import SlumberBaseException
 from ecommerce.core.constants import DEFAULT_CATALOG_PAGE_SIZE
 from ecommerce.courses.models import Course
 from ecommerce.courses.utils import get_course_info_from_catalog
-from ecommerce.coupons.utils import get_range_catalog_query_results
+from ecommerce.coupons.utils import get_catalog_course_runs
 from ecommerce.extensions.api import serializers
 from ecommerce.extensions.api.permissions import IsOffersOrIsAuthenticatedAndStaff
 from ecommerce.extensions.api.v2.views import NonDestroyableModelViewSet
@@ -140,11 +140,11 @@ class VoucherViewSet(NonDestroyableModelViewSet):
         multiple_credit_providers = False
         credit_provider_price = None
 
-        response = get_range_catalog_query_results(
+        response = get_catalog_course_runs(
+            site=request.site,
+            query=catalog_query,
             limit=request.GET.get('limit', DEFAULT_CATALOG_PAGE_SIZE),
             offset=request.GET.get('offset'),
-            query=catalog_query,
-            site=request.site
         )
         next_page = response['next']
         products, stock_records = self.retrieve_course_objects(response['results'], course_seat_types)

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -279,6 +279,9 @@ LOCAL_APPS = [
 
     # Sailthru email marketing integration
     'ecommerce.sailthru',
+
+    # Enterprise app for ecommerce
+    'ecommerce.enterprise',
 ]
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#installed-apps
@@ -568,3 +571,13 @@ ENROLLMENT_CODE_EXIPRATION_DATE = datetime.datetime.now() + datetime.timedelta(w
 AFFILIATE_COOKIE_KEY = 'affiliate_id'
 
 CRISPY_TEMPLATE_PACK = 'bootstrap3'
+
+# ENTERPRISE APP CONFIGURATION
+# URL for Enterprise service API
+ENTERPRISE_API_URL = 'http://localhost:8000/enterprise/api/v1/'
+# Cache enterprise response from Enterprise API.
+ENTERPRISE_API_CACHE_TIMEOUT = 3600  # Value is in seconds
+
+# Name for waffle switch to use for enabling enterprise features on runtime.
+ENABLE_ENTERPRISE_ON_RUNTIME_SWITCH = 'enable_enterprise_on_runtime'
+# END ENTERPRISE APP CONFIGURATION


### PR DESCRIPTION
ENT-121
@asadiqbal08 @saleem-latif @mattdrayer 

Automatically find and apply active entitlements (coupons) on the order basket, for an enterprise learner.
Added setting `ENTERPRISE_API_CACHE_TIMEOUT = 3600  # Value is in seconds` for enterprise API response cache timeout.

**Q. How to activate this feature?**
**A.** Add active waffle switch with name `enable_enterprise_on_runtime`  to enable this feature

_**NOTE:** This code is written with the assumption that for now every enterprise will have only one entitlement/voucher._

**Related PR for enterprise API (In-progress):** https://github.com/edx/edx-enterprise/pull/30

**Related Config PR:** Add a related [PR in edx configuration repo for overriding the production value for the setting `ENTERPRISE_API_URL`](https://github.com/edx/configuration/pull/3652)