### PR TITLE
Option to activate/deactivate enrollment codes

### DIFF
--- a/ecommerce/courses/views.py
+++ b/ecommerce/courses/views.py
@@ -11,7 +11,9 @@ from django.views.generic import View, TemplateView
 from edx_rest_api_client.client import EdxRestApiClient
 from requests import Timeout
 from slumber.exceptions import SlumberBaseException
+from waffle import switch_is_active
 
+from ecommerce.core.constants import ENROLLMENT_CODE_SWITCH
 from ecommerce.core.url_utils import get_lms_url
 from ecommerce.core.views import StaffOnlyMixin
 from ecommerce.extensions.partner.shortcuts import get_partner_for_site
@@ -33,6 +35,10 @@ class CourseAppView(StaffOnlyMixin, TemplateView):
             context['credit_providers'] = json.dumps(credit_providers)
         else:
             logger.warning('User [%s] has no access token, and will not be able to edit courses.', user.username)
+
+        context['bulk_enrollment_codes_enabled'] = (
+            switch_is_active(ENROLLMENT_CODE_SWITCH) and self.request.site.siteconfiguration.enable_enrollment_codes
+        )
 
         return context
 

--- a/ecommerce/extensions/api/v2/tests/views/test_courses.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_courses.py
@@ -42,6 +42,7 @@ class CourseViewSetTests(ProductSerializerMixin, CourseCatalogTestMixin, TestCas
                                                  kwargs={'parent_lookup_course_id': course.id}))
 
         last_edited = course.history.latest().history_date.strftime(ISO_8601_FORMAT)
+        enrollment_code = course.enrollment_code_product
 
         data = {
             'id': course.id,
@@ -50,7 +51,8 @@ class CourseViewSetTests(ProductSerializerMixin, CourseCatalogTestMixin, TestCas
             'type': course.type,
             'url': self.get_full_url(reverse('api:v2:course-detail', kwargs={'pk': course.id})),
             'products_url': products_url,
-            'last_edited': last_edited
+            'last_edited': last_edited,
+            'has_active_bulk_enrollment_code': True if enrollment_code else False
         }
 
         if include_products:

--- a/ecommerce/extensions/api/v2/tests/views/test_publication.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_publication.py
@@ -1,19 +1,25 @@
+import json
 from copy import deepcopy
 from datetime import datetime
 from decimal import Decimal
-import json
 
-from django.core.urlresolvers import reverse
 import mock
 import pytz
+from django.core.urlresolvers import reverse
+from freezegun import freeze_time
+from oscar.core.loading import get_model
 
-from ecommerce.core.constants import ISO_8601_FORMAT, SEAT_PRODUCT_CLASS_NAME
+from ecommerce.core.constants import (
+    ENROLLMENT_CODE_PRODUCT_CLASS_NAME, ENROLLMENT_CODE_SWITCH, ISO_8601_FORMAT, SEAT_PRODUCT_CLASS_NAME
+)
 from ecommerce.core.tests import toggle_switch
 from ecommerce.courses.models import Course
 from ecommerce.courses.publishers import LMSPublisher
 from ecommerce.extensions.api.v2.tests.views import JSON_CONTENT_TYPE
 from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
 from ecommerce.tests.testcases import TestCase
+
+Product = get_model('catalogue', 'Product')
 
 EXPIRES = datetime(year=1992, month=4, day=24, tzinfo=pytz.utc)
 EXPIRES_STRING = EXPIRES.strftime(ISO_8601_FORMAT)
@@ -31,6 +37,7 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
             'id': self.course_id,
             'name': self.course_name,
             'verification_deadline': EXPIRES_STRING,
+            'create_or_activate_enrollment_code': False,
             'products': [
                 {
                     'product_class': SEAT_PRODUCT_CLASS_NAME,
@@ -43,7 +50,6 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
                         }
                     ],
                     'course': {
-                        'create_enrollment_code': 'true',
                         'honor_mode': True,
                         'id': self.course_id,
                         'name': self.course_name,
@@ -66,7 +72,6 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
                         }
                     ],
                     'course': {
-                        'create_enrollment_code': 'true',
                         'honor_mode': True,
                         'id': self.course_id,
                         'name': self.course_name,
@@ -89,7 +94,6 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
                         }
                     ],
                     'course': {
-                        'create_enrollment_code': 'true',
                         'honor_mode': True,
                         'id': self.course_id,
                         'name': self.course_name,
@@ -120,7 +124,6 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
                         }
                     ],
                     'course': {
-                        'create_enrollment_code': 'true',
                         'honor_mode': True,
                         'id': self.course_id,
                         'name': self.course_name,
@@ -261,6 +264,7 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
             response = self.client.post(self.create_path, json.dumps(self.data), JSON_CONTENT_TYPE)
             self.assertEqual(response.status_code, 201)
             self.assert_course_saved(self.course_id, expected=self.data)
+            self.assertFalse(Product.objects.filter(product_class__name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME).exists())
 
     def test_update(self):
         """Verify that a Course and associated products can be updated and published."""
@@ -330,14 +334,53 @@ class AtomicPublicationTests(CourseCatalogTestMixin, TestCase):
         )
         self.assert_course_does_not_exist(self.course_id)
 
