### PR TITLE
Updated verification URL on receipt page

### DIFF
--- a/ecommerce/extensions/checkout/tests/test_views.py
+++ b/ecommerce/extensions/checkout/tests/test_views.py
@@ -8,7 +8,6 @@ from django.core.urlresolvers import reverse
 from oscar.core.loading import get_model
 from oscar.test import newfactories as factories
 
-from ecommerce.core.url_utils import get_lms_url
 from ecommerce.coupons.tests.mixins import CourseCatalogMockMixin
 from ecommerce.extensions.checkout.exceptions import BasketNotFreeError
 from ecommerce.extensions.checkout.utils import get_receipt_page_url
@@ -257,9 +256,7 @@ class ReceiptResponseViewTests(CourseCatalogMockMixin, LmsApiMockMixin, RefundTe
             'payment_method': None,
             'fire_tracking_events': False,
             'display_credit_messaging': False,
-            'verification_url': get_lms_url(
-                'verify_student/verify-now/{course_id}'.format(course_id=self.course.id)
-            ),
+            'verification_url': self.site.siteconfiguration.build_lms_url('verify_student/reverify'),
         }
 
         self.assertEqual(response.status_code, 200)

--- a/ecommerce/templates/oscar/checkout/_verification_data.html
+++ b/ecommerce/templates/oscar/checkout/_verification_data.html
@@ -18,7 +18,7 @@
        data-track-category="verification"
        data-track-event="edx.bi.user.verification.immediate"
        data-track-type="click"
-       href="{{ verification_url }}/">
+       href="{{ verification_url }}">
        {% trans "Verify Now" %}
     </a>
   </div>


### PR DESCRIPTION
The receipt page now points to the reverification page, which is not
course-specific. This is one step in making our receipt page more
applicable to orders containing multiple course seats.

LEARNER-278