### PR TITLE
ENT-134: Add consent gate when redeeming coupons from enterprise customers

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -283,6 +283,15 @@ class SiteConfiguration(models.Model):
         """
         return urljoin(self.lms_url_root, path)
 
+    def build_enterprise_service_url(self, path=''):
+        """
+        Returns path joined with the appropriate Enterprise service URL root for the current site.
+
+        Returns:
+            str
+        """
+        return urljoin(settings.ENTERPRISE_SERVICE_URL, path)
+
     @property
     def commerce_api_url(self):
         """ Returns the URL for the root of the Commerce API (hosted by LMS). """
@@ -311,7 +320,12 @@ class SiteConfiguration(models.Model):
     @property
     def enterprise_api_url(self):
         """ Returns the URL for the Enterprise service. """
-        return self.build_lms_url('/enterprise/api/v1')
+        return settings.ENTERPRISE_API_URL
+
+    @property
+    def enterprise_grant_data_sharing_url(self):
+        """ Returns the URL for the Enterprise data sharing permission view. """
+        return self.build_enterprise_service_url('grant_data_sharing_permissions')
 
     @property
     def access_token(self):
@@ -365,7 +379,7 @@ class SiteConfiguration(models.Model):
             EdxRestApiClient: The client to access the Enterprise service.
 
         """
-        return EdxRestApiClient(settings.ENTERPRISE_API_URL, jwt=self.access_token)
+        return EdxRestApiClient(self.enterprise_api_url, jwt=self.access_token)
 
     @cached_property
     def user_api_client(self):

--- a/ecommerce/enterprise/exceptions.py
+++ b/ecommerce/enterprise/exceptions.py
@@ -1,0 +1,10 @@
+"""
+Exceptions used by the Enterprise app.
+"""
+
+
+class EnterpriseDoesNotExist(Exception):
+    """
+    Exception for errors related to Enterprise service data.
+    """
+    pass

--- a/ecommerce/enterprise/tests/test_utils.py
+++ b/ecommerce/enterprise/tests/test_utils.py
@@ -1,0 +1,65 @@
+from __future__ import unicode_literals
+
+import ddt
+import httpretty
+
+from ecommerce.core.tests.decorators import mock_enterprise_api_client
+from ecommerce.enterprise.utils import get_enterprise_customer, get_or_create_enterprise_customer_user
+from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
+from ecommerce.tests.testcases import TestCase
+
+
+TEST_ENTERPRISE_CUSTOMER_UUID = 'cf246b88-d5f6-4908-a522-fc307e0b0c59'
+
+
+@ddt.ddt
+@httpretty.activate
+class EnterpriseUtilsTests(EnterpriseServiceMockMixin, TestCase):
+    def setUp(self):
+        super(EnterpriseUtilsTests, self).setUp()
+        self.learner = self.create_user(is_staff=True)
+        self.client.login(username=self.learner.username, password=self.password)
+
+    def test_get_enterprise_customer(self):
+        """
+        Verify that "get_enterprise_customer" returns an appropriate response from the
+        "enterprise-customer" Enterprise service API endpoint.
+        """
+        self.mock_specific_enterprise_customer_api(TEST_ENTERPRISE_CUSTOMER_UUID)
+        response = get_enterprise_customer(self.site, self.learner.access_token, TEST_ENTERPRISE_CUSTOMER_UUID)
+
+        self.assertEqual(TEST_ENTERPRISE_CUSTOMER_UUID, response.get('id'))
+
+    @mock_enterprise_api_client
+    @ddt.data(
+        (
+            ['mock_enterprise_learner_api'],
+            {'user_id': 5},
+        ),
+        (
+            [
+                'mock_enterprise_learner_api_for_learner_with_no_enterprise',
+                'mock_enterprise_learner_post_api',
+            ],
+            {
+                'enterprise_customer': 'cf246b88-d5f6-4908-a522-fc307e0b0c59',
+                'username': 'the_j_meister',
+            },
+        )
+    )
+    @ddt.unpack
+    def test_post_enterprise_customer_user(self, mock_helpers, expected_return):
+        """
+        Verify that "get_enterprise_customer" returns an appropriate response from the
+        "enterprise-customer" Enterprise service API endpoint.
+        """
+        for mock in mock_helpers:
+            getattr(self, mock)()
+
+        response = get_or_create_enterprise_customer_user(
+            self.site,
+            TEST_ENTERPRISE_CUSTOMER_UUID,
+            self.learner.username
+        )
+
+        self.assertDictContainsSubset(expected_return, response)