-    def test_verification_deadline_optional(self):
-
-        """Verify that submitting a course verification deadline is optional."""
-        self.data.pop('verification_deadline')
-        self._toggle_publication(True)
-
+    def _post_create_request(self):
+        """Send a successful POST request to the publish create endpoint."""
         with mock.patch.object(LMSPublisher, 'publish') as mock_publish:
             mock_publish.return_value = None
             response = self.client.post(self.create_path, json.dumps(self.data), JSON_CONTENT_TYPE)
             self.assertEqual(response.status_code, 201)
-            self.assert_course_saved(self.course_id, expected=self.data)
+
+    def test_verification_deadline_optional(self):
+        """Verify that submitting a course verification deadline is optional."""
+        self.data.pop('verification_deadline')
+        self._toggle_publication(True)
+
+        self._post_create_request()
+        self.assert_course_saved(self.course_id, expected=self.data)
+
+    def _enable_enrollment_codes_settings(self):
+        """Enable settings necessary for creating enrollment codes."""
+        toggle_switch(ENROLLMENT_CODE_SWITCH, True)
+        site_config = self.site.siteconfiguration
+        site_config.enable_enrollment_codes = True
+        site_config.save()
+
+    def test_create_enrollment_code(self):
+        """Verify an enrollment code is created."""
+        self._enable_enrollment_codes_settings()
+        self.data['create_or_activate_enrollment_code'] = True
+        self._post_create_request()
+
+        course = Course.objects.get(id=self.course_id)
+        enrollment_code = course.get_enrollment_code()
+        self.assertIsNotNone(enrollment_code)
+        self.assertEqual(enrollment_code.expires, EXPIRES)
+
+    @freeze_time('2017-01-01')
+    def test_deactivate_enrollment_code(self):
+        """Verify the enrollment code is not active."""
+        self._enable_enrollment_codes_settings()
+        self.data['create_or_activate_enrollment_code'] = True
+        self._post_create_request()
+        self.data['create_or_activate_enrollment_code'] = False
+
+        with mock.patch.object(LMSPublisher, 'publish') as mock_publish:
+            mock_publish.return_value = None
+            response = self.client.put(self.update_path, json.dumps(self.data), JSON_CONTENT_TYPE)
+        self.assertEqual(response.status_code, 200)
+
+        course = Course.objects.get(id=self.course_id)
+        enrollment_code = course.get_enrollment_code()
+        self.assertIsNotNone(enrollment_code)
+        self.assertIsNone(course.enrollment_code_product)

