### PR TITLE
[ENT-229] Check for consent on Enterprise-linked entitlements

### DIFF
--- a/ecommerce/conf/locale/eo/LC_MESSAGES/django.po
+++ b/ecommerce/conf/locale/eo/LC_MESSAGES/django.po
@@ -11,10 +11,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ecommerce/core/admin.py

--- a/ecommerce/conf/locale/eo/LC_MESSAGES/djangojs.po
+++ b/ecommerce/conf/locale/eo/LC_MESSAGES/djangojs.po
@@ -11,10 +11,10 @@ msgstr ""
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ecommerce/static/js/models/coupon_model.js

--- a/ecommerce/enterprise/entitlements.py
+++ b/ecommerce/enterprise/entitlements.py
@@ -131,9 +131,7 @@ def get_course_entitlements_for_learner(site, user, course_id):
         return None
 
     try:
-        # Currently, we are returning only those entitlements that
-        # do not require any further action on part of enterprise learner
-        entitlements = [item['entitlement_id'] for item in entitlements['entitlements'] if not item['requires_consent']]
+        entitlements = [item['entitlement_id'] for item in entitlements['entitlements']]
     except KeyError:
         logger.exception(
             'Invalid structure for enterprise learner entitlements API response for enterprise learner [%s].',


### PR DESCRIPTION
Currently, Enterprise entitlements are only processed if they do not require additional consent intervention. However, this is less than ideal, since we now have the ability to get consent in the middle of a coupon flow. This pull request modifies entitlement behavior to ensure that all entitlements are returned, and that we use a flow that will prompt the user for consent if required.

**JIRA tickets**: Fixes [ENT-229](https://openedx.atlassian.net/browse/ENT-229)

**Dependencies**: None

**Merge deadline**: 10 April 2017

**Testing instructions**:

1. Create an Enterprise Customer in LMS
2. Ensure that consent is enabled for that enterprise customer, and that enforcement is "at enrollment".
2. Create a course with a premium mode.
3. Create a coupon that specifies that enterprise customer and gives a discount on the premium course mode.
4. Add that coupon as an entitlement to the enterprise customer.
5. Using the Django admin, manually add a learner to the enterprise customer; ensure that no consent record exists. If the user was previously linked to the enterprise customer, unlink and relink it.
6. Logged in as the learner, browse to the course information page, and click enroll
7. Select the premium course mode.
8. Verify that you're prompted for consent.
9. Declined consent.
10. Verify that you're returned to the single-item cart, with no discount applied.
11. In the LMS, unenroll yourself from the course entirely.
12. Browse to the course and again attempt to enroll in the premium mode.
13. Verify that you're prompted for data sharing consent.
14. Consent to data sharing; verify that, if you created a discount code, the discount appears in the cart. If you created an enrollment code, verify that you are now enrolled in the premium course mode.
