### PR TITLE
ENT-169: Update offer's Range model to use course catalog query

### DIFF
--- a/ecommerce/coupons/tests/mixins.py
+++ b/ecommerce/coupons/tests/mixins.py
@@ -89,8 +89,8 @@ class CourseCatalogMockMixin(object):
 
         course_run_url_with_query_and_partner_code = '{}course_runs/?q={}&partner={}'.format(
             settings.COURSE_CATALOG_API_URL,
-            partner_code if partner_code else 'edx',
-            query if query else 'id:course*'
+            query if query else 'id:course*',
+            partner_code if partner_code else 'edx'
         )
         httpretty.register_uri(
             httpretty.GET,
@@ -127,6 +127,49 @@ class CourseCatalogMockMixin(object):
             httpretty.GET, course_run_url,
             body=course_run_info_json,
             content_type='application/json'
+        )
+
+    def mock_get_catalog_contains_api_for_failure(self, partner_code, course_run_ids, query, error):
+        """
+        Helper function to register a course catalog API endpoint with failure
+        for getting course runs information.
+        """
+        def callback(request, uri, headers):  # pylint: disable=unused-argument
+            raise error
+
+        catalog_contains_course_run_url = '{}course_runs/contains/?course_run_ids={}&query={}&partner={}'.format(
+            settings.COURSE_CATALOG_API_URL,
+            (course_run_id for course_run_id in course_run_ids),
+            query,
+            partner_code,
+        )
+        httpretty.register_uri(
+            method=httpretty.GET,
+            uri=catalog_contains_course_run_url,
+            responses=[
+                httpretty.Response(body=callback, content_type='application/json', status_code=500)
+            ]
+        )
+
+    def mock_get_catalog_course_runs_for_failure(self, partner_code, query, error):
+        """
+        Helper function to register a course catalog API endpoint with failure
+        for getting course runs information.
+        """
+        def callback(request, uri, headers):  # pylint: disable=unused-argument
+            raise error
+
+        course_run_url_with_query_and_partner_code = '{}course_runs/?q={}&partner={}'.format(
+            settings.COURSE_CATALOG_API_URL,
+            query,
+            partner_code,
+        )
+        httpretty.register_uri(
+            method=httpretty.GET,
+            uri=course_run_url_with_query_and_partner_code,
+            responses=[
+                httpretty.Response(body=callback, content_type='application/json', status_code=500)
+            ]
         )
 
 

--- a/ecommerce/courses/tests/mixins.py
+++ b/ecommerce/courses/tests/mixins.py
@@ -17,12 +17,11 @@ class CourseCatalogServiceMockMixin(object):
         super(CourseCatalogServiceMockMixin, self).setUp()
         cache.clear()
 
-    def mock_course_discovery_api_for_catalog_by_resource_id(self, catalog_query='title: *'):
+    def mock_course_discovery_api_for_catalog_by_resource_id(self, catalog_id=1, catalog_query='title: *'):
         """
         Helper function to register course catalog API endpoint for a
         single catalog with its resource id.
         """
-        catalog_id = 1
         course_discovery_api_response = {
             'id': catalog_id,
             'name': 'Catalog {}'.format(catalog_id),
@@ -122,15 +121,23 @@ class CourseCatalogServiceMockMixin(object):
             responses=mocked_api_responses
         )
 
-    def mock_course_discovery_api_for_failure(self):
+    def mock_course_discovery_api_for_catalogs_with_failure(self, error, catalog_id=None):
         """
-        Helper function to register course catalog API endpoint for a
-        failure.
+        Helper function to register course catalog API endpoint for catalogs
+        with failure.
         """
+        def callback(request, uri, headers):  # pylint: disable=unused-argument
+            raise error
+
+        if catalog_id:
+            course_catalog_uri = '{}{}/'.format(self.COURSE_DISCOVERY_CATALOGS_URL, catalog_id)
+        else:
+            course_catalog_uri = self.COURSE_DISCOVERY_CATALOGS_URL
+
         httpretty.register_uri(
             method=httpretty.GET,
-            uri=self.COURSE_DISCOVERY_CATALOGS_URL,
+            uri=course_catalog_uri,
             responses=[
-                httpretty.Response(body='Clunk', content_type='application/json', status_code=500)
+                httpretty.Response(body=callback, content_type='application/json', status_code=500)
             ]
         )

--- a/ecommerce/courses/tests/test_utils.py
+++ b/ecommerce/courses/tests/test_utils.py
@@ -3,6 +3,7 @@ import hashlib
 import ddt
 from django.core.cache import cache
 import httpretty
+from requests.exceptions import ConnectionError
 
 from ecommerce.core.constants import ENROLLMENT_CODE_SWITCH
 from ecommerce.core.tests import toggle_switch
@@ -175,7 +176,8 @@ class GetCourseCatalogUtilTests(CourseCatalogServiceMockMixin, TestCase):
         Verify that method "get_course_catalogs" raises exception in case
         the Course Discovery API fails to return data.
         """
-        self.mock_course_discovery_api_for_failure()
+        exception = ConnectionError
+        self.mock_course_discovery_api_for_catalogs_with_failure(exception)
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(exception):
             get_course_catalogs(self.request.site)

--- a/ecommerce/enterprise/tests/mixins.py
+++ b/ecommerce/enterprise/tests/mixins.py
@@ -110,7 +110,7 @@ class EnterpriseServiceMockMixin(object):
     def mock_enterprise_learner_api_for_learner_with_invalid_response(self):
         """
         Helper function to register enterprise learner API endpoint for a
