### PR TITLE
Add site to SDN Failure model.

### DIFF
--- a/ecommerce/extensions/payment/migrations/0014_sdncheckfailure_site.py
+++ b/ecommerce/extensions/payment/migrations/0014_sdncheckfailure_site.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sites', '0001_initial'),
+        ('payment', '0013_sdncheckfailure'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='sdncheckfailure',
+            name='site',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, verbose_name='Site', blank=True, to='sites.Site', null=True),
+        ),
+    ]

--- a/ecommerce/extensions/payment/models.py
+++ b/ecommerce/extensions/payment/models.py
@@ -54,6 +54,7 @@ class SDNCheckFailure(TimeStampedModel):
     full_name = models.CharField(max_length=255)
     username = models.CharField(max_length=255)
     country = models.CharField(max_length=2)
+    site = models.ForeignKey('sites.Site', verbose_name=_('Site'), null=True, blank=True, on_delete=models.SET_NULL)
     sdn_check_response = JSONField()
 
     def __unicode__(self):

--- a/ecommerce/extensions/payment/tests/test_models.py
+++ b/ecommerce/extensions/payment/tests/test_models.py
@@ -5,6 +5,7 @@ from ecommerce.extensions.payment.models import SDNCheckFailure
 
 class SDNCheckFailureTests(TestCase):
     def setUp(self):
+        super(SDNCheckFailureTests, self).setUp()
         self.full_name = 'Keyser Söze'
         self.username = 'UnusualSuspect'
         self.country = 'US'
@@ -16,6 +17,7 @@ class SDNCheckFailureTests(TestCase):
             full_name=self.full_name,
             username=self.username,
             country=self.country,
+            site=self.site,
             sdn_check_response=self.sdn_check_response
         )
         expected = 'SDN check failure [{username}]'.format(

--- a/ecommerce/extensions/payment/tests/test_utils.py
+++ b/ecommerce/extensions/payment/tests/test_utils.py
@@ -85,6 +85,7 @@ class SDNCheckTests(TestCase):
         sdn_object = SDNCheckFailure.objects.first()
         self.assertEqual(sdn_object.full_name, self.name)
         self.assertEqual(sdn_object.country, self.country)
+        self.assertEqual(sdn_object.site, self.site_configuration.site)
         self.assertEqual(sdn_object.sdn_check_response, response)
 
     @httpretty.activate

--- a/ecommerce/extensions/payment/utils.py
+++ b/ecommerce/extensions/payment/utils.py
@@ -130,7 +130,8 @@ class SDNClient(object):
             full_name=name,
             username=user.username,
             country=country,
+            site=site_configuration.site,
             sdn_check_response=search_results
         )
-        logger.warning('SDN check failed for user [%s]', name)
+        logger.warning('SDN check failed for user [%s] on site [%s]', name, site_configuration.site.name)
         user.deactivate_account(site_configuration)


### PR DESCRIPTION
Not sure if the ``site`` field should be ``null=True, blank=True``-ed. In case it's not I can create a management command to populate ``site`` attribute of existing SDN Failure entries on edX and WL(s ?) and remove the ``null=True, blank=True`` parameter.

https://openedx.atlassian.net/browse/SOL-2205