--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -1,8 +1,21 @@
 """
 Helper methods for enterprise app.
 """
+import hashlib
+import hmac
+from urllib import urlencode
+
 from django.conf import settings
+from django.core.urlresolvers import reverse
+from edx_rest_api_client.client import EdxRestApiClient
+from oscar.core.loading import get_model
 import waffle
+from slumber.exceptions import HttpNotFoundError
+
+from ecommerce.courses.utils import traverse_pagination
+from ecommerce.enterprise.exceptions import EnterpriseDoesNotExist
+
+ConditionalOffer = get_model('offer', 'ConditionalOffer')
 
 
 def is_enterprise_feature_enabled():
@@ -20,3 +33,134 @@ def is_enterprise_feature_enabled():
     """
     is_enterprise_enabled = waffle.switch_is_active(settings.ENABLE_ENTERPRISE_ON_RUNTIME_SWITCH)
     return is_enterprise_enabled
+
+
+def get_enterprise_customer(site, token, uuid):
+    """
+    Return a single enterprise customer
+    """
+    client = EdxRestApiClient(
+        site.siteconfiguration.enterprise_api_url,
+        oauth_access_token=token
+    )
+    path = ['enterprise-customer', str(uuid)]
+    client = reduce(getattr, path, client)
+
+    try:
+        response = client.get()
+    except HttpNotFoundError:
+        return None
+    return {
+        'name': response['name'],
+        'id': response['uuid'],
+        'enable_data_sharing_consent': response['enable_data_sharing_consent'],
+    }
+
+
+def get_enterprise_customers(site, token):
+    resource = 'enterprise-customer'
+    client = EdxRestApiClient(
+        site.siteconfiguration.enterprise_api_url,
+        oauth_access_token=token
+    )
+    endpoint = getattr(client, resource)
+    response = endpoint.get()
+    return [
+        {
+            'name': each['name'],
+            'id': each['uuid'],
+        }
+        for each in traverse_pagination(response, endpoint)
+    ]
+
+
+def get_or_create_enterprise_customer_user(site, enterprise_customer_uuid, username):
+    """
+    Create a new EnterpriseCustomerUser on the enterprise service if one doesn't already exist.
+    Return the EnterpriseCustomerUser data.
+    """
+    data = {
+        'enterprise_customer': str(enterprise_customer_uuid),
+        'username': username,
+    }
+    api_resource_name = 'enterprise-learner'
+    api = site.siteconfiguration.enterprise_api_client
+    endpoint = getattr(api, api_resource_name)
+
+    get_response = endpoint.get(**data)
+    if get_response.get('count') == 1:
+        result = get_response['results'][0]
+        return result
+
+    response = endpoint.post(data)
+    return response
+
+
+def get_enterprise_customer_from_voucher(site, token, voucher):
+    """
+    Given a Voucher, find the associated Enterprise Customer and retrieve data about
+    that customer from the Enterprise service. If there is no Enterprise Customer
+    associated with the Voucher, `None` is returned.
+    """
+    try:
+        offer = voucher.offers.get(benefit__range__enterprise_customer__isnull=False)
+    except ConditionalOffer.DoesNotExist:
+        # There's no Enterprise Customer associated with this voucher.
+        return None
+
+    # Get information about the enterprise customer from the Enterprise service.
+    enterprise_customer_uuid = offer.benefit.range.enterprise_customer
+    enterprise_customer = get_enterprise_customer(site, token, enterprise_customer_uuid)
+    if enterprise_customer is None:
+        raise EnterpriseDoesNotExist(
+            'Enterprise customer with UUID {uuid} does not exist in the Enterprise service.'.format(
+                uuid=enterprise_customer_uuid
+            )
+        )
+
+    return enterprise_customer
+
+
+def get_enterprise_course_consent_url(site, code, sku, consent_token, course_id, enterprise_customer_uuid):
+    """
+    Construct the URL that should be used for redirecting the user to the Enterprise service for
+    collecting consent. The URL contains a specially crafted "next" parameter that will result
+    in the user being redirected back to the coupon redemption view with the verified consent token.
+    """
+    callback_url = '{protocol}://{domain}{resource}?{params}'.format(
+        protocol=settings.PROTOCOL,
+        domain=site.domain,
+        resource=reverse('coupons:redeem'),
+        params=urlencode({
+            'code': code,
+            'sku': sku,
+            'consent_token': consent_token,
+        })
+    )
+    request_params = {
+        'course_id': course_id,
+        'enterprise_id': enterprise_customer_uuid,
+        'enrollment_deferred': True,
+        'next': callback_url,
+    }
+    redirect_url = '{base}?{params}'.format(
+        base=site.siteconfiguration.enterprise_grant_data_sharing_url,
+        params=urlencode(request_params)
+    )
+    return redirect_url
+
+
+def get_enterprise_customer_data_sharing_consent_token(access_token, course_id, enterprise_customer_uuid):
+    """
+    Generate a sha256 hmac token unique to an end-user Access Token, Course, and
+    Enterprise Customer combination.
+    """
+    consent_token_hmac = hmac.new(
+        str(access_token),
+        '{course_id}_{enterprise_uuid}'.format(
+            course_id=course_id,
+            enterprise_uuid=enterprise_customer_uuid,
+        ),
+        digestmod=hashlib.sha256,
+    )
+    return consent_token_hmac.hexdigest()

--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -23,7 +23,7 @@ class TestEnterpriseCustomerView(TestCase):
         ]
     }
 
-    @mock.patch('ecommerce.extensions.api.v2.views.enterprise.EdxRestApiClient')
+    @mock.patch('ecommerce.enterprise.utils.EdxRestApiClient')
     def test_get_customers(self, mock_client):
         instance = mock_client.return_value
         setattr(

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -1,9 +1,8 @@
-from edx_rest_api_client.client import EdxRestApiClient
 from rest_framework import generics
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from rest_framework.response import Response
 
-from ecommerce.courses.utils import traverse_pagination
+from ecommerce.enterprise.utils import get_enterprise_customers
 
 
 class EnterpriseCustomerViewSet(generics.GenericAPIView):
@@ -13,20 +12,3 @@ class EnterpriseCustomerViewSet(generics.GenericAPIView):
     def get(self, request):
         site = request.site
         return Response(data={'results': get_enterprise_customers(site, token=request.user.access_token)})
-
-
-def get_enterprise_customers(site, token):
-    resource = 'enterprise-customer'
-    client = EdxRestApiClient(
-        site.siteconfiguration.enterprise_api_url,
-        oauth_access_token=token
-    )
-    endpoint = getattr(client, resource)
-    response = endpoint.get()
-    return [
-        {
-            'name': each['name'],
-            'id': each['uuid'],
-        }
-        for each in traverse_pagination(response, endpoint)
-    ]

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -576,8 +576,8 @@ AFFILIATE_COOKIE_KEY = 'affiliate_id'
 CRISPY_TEMPLATE_PACK = 'bootstrap3'
 
 # ENTERPRISE APP CONFIGURATION
-# URL for Enterprise service API
-ENTERPRISE_API_URL = 'http://localhost:8000/enterprise/api/v1/'
+# URL for Enterprise service
+ENTERPRISE_SERVICE_URL = 'http://localhost:8000/enterprise/'
 # Cache enterprise response from Enterprise API.
 ENTERPRISE_API_CACHE_TIMEOUT = 3600  # Value is in seconds
 

--- a/ecommerce/settings/devstack.py
+++ b/ecommerce/settings/devstack.py
@@ -3,6 +3,7 @@ from ecommerce.settings.production import *
 
 DEBUG = True
 ENABLE_AUTO_AUTH = True
+PROTOCOL = 'http'
 
 # Docker does not support the syslog socket at /dev/log. Rely on the console.
 LOGGING['handlers']['local'] = {

--- a/ecommerce/settings/local.py
+++ b/ecommerce/settings/local.py
@@ -1,5 +1,6 @@
 """Development settings and globals."""
 from __future__ import absolute_import
+from urlparse import urljoin
 
 from ecommerce.settings.base import *
 
@@ -120,3 +121,5 @@ ENABLE_AUTO_AUTH = True
 # Lastly, see if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
     from .private import *  # pylint: disable=import-error
+
+ENTERPRISE_API_URL = urljoin(ENTERPRISE_SERVICE_URL, 'api/v1/')

--- a/ecommerce/settings/production.py
+++ b/ecommerce/settings/production.py
@@ -1,5 +1,6 @@
 """Production settings and globals."""
 from os import environ
+from urlparse import urljoin
 
 # Normally you should not import ANYTHING from Django directly
 # into your settings, but ImproperlyConfigured is an exception.
@@ -9,6 +10,9 @@ import yaml
 
 from ecommerce.settings.base import *
 
+
+# Protocol used for construcing absolute callback URLs
+PROTOCOL = 'https'
 
 # Enable offline compression of CSS/JS
 COMPRESS_ENABLED = True
@@ -79,3 +83,5 @@ for __, configs in PAYMENT_PROCESSOR_CONFIG.iteritems():
             'error_path': PAYMENT_PROCESSOR_ERROR_PATH,
         })
 # END PAYMENT PROCESSOR OVERRIDES
+
+ENTERPRISE_API_URL = urljoin(ENTERPRISE_SERVICE_URL, 'api/v1/')

--- a/ecommerce/settings/test.py
+++ b/ecommerce/settings/test.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import
 
 from path import Path
+from urlparse import urljoin
 
 from ecommerce.settings.base import *
 
 
 SITE_ID = 1
+PROTOCOL = 'http'
 
 # TEST SETTINGS
 INSTALLED_APPS += (
@@ -142,3 +144,5 @@ COMPREHENSIVE_THEME_DIRS = [
 ]
 
 DEFAULT_SITE_THEME = "test-theme"
+
+ENTERPRISE_API_URL = urljoin(ENTERPRISE_SERVICE_URL, 'api/v1/')

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ edx-django-sites-extensions==1.0.0
 edx-drf-extensions==1.2.2
 edx-ecommerce-worker==0.6.0
 edx-opaque-keys==0.3.1
-edx-rest-api-client==1.6.0
+edx-rest-api-client==1.7.1
 jsonfield==1.0.3
 libsass==0.9.2
 ndg-httpsclient==0.4.0


### PR DESCRIPTION
This PR is based on [#1101](https://github.com/edx/ecommerce/pull/1101), which needs to be merged first. For now, view the commit directly to see the diff of this PR.

This PR implements consent gating for coupon use by redirecting the user to the LMS course-specific consent UI when an enterprise customer is associated with a coupon. However, the coupon is not consumed nor does the user have to be associated with an Enterprise Customer until after consent is given and the order has been fulfilled.

This is achieved by a [change in edx-enterprise](https://github.com/edx/edx-enterprise/pull/40), where an option "enrollment_deferred" is added to allow removing the assumption that a user has an EnterpriseCourseEnrollment. For validating consent, this change leverages the redirect URL passed via the "next" GET parameter to the enterprise consent view.

- Say the user visits a coupon redeem URL (e.g. `/coupons/redeem/?code=IYO3SSQVEMHY2R5S&sku=BB3ECA9`), the view checks for the presence of a `consent_token` in the GET parameters (`content_token` has three degrees of uniqueness; the current OAuth2 access token (as the hmac key), the voucher ID, and the Enterprise Customer UUID).
- Because there isn't a `consent_token` in the URL, the view constructs a redirect to the enterprise consent page in the LMS, but with `enrollment_deferred` enabled and a `next` parameter containing an absolute URL that looks something like this (notice it's the same URL as before, but with the added `content_token` parameter):
    ```
    http://localhost:8002/coupons/redeem/?code=IYO3SSQVEMHY2R5S&sku=BB3ECA9&consent_token=524684104aecccb220ee362e4fccb57ce72f03fb1359970b6556a9f7d808695c
    ```
- So after the user provides consent and presses "Submit", they're redirected to the URL provided in the `next` parameter, which provides a `consent_token`.
- Now that the `consent_token` has been given, the coupon redeem view validates that it's correct before processing the coupon and order.

The security lies in the fact that constructing the valid `consent_token` requires knowledge of the user's current OAuth2 access token with the LMS. So for a third party adversary, constructing a URL that directly enrolls a user without asking for consent isn't feasible.

**JIRA tickets**: ENT-134.

**Dependencies**: #1101 and https://github.com/edx/edx-enterprise/pull/40

**Testing instructions**:

Initial setup:
1. Setup a devstack.
1. Override the edx-enterprise version with the [correct branch](https://github.com/edx/edx-enterprise/pull/40):
   ```
   /edx/bin/pip.edxapp install -e git+https://github.com/open-craft/edx-enterprise.git@bdero/optional-consent-enrollment#egg=edx-enterprise==optional-consent-enrollment
   /edx/bin/manage.edxapp lms migrate --settings=devstack
   ```
1. Checkout this branch (open-craft:bdero/coupon-enrollment-consent) for ecommerce.
1. Connect [ecommerce to the LMS](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/ecommerce/install_ecommerce.html#configure-edx-openid-connect-oidc).
1. (Optionally) setup the [course discovery](https://open-edx-course-catalog.readthedocs.io/en/latest/getting_started.html) service and [connect it to the LMS](https://open-edx-course-catalog.readthedocs.io/en/latest/oidc.html).
1. Create an Enterprise Customer in the LMS: http://localhost:8000/admin/enterprise/enterprisecustomer/add/
    1. Give it any name.
    1. Check the **Enable data sharing consent** box.
    1. For **Enforce data sharing consent**, select **At Enrollment**.
1. Add a new Course in Ecommerce: http://localhost:8002/courses/new/
    1. For the course ID, use "course-v1:edX+DemoX+Demo_Course".
    1. Name it "edX Demonstration Course".
    1. Choose "Professional Education" for the Course Type.
1. Create a new Coupon in Ecommerce: http://localhost:8002/coupons/new
    1. Give it any Coupon Name.
    1. Under Code Type choose "Enrollment Code".
    1. Give it a valid date range that includes today.
    1. For Client, type any name. E.g. "Some Client".
    1. Select the "Single course" radio button.
    1. For the Course ID, use "course-v1:edX+DemoX+Demo_Course"
    1. The only available Seat Type should be automatically populated: "Professional"
    1. For the Enterprise Customer, select the name of the customer created in step 6.

Testing the PR:
1. Navigate to the [coupon list](http://localhost:8002/coupons/) and click "Download Coupon Report" to retrieve a CSV containing the coupon URL.
    ![coupon report button screenshot](https://i.imgur.com/icRxZMr.png)
1. Log out of the LMS/ecommerce.
1. The coupon report CSV should contain an offer URL that looks like this:
    ```
    http://localhost:8002/coupons/offer/?code=EGGZYLXDKNZK6W7C
    ```
    Navigate to that URL.
1. The first screen is the offer landing page.
    ![offer landing page screenshot](https://i.imgur.com/Ppfb6OC.png)
    Click "Enroll Now".
1. Next, you should be redirected to the LMS to login.
    ![login page screenshot](https://i.imgur.com/WuMSvC5.png)
    Login using a user that's not already enrolled in the Demo course.
1. Upon logging in, you should be redirected to the course-specific Data Sharing Consent screen. The correct Enterprise Customer name and Course name should show up in the dialog.
    ![data sharing consent screenshot](https://i.imgur.com/vxA01hn.png)
    **Leave the "I agree" checkbox unchecked** and click Submit.
1. An alert dialog should show up alerting you that if you don't agree, you won't be given access to the course. Click Ok and note that you're redirected to the dashboard.
1. Navigate back to the offer URL (from step 3). This time, **check the "I agree" box** and click Submit. You should be redirected to the dashboard and now be enrolled in the course.
1. Navigate to the offer URL (from step 3) again. This time, there should be an error saying "This coupon has already been used."
    ![coupon error screenshot](https://i.imgur.com/P8y9ev1.png)
1. Verify that there is a new EnterpriseCustomerUser (se the [admin view](http://localhost:8000/admin/enterprise/enterprisecustomeruser/)) that links the EnterpriseCustomer and User.

**Reviewers**
- [ ] OpenCraft: @mtyaka 
- [ ] edX: @mattdrayer 