### PR TITLE
Revert to correct the Learners getting errors on SingleBasketItemView

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -17,7 +17,7 @@ from django.utils.translation import ugettext_lazy as _
 from edx_rest_api_client.client import EdxRestApiClient
 from jsonfield.fields import JSONField
 from requests.exceptions import ConnectionError, Timeout
-from slumber.exceptions import HttpNotFoundError, SlumberBaseException, HttpClientError
+from slumber.exceptions import HttpNotFoundError, SlumberBaseException
 
 from ecommerce.core.exceptions import VerificationStatusError
 from ecommerce.core.url_utils import get_lms_url
@@ -434,11 +434,11 @@ class User(AbstractUser):
         try:
             api = EdxRestApiClient(
                 request.site.siteconfiguration.build_lms_url('/api/enrollment/v1'),
-                jwt=request.site.siteconfiguration.access_token,
+                oauth_access_token=self.access_token,
                 append_slash=False
             )
             status = api.enrollment(','.join([self.username, course_key])).get()
-        except (ConnectionError, SlumberBaseException, Timeout, HttpClientError):
+        except (ConnectionError, SlumberBaseException, Timeout):
             log.exception(
                 'Failed to retrieve enrollment details for [%s] in course [%s]',
                 self.username,

--- a/ecommerce/core/tests/test_models.py
+++ b/ecommerce/core/tests/test_models.py
@@ -78,7 +78,6 @@ class UserTests(CourseCatalogTestMixin, LmsApiMockMixin, TestCase):
         """ Verify check for user enrollment in a course. """
         user = self.create_user()
         self.request.user = user
-        self.mock_access_token_response()
         course_id1 = 'course-v1:test+test+test'
         __, enrolled_seat = self.create_course_and_seat(
             course_id=course_id1, seat_type=mode, id_verification=id_verification

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -62,9 +62,10 @@ class BasketSingleItemView(View):
             msg = _('Product [{product}] not available to buy.').format(product=product.title)
             return HttpResponseBadRequest(msg)
 
-        # If the product is not an Enrollment Code, we check to see if the user is already
-        # enrolled to prevent double-enrollment and/or accidental coupon usage
-        if not product.is_enrollment_code_product:
+        # If the product is not an Enrollment Code and this is a Coupon Redemption request,
+        # we check to see if the user is already enrolled
+        # to prevent double-enrollment and/or accidental coupon usage.
+        if not product.is_enrollment_code_product and code:
             try:
                 if request.user.is_user_already_enrolled(request, product):
                     logger.warning(


### PR DESCRIPTION
@rlucioni @mjfrey Please review

Revert "[SOL-2083] Check if user is enrolled in course only if the request arrives from the Offer Landing Page" and "ECOM-7349 Learners cannot get enrollment status on Ecommerce SingleBasketItemView"