### PR TITLE
Add is_active attribute to bulk enrollment code products.

### DIFF
--- a/ecommerce/courses/models.py
+++ b/ecommerce/courses/models.py
@@ -260,8 +260,7 @@ class Course(models.Model):
 
         return seat
 
-    @property
-    def enrollment_code_product(self):
+    def get_enrollment_code(self):
         """ Returns an enrollment code Product related to this course. """
         try:
             # Current use cases dictate that only one enrollment code product exists for a given course
@@ -271,6 +270,14 @@ class Course(models.Model):
             )
         except Product.DoesNotExist:
             return None
+
+    @property
+    def enrollment_code_product(self):
+        """Returns this course's enrollment code if it exists and is active."""
+        enrollment_code = self.get_enrollment_code()
+        if enrollment_code and enrollment_code.attr.is_active:
+            return enrollment_code
+        return None
 
     def _create_or_update_enrollment_code(self, seat_type, id_verification_required, partner, price):
         """
@@ -299,6 +306,7 @@ class Course(models.Model):
             )
         enrollment_code.attr.course_key = self.id
         enrollment_code.attr.seat_type = seat_type
+        enrollment_code.attr.is_active = True
         enrollment_code.attr.id_verification_required = id_verification_required
         enrollment_code.save()
 
@@ -317,3 +325,13 @@ class Course(models.Model):
         stock_record.save()
 
         return enrollment_code
+
+    def toggle_enrollment_code_status(self, is_active):
+        enrollment_code = self.get_enrollment_code()
+        # For some reason needs to be initialized first. See discussion here:
+        # https://groups.google.com/forum/?fromgroups=#!topic/django-oscar/Q4cSzVwKMGI
+        enrollment_code.attr.initialised = True
+
+        if enrollment_code:
+            enrollment_code.attr.is_active = is_active
+            enrollment_code.save()

--- a/ecommerce/courses/models.py
+++ b/ecommerce/courses/models.py
@@ -293,7 +293,8 @@ class Course(models.Model):
             Enrollment code product.
         """
         enrollment_code_product_class = ProductClass.objects.get(name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME)
-        enrollment_code = self.enrollment_code_product
+        enrollment_code = self.get_enrollment_code()
+
         if not enrollment_code:
             title = 'Enrollment code for {seat_type} seat in {course_name}'.format(
                 seat_type=seat_type,

--- a/ecommerce/courses/tests/test_views.py
+++ b/ecommerce/courses/tests/test_views.py
@@ -1,10 +1,13 @@
 import json
 
+import ddt
 import httpretty
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from testfixtures import LogCapture
 
+from ecommerce.core.constants import ENROLLMENT_CODE_SWITCH
+from ecommerce.core.tests import toggle_switch
 from ecommerce.core.url_utils import get_lms_url
 from ecommerce.tests.testcases import TestCase
 
@@ -49,6 +52,7 @@ class ConvertCourseView(ManagementCommandViewMixin, TestCase):
     path = reverse('courses:convert_course')
 
 
+@ddt.ddt
 class CourseAppViewTests(TestCase):
     path = reverse('courses:app', args=[''])
 
@@ -93,6 +97,13 @@ class CourseAppViewTests(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertIn(settings.LOGIN_URL, response.url)
 
+    def _create_and_login_staff_user(self):
+        """Setup staff user with an OAuth2 access token and log the user in."""
+        user = self.create_user(is_staff=True)
+        self.create_access_token(user)
+        self.assertIsNotNone(user.access_token)
+        self.client.login(username=user.username, password=self.password)
+
     @httpretty.activate
     def test_staff_user_required(self):
         """ Verify the view is only accessible to staff users. """
@@ -103,20 +114,14 @@ class CourseAppViewTests(TestCase):
         response = self.client.get(self.path)
         self.assertEqual(response.status_code, 404)
 
-        user = self.create_user(is_staff=True)
-        self.create_access_token(user)
-        self.client.login(username=user.username, password=self.password)
+        self._create_and_login_staff_user()
         response = self.client.get(self.path)
         self.assertEqual(response.status_code, 200)
 
     @httpretty.activate
     def test_credit_providers_in_context(self):
         """ Verify the context data includes a list of credit providers. """
-        # Setup staff user with an OAuth 2 access token
-        user = self.create_user(is_staff=True)
-        self.create_access_token(user)
-        self.assertIsNotNone(user.access_token)
-        self.client.login(username=user.username, password=self.password)
+        self._create_and_login_staff_user()
 
         # Mock Credit API
         __, provider_json = self.mock_credit_api_providers()
@@ -125,13 +130,26 @@ class CourseAppViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['credit_providers'], provider_json)
 
+    @ddt.data(True, False)
+    @httpretty.activate
+    def test_bulk_enrollment_code_flag_is_context(self, enabled):
+        self._create_and_login_staff_user()
+        self.mock_credit_api_providers()
+
+        toggle_switch(ENROLLMENT_CODE_SWITCH, enabled)
+        site_config = self.site.siteconfiguration
+        site_config.enable_enrollment_codes = enabled
+        site_config.save()
+
+        response = self.client.get(self.path)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['bulk_enrollment_codes_enabled'], enabled)
+
     @httpretty.activate
     def test_credit_api_failure(self):
         """ Verify the view logs an error if it fails to retrieve credit providers. """
         # Setup staff user with an OAuth 2 access token
