### PR TITLE
Fix enrollment code product class slug.

### DIFF
--- a/ecommerce/extensions/catalogue/management/commands/remove_wrong_product_class.py
+++ b/ecommerce/extensions/catalogue/management/commands/remove_wrong_product_class.py
@@ -1,0 +1,37 @@
+import logging
+
+from django.core.management import BaseCommand
+from oscar.core.loading import get_model
+
+logger = logging.getLogger(__name__)
+Product = get_model('catalogue', 'Product')
+ProductClass = get_model('catalogue', 'ProductClass')
+
+WRONG_SLUG = 'enrollment-code'
+RIGHT_SLUG = 'enrollment_code'
+
+
+class Command(BaseCommand):
+    """Remove product class with wrong slug."""
+    def handle(self, *args, **kwargs):  # pylint: disable=unused-argument
+        faulty_product_class = ProductClass.objects.filter(slug=WRONG_SLUG).first()
+        right_product_class = ProductClass.objects.filter(slug=RIGHT_SLUG).first()
+
+        if faulty_product_class and right_product_class:
+            logger.info('Faulty and right product class found.')
+            enrollment_codes = Product.objects.filter(product_class=faulty_product_class)
+            logger.info('Found %d enrollment codes with faulty product class.', enrollment_codes.count())
+
+            enrollment_codes.update(product_class=right_product_class)
+            faulty_product_class.delete()
+            remaining = Product.objects.filter(product_class=faulty_product_class).count()
+            logger.info(
+                'Faulty product class deleted. %d enrollment codes with faulty product class remain.',
+                remaining
+            )
+        elif faulty_product_class:
+            logger.info('Faulty product class found.')
+            faulty_product_class.slug = RIGHT_SLUG
+            faulty_product_class.save()
+        else:
+            logger.info('Faulty product class not found.')

--- a/ecommerce/extensions/catalogue/migrations/0017_enrollment_code_product_class.py
+++ b/ecommerce/extensions/catalogue/migrations/0017_enrollment_code_product_class.py
@@ -19,7 +19,7 @@ def create_enrollment_code_product_class(apps, schema_editor):
         track_stock=False,
         requires_shipping=False,
         name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME,
-        slug=slugify(ENROLLMENT_CODE_PRODUCT_CLASS_NAME),
+        slug='enrollment_code',
     )
 
     ProductAttribute.objects.create(

--- a/ecommerce/extensions/catalogue/tests/mixins.py
+++ b/ecommerce/extensions/catalogue/tests/mixins.py
@@ -110,7 +110,7 @@ class CourseCatalogTestMixin(object):
             ('id_verification_required', 'boolean')
         )
         product_class = self._create_product_class(
-            ENROLLMENT_CODE_PRODUCT_CLASS_NAME, slugify(ENROLLMENT_CODE_PRODUCT_CLASS_NAME), attributes
+            ENROLLMENT_CODE_PRODUCT_CLASS_NAME, 'enrollment_code', attributes
         )
         return product_class
 

