### PR TITLE
ENT-264: Fix invalid use of request.user.access_token for enterprise customer lookups

### DIFF
--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -181,7 +181,6 @@ class GetVoucherTests(CourseCatalogTestMixin, TestCase):
 
 
 @ddt.ddt
-@httpretty.activate
 class CouponOfferViewTests(ApiMockMixin, CouponMixin, CourseCatalogTestMixin, EnterpriseServiceMockMixin,
                            LmsApiMockMixin, TestCase):
     path = reverse('coupons:offer')
@@ -304,8 +303,10 @@ class CouponOfferViewTests(ApiMockMixin, CouponMixin, CourseCatalogTestMixin, En
         ),
     )
     @ddt.unpack
+    @httpretty.activate
     def test_consent_failed_message(self, contact_email, expected_response):
         """ Verify that the consent failure message shows up when the consent_failed parameter is a valid SKU. """
+        self.mock_access_token_response()
         self.mock_specific_enterprise_customer_api(
             ENTERPRISE_CUSTOMER,
             name='TestShib',

--- a/ecommerce/coupons/utils.py
+++ b/ecommerce/coupons/utils.py
@@ -7,8 +7,7 @@ from django.core.cache import cache
 from oscar.core.loading import get_model
 from slumber.exceptions import HttpNotFoundError
 
-from ecommerce.core.utils import get_cache_key
-from ecommerce.courses.utils import traverse_pagination
+from ecommerce.core.utils import get_cache_key, traverse_pagination
 
 Product = get_model('catalogue', 'Product')
 

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -172,7 +172,7 @@ class CouponRedeemView(EdxOrderPlacementMixin, View):
             return render(request, template_name, {'error': _('You are already enrolled in the course.')})
 
         try:
-            enterprise_customer = get_enterprise_customer_from_voucher(request.site, request.user.access_token, voucher)
+            enterprise_customer = get_enterprise_customer_from_voucher(request.site, voucher)
         except EnterpriseDoesNotExist as e:
             # If an EnterpriseException is caught while pulling the EnterpriseCustomer, that means there's no
             # corresponding EnterpriseCustomer in the Enterprise service (which should never happen).

--- a/ecommerce/courses/utils.py
+++ b/ecommerce/courses/utils.py
@@ -1,9 +1,10 @@
 import hashlib
-from urlparse import parse_qs, urlparse
 
 from django.conf import settings
 from django.core.cache import cache
 from django.utils.translation import ugettext_lazy as _
+
+from ecommerce.core.utils import traverse_pagination
 
 
 def mode_for_seat(product):
@@ -70,33 +71,6 @@ def get_course_catalogs(site, resource_id=None):
         results = traverse_pagination(response, endpoint)
 
     cache.set(cache_key, results, settings.COURSES_API_CACHE_TIMEOUT)
-    return results
-
-
-def traverse_pagination(response, endpoint):
-    """
-    Traverse a paginated API response.
-
-    Extracts and concatenates "results" (list of dict) returned by DRF-powered
-    APIs.
-
-    Arguments:
-        response (Dict): Current response dict from service API
-        endpoint (slumber Resource object): slumber Resource object from edx-rest-api-client
-
-    Returns:
-        list of dict.
-
-    """
-    results = response.get('results', [])
-
-    next_page = response.get('next')
-    while next_page:
-        querystring = parse_qs(urlparse(next_page).query, keep_blank_values=True)
-        response = endpoint.get(**querystring)
-        results += response.get('results', [])
-        next_page = response.get('next')
-
     return results
 
 

--- a/ecommerce/enterprise/tests/mixins.py
+++ b/ecommerce/enterprise/tests/mixins.py
@@ -1,11 +1,14 @@
+import copy
 import json
+from uuid import uuid4
 
 import httpretty
 from django.conf import settings
-from django.core.cache import cache
+
+from ecommerce.tests.testcases import TestCase
 
 
-class EnterpriseServiceMockMixin(object):
+class EnterpriseServiceMockMixin(TestCase):
     """
     Mocks for the Open edX service 'Enterprise Service' responses.
     """
@@ -18,7 +21,57 @@ class EnterpriseServiceMockMixin(object):
 
     def setUp(self):
         super(EnterpriseServiceMockMixin, self).setUp()
-        cache.clear()
+
+    def mock_enterprise_customer_list_api_get(self):
+        """
+        Helper function to register the enterprise customer API endpoint.
+        """
+        enterprise_customer_data = {
+            'uuid': str(uuid4()),
+            'name': "Enterprise Customer 1",
+            'catalog': 0,
+            'active': True,
+            'site': {
+                'domain': 'example.com',
+                'name': 'example.com'
+            },
+            'enable_data_sharing_consent': True,
+            'enforce_data_sharing_consent': 'at_login',
+            'enterprise_customer_users': [
+                1
+            ],
+            'branding_configuration': {
+                'enterprise_customer': 'cf246b88-d5f6-4908-a522-fc307e0b0c59',
+                'logo': 'https://open.edx.org/sites/all/themes/edx_open/logo.png'
+            },
+            'enterprise_customer_entitlements': [
+                {
+                    'enterprise_customer': 'cf246b88-d5f6-4908-a522-fc307e0b0c59',
+                    'entitlement_id': 0
+                }
+            ],
+            'contact_email': "administrator@enterprisecustomer.com",
+        }
+
+        enterprise_customer2_data = copy.deepcopy(enterprise_customer_data)
+        enterprise_customer2_data['uuid'] = str(uuid4())
+        enterprise_customer2_data['name'] = 'Enterprise Customer 2'
+
+        enterprise_customer_api_response = {
+            'results':
+                [
+                    enterprise_customer_data,
+                    enterprise_customer2_data
+                ]
+        }
+
+        enterprise_customer_api_response_json = json.dumps(enterprise_customer_api_response)
+        httpretty.register_uri(
+            method=httpretty.GET,
+            uri=self.ENTERPRISE_CUSTOMER_URL,
+            body=enterprise_customer_api_response_json,
+            content_type='application/json'
+        )
 
     def mock_specific_enterprise_customer_api(self, uuid, name='TestShib', contact_email=''):
         """

--- a/ecommerce/enterprise/tests/test_api.py
+++ b/ecommerce/enterprise/tests/test_api.py
@@ -9,14 +9,13 @@ from ecommerce.core.utils import get_cache_key
 from ecommerce.enterprise import api as enterprise_api
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
 from ecommerce.extensions.partner.strategy import DefaultStrategy
-from ecommerce.tests.testcases import TestCase
 
 Catalog = get_model('catalogue', 'Catalog')
 StockRecord = get_model('partner', 'StockRecord')
 
 
 @httpretty.activate
-class EnterpriseAPITests(EnterpriseServiceMockMixin, TestCase):
+class EnterpriseAPITests(EnterpriseServiceMockMixin):
     def setUp(self):
         super(EnterpriseAPITests, self).setUp()
         self.learner = self.create_user(is_staff=True)

--- a/ecommerce/enterprise/tests/test_utils.py
+++ b/ecommerce/enterprise/tests/test_utils.py
@@ -5,27 +5,39 @@ import httpretty
 
 from ecommerce.core.tests.decorators import mock_enterprise_api_client
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
-from ecommerce.enterprise.utils import get_enterprise_customer, get_or_create_enterprise_customer_user
-from ecommerce.tests.testcases import TestCase
+from ecommerce.enterprise.utils import (get_enterprise_customer, get_enterprise_customers,
+                                        get_or_create_enterprise_customer_user)
 
 TEST_ENTERPRISE_CUSTOMER_UUID = 'cf246b88-d5f6-4908-a522-fc307e0b0c59'
 
 
 @ddt.ddt
 @httpretty.activate
-class EnterpriseUtilsTests(EnterpriseServiceMockMixin, TestCase):
+class EnterpriseUtilsTests(EnterpriseServiceMockMixin):
     def setUp(self):
         super(EnterpriseUtilsTests, self).setUp()
         self.learner = self.create_user(is_staff=True)
         self.client.login(username=self.learner.username, password=self.password)
+
+    def test_get_enterprise_customers(self):
+        """
+        Verify that "get_enterprise_customers" returns an appropriate response from the
+        "enterprise-customer" Enterprise service API endpoint.
+        """
+        self.mock_access_token_response()
+        self.mock_enterprise_customer_list_api_get()
+        response = get_enterprise_customers(self.site)
+        self.assertEqual(response[0]['name'], "Enterprise Customer 1")
+        self.assertEqual(response[1]['name'], "Enterprise Customer 2")
 
     def test_get_enterprise_customer(self):
         """
         Verify that "get_enterprise_customer" returns an appropriate response from the
         "enterprise-customer" Enterprise service API endpoint.
         """
+        self.mock_access_token_response()
         self.mock_specific_enterprise_customer_api(TEST_ENTERPRISE_CUSTOMER_UUID)
-        response = get_enterprise_customer(self.site, self.learner.access_token, TEST_ENTERPRISE_CUSTOMER_UUID)
+        response = get_enterprise_customer(self.site, TEST_ENTERPRISE_CUSTOMER_UUID)
 
         self.assertEqual(TEST_ENTERPRISE_CUSTOMER_UUID, response.get('id'))
 

--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -1,12 +1,14 @@
 from __future__ import unicode_literals
 
+import httpretty
 import mock
+
 from django.core.urlresolvers import reverse
 
-from ecommerce.tests.testcases import TestCase
+from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
 
 
-class TestEnterpriseCustomerView(TestCase):
+class TestEnterpriseCustomerView(EnterpriseServiceMockMixin):
 
     dummy_enterprise_customer_data = {
         'results': [
@@ -23,7 +25,9 @@ class TestEnterpriseCustomerView(TestCase):
     }
 
     @mock.patch('ecommerce.enterprise.utils.EdxRestApiClient')
+    @httpretty.activate
     def test_get_customers(self, mock_client):
+        self.mock_access_token_response()
         instance = mock_client.return_value
         setattr(
             instance,

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -11,4 +11,4 @@ class EnterpriseCustomerViewSet(generics.GenericAPIView):
 
     def get(self, request):
         site = request.site
-        return Response(data={'results': get_enterprise_customers(site, token=request.user.access_token)})
+        return Response(data={'results': get_enterprise_customers(site)})


### PR DESCRIPTION
Addresses bug reported in ENT-264: List of Enterprise Customers is not appearing in the "Enterprise Customer" dropdown of the Coupon Administration Tool

Explanation: 
The `get_enterprise_customers` call included in `EnterpriseCustomerViewSet.get` currently specifies the `request.user.access_token` field, which results in an incorrect value.  This was not detected on devstack or in sandboxes because all of the testing is typically done using the 'staff' user, which has elevated permissions.  It became clear in the staging environment using a regular user's access token which does not translate to the same level of permissions as the site's access token.

Solution:
Update reference to instead use the site's token, via `site.siteconfiguration.access_token`

@mjfrey, FYI