-        user = self.create_user(is_staff=True)
-        self.create_access_token(user)
-        self.client.login(username=user.username, password=self.password)
+        self._create_and_login_staff_user()
         self.mock_credit_api_error()
 
         with LogCapture(LOGGER_NAME) as l:

--- a/ecommerce/courses/views.py
+++ b/ecommerce/courses/views.py
@@ -11,7 +11,9 @@ from django.views.generic import View, TemplateView
 from edx_rest_api_client.client import EdxRestApiClient
 from requests import Timeout
 from slumber.exceptions import SlumberBaseException
+from waffle import switch_is_active
 
+from ecommerce.core.constants import ENROLLMENT_CODE_SWITCH
 from ecommerce.core.url_utils import get_lms_url
 from ecommerce.core.views import StaffOnlyMixin
 from ecommerce.extensions.partner.shortcuts import get_partner_for_site
@@ -33,6 +35,10 @@ class CourseAppView(StaffOnlyMixin, TemplateView):
             context['credit_providers'] = json.dumps(credit_providers)
         else:
             logger.warning('User [%s] has no access token, and will not be able to edit courses.', user.username)
+
+        context['bulk_enrollment_codes_enabled'] = 'false'
+        if switch_is_active(ENROLLMENT_CODE_SWITCH) and self.request.site.siteconfiguration.enable_enrollment_codes:
+            context['bulk_enrollment_codes_enabled'] = 'true'
 
         return context
 

--- a/ecommerce/courses/views.py
+++ b/ecommerce/courses/views.py
@@ -36,9 +36,9 @@ class CourseAppView(StaffOnlyMixin, TemplateView):
         else:
             logger.warning('User [%s] has no access token, and will not be able to edit courses.', user.username)
 
-        context['bulk_enrollment_codes_enabled'] = 'false'
-        if switch_is_active(ENROLLMENT_CODE_SWITCH) and self.request.site.siteconfiguration.enable_enrollment_codes:
-            context['bulk_enrollment_codes_enabled'] = 'true'
+        context['bulk_enrollment_codes_enabled'] = (
+            switch_is_active(ENROLLMENT_CODE_SWITCH) and self.request.site.siteconfiguration.enable_enrollment_codes
+        )
 
         return context
 

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -400,7 +400,6 @@ class AtomicPublicationSerializer(serializers.Serializer):  # pylint: disable=ab
                     attrs = self._flatten(product['attribute_values'])
                     # Extract arguments required for Seat creation, deserializing as necessary.
                     certificate_type = attrs.get('certificate_type', '')
-
                     id_verification_required = attrs['id_verification_required']
                     price = Decimal(product['price'])
 

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -14,7 +14,7 @@ from rest_framework import serializers
 from rest_framework.reverse import reverse
 import waffle
 
-from ecommerce.core.constants import ISO_8601_FORMAT, COURSE_ID_REGEX
+from ecommerce.core.constants import COURSE_ID_REGEX, ENROLLMENT_CODE_SWITCH, ISO_8601_FORMAT
 from ecommerce.core.models import Site, SiteConfiguration
 from ecommerce.core.url_utils import get_ecommerce_url
 from ecommerce.courses.models import Course
@@ -280,6 +280,7 @@ class CourseSerializer(serializers.HyperlinkedModelSerializer):
     products = ProductSerializer(many=True)
     products_url = serializers.SerializerMethodField()
     last_edited = serializers.SerializerMethodField()
+    has_active_bulk_enrollment_code = serializers.SerializerMethodField()
 
     def __init__(self, *args, **kwargs):
         super(CourseSerializer, self).__init__(*args, **kwargs)
