### PR TITLE
ENT-199: Catalog coupons add course seat types selection

### DIFF
--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -286,10 +286,9 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
             course_catalog = course_catalog_data.get('id')
             range_data['course_catalog'] = course_catalog
 
-            # Remove catalog_query and course_seat_types, switching from
-            # dynamic query to course catalog
+            # Remove catalog_query, switching from the dynamic query coupon to
+            # course catalog coupon
             range_data['catalog_query'] = None
-            range_data['course_seat_types'] = None
         else:
             range_data['course_catalog'] = None
 
@@ -299,7 +298,10 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
         else:
             range_data['enterprise_customer'] = None
 
-        Range.objects.filter(id=voucher_range.id).update(**range_data)
+        for attr, value in range_data.iteritems():
+            setattr(voucher_range, attr, value)
+
+        voucher_range.save()
 
     def update(self, request, *args, **kwargs):
         """Update coupon depending on request data sent."""

--- a/ecommerce/static/js/models/coupon_model.js
+++ b/ecommerce/static/js/models/coupon_model.js
@@ -89,7 +89,9 @@ define([
                     }
                 },
                 course_seat_types: function (val) {
-                    if (this.get('catalog_type') === CATALOG_TYPES.multiple_courses && val.length === 0) {
+                    // add validation only for dynamic coupons, e.g. dynamic query coupon or catalog coupon
+                    var dynamicCoupons = [CATALOG_TYPES.multiple_courses, CATALOG_TYPES.catalog];
+                    if (dynamicCoupons.indexOf(this.get('catalog_type')) !== -1 && val.length === 0) {
                         return Backbone.Validation.messages.seat_types;
                     }
                 },

--- a/ecommerce/static/js/test/specs/models/coupon_model_spec.js
+++ b/ecommerce/static/js/test/specs/models/coupon_model_spec.js
@@ -92,7 +92,7 @@ define([
                     expect(model.isValid()).toBeTruthy();
                 });
 
-                it('should validate course catalog for type Catalog', function () {
+                it('should validate course catalog and course seat types for type Catalog', function () {
                     model.set('catalog_type', 'Catalog');
                     model.set('course_catalog', '');
                     model.validate();
@@ -103,6 +103,12 @@ define([
                     expect(model.isValid()).toBe(false);
 
                     model.set('course_catalog', '1');
+                    model.set('course_seat_types', []);
+                    model.validate();
+                    expect(model.isValid()).toBe(false);
+
+                    model.set('course_catalog', '1');
+                    model.set('course_seat_types', ['verified']);
                     model.validate();
                     expect(model.isValid()).toBe(true);
                 });

--- a/ecommerce/static/js/test/specs/views/coupon_detail_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/coupon_detail_view_spec.js
@@ -140,14 +140,20 @@ define([
                 expect(view.$('.invoice-discount-type > .value').text()).toEqual('');
             });
 
-             it('should display course catalog name on render.', function() {
+             it('should display course catalog name and course seats without preview button on render.', function() {
                  ecommerce.coupons.catalogs = new CatalogCollection([{id: 1, name: 'Test Catalog'}]);
 
                  data.course_catalog = 1;
+                 data.course_seat_types = ['verified'];
                  model = Coupon.findOrCreate(data, {parse: true, create: true});
                  view = new CouponDetailView({model: model});
                  view.render();
+
                  expect(view.$('.catalog-name > .value').text()).toEqual('Test Catalog');
+                 expect(view.$('.seat-types .value').text()).toEqual(
+                     data.course_seat_types.join(', ')
+                 );
+                 expect(view.$('.catalog_buttons').text()).toEqual('');
              });
 
             it('should format seat types.', function() {

--- a/ecommerce/static/js/views/coupon_detail_view.js
+++ b/ecommerce/static/js/views/coupon_detail_view.js
@@ -153,14 +153,16 @@ define([
                 this.renderCourseData();
                 this.delegateEvents();
 
-                this.dynamic_catalog_view = new DynamicCatalogView({
-                    'query': this.model.get('catalog_query'),
-                    'seat_types': this.model.get('course_seat_types')
-                });
+                if (this.model.get('catalog_type') === this.model.catalogTypes.multiple_courses) {
+                    this.dynamic_catalog_view = new DynamicCatalogView({
+                        'query': this.model.get('catalog_query'),
+                        'seat_types': this.model.get('course_seat_types')
+                    });
 
-                this.dynamic_catalog_view.$el = this.$('.catalog_buttons');
-                this.dynamic_catalog_view.render();
-                this.dynamic_catalog_view.delegateEvents();
+                    this.dynamic_catalog_view.$el = this.$('.catalog_buttons');
+                    this.dynamic_catalog_view.render();
+                    this.dynamic_catalog_view.delegateEvents();
+                }
 
                 this.$('.coupon-information').before(AlertDivTemplate);
                 this.$alerts = this.$el.find('.alerts');

--- a/ecommerce/static/js/views/coupon_form_view.js
+++ b/ecommerce/static/js/views/coupon_form_view.js
@@ -480,15 +480,19 @@ define([
                     this.model.unset('seat_type');
                     this.model.unset('stock_record_ids');
                     this.model.unset('catalog_query');
-                    this.model.unset('course_seat_types');
                     this.formGroup('[name=enterprise_customer]').addClass(this.hiddenClass);
                     this.model.unset('enterprise_customer');
                     this.formGroup('[name=catalog_query]').addClass(this.hiddenClass);
-                    this.formGroup('[name=course_seat_types]').addClass(this.hiddenClass);
+                    this.formGroup('[name=course_seat_types]').removeClass(this.hiddenClass);
                     this.formGroup('[name=course_id]').addClass(this.hiddenClass);
                     this.formGroup('[name=seat_type]').addClass(this.hiddenClass);
                     this.formGroup('[name=course_catalog]').removeClass(this.hiddenClass);
                     this.formGroup('[name=seat_type] option').remove();
+
+                    this.$('.catalog_buttons').addClass(this.hiddenClass);
+                    if (!this.model.get('course_seat_types')) {
+                        this.model.set('course_seat_types', []);
+                    }
                 } else {
                     this.formGroup('[name=catalog_query]').removeClass(this.hiddenClass);
                     this.formGroup('[name=course_seat_types]').removeClass(this.hiddenClass);
@@ -502,6 +506,7 @@ define([
                     this.model.unset('stock_record_ids');
                     this.model.set('course_catalog', this.model.defaults.course_catalog);
 
+                    this.$('.catalog_buttons').removeClass(this.hiddenClass);
                     if (!this.model.get('course_seat_types')) {
                         this.model.set('course_seat_types', []);
                     }

--- a/ecommerce/static/templates/coupon_form.html
+++ b/ecommerce/static/templates/coupon_form.html
@@ -185,6 +185,11 @@
             <span>Query length: <span class="query_length">0</span></span>
             <p class="help-block"></p>
         </div>
+        <div class="form-group course-catalog">
+            <label for="course-catalog"><%= gettext('Select from course catalogs:') %> *</label>
+            <select id="course-catalog" class="form-control" name="course_catalog"></select>
+            <p class="help-block"></p>
+        </div>
         <div class="form-group course-seat-types">
             <label for="course-seat-types"><%= gettext('Seat Types:') %> *</label>
             <div class="checkboxes">
@@ -205,11 +210,6 @@
                 <p class="help-block"></p>
             </div>
             <div class="catalog_buttons"></div>
-        </div>
-        <div class="form-group course-catalog">
-            <label for="course-catalog"><%= gettext('Select from course catalogs:') %> *</label>
-            <select id="course-catalog" class="form-control" name="course_catalog"></select>
-            <p class="help-block"></p>
         </div>
         <div class="form-group enterprise-customer">
             <label for="enterprise-customer"><%= gettext('Enterprise Customer:') %></label>


### PR DESCRIPTION
ENT-199
@saleem-latif @asadiqbal08 @mattdrayer 
* Add course seat types selection for Catalog coupons create/edit view.
* Add course seat types selection for Catalog coupons details view.
* Hide seat types `Preview` button from Catalog coupons create/edit and details view since we have only catalog id not the catalog query to fetch the course runs.
* Add/update unittests for catalog coupons with course seat types
* Add/update js tests for catalog coupons with course seat types

**Related PR for coupons validation on course seat types:** https://github.com/edx/ecommerce/pull/1158/

<img width="800" alt="screen shot 2017-02-20 at 5 38 42 pm" src="https://cloud.githubusercontent.com/assets/5072991/23125487/cb8b7fd8-f793-11e6-9a64-b68ef9cfee4d.png">

<img width="806" alt="screen shot 2017-02-20 at 5 40 49 pm" src="https://cloud.githubusercontent.com/assets/5072991/23125496/d42d391a-f793-11e6-82c3-c1c767424fc5.png">
