### PR TITLE
Updated refund processing methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "requirejs": "^2.1.18"
   },
   "devDependencies": {
-    "geckodriver": "^1.1.3",
+    "geckodriver": "^1.3.0",
     "gulp": "^3.9.0",
     "gulp-jscs": "3.0.0",
     "gulp-jshint": "1.12.0",


### PR DESCRIPTION
- Attempts to approve previously-approved refunds return True
- Attempts to approve refunds in an incorrect state are logged as warnings instead of debug
- Removed unnecessary mocking in test_success_approve_payment_only

ECOM-6975