### PR TITLE
[WL-962] Prevent CyberSource Notify View from creating an order when the Otto Receipt Page is turned on

### DIFF
--- a/ecommerce/extensions/payment/tests/views/test_cybersource.py
+++ b/ecommerce/extensions/payment/tests/views/test_cybersource.py
@@ -35,6 +35,21 @@ class CybersourceNotifyViewTests(CybersourceNotificationTestsMixin, TestCase):
     path = reverse('cybersource_notify')
     view = CybersourceNotifyView
 
+    def setUp(self):
+        super(CybersourceNotifyViewTests, self).setUp()
+        self.site.siteconfiguration.enable_otto_receipt_page = False
+        self.site.siteconfiguration.save()
+
+    def test_otto_receipt_page_enabled(self):
+        """
+        Verify that the Notify view returns HTTP response with 200 status
+        when the Otto hosted receipt page is enabled.
+        """
+        self.site.siteconfiguration.enable_otto_receipt_page = True
+        self.site.siteconfiguration.save()
+        response = self.client.post(self.path)
+        self.assertEqual(response.status_code, 200)
+
 
 @ddt.ddt
 class CybersourceSubmitViewTests(CybersourceMixin, TestCase):

--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -271,6 +271,11 @@ class CybersourceNotifyView(CybersourceNotificationMixin, View):
     def post(self, request):
         """Process a CyberSource merchant notification and place an order for paid products as appropriate."""
 
+        # If the Otto receipt page is enabled, CyberSource Interstitial View
+        # should handle the CyberSource response
+        if request.site.siteconfiguration.enable_otto_receipt_page:
+            return HttpResponse()
+
         try:
             notification = request.POST.dict()
             basket = self.validate_notification(notification)


### PR DESCRIPTION
@mjfrey Here's the PR that adds the fix you proposed yesterday. Please take a look.

JIRA ticket: https://openedx.atlassian.net/browse/WL-962
