### PR TITLE
[ECOM-7533] Catch verification error on new receipt page

### DIFF
--- a/ecommerce/core/exceptions.py
+++ b/ecommerce/core/exceptions.py
@@ -6,8 +6,3 @@ class MissingRequestError(Exception):
 class SiteConfigurationError(Exception):
     """ Raised when SiteConfiguration is invalid. """
     pass
-
-
-class VerificationStatusError(Exception):
-    """ Raised when the verification fails to connect to LMS. """
-    pass

--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -19,7 +19,6 @@ from jsonfield.fields import JSONField
 from requests.exceptions import ConnectionError, Timeout
 from slumber.exceptions import HttpNotFoundError, SlumberBaseException
 
-from ecommerce.core.exceptions import VerificationStatusError
 from ecommerce.core.url_utils import get_lms_url
 from ecommerce.core.utils import log_message_and_raise_validation_error
 from ecommerce.courses.utils import mode_for_seat
@@ -525,10 +524,6 @@ class User(AbstractUser):
 
         Returns:
             True if the user is verified, false otherwise.
-
-        Raises:
-            ConnectionError, SlumberBaseException and Timeout for failures in
-            establishing a connection with the LMS verification status API endpoint.
         """
         try:
             cache_key = 'verification_status_{username}'.format(username=self.username)
@@ -552,7 +547,7 @@ class User(AbstractUser):
         except (ConnectionError, SlumberBaseException, Timeout):
             msg = 'Failed to retrieve verification status details for [{username}]'.format(username=self.username)
             log.exception(msg)
-            raise VerificationStatusError(msg)
+            return False
 
     def deactivate_account(self, site_configuration):
         """Deactive the user's account.

--- a/ecommerce/core/tests/test_models.py
+++ b/ecommerce/core/tests/test_models.py
@@ -10,7 +10,6 @@ from django.test import override_settings
 from edx_rest_api_client.auth import SuppliedJwtAuth
 from requests.exceptions import ConnectionError
 
-from ecommerce.core.exceptions import VerificationStatusError
 from ecommerce.core.models import BusinessClient, SiteConfiguration, User
 from ecommerce.core.tests import toggle_switch
 from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
@@ -158,8 +157,7 @@ class UserTests(CourseCatalogTestMixin, LmsApiMockMixin, TestCase):
     def test_user_verification_connection_error(self):
         """ Verify verification status exception is raised for connection issues. """
         user = self.create_user()
-        with self.assertRaises(VerificationStatusError):
-            user.is_verified(self.site)
+        self.assertFalse(user.is_verified(self.site))
 
     @httpretty.activate
     def test_user_verification_status_cache(self):
@@ -179,8 +177,7 @@ class UserTests(CourseCatalogTestMixin, LmsApiMockMixin, TestCase):
         self.assertFalse(user.is_verified(self.site))
 
         httpretty.disable()
-        with self.assertRaises(VerificationStatusError):
-            user.is_verified(self.site)
+        self.assertFalse(user.is_verified(self.site))
 
     @httpretty.activate
     def test_deactivation(self):


### PR DESCRIPTION
JIRA ticket: https://openedx.atlassian.net/browse/ECOM-7533

Since the custom Exception is used only on the new receipt page, I removed it.
If Verification endpoint is unavailable, `False` is assumed.

@mjfrey, @vkaracic: Please review. Thanks!