### PR TITLE
Disabled console logging for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ addons:
 before_install:
     - docker-compose -f ./.travis/docker-compose-travis.yml up -d
 
+# Prevent Travis CI from installing requirments.txt. The requirements will be installed by the script below.
+install: true
+
 script:
     - docker exec ecommerce_testing /edx/app/ecommerce/ecommerce/.travis/run_tests.sh
 

--- a/ecommerce/settings/test.py
+++ b/ecommerce/settings/test.py
@@ -14,7 +14,11 @@ INSTALLED_APPS += (
 
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
+# Disable syslog logging since we usually do not have syslog enabled in test environments.
 LOGGING['handlers']['local'] = {'class': 'logging.NullHandler'}
+
+# Disable console logging to cut down on log size. Nose will capture the logs for us.
+LOGGING['handlers']['console'] = {'class': 'logging.NullHandler'}
 
 if os.getenv('DISABLE_MIGRATIONS'):
 


### PR DESCRIPTION
Our test logs are so large Travis doesn't display them on the default build summary page. Most of the information logged is useless. In the event of an error, the logs will displayed alongside a stack trace thanks to nose. This change disables console logging, removing the extraneous log output.

ECOM-3054