### PR TITLE
[WIP] Upgrade to DRF 3.5.4

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ django_simple_history==1.6.3
 django-solo==1.1.2
 django-threadlocals==0.8
 django-waffle==0.11.1
-djangorestframework==3.2.3
+djangorestframework==3.5.4
 djangorestframework-jwt==1.8.0
 drf-extensions==0.2.8
 edx-auth-backends==0.6.0


### PR DESCRIPTION
This would require a bump of the [DRF version] on edx-platform (working on a PR for this). This PR is being opened right now to make sure the edx-enterprise test suite doesn't fail with it.