--- a/ecommerce/extensions/catalogue/tests/test_remove_wrong_product_class.py
+++ b/ecommerce/extensions/catalogue/tests/test_remove_wrong_product_class.py
@@ -1,0 +1,55 @@
+from django.core.management import call_command
+from oscar.core.loading import get_model
+
+from ecommerce.core.constants import ENROLLMENT_CODE_PRODUCT_CLASS_NAME
+from ecommerce.tests.factories import ProductFactory
+from ecommerce.tests.testcases import TestCase
+
+ProductClass = get_model('catalogue', 'ProductClass')
+
+WRONG_SLUG = 'enrollment-code'
+RIGHT_SLUG = 'enrollment_code'
+
+
+class RemoveWrongProductClassTest(TestCase):
+    def _create_product_class(self, slug):
+        product_class, __ = ProductClass.objects.get_or_create(
+            track_stock=False,
+            requires_shipping=False,
+            name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME,
+            slug=slug,
+        )
+        return product_class
+
+    def test_remove_product_class(self):
+        """Faulty product class removed and products fixed."""
+        faulty_product_class = self._create_product_class(WRONG_SLUG)
+        product_class = self._create_product_class(RIGHT_SLUG)
+        faulty_enrollment_code = ProductFactory(product_class=faulty_product_class)
+        call_command('remove_wrong_product_class')
+
+        faulty_enrollment_code.refresh_from_db()
+        self.assertEqual(faulty_enrollment_code.product_class, product_class)
+        self.assertFalse(ProductClass.objects.filter(slug=WRONG_SLUG).exists())
+
+    def test_update_product_class(self):
+        """Faulty product class updated."""
+        faulty_product_class = self._create_product_class(WRONG_SLUG)
+        faulty_enrollment_code = ProductFactory(product_class=faulty_product_class)
+        call_command('remove_wrong_product_class')
+
+        faulty_enrollment_code.refresh_from_db()
+        faulty_product_class.refresh_from_db()
+        self.assertEqual(faulty_enrollment_code.product_class.slug, RIGHT_SLUG)
+        self.assertFalse(ProductClass.objects.filter(slug=WRONG_SLUG).exists())
+
+    def test_no_actin(self):
+        """Enrollment codes not updated."""
+        product_class = self._create_product_class(RIGHT_SLUG)
+        enrollment_code = ProductFactory(product_class=product_class)
+        self.assertEqual(ProductClass.objects.count(), 1)
+        call_command('remove_wrong_product_class')
+
+        self.assertEqual(ProductClass.objects.count(), 1)
+        enrollment_code.refresh_from_db()
+        self.assertEqual(enrollment_code.product_class, product_class)

--- a/ecommerce/extensions/catalogue/tests/test_remove_wrong_product_class.py
+++ b/ecommerce/extensions/catalogue/tests/test_remove_wrong_product_class.py
@@ -25,7 +25,7 @@ class RemoveWrongProductClassTest(TestCase):
         """Faulty product class removed and products fixed."""
         faulty_product_class = self._create_product_class(WRONG_SLUG)
         product_class = self._create_product_class(RIGHT_SLUG)
-        faulty_enrollment_code = ProductFactory(product_class=faulty_product_class)
+        faulty_enrollment_code = ProductFactory(product_class=faulty_product_class, categories=None)
         call_command('remove_wrong_product_class')
 
         faulty_enrollment_code.refresh_from_db()
@@ -35,21 +35,21 @@ class RemoveWrongProductClassTest(TestCase):
     def test_update_product_class(self):
         """Faulty product class updated."""
         faulty_product_class = self._create_product_class(WRONG_SLUG)
-        faulty_enrollment_code = ProductFactory(product_class=faulty_product_class)
+        faulty_enrollment_code = ProductFactory(product_class=faulty_product_class, categories=None)
         call_command('remove_wrong_product_class')
 
         faulty_enrollment_code.refresh_from_db()
-        faulty_product_class.refresh_from_db()
         self.assertEqual(faulty_enrollment_code.product_class.slug, RIGHT_SLUG)
         self.assertFalse(ProductClass.objects.filter(slug=WRONG_SLUG).exists())
 
     def test_no_actin(self):
         """Enrollment codes not updated."""
         product_class = self._create_product_class(RIGHT_SLUG)
-        enrollment_code = ProductFactory(product_class=product_class)
-        self.assertEqual(ProductClass.objects.count(), 1)
+        enrollment_code = ProductFactory(product_class=product_class, categories=None)
+        # Product classes: Seat, Coupon, Enrollment Code
+        self.assertEqual(ProductClass.objects.count(), 3)
         call_command('remove_wrong_product_class')
 
-        self.assertEqual(ProductClass.objects.count(), 1)
+        self.assertEqual(ProductClass.objects.count(), 3)
         enrollment_code.refresh_from_db()
         self.assertEqual(enrollment_code.product_class, product_class)


### PR DESCRIPTION
So ``slugify`` does not work as I expect it to, could've sworn that I tested that function, obviously not.
This PR contains the management command approach to updating the product class and enrollment codes, [this branch](https://github.com/edx/ecommerce/tree/vkaracic/ECOM-7393b) contains the migration approach. Not sure which one is more appropriate. Thoughts, @clintonb ?

https://openedx.atlassian.net/browse/ECOM-7393