### PR TITLE
Remove the check of the LMS heartbeat

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -307,11 +307,6 @@ class SiteConfiguration(models.Model):
         return self.build_lms_url('/api/enrollment/v1/')
 
     @property
-    def lms_heartbeat_url(self):
-        """ Returns the URL for the LMS heartbeat page. """
-        return self.build_lms_url('/heartbeat')
-
-    @property
     def oauth2_provider_url(self):
         """ Returns the URL for the OAuth 2.0 provider. """
         return self.build_lms_url('/oauth2')

--- a/ecommerce/core/tests/test_views.py
+++ b/ecommerce/core/tests/test_views.py
@@ -8,76 +8,36 @@ from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 from django.db import DatabaseError
 from django.test.utils import override_settings
-from requests import Response
-from requests.exceptions import RequestException
 from rest_framework import status
-from testfixtures import LogCapture
 
-from ecommerce.core.constants import Status, UnavailabilityMessage
+from ecommerce.core.constants import Status
 from ecommerce.tests.testcases import TestCase
 
 LOGGER_NAME = 'ecommerce.core.views'
 User = get_user_model()
 
 
-@mock.patch('requests.get')
 class HealthTests(TestCase):
     """Tests of the health endpoint."""
 
     def setUp(self):
         super(HealthTests, self).setUp()
-        self.fake_lms_response = Response()
 
-    def test_all_services_available(self, mock_lms_request):
+    def test_all_services_available(self):
         """Test that the endpoint reports when all services are healthy."""
-        self.fake_lms_response.status_code = status.HTTP_200_OK
-        mock_lms_request.return_value = self.fake_lms_response
+        self._assert_health(status.HTTP_200_OK, Status.OK, Status.OK)
 
-        self._assert_health(status.HTTP_200_OK, Status.OK, Status.OK, Status.OK)
-
-    @mock.patch('ecommerce.core.views.get_lms_heartbeat_url', mock.Mock(return_value=''))
     @mock.patch('django.contrib.sites.middleware.get_current_site', mock.Mock(return_value=None))
     @mock.patch('django.db.backends.base.base.BaseDatabaseWrapper.cursor', mock.Mock(side_effect=DatabaseError))
-    def test_database_outage(self, mock_lms_request):
+    def test_database_outage(self):
         """Test that the endpoint reports when the database is unavailable."""
-        self.fake_lms_response.status_code = status.HTTP_200_OK
-        mock_lms_request.return_value = self.fake_lms_response
-
         self._assert_health(
             status.HTTP_503_SERVICE_UNAVAILABLE,
             Status.UNAVAILABLE,
             Status.UNAVAILABLE,
-            Status.OK
         )
 
-    def test_lms_outage(self, mock_lms_request):
-        """Test that the endpoint reports when the LMS is unhealthy."""
-        self.fake_lms_response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
-        mock_lms_request.return_value = self.fake_lms_response
-
-        with LogCapture(LOGGER_NAME) as l:
-            self._assert_health(
-                status.HTTP_200_OK,
-                Status.OK,
-                Status.OK,
-                Status.UNAVAILABLE
-            )
-            l.check((LOGGER_NAME, 'CRITICAL', UnavailabilityMessage.LMS))
-
-    def test_lms_connection_failure(self, mock_lms_request):
-        """Test that the endpoint reports when it cannot contact the LMS."""
-        mock_lms_request.side_effect = RequestException
-
-        with LogCapture(LOGGER_NAME) as l:
-            self._assert_health(
-                status.HTTP_200_OK,
-                Status.OK,
-                Status.OK,
-                Status.UNAVAILABLE
-            )
-            l.check((LOGGER_NAME, 'CRITICAL', UnavailabilityMessage.LMS))
-
-    def _assert_health(self, status_code, overall_status, database_status, lms_status):
+    def _assert_health(self, status_code, overall_status, database_status):
         """Verify that the response matches expectations."""
         response = self.client.get(reverse('health'))
         self.assertEqual(response.status_code, status_code)
@@ -87,7 +47,6 @@ class HealthTests(TestCase):
             'overall_status': overall_status,
             'detailed_status': {
                 'database_status': database_status,
-                'lms_status': lms_status
             }
         }
         self.assertDictEqual(json.loads(response.content), expected_data)

--- a/ecommerce/core/url_utils.py
+++ b/ecommerce/core/url_utils.py
@@ -56,11 +56,6 @@ def get_lms_enrollment_base_api_url():
     return site_configuration.enrollment_api_url
 
 
-def get_lms_heartbeat_url():
-    site_configuration = _get_site_configuration()
-    return site_configuration.lms_heartbeat_url
-
-
 def get_lms_url(path=''):
     """
     Returns path joined with the appropriate LMS URL root for the current site


### PR DESCRIPTION
We know that ecommerce won't fall out of the loadbalancer, but it still
puts load on the LMS (800 of the roughly 4,000 checks we see).  We're
also ratcheting down the frequency of heartbeats based on the discussion
here
https://openedx.atlassian.net/wiki/display/EdxOps/Design+for+scaling+White+Labels+and+not+drowning+in+health+checks

We forsee in the future a "is gunicorn alive" and "detailed heartbeat"
as discussed there.  At that time it might make sense to revert this and
then refactor it, but this is a much smaller/simpler change.