@@ -297,9 +298,14 @@ class CourseSerializer(serializers.HyperlinkedModelSerializer):
         return reverse('api:v2:course-product-list', kwargs={'parent_lookup_course_id': obj.id},
                        request=self.context['request'])
 
+    def get_has_active_bulk_enrollment_code(self, obj):
+        return True if obj.enrollment_code_product else False
+
     class Meta(object):
         model = Course
-        fields = ('id', 'url', 'name', 'verification_deadline', 'type', 'products_url', 'last_edited', 'products')
+        fields = (
+            'id', 'url', 'name', 'verification_deadline', 'type',
+            'products_url', 'last_edited', 'products', 'has_active_bulk_enrollment_code')
         read_only_fields = ('type', 'products')
         extra_kwargs = {
             'url': {'view_name': COURSE_DETAIL_VIEW}
@@ -317,6 +323,7 @@ class AtomicPublicationSerializer(serializers.Serializer):  # pylint: disable=ab
     # Verification deadline should only be required if the course actually requires verification.
     verification_deadline = serializers.DateTimeField(required=False, allow_null=True)
     products = serializers.ListField()
+    create_or_activate_enrollment_code = serializers.BooleanField()
 
     def __init__(self, *args, **kwargs):
         super(AtomicPublicationSerializer, self).__init__(*args, **kwargs)
@@ -363,6 +370,7 @@ class AtomicPublicationSerializer(serializers.Serializer):  # pylint: disable=ab
         course_id = self.validated_data['id']
         course_name = self.validated_data['name']
         course_verification_deadline = self.validated_data.get('verification_deadline')
+        create_or_activate_enrollment_code = self.validated_data.get('create_or_activate_enrollment_code')
         products = self.validated_data['products']
         partner = self.get_partner()
 
@@ -383,13 +391,16 @@ class AtomicPublicationSerializer(serializers.Serializer):  # pylint: disable=ab
                 course.verification_deadline = course_verification_deadline
                 course.save()
 
+                create_enrollment_code = False
+                if waffle.switch_is_active(ENROLLMENT_CODE_SWITCH) and \
+                        self.context['request'].site.siteconfiguration.enable_enrollment_codes:
+                    create_enrollment_code = create_or_activate_enrollment_code
+
                 for product in products:
                     attrs = self._flatten(product['attribute_values'])
-
                     # Extract arguments required for Seat creation, deserializing as necessary.
                     certificate_type = attrs.get('certificate_type', '')
-                    create_enrollment_code = product['course'].get('create_enrollment_code') and \
-                        self.context['request'].site.siteconfiguration.enable_enrollment_codes
+
                     id_verification_required = attrs['id_verification_required']
                     price = Decimal(product['price'])
 
@@ -410,6 +421,9 @@ class AtomicPublicationSerializer(serializers.Serializer):  # pylint: disable=ab
                         credit_hours=credit_hours,
                         create_enrollment_code=create_enrollment_code
                     )
+
+                if course.get_enrollment_code():
+                    course.toggle_enrollment_code_status(is_active=create_enrollment_code)
 
                 resp_message = course.publish_to_lms(access_token=self.access_token)
                 published = (resp_message is None)

--- a/ecommerce/extensions/api/v2/tests/views/test_courses.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_courses.py
@@ -42,6 +42,7 @@ class CourseViewSetTests(ProductSerializerMixin, CourseCatalogTestMixin, TestCas
                                                  kwargs={'parent_lookup_course_id': course.id}))
 
         last_edited = course.history.latest().history_date.strftime(ISO_8601_FORMAT)
