### PR TITLE
Removed systems checks for the update_assets management command

### DIFF
--- a/ecommerce/theming/management/commands/update_assets.py
+++ b/ecommerce/theming/management/commands/update_assets.py
@@ -33,6 +33,9 @@ class Command(BaseCommand):
 
     help = 'Compile and collect assets'
 
+    # NOTE (CCB): This allows us to compile static assets in Docker containers without database access.
+    requires_system_checks = False
+
     ch = logging.StreamHandler()
     ch.setLevel(logging.DEBUG)
     logger.addHandler(ch)


### PR DESCRIPTION
System checks require database access, which is not available when creating Docker images. Given that we don't need the checks, they have been removed.