### PR TITLE
[SOL-2197] Do not allow unsupported CCs from new basket page.

### DIFF
--- a/ecommerce/static/js/pages/basket_page.js
+++ b/ecommerce/static/js/pages/basket_page.js
@@ -124,7 +124,7 @@ define([
 
             if (!CreditCardUtils.isValidCardNumber(cardNumber)) {
                 appendCardValidationErrorMsg(event, cardNumberField, 'Invalid card number');
-            } else if (typeof cardType === 'undefined') {
+            } else if (typeof cardType === 'undefined' || !isCardTypeSupported(cardType.name)) {
                 appendCardValidationErrorMsg(event, cardNumberField, 'Unsupported card type');
             } else if (cvnNumber.length !== cardType.cvnLength || !Number.isInteger(Number(cvnNumber))) {
                 appendCardValidationErrorMsg(event, cvnNumberField, 'Invalid CVN');
@@ -148,6 +148,11 @@ define([
             if (cardNumber.length > 12) {
                 card = CreditCardUtils.getCreditCardType(cardNumber);
 
+                if (!CreditCardUtils.isValidCardNumber(cardNumber)) {
+                    $('.card-type-icon').attr('src', '').addClass('hidden');
+                    return;
+                }
+
                 if (typeof card !== 'undefined') {
                     $('.card-type-icon').attr(
                         'src',
@@ -161,6 +166,10 @@ define([
             } else {
                 $('.card-type-icon').attr('src', '').addClass('hidden');
             }
+        },
+
+        isCardTypeSupported = function (cardType) {
+            return $.inArray(cardType, ['amex', 'discover', 'mastercard', 'visa']) > -1;
         },
 
         onReady = function() {
@@ -347,6 +356,7 @@ define([
             cardInfoValidation: cardInfoValidation,
             checkoutPayment: checkoutPayment,
             hideVoucherForm: hideVoucherForm,
+            isCardTypeSupported: isCardTypeSupported,
             onFail: onFail,
             onReady: onReady,
             onSuccess: onSuccess,

--- a/ecommerce/static/js/test/specs/pages/basket_page_spec.js
+++ b/ecommerce/static/js/test/specs/pages/basket_page_spec.js
@@ -184,12 +184,9 @@ define([
                 it('should recognize the credit card', function() {
                     var validCardList = [
                         {'number': '378282246310005', 'name': 'amex', 'type': '003'},
-                        {'number': '30569309025904', 'name': 'diners', 'type': '005'},
                         {'number': '6011111111111117', 'name': 'discover', 'type': '004'},
-                        {'number': '3530111333300000', 'name': 'jcb', 'type': '007'},
                         {'number': '5105105105105100', 'name': 'mastercard', 'type': '002'},
-                        {'number': '4111111111111111', 'name': 'visa', 'type': '001'},
-                        {'number': '6759649826438453', 'name': 'maestro', 'type': '042'}
+                        {'number': '4111111111111111', 'name': 'visa', 'type': '001'}
                     ];
                     BasketPage.onReady();
 
@@ -207,6 +204,19 @@ define([
                             '/static/images/credit_cards/' + card.name + '.png'
                         );
                         expect($('input[name=card_type]').val()).toEqual(card.type);
+                    });
+                });
+
+                it('should determine if credit card type is supported', function () {
+                    var validCardTypes = ['amex', 'discover', 'mastercard', 'visa'],
+                        invalidCardTypes = ['diners', 'jcb', 'maestro'];
+
+                    _.each(validCardTypes, function (cardType) {
+                        expect(BasketPage.isCardTypeSupported(cardType)).toBeTruthy();
+                    });
+
+                    _.each(invalidCardTypes, function (cardType) {
+                        expect(BasketPage.isCardTypeSupported(cardType)).toBeFalsy();
                     });
                 });
             });

--- a/ecommerce/static/js/utils/credit_card.js
+++ b/ecommerce/static/js/utils/credit_card.js
@@ -34,24 +34,9 @@ define([],function () {
                         cybersourceTypeId: '003',
                         cvnLength: 4
                     },
-                    diners: {
-                        regex: /^3(?:0[0-59]|[689]\d)\d{11}$/,
-                        cybersourceTypeId: '005',
-                        cvnLength: 3
-                    },
                     discover: {
                         regex: /^(6011\d{2}|65\d{4}|64[4-9]\d{3}|62212[6-9]|6221[3-9]\d|622[2-8]\d{2}|6229[01]\d|62292[0-5])\d{10,13}$/,  // jshint ignore:line
                         cybersourceTypeId: '004',
-                        cvnLength: 3
-                    },
-                    jcb: {
-                        regex: /^(?:2131|1800|35\d{3})\d{11}$/,
-                        cybersourceTypeId: '007',
-                        cvnLength: 4
-                    },
-                    maestro: {
-                        regex: /^(5[06789]|6\d)[0-9]{10,17}$/,
-                        cybersourceTypeId: '042',
                         cvnLength: 3
                     },
                     mastercard: {


### PR DESCRIPTION
@mjfrey @vkaracic @marjev https://openedx.atlassian.net/browse/SOL-2197
The following credit card types are supported: American express, discover, mastercard, visa.
I also included a card number check before the card image is displayed that means the image will not be displayed if the card number doesn't pass the validation.
For unsupported card types a message will appear
![screen shot 2017-01-27 at 13 29 56](https://cloud.githubusercontent.com/assets/16685686/22371136/940591ae-e495-11e6-8898-5fb0e46bcb36.png)
