### PR TITLE
Upgrade nodeenv to 1.1.1

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -12,4 +12,4 @@ MySQL-python==1.2.5
 newrelic==2.74.0.54
 python-memcached==1.58
 PyYAML==3.12
-nodeenv==1.0.0
+nodeenv==1.1.1


### PR DESCRIPTION
This fixes a bug in the Ansible provisioning process where an existing nodeenv could fail to be created when the node version was changed.

See https://github.com/edx/configuration/pull/3648 and https://github.com/ekalinin/nodeenv/pull/183 for more details.