--- a/ecommerce/extensions/catalogue/tests/test_models.py
+++ b/ecommerce/extensions/catalogue/tests/test_models.py
@@ -1,0 +1,44 @@
+from django.utils.timezone import now, timedelta
+
+from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
+from ecommerce.tests.testcases import TestCase
+
+
+class ModelsTests(CourseCatalogTestMixin, TestCase):
+    def update_product_expires(self, product):
+        expiration_datetime = now()
+        product.expires = expiration_datetime
+        product.save()
+        return expiration_datetime
+
+    def test_seat_expires_update(self):
+        """Verify updating a seat's expiration date updates enrollment code's."""
+        __, seat, enrollment_code = self.create_course_seat_and_enrollment_code()
+        self.assertEqual(seat.expires, enrollment_code.expires)
+
+        expiration_datetime = self.update_product_expires(seat)
+        enrollment_code.refresh_from_db()
+        self.assertEqual(enrollment_code.expires, expiration_datetime)
+
+    def test_enrollment_code_expires_update(self):
+        """Verify updating enrollment code's expiration date does not update seat's."""
+        __, seat, enrollment_code = self.create_course_seat_and_enrollment_code()
+        self.assertEqual(seat.expires, enrollment_code.expires)
+
+        expiration_datetime = self.update_product_expires(enrollment_code)
+        seat.refresh_from_db()
+        self.assertNotEqual(seat.expires, expiration_datetime)
+
+    def mock_enrollment_code_deactivation(self, enrollment_code):
+        enrollment_code.expires = now() - timedelta(days=1)
+        enrollment_code.save()
+
+    def test_deactivated_enrollment_code_update(self):
+        """Verify a deactivated enrollment code's expiration date is not updated."""
+        __, seat, enrollment_code = self.create_course_seat_and_enrollment_code()
+        self.assertEqual(seat.expires, enrollment_code.expires)
+
+        self.mock_enrollment_code_deactivation(enrollment_code)
+        expiration_datetime = self.update_product_expires(seat)
+        enrollment_code.refresh_from_db()
+        self.assertNotEqual(enrollment_code.expires, expiration_datetime)

