### PR TITLE
Only log a warning if verification status failed.

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -541,7 +541,7 @@ class User(AbstractUser):
             return False
         except (ConnectionError, SlumberBaseException, Timeout):
             msg = 'Failed to retrieve verification status details for [{username}]'.format(username=self.username)
-            log.exception(msg)
+            log.warning(msg)
             return False
 
     def deactivate_account(self, site_configuration):


### PR DESCRIPTION
No need to log an exception when verification status fails calling LMS.  Changed to a warning.