### PR TITLE
ENT-213 Consent Declined message on Offers page

### DIFF
--- a/ecommerce/enterprise/tests/mixins.py
+++ b/ecommerce/enterprise/tests/mixins.py
@@ -20,13 +20,13 @@ class EnterpriseServiceMockMixin(object):
         super(EnterpriseServiceMockMixin, self).setUp()
         cache.clear()
 
-    def mock_specific_enterprise_customer_api(self, uuid):
+    def mock_specific_enterprise_customer_api(self, uuid, name='TestShib', contact_email=''):
         """
         Helper function to register the enterprise customer API endpoint.
         """
         enterprise_customer_api_response = {
             'uuid': uuid,
-            'name': 'TestShib',
+            'name': name,
             'catalog': 0,
             'active': True,
             'site': {
@@ -47,7 +47,8 @@ class EnterpriseServiceMockMixin(object):
                     'enterprise_customer': 'cf246b88-d5f6-4908-a522-fc307e0b0c59',
                     'entitlement_id': 0
                 }
-            ]
+            ],
+            'contact_email': contact_email,
         }
         enterprise_customer_api_response_json = json.dumps(enterprise_customer_api_response)
 

--- a/ecommerce/static/js/routers/offer_router.js
+++ b/ecommerce/static/js/routers/offer_router.js
@@ -11,8 +11,11 @@ define([
             // Base/root path of the app
             root: '/coupons/',
 
-            routes: {
-                'offer/?code=:code': 'showOfferPage'
+            initialize: function(options) {
+                // This is where views will be rendered
+                this.$el = options.$el;
+
+                this.route(/^offer\/\?code=(\w+)/, 'showOfferPage');
             },
 
             showOfferPage: function(code) {

--- a/ecommerce/static/sass/partials/views/_error.scss
+++ b/ecommerce/static/sass/partials/views/_error.scss
@@ -11,3 +11,28 @@
     font-weight: bold;
   }
 }
+
+#info-message {
+  background-color: #0075b4;
+
+  .container {
+    background: none;
+    color: white;
+
+    h3 {
+      margin-bottom: 0;
+      font-weight: bold;
+      color: white;
+    }
+
+    i.fa-info-circle {
+      font-size: 2.5em;
+      float: left;
+      padding-top: 20px;
+    }
+  }
+}
+
+.message-info-content {
+  margin-left: 40px;
+}

--- a/ecommerce/templates/edx/base.html
+++ b/ecommerce/templates/edx/base.html
@@ -32,6 +32,10 @@
     {% include 'edx/partials/_staff_navbar.html' %}
 {% endblock navbar %}
 
+{% block info_message %}
+    {% include 'edx/partials/_info_message.html' %}
+{% endblock info_message %}
+
 {% block content %}
 {% endblock content %}
 

--- a/ecommerce/templates/edx/partials/_info_message.html
+++ b/ecommerce/templates/edx/partials/_info_message.html
@@ -1,0 +1,11 @@
+{% if info %}
+    <div id="info-message">
+        <div class="container">
+            <i class="fa fa-info-circle" aria-hidden="true"></i>
+            <div class="depth depth message-info-content">
+                <h3>{{ info.title }}</h3>
+                {{ info.message }}
+            </div>
+        </div>
+    </div>
+{% endif %}


### PR DESCRIPTION
This change adds:

- A generic info message that can be used by passing an `info` dict to the context of any templates extending `edx/base.html`.
- A `failure_url` callback as a parameter to the consent URL.
- A consent failure message informing the user that they weren't enrolled in the course. It shows up when `consent_failure={SKU}` is passed to the coupon offer view.

**JIRA tickets**: Implements [ENT-213](https://openedx.atlassian.net/browse/ENT-213).

**Dependencies**:
This PR depends on this `edx-enterprise` PR: https://github.com/edx/edx-enterprise/pull/66

This change will come into effect with an Enterprise PR that @haikuginger will be making for ENT-185/ENT-212, where he will be including the `failure_url` call. Everything in this PR can be tested without it, though.

**Screenshots**:

*Desktop:*
![desktop screenshot](https://i.imgur.com/EkuwoGi.png)

*Mobile:*
![mobile screenshot](https://i.imgur.com/SWSXrMD.png)

**Sandbox URL**: TBD.

**Testing instructions**:

Initial setup:
1. Setup a devstack.
1. Checkout this branch (open-craft:bdero/ent-213) for ecommerce.
1. Override the edx-enterprise version with the [correct branch](https://github.com/edx/edx-enterprise/pull/66):
   ```
   /edx/bin/pip.edxapp install -e git+https://github.com/open-craft/edx-enterprise.git@bdero/add-contact-email#egg=edx-enterprise==add-contact-email
   /edx/bin/manage.edxapp lms migrate --settings=devstack
   ```
1. Connect [ecommerce to the LMS](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/ecommerce/install_ecommerce.html#configure-edx-openid-connect-oidc).
1. Setup the [course discovery](https://open-edx-course-catalog.readthedocs.io/en/latest/getting_started.html) service and [connect it to the LMS](https://open-edx-course-catalog.readthedocs.io/en/latest/oidc.html).
1. Create an Enterprise Customer in the LMS: http://localhost:8000/admin/enterprise/enterprisecustomer/add/
    1. Give it any name.
    1. Check the **Enable data sharing consent** box.
    1. For **Enforce data sharing consent**, select **At Enrollment**.
    1. Leave the **Contact email** field blank for now.
1. Add a new Course in Ecommerce: http://localhost:8002/courses/new/
    1. For the course ID, use "course-v1:edX+DemoX+Demo_Course".
    1. Name it "edX Demonstration Course".
    1. Choose "Professional Education" for the Course Type.
1. Create a new Coupon in Ecommerce: http://localhost:8002/coupons/new
    1. Give it any Coupon Name.
    1. Under Code Type choose "Enrollment Code".
    1. Give it a valid date range that includes today.
    1. For Client, type any name. E.g. "Some Client".
    1. Select the "Single course" radio button.
    1. For the Course ID, use "course-v1:edX+DemoX+Demo_Course"
    1. The only available Seat Type should be automatically populated: "Professional"
    1. For the Enterprise Customer, select the name of the customer created in step 6.

Testing the PR:
1. Navigate to the [coupon list](http://localhost:8002/coupons/) and click "Download Coupon Report" to retrieve a CSV containing the coupon URL.
    ![coupon report button screenshot](https://i.imgur.com/icRxZMr.png)
1. The coupon report CSV should contain an offer URL that looks like this:
    ```
    http://localhost:8002/coupons/offer/?code=EGGZYLXDKNZK6W7C
    ```
    Navigate to that URL.
1. Click on the "Enroll Now" button.
    ![offer landing page screenshot](https://i.imgur.com/Ppfb6OC.png)
    You should be redirected to the course-specific Data Sharing Consent screen.
    ![data sharing consent screenshot](https://i.imgur.com/vxA01hn.png)
1. Inspect the URL of the page to find that there's a `failure_url` parameter that looks something like this: `&failure_url=http%3A%2F%2Flocalhost%3A8002%2Fcoupons%2Foffer%2F%3Fcode%3DHV7SMPXDYJFTGRU2%26consent_failed%3DBB3ECA9`
1. URL decode the parameter.
    For example:
    ```
    python2 -c 'import urllib; print urllib.unquote_plus("http%3A%2F%2Flocalhost%3A8002%2Fcoupons%2Foffer%2F%3Fcode%3DHV7SMPXDYJFTGRU2%26consent_failed%3DBB3ECA9")'
    ```
    Which yields: http://localhost:8002/coupons/offer/?code=HV7SMPXDYJFTGRU2&consent_failed=BB3ECA9
1. Navigate to your decoded URL.
1. You should arrive back on the offers page. Observe that there is a blue info message area that looks similar to this:
    ![info message screenshot](https://i.imgur.com/HqJCvGw.png)
1. Navigate back to the Enterprise Customer list in the LMS and edit the Enterprise Customer you created during the initial setup: http://localhost:8000/admin/enterprise/enterprisecustomer/
    1. Fill in the **Contact email** field with "contact@example.com".
1. Repeat steps 3 through 6.
1. Observe that the content failure message now contains the contact email:
   ![screenshot with contact email](https://i.imgur.com/JrMZwfb.png)

**Author notes and concerns**:

The image attached in the [original ticket](https://openedx.atlassian.net/browse/ENT-213) wants to show "custom contact info". We're not currently storing this information anywhere AFAICT, so I've excluded it from this PR for the time being. CC @bradenmacdonald @haikuginger 

**Reviewers**
- [ ] @pomegranited 
- [ ] edX reviewer[s] TBD