### PR TITLE
Change SDN check address parameter to city only.

### DIFF
--- a/ecommerce/static/js/pages/basket_page.js
+++ b/ecommerce/static/js/pages/basket_page.js
@@ -171,7 +171,6 @@ define([
         function sdnCheck(event) {
             var first_name = $('input[name=first_name]').val(),
                 last_name = $('input[name=last_name]').val(),
-                address = $('input[name=address_line1]').val(),
                 city = $('input[name=city]').val(),
                 country = $('select[name=country]').val();
 
@@ -185,7 +184,7 @@ define([
                 },
                 data: JSON.stringify({
                     'name': _s.sprintf('%s %s', first_name, last_name),
-                    'address': _s.sprintf('%s, %s', address, city),
+                    'address': city,
                     'country': country
                 }),
                 async: false,

--- a/ecommerce/static/js/test/specs/pages/basket_page_spec.js
+++ b/ecommerce/static/js/test/specs/pages/basket_page_spec.js
@@ -304,7 +304,7 @@ define([
                         expect(args.url).toEqual('/api/v2/sdn/search/');
                         expect(args.contentType).toEqual('application/json; charset=utf-8');
                         expect(ajaxData.name).toEqual(_s.sprintf('%s %s', first_name, last_name));
-                        expect(ajaxData.address).toEqual(_s.sprintf('%s, %s', address, city));
+                        expect(ajaxData.address).toEqual(city);
                         expect(ajaxData.country).toEqual(country);
                     });
                 });


### PR DESCRIPTION
The Treasury Dept. SDN check endpoint accepts as the address
parameter only the address or the city, but not both. Since
their documentation mentions only an example where the address
parameter is a city name, our SDN check call is changed to
send only the city as the address parameter accordingly.