### PR TITLE
Send identify events to Segment before page events from ecommerce

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -429,13 +429,6 @@ EXTRA_SCOPE = ['permissions']
 # END AUTHENTICATION
 
 
-# ANALYTICS
-# Specify a key to emit events to the corresponding Segment project. `None` disables tracking.
-# See: https://segment.com/docs/libraries/python/
-SEGMENT_KEY = None
-# END ANALYTICS
-
-
 # DJANGO REST FRAMEWORK
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (

--- a/ecommerce/static/js/test/specs/pages/basket_page_spec.js
+++ b/ecommerce/static/js/test/specs/pages/basket_page_spec.js
@@ -486,6 +486,8 @@ define([
                 });
 
                 it('should trigger page load analytics event', function() {
+                    $('<script type="text/javascript">var initModelData = {"course": {"courseId": "a/b/c"}};</script>')
+                        .appendTo('body');
                     AnalyticsUtils.analyticsSetUp();
                     expect(window.analytics.page).toHaveBeenCalled();
                 });

--- a/ecommerce/static/js/views/analytics_view.js
+++ b/ecommerce/static/js/views/analytics_view.js
@@ -42,6 +42,7 @@ define([
                     // kick off segment
                     this.initSegment(trackId);
                     this.logUser();
+                    this.recordPageData();
 
                     // now segment has been loaded, we can track events
                     this.listenTo(this.model, 'segment:track', this.track);
@@ -49,13 +50,12 @@ define([
             },
 
             /**
-             * This sets up Segment for our application and loads the initial
-             * page load.
+             * This sets up Segment for our application
              *
              * this.segment is set for convenience.
              */
             initSegment: function (applicationKey) {
-                var analytics, pageData;
+                var analytics;
 
                 /* jshint ignore:start */
                 // jscs:disable
@@ -65,20 +65,19 @@ define([
 
                 // provide our application key for logging
                 analytics.load(applicationKey);
-
-                pageData = this.getSegmentPageData();
-                analytics.page(pageData);
             },
 
             /**
-             * Get data for initializing segment.
+             * Get data for initializing segment and record the initial page load.
              */
-            getSegmentPageData: function () {
+            recordPageData: function () {
+                var pageData = {};
+
                 if (this.options.courseModel.get('courseId')) {
-                    return this.buildCourseProperties();
+                    pageData = this.buildCourseProperties();
                 }
 
-                return {};
+                analytics.page(pageData);
             },
 
             /**


### PR DESCRIPTION
ECOM-6650

Calling the logging of the user to segment before calling the tracking function, so events are attributed to the correct user.  Also, small cleanup of settings file.

@edx/ecommerce for review