+        enrollment_code = course.enrollment_code_product
 
         data = {
             'id': course.id,
@@ -50,7 +51,8 @@ class CourseViewSetTests(ProductSerializerMixin, CourseCatalogTestMixin, TestCas
             'type': course.type,
             'url': self.get_full_url(reverse('api:v2:course-detail', kwargs={'pk': course.id})),
             'products_url': products_url,
-            'last_edited': last_edited
+            'last_edited': last_edited,
+            'has_active_bulk_enrollment_code': True if enrollment_code else False
         }
 
         if include_products:

--- a/ecommerce/extensions/api/v2/tests/views/test_publication.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_publication.py
@@ -1,19 +1,22 @@
+import json
 from copy import deepcopy
 from datetime import datetime
 from decimal import Decimal
-import json
 
-from django.core.urlresolvers import reverse
 import mock
 import pytz
+from django.core.urlresolvers import reverse
+from oscar.core.loading import get_model
 
-from ecommerce.core.constants import ISO_8601_FORMAT
+from ecommerce.core.constants import ENROLLMENT_CODE_PRODUCT_CLASS_NAME, ENROLLMENT_CODE_SWITCH, ISO_8601_FORMAT
 from ecommerce.core.tests import toggle_switch
 from ecommerce.courses.models import Course
 from ecommerce.courses.publishers import LMSPublisher
 from ecommerce.extensions.api.v2.tests.views import JSON_CONTENT_TYPE
 from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
 from ecommerce.tests.testcases import TestCase
+
+Product = get_model('catalogue', 'Product')
 
 EXPIRES = datetime(year=1992, month=4, day=24, tzinfo=pytz.utc)
 EXPIRES_STRING = EXPIRES.strftime(ISO_8601_FORMAT)
@@ -43,7 +46,7 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
                         }
                     ],
                     'course': {
-                        'create_enrollment_code': 'true',
+                        'has_active_bulk_enrollment_code': 'true',
                         'honor_mode': True,
                         'id': self.course_id,
                         'name': self.course_name,
@@ -55,6 +58,7 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
                     'product_class': 'Seat',
                     'expires': None,
                     'price': 0.00,
+                    'structure': 'child',
                     'attribute_values': [
                         {
                             'name': 'certificate_type',
@@ -66,7 +70,7 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
                         }
                     ],
                     'course': {
-                        'create_enrollment_code': 'true',
+                        'has_active_bulk_enrollment_code': 'true',
                         'honor_mode': True,
                         'id': self.course_id,
                         'name': self.course_name,
@@ -78,6 +82,7 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
                     'product_class': 'Seat',
                     'expires': EXPIRES_STRING,
                     'price': 10.00,
+                    'structure': 'child',
                     'attribute_values': [
                         {
                             'name': 'certificate_type',
@@ -89,7 +94,7 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
                         }
                     ],
                     'course': {
-                        'create_enrollment_code': 'true',
+                        'has_active_bulk_enrollment_code': 'true',
                         'honor_mode': True,
                         'id': self.course_id,
                         'name': self.course_name,
@@ -101,6 +106,7 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
                     'product_class': 'Seat',
                     'expires': EXPIRES_STRING,
                     'price': 100.00,
+                    'structure': 'child',
                     'attribute_values': [
                         {
                             'name': 'certificate_type',
@@ -120,7 +126,7 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
                         }
                     ],
                     'course': {
-                        'create_enrollment_code': 'true',
+                        'has_active_bulk_enrollment_code': 'true',
                         'honor_mode': True,
                         'id': self.course_id,
                         'name': self.course_name,
@@ -330,14 +336,48 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
         )
         self.assert_course_does_not_exist(self.course_id)
 
-    def test_verification_deadline_optional(self):
-
-        """Verify that submitting a course verification deadline is optional."""
-        self.data.pop('verification_deadline')
-        self._toggle_publication(True)
-
+    def _post_create_request(self):
+        """Send a successful POST request to the publish create endpoint."""
         with mock.patch.object(LMSPublisher, 'publish') as mock_publish:
             mock_publish.return_value = None
             response = self.client.post(self.create_path, json.dumps(self.data), JSON_CONTENT_TYPE)
             self.assertEqual(response.status_code, 201)
-            self.assert_course_saved(self.course_id, expected=self.data)
+
+    def test_verification_deadline_optional(self):
+        """Verify that submitting a course verification deadline is optional."""
+        self.data.pop('verification_deadline')
+        self._toggle_publication(True)
+
+        self._post_create_request()
+        self.assert_course_saved(self.course_id, expected=self.data)
+
+    def _enable_enrollment_codes(self):
+        """Enable settings necessary for creating enrollment codes."""
+        toggle_switch(ENROLLMENT_CODE_SWITCH, True)
+        site_config = self.site.siteconfiguration
+        site_config.enable_enrollment_codes = True
+        site_config.save()
+
+    def test_create_enrollment_code(self):
+        """Verify an enrollment code is created."""
+        self._enable_enrollment_codes()
+        self._post_create_request()
+
+        course = Course.objects.get(id=self.course_id)
+        self.assertIsNotNone(course.enrollment_code_product)
+        self.assertTrue(course.enrollment_code_product.attr.is_active)
+
+    def test_deactivate_enrollment_code(self):
+        """Verify the enrollment code is not active."""
+        self._enable_enrollment_codes()
+        self._post_create_request()
+        self.data['products'][0]['course']['has_active_bulk_enrollment_code'] = None
+
+        with mock.patch.object(LMSPublisher, 'publish') as mock_publish:
+            mock_publish.return_value = None
+            response = self.client.put(self.update_path, json.dumps(self.data), JSON_CONTENT_TYPE)
+            self.assertEqual(response.status_code, 200)
+
+            enrollment_code = Product.objects.filter(product_class__name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME).first()
+            self.assertIsNotNone(enrollment_code)
+            self.assertFalse(enrollment_code.attr.is_active)

--- a/ecommerce/extensions/api/v2/tests/views/test_publication.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_publication.py
@@ -34,6 +34,7 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
             'id': self.course_id,
             'name': self.course_name,
             'verification_deadline': EXPIRES_STRING,
+            'create_or_activate_enrollment_code': False,
             'products': [
                 {
                     'product_class': 'Seat',
@@ -46,7 +47,6 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
                         }
                     ],
                     'course': {
-                        'has_active_bulk_enrollment_code': 'true',
                         'honor_mode': True,
                         'id': self.course_id,
                         'name': self.course_name,
@@ -58,7 +58,6 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
                     'product_class': 'Seat',
                     'expires': None,
                     'price': 0.00,
-                    'structure': 'child',
                     'attribute_values': [
                         {
                             'name': 'certificate_type',
@@ -70,7 +69,6 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
                         }
                     ],
                     'course': {
-                        'has_active_bulk_enrollment_code': 'true',
                         'honor_mode': True,
                         'id': self.course_id,
                         'name': self.course_name,
@@ -82,7 +80,6 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
                     'product_class': 'Seat',
                     'expires': EXPIRES_STRING,
                     'price': 10.00,
-                    'structure': 'child',
                     'attribute_values': [
                         {
                             'name': 'certificate_type',
@@ -94,7 +91,6 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
                         }
                     ],
                     'course': {
-                        'has_active_bulk_enrollment_code': 'true',
                         'honor_mode': True,
                         'id': self.course_id,
                         'name': self.course_name,
@@ -106,7 +102,6 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
                     'product_class': 'Seat',
                     'expires': EXPIRES_STRING,
                     'price': 100.00,
-                    'structure': 'child',
                     'attribute_values': [
                         {
                             'name': 'certificate_type',
@@ -126,7 +121,6 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
                         }
                     ],
                     'course': {
-                        'has_active_bulk_enrollment_code': 'true',
                         'honor_mode': True,
                         'id': self.course_id,
                         'name': self.course_name,
@@ -267,6 +261,7 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
             response = self.client.post(self.create_path, json.dumps(self.data), JSON_CONTENT_TYPE)
             self.assertEqual(response.status_code, 201)
             self.assert_course_saved(self.course_id, expected=self.data)
+            self.assertFalse(Product.objects.filter(product_class__name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME).exists())
 
     def test_update(self):
         """Verify that a Course and associated products can be updated and published."""
@@ -351,7 +346,7 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
         self._post_create_request()
         self.assert_course_saved(self.course_id, expected=self.data)
 
-    def _enable_enrollment_codes(self):
+    def _enable_enrollment_codes_settings(self):
         """Enable settings necessary for creating enrollment codes."""
         toggle_switch(ENROLLMENT_CODE_SWITCH, True)
         site_config = self.site.siteconfiguration
@@ -360,7 +355,8 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
 
     def test_create_enrollment_code(self):
         """Verify an enrollment code is created."""
-        self._enable_enrollment_codes()
+        self._enable_enrollment_codes_settings()
+        self.data['create_or_activate_enrollment_code'] = True
         self._post_create_request()
 
         course = Course.objects.get(id=self.course_id)
@@ -369,15 +365,16 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
 
     def test_deactivate_enrollment_code(self):
         """Verify the enrollment code is not active."""
-        self._enable_enrollment_codes()
+        self._enable_enrollment_codes_settings()
+        self.data['create_or_activate_enrollment_code'] = True
         self._post_create_request()
-        self.data['products'][0]['course']['has_active_bulk_enrollment_code'] = None
+        self.data['create_or_activate_enrollment_code'] = False
 
         with mock.patch.object(LMSPublisher, 'publish') as mock_publish:
             mock_publish.return_value = None
             response = self.client.put(self.update_path, json.dumps(self.data), JSON_CONTENT_TYPE)
-            self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
-            enrollment_code = Product.objects.filter(product_class__name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME).first()
-            self.assertIsNotNone(enrollment_code)
-            self.assertFalse(enrollment_code.attr.is_active)
+        enrollment_code = Product.objects.filter(product_class__name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME).first()
+        self.assertIsNotNone(enrollment_code)
+        self.assertFalse(enrollment_code.attr.is_active)

--- a/ecommerce/extensions/catalogue/migrations/0021_enrollment_code_active_attribute.py
+++ b/ecommerce/extensions/catalogue/migrations/0021_enrollment_code_active_attribute.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from oscar.core.loading import get_model
+
+from ecommerce.core.constants import ENROLLMENT_CODE_PRODUCT_CLASS_NAME
+
+ProductAttribute = get_model('catalogue', 'ProductAttribute')
+ProductClass = get_model('catalogue', 'ProductClass')
+
+
+def create_enrollment_code_active_attribute(apps, schema_editor):
+    """Create a new product attribute 'is_active' for Enrollment code products."""
+    ec_class = ProductClass.objects.get(name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME)
+    ProductAttribute.objects.create(
+        product_class=ec_class,
+        name='Is active',
+        code='is_active',
+        type='boolean',
+        required=True
+    )
+
+
+def remove_enrollment_code_active_attribute(apps, schema_editor):
+    """Remove the 'is_active' product attribute."""
+    ProductAttribute.objects.get(code='is_active').delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('catalogue', '0001_initial'),
+        ('catalogue', '0020_auto_20161025_1446')
+    ]
+    operations = [
+        migrations.RunPython(create_enrollment_code_active_attribute, remove_enrollment_code_active_attribute)
+    ]

--- a/ecommerce/extensions/catalogue/tests/mixins.py
+++ b/ecommerce/extensions/catalogue/tests/mixins.py
@@ -95,7 +95,8 @@ class CourseCatalogTestMixin(object):
         attributes = (
             ('seat_type', 'text'),
             ('course_key', 'text'),
-            ('id_verification_required', 'boolean')
+            ('id_verification_required', 'boolean'),
+            ('is_active', 'boolean')
         )
         product_class = self._create_product_class(ENROLLMENT_CODE_PRODUCT_CLASS_NAME, 'enrollment_code', attributes)
         return product_class

--- a/ecommerce/static/js/models/course_model.js
+++ b/ecommerce/static/js/models/course_model.js
@@ -337,7 +337,6 @@ define([
                     return product.toJSON();
                 }, this);
 
-
                 if (this.isIdVerified()) {
                     verificationDeadline = this.get('verification_deadline');
 

--- a/ecommerce/static/js/models/course_model.js
+++ b/ecommerce/static/js/models/course_model.js
@@ -311,7 +311,8 @@ define([
                     data = {
                         id: this.get('id'),
                         name: this.get('name'),
-                        verification_deadline: null
+                        verification_deadline: null,
+                        create_or_activate_enrollment_code: this.get('has_active_bulk_enrollment_code') || false
                     };
 
                 if (this.includeHonorMode()) {
@@ -335,6 +336,7 @@ define([
                 data.products = _.map(this.getCleanProducts(), function (product) {
                     return product.toJSON();
                 }, this);
+
 
                 if (this.isIdVerified()) {
                     verificationDeadline = this.get('verification_deadline');

--- a/ecommerce/static/js/test/specs/models/course_model_spec.js
+++ b/ecommerce/static/js/test/specs/models/course_model_spec.js
@@ -272,7 +272,8 @@ define([
                         expected = {
                             id: data.id,
                             name: data.name,
-                            verification_deadline: moment.utc(data.verification_deadline).format()
+                            verification_deadline: moment.utc(data.verification_deadline).format(),
+                            create_or_activate_enrollment_code: false
                         };
 
                     products = _.filter(data.products, function (product) {

--- a/ecommerce/static/js/test/specs/views/course_create_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/course_create_view_spec.js
@@ -41,19 +41,20 @@ define([
                 var bulk_enrollment_seat_types = ['verified', 'professional', 'credit'];
                 view.model.set('type', 'audit');
                 view.formView.toggleBulkEnrollmentField();
-                expect(SpecUtils.formGroup(view, '[name=create_enrollment_code]')).not.toBeVisible();
+                expect(SpecUtils.formGroup(view, '[name=bulk_enrollment_code]')).not.toBeVisible();
 
                 _.each(bulk_enrollment_seat_types, function(seat) {
                     view.model.set('type', seat);
                     view.formView.toggleBulkEnrollmentField();
-                    expect(SpecUtils.formGroup(view, '[name=create_enrollment_code]')).toBeVisible();
+                    expect(SpecUtils.formGroup(view, '[name=bulk_enrollment_code]')).toBeVisible();
                 }, this);
             });
 
             it('should set the bulk enrollment enabled if it is selected', function() {
-                view.$('[name=create_enrollment_code]').prop('checked', true).trigger('change');
-                expect(view.model.get('create_enrollment_code')).toBe('true');
+                view.$('[name=bulk_enrollment_code]').prop('checked', true).trigger('change');
+                expect(view.model.get('bulk_enrollment_code')).toBe('true');
             });
+
         });
     }
 );

--- a/ecommerce/static/js/test/specs/views/course_create_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/course_create_view_spec.js
@@ -49,12 +49,6 @@ define([
                     expect(SpecUtils.formGroup(view, '[name=bulk_enrollment_code]')).toBeVisible();
                 }, this);
             });
-
-            it('should set the bulk enrollment enabled if it is selected', function() {
-                view.$('[name=bulk_enrollment_code]').prop('checked', true).trigger('change');
-                expect(view.model.get('bulk_enrollment_code')).toBe('true');
-            });
-
         });
     }
 );

--- a/ecommerce/static/js/test/specs/views/course_form_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/course_form_view_spec.js
@@ -16,10 +16,12 @@ define([
         });
 
         describe('course form view', function () {
+            window.bulkEnrollmentCodesEnabled = false;
+
             describe('cleanHonorCode', function () {
                 it('should always return a boolean', function () {
-                    expect(view.cleanHonorMode('false')).toEqual(false);
-                    expect(view.cleanHonorMode('true')).toEqual(true);
+                    expect(view.cleanBooleanValue('false')).toEqual(false);
+                    expect(view.cleanBooleanValue('true')).toEqual(true);
                 });
             });
 
@@ -44,25 +46,13 @@ define([
 
             describe('Bulk enrollment code tests', function() {
                 it('should check enrollment code checkbox', function() {
-                    view.$el.append('<input type="checkbox" name="bulk_enrollment_code">');
+                    view.$el.append(
+                        '<input type="radio" name="bulk_enrollment_code" value="true" id="enableBulkEnrollmentCode">' +
+                        '<input type="radio" name="bulk_enrollment_code" value="false" id="disableBulkEnrollmentCode">'
+                        );
                     view.model.set('bulk_enrollment_code', true);
-                    view.renderBulkEnrollmentCode();
-                    expect(view.$('[name=bulk_enrollment_code]').prop('checked')).toBeTruthy();
-                });
-
-                it('should make an ajax call to site configuration', function() {
-                    var mockAjaxData = {'results': [{
-                            'enable_enrollment_codes': true,
-                            'site': {
-                                'domain': 'test.site.domain'
-                            }
-                        }]
-                    };
-                    spyOn($, 'ajax').and.callFake(function(options) {
-                        options.success(mockAjaxData);
-                    });
-                    view.toggleDisabledBulkEnrollmentField();
-                    expect($.ajax).toHaveBeenCalled();
+                    view.toggleBulkEnrollmentField();
+                    expect(view.$('#enableBulkEnrollmentCode').prop('checked')).toBeTruthy();
                 });
             });
         });

--- a/ecommerce/static/js/test/specs/views/course_form_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/course_form_view_spec.js
@@ -25,6 +25,32 @@ define([
 
             describe('getActiveCourseTypes', function () {
                 it('should return expected course types', function () {
+                    view.model.set('type', 'audit');
+                    expect(view.getActiveCourseTypes()).toEqual(['audit', 'verified', 'credit']);
+
+                    view.model.set('type', 'verified');
+                    expect(view.getActiveCourseTypes()).toEqual(['verified', 'credit']);
+
+                    view.model.set('type', 'professional');
+                    expect(view.getActiveCourseTypes()).toEqual(['professional']);
+
+                    view.model.set('type', 'credit');
+                    expect(view.getActiveCourseTypes()).toEqual(['credit']);
+
+                    view.model.set('type', 'default');
+                    expect(view.getActiveCourseTypes()).toEqual(['audit', 'verified', 'professional', 'credit']);
+                });
+            });
+
+            describe('Bulk enrollment code tests', function() {
+                it('should check enrollment code checkbox', function() {
+                    view.$el.append('<input type="checkbox" name="bulk_enrollment_code">');
+                    view.model.set('bulk_enrollment_code', true);
+                    view.renderBulkEnrollmentCode();
+                    expect(view.$('[name=bulk_enrollment_code]').prop('checked')).toBeTruthy();
+                });
+
+                it('should make an ajax call to site configuration', function() {
                     var mockAjaxData = {'results': [{
                             'enable_enrollment_codes': true,
                             'site': {
@@ -35,24 +61,7 @@ define([
                     spyOn($, 'ajax').and.callFake(function(options) {
                         options.success(mockAjaxData);
                     });
-                    view.model.set('type', 'audit');
-                    expect(view.getActiveCourseTypes()).toEqual(['audit', 'verified', 'credit']);
-                    expect($.ajax).toHaveBeenCalled();
-
-                    view.model.set('type', 'verified');
-                    expect(view.getActiveCourseTypes()).toEqual(['verified', 'credit']);
-                    expect($.ajax).toHaveBeenCalled();
-
-                    view.model.set('type', 'professional');
-                    expect(view.getActiveCourseTypes()).toEqual(['professional']);
-                    expect($.ajax).toHaveBeenCalled();
-
-                    view.model.set('type', 'credit');
-                    expect(view.getActiveCourseTypes()).toEqual(['credit']);
-                    expect($.ajax).toHaveBeenCalled();
-
-                    view.model.set('type', 'default');
-                    expect(view.getActiveCourseTypes()).toEqual(['audit', 'verified', 'professional', 'credit']);
+                    view.toggleDisabledBulkEnrollmentField();
                     expect($.ajax).toHaveBeenCalled();
                 });
             });

--- a/ecommerce/static/js/views/course_form_view.js
+++ b/ecommerce/static/js/views/course_form_view.js
@@ -342,7 +342,7 @@ define([
                     if (this.model.get('bulk_enrollment_code')) {
                         this.$('#enableBulkEnrollmentCode').prop('checked', true);
                     }
-                    if (!bulkEnrollmentCodesEnabled) {
+                    if (!window.bulkEnrollmentCodesEnabled) {
                         this.$('[name=bulk_enrollment_code]').attr('disabled', true);
                     }
                 }

--- a/ecommerce/static/templates/course_form.html
+++ b/ecommerce/static/templates/course_form.html
@@ -76,11 +76,22 @@
 </div>
 
 <div class="fields">
-    <div class="form-group create-enrollment-code hidden checkbox">
-        <label for="bulkEnrollment">
-        <input type="checkbox" id="bulkEnrollment" name="create_enrollment_code" value="true"> <%- gettext('Include Enrollment Code') %>
-        </label>
-        <span class="help-block"></span>
+    <div class="form-group bulk-enrollment-code hidden">
+        <label class="hd-4"><%- gettext('Include Bulk Enrollment Code') %></label>
+
+        <div class="input-group">
+            <label class="radio-inline">
+                <input type="radio" name="bulk_enrollment_code" value="true" aria-describedby="bulkEnrollmentCodeHelpBlock" id="enableBulkEnrollmentCode"> Yes
+            </label>
+            <label class="radio-inline">
+                <input type="radio" name="bulk_enrollment_code" value="false" aria-describedby="bulkEnrollmentCodeHelpBlock" id="disableBulkEnrollmentCode"> No
+            </label>
+            <!-- NOTE: This help-block is here for validation messages. -->
+            <span class="help-block"></span>
+            <span id="bulkEnrollmentCodeHelpBlock" class="help-block">
+                <%- gettext('Include a Bulk Enrollment Code with this course') %>
+            </span>
+        </div>
     </div>
 </div>
 

--- a/ecommerce/templates/courses/course_app.html
+++ b/ecommerce/templates/courses/course_app.html
@@ -62,6 +62,9 @@
 
 {% block content %}
     <div id="app" class="container" data-credit-providers="{{ credit_providers }}"></div>
+    <script>
+        window.bulkEnrollmentCodesEnabled = {% if bulk_enrollment_codes_enabled %}true{% else %}false{% endif %};
+    </script>
 {% endblock %}
 
 {% block footer %}
@@ -77,8 +80,5 @@
 {% endblock footer %}
 
 {% block javascript %}
-    <script>
-        bulkEnrollmentCodesEnabled = {{ bulk_enrollment_codes_enabled }};
-    </script>
     <script src="{% static 'js/apps/course_admin_app.js' %}"></script>
 {% endblock %}

--- a/ecommerce/templates/courses/course_app.html
+++ b/ecommerce/templates/courses/course_app.html
@@ -77,5 +77,8 @@
 {% endblock footer %}
 
 {% block javascript %}
+    <script>
+        bulkEnrollmentCodesEnabled = {{ bulk_enrollment_codes_enabled }};
+    </script>
     <script src="{% static 'js/apps/course_admin_app.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
The intention of this PR is to add the possibility to remove an enrollment code from use once it's created. Because the enrollment code product object is linked to in orders and basket lines, deleting it wasn't a good option because it would remove it from all records, therefor I've created a new product attribute ``is_active`` that would handle that.

https://openedx.atlassian.net/browse/SOL-2104