### PR TITLE
Get account details with site configuration access token

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -425,7 +425,7 @@ class User(AbstractUser):
         try:
             api = EdxRestApiClient(
                 request.site.siteconfiguration.build_lms_url('/api/user/v1'),
-                oauth_access_token=self.access_token,
+                jwt=request.site.siteconfiguration.access_token,
                 append_slash=False
             )
             response = api.accounts(self.username).get()

--- a/ecommerce/core/tests/test_models.py
+++ b/ecommerce/core/tests/test_models.py
@@ -98,6 +98,17 @@ class UserTests(CourseCatalogTestMixin, LmsApiMockMixin, TestCase):
         self.mock_account_api(self.request, user.username, data=user_details)
         self.assertDictEqual(user.account_details(self.request), user_details)
 
+    def test_user_details_uses_jwt(self):
+        """Verify user_details uses jwt from site configuration to call EdxRestApiClient."""
+        user = self.create_user()
+        with mock.patch("ecommerce.core.models.EdxRestApiClient") as patched_info:
+            user.account_details(self.request)
+            patched_info.assert_called_once_with(
+                self.request.site.siteconfiguration.build_lms_url('/api/user/v1'),
+                append_slash=False,
+                jwt=self.request.site.siteconfiguration.access_token
+            )
+
     def test_no_user_details(self):
         """ Verify False is returned when there is a connection error. """
         user = self.create_user()


### PR DESCRIPTION
@clintonb Did I understand your comment correctly https://openedx.atlassian.net/browse/SOL-2163?focusedCommentId=241447&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-241447
Instead of using the users access token we should use site configuration access token on every server-to-server API call?
If that's the case can you tell me what I'm missing because the change doesn't work. The 401 HttpClientError is still getting raised.