### PR TITLE
ECOM-6928 : Revert [SOL-2083] Because it enables student to create multiple orders for same course seat

### DIFF
--- a/ecommerce/extensions/basket/tests/test_views.py
+++ b/ecommerce/extensions/basket/tests/test_views.py
@@ -168,13 +168,12 @@ class BasketSingleItemViewTests(CouponMixin, CourseCatalogTestMixin, CourseCatal
         """
         course = CourseFactory()
         self.mock_enrollment_api_success_enrolled(course.id, mode=mode)
-        product = course.create_or_update_seat(mode, id_verification, 0, self.partner)
+        product = course.create_or_update_seat(mode, id_verification, 0, self.partner, create_enrollment_code=False)
         stock_record = StockRecordFactory(product=product, partner=self.partner)
         catalog = Catalog.objects.create(partner=self.partner)
         catalog.stock_records.add(stock_record)
-        self.create_coupon(catalog=catalog, code=COUPON_CODE, benefit_value=5)
 
-        url = '{path}?sku={sku}&code={code}'.format(path=self.path, sku=stock_record.partner_sku, code=COUPON_CODE)
+        url = '{path}?sku={sku}'.format(path=self.path, sku=stock_record.partner_sku)
         expected_content = 'You are already enrolled in {product}.'.format(product=product.course.name)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 400)
@@ -204,6 +203,30 @@ class BasketSingleItemViewTests(CouponMixin, CourseCatalogTestMixin, CourseCatal
         self.assertEqual(response.wsgi_request.GET['sku'], sku)
 
     @httpretty.activate
+    @ddt.data(('verified', False), ('professional', True), ('no-id-professional', False))
+    @ddt.unpack
+    def test_enrolled_verified_student_for_enrollment_code(self, mode, id_verification):
+        """
+        Verify the view return HTTP 303 if the student is enrolled as verified and purchasing enrollment code
+        (The Enrollment API call being used returns an inactive enrollment record in this case)
+        """
+        course = CourseFactory()
+        self.mock_enrollment_api_success_enrolled(course.id, mode=mode)
+        toggle_switch(ENROLLMENT_CODE_SWITCH, True)
+        course.create_or_update_seat(mode, id_verification, 10, self.partner, create_enrollment_code=True)
+        product = Product.objects.get(product_class__name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME)
+        stock_record = StockRecordFactory(product=product, partner=self.partner)
+        catalog = Catalog.objects.create(partner=self.partner)
+        catalog.stock_records.add(stock_record)
+
+        url = '{path}?sku={sku}'.format(path=self.path, sku=stock_record.partner_sku)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 303)
+        self.assertEqual(response.reason_phrase, "SEE OTHER")
+        self.assertEqual(response.wsgi_request.path_info, '/basket/single-item/')
+        self.assertEqual(response.wsgi_request.GET['sku'], stock_record.partner_sku)
+
+    @httpretty.activate
     @ddt.data(ConnectionError, SlumberBaseException, Timeout)
     def test_enrollment_api_failure(self, error):
         """
@@ -211,8 +234,7 @@ class BasketSingleItemViewTests(CouponMixin, CourseCatalogTestMixin, CourseCatal
         """
         self.request.user = self.user
         self.mock_enrollment_api_error(self.request, self.user, self.course.id, error)
-        self.create_coupon(catalog=self.catalog, code=COUPON_CODE, benefit_value=5)
-        url = '{path}?sku={sku}&code={code}'.format(path=self.path, sku=self.stock_record.partner_sku, code=COUPON_CODE)
+        url = '{path}?sku={sku}'.format(path=self.path, sku=self.stock_record.partner_sku)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 400)
 

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -64,10 +64,9 @@ class BasketSingleItemView(View):
             msg = _('Product [{product}] not available to buy.').format(product=product.title)
             return HttpResponseBadRequest(msg)
 
-        # If the product is not an Enrollment Code and this is a Coupon Redemption request,
-        # we check to see if the user is already enrolled
-        # to prevent double-enrollment and/or accidental coupon usage.
-        if product.get_product_class().name != ENROLLMENT_CODE_PRODUCT_CLASS_NAME and code:
+        # If the product is not an Enrollment Code, we check to see if the user is already
+        # enrolled to prevent double-enrollment and/or accidental coupon usage
+        if product.get_product_class().name != ENROLLMENT_CODE_PRODUCT_CLASS_NAME:
             try:
                 if request.user.is_user_already_enrolled(request, product):
                     logger.warning(


### PR DESCRIPTION
Reverts edx/ecommerce#953

**ECOM-6928** :
In SOL-2083 changes enrollment check to work only for coupon baskets, thus enabling other students to place multiple orders for same course(aka Multiple Order Issue). 

**Steps to Reproduce:**
1. Enroll in a verified course on stage.
2. Open Basket page from dashboard in new tab and pay for the course.
3. Open Basket page from same dashboard again and pay for the course.

**Expected** : 
Student should not be able to pay multiple times for single course seat.
**Actual** : 
Student can pay for a course multiple times. 

fyi @mjfrey 