### PR TITLE
mattdrayer: Add ability to filter offers view by course

### DIFF
--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -270,6 +270,15 @@ class CouponOfferViewTests(ApiMockMixin, CouponMixin, CourseCatalogTestMixin, Lm
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
+    def test_get_context_data_course_filter(self):
+        """ Verify the course filter works as expected """
+        code = 'VALIDCODE'
+        voucher, product = prepare_voucher(code=code)
+        self.client.logout()
+        url = self.path + '?code={0}&course={1}'.format(code, product.course_id)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
 
 class CouponRedeemViewTests(CouponMixin, CourseCatalogTestMixin, LmsApiMockMixin, EnterpriseServiceMockMixin,
                             TestCase):

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -109,6 +109,12 @@ class CouponOfferView(TemplateView):
                 return {'error': _('The voucher is not applicable to your current basket.')}
             valid_voucher, msg = voucher_is_valid(voucher, products, self.request)
             if valid_voucher:
+
+                # If a course filter is specified, restrict the set of products accordingly
+                course_id = self.request.GET.get('course', None)
+                if course_id:
+                    products = [product for product in products if product.course_id == course_id]
+
                 self.template_name = 'coupons/offer.html'
                 return
 


### PR DESCRIPTION
@zubair-arbi @saleem-latif @asadiqbal08 -- revisiting some work we attempted in the past on the Otto Offers Page (see #1061) -- this PR introduces the ability to filter the set of products to an indicated course.