### PR TITLE
Sending notification after refund approval

### DIFF
--- a/ecommerce/core/constants.py
+++ b/ecommerce/core/constants.py
@@ -1,16 +1,14 @@
 """Constants core to the ecommerce app."""
+from __future__ import unicode_literals
 
-ISO_8601_FORMAT = u'%Y-%m-%dT%H:%M:%SZ'
-
+ISO_8601_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
 # Regex used to match course IDs.
 COURSE_ID_REGEX = r'[^/+]+(/|\+)[^/+]+(/|\+)[^/]+'
 COURSE_ID_PATTERN = r'(?P<course_id>{})'.format(COURSE_ID_REGEX)
 
-
 # Seat constants
-SEAT_PRODUCT_CLASS_NAME = "Seat"
-
+SEAT_PRODUCT_CLASS_NAME = 'Seat'
 
 # Enrollment Code constants
 ENROLLMENT_CODE_PRODUCT_CLASS_NAME = 'Enrollment Code'
@@ -23,11 +21,11 @@ DEFAULT_CATALOG_PAGE_SIZE = 100
 
 class Status(object):
     """Health statuses."""
-    OK = u"OK"
-    UNAVAILABLE = u"UNAVAILABLE"
+    OK = 'OK'
+    UNAVAILABLE = 'UNAVAILABLE'
 
 
 class UnavailabilityMessage(object):
     """Messages to be logged when services are unavailable."""
-    DATABASE = u"Unable to connect to database"
-    LMS = u"Unable to connect to LMS"
+    DATABASE = 'Unable to connect to database'
+    LMS = 'Unable to connect to LMS'

--- a/ecommerce/core/management/commands/create_or_update_site.py
+++ b/ecommerce/core/management/commands/create_or_update_site.py
@@ -106,6 +106,11 @@ class Command(BaseCommand):
                             type=str,
                             required=False,
                             help='URL displayed to user for payment support')
+        parser.add_argument('--send-refund-notifications',
+                            action='store_true',
+                            dest='send_refund_notifications',
+                            default=False,
+                            help='Enable refund notification emails')
 
     def handle(self, *args, **options):
         site_id = options.get('site_id')
@@ -149,6 +154,7 @@ class Command(BaseCommand):
             'segment_key': segment_key,
             'from_email': from_email,
             'enable_enrollment_codes': enable_enrollment_codes,
+            'send_refund_notifications': options['send_refund_notifications'],
             'oauth_settings': {
                 'SOCIAL_AUTH_EDX_OIDC_URL_ROOT': '{lms_url_root}/oauth2'.format(lms_url_root=lms_url_root),
                 'SOCIAL_AUTH_EDX_OIDC_KEY': client_id,

--- a/ecommerce/core/migrations/0023_siteconfiguration_send_refund_notifications.py
+++ b/ecommerce/core/migrations/0023_siteconfiguration_send_refund_notifications.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0022_auto_20161108_2101'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='siteconfiguration',
+            name='send_refund_notifications',
+            field=models.BooleanField(default=False, verbose_name='Send refund email notification'),
+        ),
+    ]

--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -126,6 +126,11 @@ class SiteConfiguration(models.Model):
         blank=True,
         default=False
     )
+    send_refund_notifications = models.BooleanField(
+        verbose_name=_('Send refund email notification'),
+        blank=True,
+        default=False
+    )
 
     class Meta(object):
         unique_together = ('site', 'partner')

--- a/ecommerce/extensions/api/v2/tests/views/test_refunds.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_refunds.py
@@ -228,7 +228,7 @@ class RefundProcessViewTests(ThrottlingMixin, TestCase):
                 refund = Refund.objects.get(id=self.refund.id)
                 self.assertEqual(response.data['status'], refund.status)
                 self.assertEqual(response.data['status'], "Complete")