-        learner with invalid API reponse structure.
+        learner with invalid API response structure.
         """
         enterprise_learner_api_response = {
             'count': 0,
@@ -135,6 +135,49 @@ class EnterpriseServiceMockMixin(object):
                                 }
                             ]
                         },
+                    }
+                }
+            ],
+            'next': None,
+            'start': 0,
+            'previous': None
+        }
+        enterprise_learner_api_response_json = json.dumps(enterprise_learner_api_response)
+
+        httpretty.register_uri(
+            method=httpretty.GET,
+            uri=self.ENTERPRISE_LEARNER_URL,
+            body=enterprise_learner_api_response_json,
+            content_type='application/json'
+        )
+
+    def mock_enterprise_learner_api_for_learner_with_invalid_entitlements_response(self):
+        """
+        Helper function to register enterprise learner API endpoint for a
+        learner with partial invalid API response structure for the enterprise
+        customer entitlements.
+        """
+        enterprise_learner_api_response = {
+            'count': 0,
+            'num_pages': 1,
+            'current_page': 1,
+            'results': [
+                {
+                    'enterprise_customer': {
+                        'uuid': 'cf246b88-d5f6-4908-a522-fc307e0b0c59',
+                        'name': 'TestShib',
+                        'catalog': 1,
+                        'active': True,
+                        'site': {
+                            'domain': 'example.com',
+                            'name': 'example.com'
+                        },
+                        'invalid-unexpected-enterprise_customer_entitlements-key': [
+                            {
+                                'enterprise_customer': 'cf246b88-d5f6-4908-a522-fc307e0b0c59',
+                                'entitlement_id': 1
+                            }
+                        ]
                     }
                 }
             ],

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -83,6 +83,11 @@ def retrieve_voucher(obj):
     return obj.attr.coupon_vouchers.vouchers.first()
 
 
+def retrieve_all_vouchers(obj):
+    """Helper method to retrieve all vouchers from coupon. """
+    return obj.attr.coupon_vouchers.vouchers.all()
+
+
 def retrieve_voucher_usage(obj):
     """Helper method to retrieve usage from voucher. """
     return retrieve_voucher(obj).usage

--- a/ecommerce/extensions/api/v2/tests/views/test_catalog.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_catalog.py
@@ -179,7 +179,7 @@ class CatalogViewSetTest(CatalogMixin, CourseCatalogMockMixin, CourseCatalogServ
         empty results list in case the Course Discovery API fails to return
         data.
         """
-        self.mock_course_discovery_api_for_failure()
+        self.mock_course_discovery_api_for_catalogs_with_failure(ConnectionError)
 
         request = self.prepare_request('/api/v2/coupons/course_catalogs/')
         response = CatalogViewSet().course_catalogs(request)


### PR DESCRIPTION
…nterprise coupon

ENT-169
@asadiqbal08 @saleem-latif @mattdrayer 

* Update the method `contains_product` of `Range` model to get the catalog query from the linked catalog in the course catalog service.
* Update the method `run_catalog_query` of `Range` model to use optional parameter `query` for custom catalog course run queries (in case of course catalog coupons)
* Add method `is_course_in_enterprise_courses` for verification that the basket product (course run) exists in the learner's related enterprise catalog.
* Remove the custom entitlement method `get_course_ids_from_voucher` for enterprise and use the updated method `contains_product` of `Range` model for checking the product in the enterprise entitlement/coupon course runs
* Fix bug [ENT-174](https://openedx.atlassian.net/browse/ENT-174): For enterprise entitlements, first verify that the basket product (course run) exists in the related enterprise catalog before checking the product in the related coupon course runs list
* Update auto entitlements to be able to use multiple coupon codes
* Add/Update unittests

## Testing Steps:
**Sandbox:** https://zubair-arbi.sandbox.edx.org/

As a staff user setup an enterprise with entitlements:
1. Add a course catalog in Discovery django admin: https://discovery-enterprise.sandbox.edx.org/admin/catalogs/catalog/
2. Add an enterprise using LMS django admin with course catalog created above: https://zubair-arbi.sandbox.edx.org/admin/enterprise/enterprisecustomer/
3. Use CAT tool in ECOM to add a catalog coupon (enrollment or discount) with with enterprise course catalog: https://ecommerce-zubair-arbi.sandbox.edx.org/coupons/
4. Add the newly created coupon id (get it from the coupon url, e.g. 65 in "https://ecommerce-zubair-arbi.sandbox.edx.org/coupons/65/") and add it in the section "Enterprise Customer Entitlements" in LMS django admin for enterprise.
5. Link some user/learner with the enterprise using LMS django admin: https://zubair-arbi.sandbox.edx.org/admin/enterprise/enterprisecustomeruser/add/

As an enterprise learner:
1. Try to enroll in the course available in the enterprise catalog and verify that the enterprise entitlement coupon voucher is automatically applied.
2. Remove the auto applied enterprise coupon.
3. Try to enroll in the course which is not available in the enterprise catalog and verify that the enterprise entitlement coupon voucher is not applied.

_**Note:** For testing you can use the enterprise learner "`zubair@edx.org`" and an existing course "https://zubair-arbi.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/about" which are linked with the enterprise "`Arbisoft ENT`" which has an enrollment discount coupon "https://ecommerce-zubair-arbi.sandbox.edx.org/coupons/65" available._