### PR TITLE
Change edx-django-release-util version.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ djangorestframework==3.3.3
 djangorestframework-jwt==1.8.0
 drf-extensions==0.3.1
 edx-auth-backends==0.6.0
-edx-django-release-util==0.2.0
+edx-django-release-util==0.3.0
 edx-django-sites-extensions==1.0.0
 edx-drf-extensions==1.2.2
 edx-ecommerce-worker==0.6.0


### PR DESCRIPTION
Change the required version of edx-django-release-util to 0.3.0.

@edx-ops/pipeline-team Please review and tag appropriate parties.