### PR TITLE
ECOM-7349 Learners cannot get enrollment status on Ecommerce SingleBasketItemView

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -17,7 +17,7 @@ from django.utils.translation import ugettext_lazy as _
 from edx_rest_api_client.client import EdxRestApiClient
 from jsonfield.fields import JSONField
 from requests.exceptions import ConnectionError, Timeout
-from slumber.exceptions import HttpNotFoundError, SlumberBaseException
+from slumber.exceptions import HttpNotFoundError, SlumberBaseException, HttpClientError
 
 from ecommerce.core.exceptions import VerificationStatusError
 from ecommerce.core.url_utils import get_lms_url
@@ -434,11 +434,11 @@ class User(AbstractUser):
         try:
             api = EdxRestApiClient(
                 request.site.siteconfiguration.build_lms_url('/api/enrollment/v1'),
-                oauth_access_token=self.access_token,
+                jwt=request.site.siteconfiguration.access_token,
                 append_slash=False
             )
             status = api.enrollment(','.join([self.username, course_key])).get()
-        except (ConnectionError, SlumberBaseException, Timeout):
+        except (ConnectionError, SlumberBaseException, Timeout, HttpClientError):
             log.exception(
                 'Failed to retrieve enrollment details for [%s] in course [%s]',
                 self.username,

--- a/ecommerce/core/tests/test_models.py
+++ b/ecommerce/core/tests/test_models.py
@@ -78,6 +78,7 @@ class UserTests(CourseCatalogTestMixin, LmsApiMockMixin, TestCase):
         """ Verify check for user enrollment in a course. """
         user = self.create_user()
         self.request.user = user
+        self.mock_access_token_response()
         course_id1 = 'course-v1:test+test+test'
         __, enrolled_seat = self.create_course_and_seat(
             course_id=course_id1, seat_type=mode, id_verification=id_verification

--- a/ecommerce/extensions/basket/tests/test_views.py
+++ b/ecommerce/extensions/basket/tests/test_views.py
@@ -37,7 +37,7 @@ from ecommerce.extensions.payment.forms import PaymentForm
 from ecommerce.extensions.payment.tests.processors import DummyProcessor
 from ecommerce.extensions.test.factories import prepare_voucher
 from ecommerce.tests.factories import StockRecordFactory
-from ecommerce.tests.mixins import ApiMockMixin, LmsApiMockMixin
+from ecommerce.tests.mixins import ApiMockMixin, LmsApiMockMixin, SiteMixin
 from ecommerce.tests.testcases import TestCase
 
 Applicator = get_class('offer.utils', 'Applicator')
@@ -57,7 +57,8 @@ COUPON_CODE = 'COUPONTEST'
 
 
 @ddt.ddt
-class BasketSingleItemViewTests(CouponMixin, CourseCatalogTestMixin, CourseCatalogMockMixin, LmsApiMockMixin, TestCase):
+class BasketSingleItemViewTests(CouponMixin, CourseCatalogTestMixin, CourseCatalogMockMixin, LmsApiMockMixin, TestCase,
+                                SiteMixin):
     """ BasketSingleItemView view tests. """
     path = reverse('basket:single-item')
 
@@ -143,6 +144,7 @@ class BasketSingleItemViewTests(CouponMixin, CourseCatalogTestMixin, CourseCatal
         Verify the view redirects to the basket summary page, and that the user's basket is prepared for checkout.
         """
         self.mock_enrollment_api_success_enrolled(self.course.id)
+        self.mock_access_token_response()
         self.create_coupon(catalog=self.catalog, code=COUPON_CODE, benefit_value=5)
 
         self.mock_dynamic_catalog_course_runs_api(course_run=self.course)
@@ -167,6 +169,7 @@ class BasketSingleItemViewTests(CouponMixin, CourseCatalogTestMixin, CourseCatal
         (The Enrollment API call being used returns an active enrollment record in this case)
         """
         course = CourseFactory()
+        self.mock_access_token_response()
         self.mock_enrollment_api_success_enrolled(course.id, mode=mode)
         product = course.create_or_update_seat(mode, id_verification, 0, self.partner, create_enrollment_code=False)
         stock_record = StockRecordFactory(product=product, partner=self.partner)
@@ -188,6 +191,7 @@ class BasketSingleItemViewTests(CouponMixin, CourseCatalogTestMixin, CourseCatal
         (The Enrollment API call being used returns an inactive enrollment record in this case)
         """
         course = CourseFactory()
+        self.mock_access_token_response()
         self.mock_enrollment_api_success_unenrolled(course.id, mode=mode)
         product = course.create_or_update_seat(mode, id_verification, 0, self.partner)
         stock_record = StockRecordFactory(product=product, partner=self.partner)


### PR DESCRIPTION
**ECOM-7349** 
Learners cannot get enrollment status on Ecommerce SingleBasketItemView because of user oauth token expiration. 
Updated the Oauth access token for enrolment check on basket page from learner Oauth token to Service User Oauth token. 
