### PR TITLE
Demote duplicate PayPal payment message to a warning

### DIFF
--- a/ecommerce/extensions/payment/tests/views/test_paypal.py
+++ b/ecommerce/extensions/payment/tests/views/test_paypal.py
@@ -256,7 +256,7 @@ class PaypalPaymentExecutionViewTests(PaypalMixin, PaymentEventsMixin, TestCase)
                 ),
                 (
                     logger_name,
-                    'ERROR',
+                    'WARNING',
                     'Duplicate payment ID [{payment_id}] received from PayPal.'.format(payment_id=self.PAYMENT_ID),
                 ),
             )

--- a/ecommerce/extensions/payment/views/paypal.py
+++ b/ecommerce/extensions/payment/views/paypal.py
@@ -68,7 +68,7 @@ class PaypalPaymentExecutionView(EdxOrderPlacementMixin, View):
             Applicator().apply(basket, basket.owner, self.request)
             return basket
         except MultipleObjectsReturned:
-            logger.exception(u"Duplicate payment ID [%s] received from PayPal.", payment_id)
+            logger.warning(u"Duplicate payment ID [%s] received from PayPal.", payment_id)
             return None
         except Exception:  # pylint: disable=broad-except
             logger.exception(u"Unexpected error during basket retrieval while executing PayPal payment.")


### PR DESCRIPTION
We can't prevent PayPal from sending us these duplicate notifications. We're already doing the right thing by ignoring duplicate notifications instead of trying to execute them.

@mikedikan we should be making more changes like these as we find errors that are really warnings.