### PR TITLE
ENT-201 use catalog contains endpoint for varifying the course seats against …

### DIFF
--- a/ecommerce/coupons/tests/mixins.py
+++ b/ecommerce/coupons/tests/mixins.py
@@ -166,7 +166,7 @@ class CourseCatalogMockMixin(object):
             content_type='application/json'
         )
 
-    def mock_get_catalog_contains_api_for_failure(self, partner_code, course_run_ids, query, error):
+    def mock_get_catalog_contains_api_for_failure(self, course_run_ids, catalog_id, error):
         """
         Helper function to register a course catalog API endpoint with failure
         for getting course runs information.
@@ -174,11 +174,10 @@ class CourseCatalogMockMixin(object):
         def callback(request, uri, headers):  # pylint: disable=unused-argument
             raise error
 
-        catalog_contains_course_run_url = '{}course_runs/contains/?course_run_ids={}&query={}&partner={}'.format(
+        catalog_contains_course_run_url = '{}catalogs/{}/contains/?course_run_id={}'.format(
             settings.COURSE_CATALOG_API_URL,
-            (course_run_id for course_run_id in course_run_ids),
-            query,
-            partner_code,
+            catalog_id,
+            ','.join(course_run_id for course_run_id in course_run_ids),
         )
         httpretty.register_uri(
             method=httpretty.GET,

--- a/ecommerce/courses/tests/mixins.py
+++ b/ecommerce/courses/tests/mixins.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 
 import httpretty
@@ -35,6 +37,28 @@ class CourseCatalogServiceMockMixin(object):
         httpretty.register_uri(
             method=httpretty.GET,
             uri=single_catalog_uri,
+            body=course_discovery_api_response_json,
+            content_type='application/json'
+        )
+
+    def mock_course_discovery_api_for_catalog_contains(self, catalog_id=1, course_run_ids=None):
+        """
+        Helper function to register course catalog contains API endpoint.
+        """
+        course_run_ids = course_run_ids or []
+        courses = {course_run_id: True for course_run_id in course_run_ids}
+
+        course_discovery_api_response = {
+            'courses': courses
+        }
+        course_discovery_api_response_json = json.dumps(course_discovery_api_response)
+        catalog_contains_uri = '{}{}/contains/?course_run_id={}'.format(
+            self.COURSE_DISCOVERY_CATALOGS_URL, catalog_id, ','.join(course_run_ids)
+        )
+
+        httpretty.register_uri(
+            method=httpretty.GET,
+            uri=catalog_contains_uri,
             body=course_discovery_api_response_json,
             content_type='application/json'
         )


### PR DESCRIPTION
…a course catalog range
@saleem-latif @asadiqbal08 @mattdrayer 

Previously we were using two API calls for checking if a course run exists for a catalog by first retrieving the catalog and then using the course_runs contains endpoint for the provided course run, from discovery service.

Now we are using the updated catalog contains endpoint which tells us if a course run is available in its query.

**Depends on:** [add support for course run key in catalog contains endpoint](https://github.com/edx/course-discovery/pull/721)