-                patched_log.info.assert_called_once_with(
+                patched_log.info.assert_called_with(
                     "Skipping the revocation step for refund [%d].", self.refund.id)
 
     @ddt.data(

--- a/ecommerce/extensions/checkout/utils.py
+++ b/ecommerce/extensions/checkout/utils.py
@@ -1,14 +1,13 @@
 import logging
 import urllib
 
-from babel.numbers import format_currency
+from babel.numbers import format_currency as default_format_currency
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.utils.translation import get_language, to_locale
 from edx_rest_api_client.client import EdxRestApiClient
 from requests.exceptions import ConnectionError, Timeout
 from slumber.exceptions import SlumberHttpBaseException
-
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +59,18 @@ def get_receipt_page_url(site_configuration, order_number=None, override_url=Non
     )
 
 
+def format_currency(currency, amount, format=None, locale=None):  # pylint: disable=redefined-builtin
+    locale = locale or to_locale(get_language())
+    format = format or getattr(settings, 'OSCAR_CURRENCY_FORMAT', None)
+
+    return default_format_currency(
+        amount,
+        currency,
+        format=format,
+        locale=locale
+    )
+
+
 def add_currency(amount):
     """ Adds currency to the price amount.
 
@@ -69,9 +80,4 @@ def add_currency(amount):
     Returns:
         str: Formatted price with currency.
     """
-    return format_currency(
-        amount,
-        settings.OSCAR_DEFAULT_CURRENCY,
-        format=u'#,##0.00',
-        locale=to_locale(get_language())
-    )
+    return format_currency(settings.OSCAR_DEFAULT_CURRENCY, amount, u'#,##0.00')

--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -15,7 +15,7 @@ from rest_framework import status
 import requests
 from requests.exceptions import ConnectionError, Timeout
 
-from ecommerce.core.constants import ENROLLMENT_CODE_PRODUCT_CLASS_NAME
+from ecommerce.core.constants import ENROLLMENT_CODE_PRODUCT_CLASS_NAME, SEAT_PRODUCT_CLASS_NAME
 from ecommerce.core.url_utils import get_lms_enrollment_api_url
 from ecommerce.courses.models import Course
 from ecommerce.courses.utils import mode_for_seat
@@ -125,7 +125,7 @@ class EnrollmentFulfillmentModule(BaseFulfillmentModule):
         return requests.post(enrollment_api_url, data=json.dumps(data), headers=headers, timeout=timeout)
 
     def supports_line(self, line):
-        return line.product.get_product_class().name == 'Seat'
+        return line.product.get_product_class().name == SEAT_PRODUCT_CLASS_NAME
 
     def get_supported_lines(self, lines):
         """ Return a list of lines that can be fulfilled through enrollment.

--- a/ecommerce/extensions/refund/models.py
+++ b/ecommerce/extensions/refund/models.py
@@ -1,15 +1,20 @@
+from __future__ import unicode_literals
+
 import logging
 
 from django.conf import settings
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django_extensions.db.models import TimeStampedModel
+from ecommerce_worker.sailthru.v1.tasks import send_course_refund_email
 from oscar.apps.payment.exceptions import PaymentError
 from oscar.core.loading import get_class, get_model
 from oscar.core.utils import get_default_currency
 from simple_history.models import HistoricalRecords
 
+from ecommerce.core.constants import SEAT_PRODUCT_CLASS_NAME
 from ecommerce.extensions.analytics.utils import audit_log
+from ecommerce.extensions.checkout.utils import get_receipt_page_url, format_currency
 from ecommerce.extensions.fulfillment.api import revoke_fulfillment_for_refund
 from ecommerce.extensions.order.constants import PaymentEventTypeName
 from ecommerce.extensions.payment.helpers import get_processor_class_by_name
@@ -186,6 +191,39 @@ class Refund(StatusMixin, TimeStampedModel):
             # This occurs when attempting to refund free orders.
             logger.info("No payments to credit for Refund [%d]", self.id)
 
+    def _notify_purchaser(self):
+        """ Notify the purchaser that the refund has been processed. """
+        site_configuration = self.order.site.siteconfiguration
+        site_code = site_configuration.partner.short_code
+
+        if not site_configuration.send_refund_notifications:
+            logger.info(
+                'Refund notifications are disabled for Partner [%s]. No notification will be sent for Refund [%d]',
+                site_code, self.id
+            )
+            return
+
+        # NOTE (CCB): The initial version of the refund email only supports refunding a single course.
+        product = self.lines.first().order_line.product
+        product_class = product.get_product_class().name
+
+        if product_class != SEAT_PRODUCT_CLASS_NAME:
+            logger.warning(
+                ('No refund notification will be sent for Refund [%d]. The notification supports product lines '
+                 'of type Course, not [%s].'),
+                self.id, product_class
+            )
+            return
+
+        course_name = self.lines.first().order_line.product.course.name
+        order_number = self.order.number
+        order_url = get_receipt_page_url(site_configuration, order_number)
+        amount = format_currency(self.currency, self.total_credit_excl_tax)
+
+        send_course_refund_email.delay(self.user.email, self.id, amount, course_name, order_number,
+                                       order_url, site_code=site_code)
+        logger.info('Course refund notification scheduled for Refund [%d].', self.id)
+
     def _revoke_lines(self):
         """Revoke fulfillment for the lines in this Refund."""
         if revoke_fulfillment_for_refund(self):
@@ -202,6 +240,7 @@ class Refund(StatusMixin, TimeStampedModel):
             try:
                 self._issue_credit()
                 self.set_status(REFUND.PAYMENT_REFUNDED)
+                self._notify_purchaser()
             except PaymentError:
                 logger.exception('Failed to issue credit for refund [%d].', self.id)
                 self.set_status(REFUND.PAYMENT_REFUND_ERROR)

--- a/ecommerce/extensions/refund/tests/mixins.py
+++ b/ecommerce/extensions/refund/tests/mixins.py
@@ -70,8 +70,8 @@ class RefundTestMixin(CourseCatalogTestMixin):
             self.assertEqual(refund_line.line_credit_excl_tax, order_line.line_price_excl_tax)
             self.assertEqual(refund_line.quantity, order_line.quantity)
 
-    def create_refund(self, processor_name=DummyProcessor.NAME):
-        refund = RefundFactory()
+    def create_refund(self, processor_name=DummyProcessor.NAME, **kwargs):
+        refund = RefundFactory(**kwargs)
         order = refund.order
         source_type, __ = SourceType.objects.get_or_create(name=processor_name)
         Source.objects.create(source_type=source_type, order=order, currency=refund.currency,

--- a/ecommerce/tests/factories.py
+++ b/ecommerce/tests/factories.py
@@ -28,6 +28,7 @@ class SiteConfigurationFactory(factory.DjangoModelFactory):
     lms_url_root = factory.LazyAttribute(lambda obj: "http://lms.testserver.fake")
     site = factory.SubFactory(SiteFactory)
     partner = factory.SubFactory(PartnerFactory)
+    send_refund_notifications = False
 
 
 class StockRecordFactory(OscarStockRecordFactory):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,7 +19,7 @@ edx-auth-backends==0.6.0
 edx-django-release-util==0.2.0
 edx-django-sites-extensions==1.0.0
 edx-drf-extensions==1.2.2
-edx-ecommerce-worker==0.5.0
+edx-ecommerce-worker==0.6.0
 edx-opaque-keys==0.3.1
 edx-rest-api-client==1.6.0
 jsonfield==1.0.3


### PR DESCRIPTION
An email is now sent to learners after a credit is issued for a refund. This functionality can be controlled for each site, and is only applicable for refunds of a course seat.

ECOM-6975