--- a/ecommerce/static/js/models/course_model.js
+++ b/ecommerce/static/js/models/course_model.js
@@ -311,7 +311,8 @@ define([
                     data = {
                         id: this.get('id'),
                         name: this.get('name'),
-                        verification_deadline: null
+                        verification_deadline: null,
+                        create_or_activate_enrollment_code: this.get('has_active_bulk_enrollment_code') || false
                     };
 
                 if (this.includeHonorMode()) {

--- a/ecommerce/static/js/test/specs/models/course_model_spec.js
+++ b/ecommerce/static/js/test/specs/models/course_model_spec.js
@@ -272,7 +272,8 @@ define([
                         expected = {
                             id: data.id,
                             name: data.name,
-                            verification_deadline: moment.utc(data.verification_deadline).format()
+                            verification_deadline: moment.utc(data.verification_deadline).format(),
+                            create_or_activate_enrollment_code: false
                         };
 
                     products = _.filter(data.products, function (product) {

--- a/ecommerce/static/js/test/specs/views/course_create_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/course_create_view_spec.js
@@ -41,18 +41,13 @@ define([
                 var bulk_enrollment_seat_types = ['verified', 'professional', 'credit'];
                 view.model.set('type', 'audit');
                 view.formView.toggleBulkEnrollmentField();
-                expect(SpecUtils.formGroup(view, '[name=create_enrollment_code]')).not.toBeVisible();
+                expect(SpecUtils.formGroup(view, '[name=bulk_enrollment_code]')).not.toBeVisible();
 
                 _.each(bulk_enrollment_seat_types, function(seat) {
                     view.model.set('type', seat);
                     view.formView.toggleBulkEnrollmentField();
-                    expect(SpecUtils.formGroup(view, '[name=create_enrollment_code]')).toBeVisible();
+                    expect(SpecUtils.formGroup(view, '[name=bulk_enrollment_code]')).toBeVisible();
                 }, this);
-            });
-
-            it('should set the bulk enrollment enabled if it is selected', function() {
-                view.$('[name=create_enrollment_code]').prop('checked', true).trigger('change');
-                expect(view.model.get('create_enrollment_code')).toBe('true');
             });
         });
     }

--- a/ecommerce/static/js/test/specs/views/course_form_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/course_form_view_spec.js
@@ -16,44 +16,43 @@ define([
         });
 
         describe('course form view', function () {
+            window.bulkEnrollmentCodesEnabled = false;
+
             describe('cleanHonorCode', function () {
                 it('should always return a boolean', function () {
-                    expect(view.cleanHonorMode('false')).toEqual(false);
-                    expect(view.cleanHonorMode('true')).toEqual(true);
+                    expect(view.cleanBooleanValue('false')).toEqual(false);
+                    expect(view.cleanBooleanValue('true')).toEqual(true);
                 });
             });
 
             describe('getActiveCourseTypes', function () {
                 it('should return expected course types', function () {
-                    var mockAjaxData = {'results': [{
-                            'enable_enrollment_codes': true,
-                            'site': {
-                                'domain': 'test.site.domain'
-                            }
-                        }]
-                    };
-                    spyOn($, 'ajax').and.callFake(function(options) {
-                        options.success(mockAjaxData);
-                    });
                     view.model.set('type', 'audit');
                     expect(view.getActiveCourseTypes()).toEqual(['audit', 'verified', 'credit']);
-                    expect($.ajax).toHaveBeenCalled();
 
                     view.model.set('type', 'verified');
                     expect(view.getActiveCourseTypes()).toEqual(['verified', 'credit']);
-                    expect($.ajax).toHaveBeenCalled();
 
                     view.model.set('type', 'professional');
                     expect(view.getActiveCourseTypes()).toEqual(['professional']);
-                    expect($.ajax).toHaveBeenCalled();
 
                     view.model.set('type', 'credit');
                     expect(view.getActiveCourseTypes()).toEqual(['credit']);
-                    expect($.ajax).toHaveBeenCalled();
 
                     view.model.set('type', 'default');
                     expect(view.getActiveCourseTypes()).toEqual(['audit', 'verified', 'professional', 'credit']);
-                    expect($.ajax).toHaveBeenCalled();
+                });
+            });
+
+            describe('Bulk enrollment code tests', function() {
+                it('should check enrollment code checkbox', function() {
+                    view.$el.append(
+                        '<input type="radio" name="bulk_enrollment_code" value="true" id="enableBulkEnrollmentCode">' +
+                        '<input type="radio" name="bulk_enrollment_code" value="false" id="disableBulkEnrollmentCode">'
+                        );
+                    view.model.set('bulk_enrollment_code', true);
+                    view.toggleBulkEnrollmentField();
+                    expect(view.$('#enableBulkEnrollmentCode').prop('checked')).toBeTruthy();
                 });
             });
         });

--- a/ecommerce/static/js/views/course_form_view.js
+++ b/ecommerce/static/js/views/course_form_view.js
@@ -118,10 +118,11 @@ define([
                     setOptions: {
                         validate: true
                     },
-                    onSet: 'cleanHonorMode'
+                    onSet: 'cleanBooleanValue'
                 },
-                'input[name=create_enrollment_code]': {
-                    observe: 'create_enrollment_code'
+                'input[name=bulk_enrollment_code]': {
+                    observe: 'has_active_bulk_enrollment_code',
+                    onSet: 'cleanBooleanValue'
                 }
             },
 
@@ -189,7 +190,7 @@ define([
                 this.lockedCourseType = this.model.get('type');
             },
 
-            cleanHonorMode: function (val) {
+            cleanBooleanValue: function (val) {
                 return _s.toBoolean(val);
             },
 
@@ -206,7 +207,7 @@ define([
                 this.$('.fields:first').before(AlertDivTemplate);
 
                 this.stickit();
-
+                this.toggleBulkEnrollmentField();
                 this._super();
 
                 return this;
@@ -288,7 +289,6 @@ define([
 
                         if (!view) {
                             seats = this.model.getOrCreateSeats(seatType);
-                            // seats = new ProductCollection(this.model.getOrCreateSeats(seatType));
                             viewClass = this.courseSeatViewMappings[seatType];
 
                             if (viewClass && seats.length > 0) {
@@ -331,33 +331,22 @@ define([
              * Toggle the bulk enrollment checkbox. Hidden only for audit mode.
              */
             toggleBulkEnrollmentField: function() {
-                var bulk_enrollment_field = this.$('[name=create_enrollment_code]'),
-                    form_group = bulk_enrollment_field.closest('.form-group');
-                $.ajax({
-                    url: '/api/v2/siteconfiguration/',
-                    method: 'get',
-                    contentType: 'application/json',
-                    async: false,
-                    success: this.onSuccess.bind(this)
-                });
+                var disableBEC = this.$('#disableBulkEnrollmentCode'),
+                    formGroup = disableBEC.closest('.form-group');
 
                 if (this.$('[name=type]:checked').val() === 'audit') {
-                    bulk_enrollment_field.prop('checked', false).trigger('change');
-                    form_group.addClass('hidden');
+                    disableBEC.prop('checked', false).trigger('change');
+                    formGroup.addClass('hidden');
                 } else {
-                    form_group.removeClass('hidden');
+                    formGroup.removeClass('hidden');
+                    if (this.model.get('bulk_enrollment_code')) {
+                        this.$('#enableBulkEnrollmentCode').prop('checked', true);
+                    }
+                    if (!window.bulkEnrollmentCodesEnabled) {
+                        this.$('[name=bulk_enrollment_code]').attr('disabled', true);
+                    }
                 }
             },
-
-            onSuccess: function(data) {
-                var site_configuration;
-                site_configuration = _.find(data.results, function(item) {
-                    return item.site.domain === window.location.host;
-                }) || {};
-                if (!site_configuration.enable_enrollment_codes) {
-                    this.$('[name=create_enrollment_code]').attr('disabled', true);
-                }
-            }
         });
     }
 );

--- a/ecommerce/static/templates/course_form.html
+++ b/ecommerce/static/templates/course_form.html
@@ -76,11 +76,22 @@
 </div>
 
 <div class="fields">
-    <div class="form-group create-enrollment-code hidden checkbox">
-        <label for="bulkEnrollment">
-        <input type="checkbox" id="bulkEnrollment" name="create_enrollment_code" value="true"> <%- gettext('Include Enrollment Code') %>
-        </label>
-        <span class="help-block"></span>
+    <div class="form-group bulk-enrollment-code hidden">
+        <label class="hd-4"><%- gettext('Include Bulk Enrollment Code') %></label>
+
+        <div class="input-group">
+            <label class="radio-inline">
+                <input type="radio" name="bulk_enrollment_code" value="true" aria-describedby="bulkEnrollmentCodeHelpBlock" id="enableBulkEnrollmentCode"> Yes
+            </label>
+            <label class="radio-inline">
+                <input type="radio" name="bulk_enrollment_code" value="false" aria-describedby="bulkEnrollmentCodeHelpBlock" id="disableBulkEnrollmentCode"> No
+            </label>
+            <!-- NOTE: This help-block is here for validation messages. -->
+            <span class="help-block"></span>
+            <span id="bulkEnrollmentCodeHelpBlock" class="help-block">
+                <%- gettext('Include a Bulk Enrollment Code with this course') %>
+            </span>
+        </div>
     </div>
 </div>
 

--- a/ecommerce/templates/courses/course_app.html
+++ b/ecommerce/templates/courses/course_app.html
@@ -62,6 +62,9 @@
 
 {% block content %}
     <div id="app" class="container" data-credit-providers="{{ credit_providers }}"></div>
+    <script>
+        window.bulkEnrollmentCodesEnabled = {% if bulk_enrollment_codes_enabled %}true{% else %}false{% endif %};
+    </script>
 {% endblock %}
 
 {% block footer %}


### PR DESCRIPTION
This is a different version of https://github.com/edx/ecommerce/pull/1151. Here ``Product.expires`` was used to indicate if an enrollment code is active or inactive.

@clintonb is this what you suggested in that other PR? Another thing that needs to be addressed here is when the verification is closed for a seat, i.e. the seat product is set to be expired, the accompanying enrollment code should be disabled as well. 