### PR TITLE
Removed course-centric event tracking

### DIFF
--- a/ecommerce/credit/views.py
+++ b/ecommerce/credit/views.py
@@ -83,7 +83,6 @@ class Checkout(TemplateView):
             'analytics_data': prepare_analytics_data(
                 self.request.user,
                 self.request.site.siteconfiguration.segment_key,
-                course.id
             ),
             'course': course,
             'deadline': deadline,

--- a/ecommerce/extensions/analytics/tests/test_utils.py
+++ b/ecommerce/extensions/analytics/tests/test_utils.py
@@ -17,9 +17,8 @@ class UtilsTest(TestCase):
             email='test@example.com',
             tracking_context={'lms_user_id': '1235123'}
         )
-        data = prepare_analytics_data(user, self.site.siteconfiguration.segment_key, 'a/b/c')
+        data = prepare_analytics_data(user, self.site.siteconfiguration.segment_key)
         self.assertDictEqual(json.loads(data), {
-            'course': {'courseId': 'a/b/c'},
             'tracking': {'segmentApplicationId': self.site.siteconfiguration.segment_key},
             'user': {'user_tracking_id': '1235123', 'name': 'John Doe', 'email': 'test@example.com'}
         })
@@ -27,9 +26,8 @@ class UtilsTest(TestCase):
     def test_anon_prepare_analytics_data(self):
         """ Verify the function returns correct analytics data for an anonymous user."""
         user = AnonymousUser()
-        data = prepare_analytics_data(user, self.site.siteconfiguration.segment_key, 'a/b/c')
+        data = prepare_analytics_data(user, self.site.siteconfiguration.segment_key)
         self.assertDictEqual(json.loads(data), {
-            'course': {'courseId': 'a/b/c'},
             'tracking': {'segmentApplicationId': self.site.siteconfiguration.segment_key},
             'user': 'AnonymousUser'
         })

--- a/ecommerce/extensions/analytics/utils.py
+++ b/ecommerce/extensions/analytics/utils.py
@@ -87,21 +87,17 @@ def audit_log(name, **kwargs):
     logger.info(message)
 
 
-def prepare_analytics_data(user, segment_key, course_id=None):
+def prepare_analytics_data(user, segment_key):
     """ Helper function for preparing necessary data for analytics.
 
     Arguments:
         user (User): The user making the request.
         segment_key (str): Segment write/API key.
-        course_id (str): The course ID.
 
     Returns:
         str: JSON object with the data for analytics.
     """
     data = {
-        'course': {
-            'courseId': course_id
-        },
         'tracking': {
             'segmentApplicationId': segment_key
         }

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -295,7 +295,6 @@ class BasketSummaryView(BasketView):
             'analytics_data': prepare_analytics_data(
                 user,
                 site_configuration.segment_key,
-                unicode(course_key)
             ),
             'enable_client_side_checkout': False,
             'sdn_check': site_configuration.enable_sdn_check

--- a/ecommerce/static/js/test/specs/pages/basket_page_spec.js
+++ b/ecommerce/static/js/test/specs/pages/basket_page_spec.js
@@ -7,7 +7,6 @@ define([
         'utils/analytics_utils',
         'models/tracking_model',
         'models/user_model',
-        'views/analytics_view',
         'js-cookie',
         'moment'
     ],
@@ -19,7 +18,6 @@ define([
               AnalyticsUtils,
               TrackingModel,
               UserModel,
-              AnalyticsView,
               Cookies,
               moment) {
         'use strict';
@@ -468,15 +466,15 @@ define([
                     spyOn(TrackingModel.prototype, 'isTracking').and.callFake(function () {
                         return true;
                     });
-                    spyOn(AnalyticsView.prototype, 'track');
+                    spyOn(window.analytics, 'page');
+                    spyOn(window.analytics, 'track');
                     AnalyticsUtils.analyticsSetUp();
                     BasketPage.onReady();
-                    spyOn(window.analytics, 'page');
                 });
 
                 it('should trigger voucher applied analytics event', function () {
                     $('button.apply_voucher').trigger('click');
-                    expect(AnalyticsView.prototype.track).toHaveBeenCalledWith(
+                    expect(window.analytics.track).toHaveBeenCalledWith(
                         'edx.bi.ecommerce.basket.voucher_applied',
                         {type: 'click'}
                     );
@@ -484,14 +482,14 @@ define([
 
                 it('should trigger checkout analytics event', function () {
                     $('button.payment-button').trigger('click');
-                    expect(AnalyticsView.prototype.track).toHaveBeenCalledWith(
+                    expect(window.analytics.track).toHaveBeenCalledWith(
                         'edx.bi.ecommerce.basket.payment_selected',
                         {category: 'cybersource', type: 'click'}
                     );
                 });
 
                 it('should trigger page load analytics event', function () {
-                    $('<script type="text/javascript">var initModelData = {"course": {"courseId": "a/b/c"}};</script>')
+                    $('<script type="text/javascript">var initModelData = {};</script>')
                         .appendTo('body');
                     AnalyticsUtils.analyticsSetUp();
                     expect(window.analytics.page).toHaveBeenCalled();

--- a/ecommerce/static/js/test/specs/pages/coupon_offer_spec.js
+++ b/ecommerce/static/js/test/specs/pages/coupon_offer_spec.js
@@ -2,16 +2,12 @@ define([
         'jquery',
         'utils/analytics_utils',
         'pages/coupon_offer_page',
-        'models/tracking_model',
-        'models/user_model',
-        'views/analytics_view',
+        'models/tracking_model'
     ],
     function($,
              AnalyticsUtils,
              CouponOfferPage,
-             TrackingModel,
-             UserModel,
-             AnalyticsView
+             TrackingModel
              ) {
         'use strict';
 
@@ -38,14 +34,14 @@ define([
                     spyOn(TrackingModel.prototype, 'isTracking').and.callFake(function() {
                         return true;
                     });
-                    spyOn(AnalyticsView.prototype, 'track');
+                    spyOn(window.analytics, 'track');
                     AnalyticsUtils.analyticsSetUp();
                     new CouponOfferPage();
                 });
 
                 it('should trigger purchase certificate event', function() {
                     $('a#PurchaseCertificate').trigger('click');
-                    expect(AnalyticsView.prototype.track).toHaveBeenCalledWith(
+                    expect(window.analytics.track).toHaveBeenCalledWith(
                         'edx.bi.ecommerce.coupons.accept_offer',
                         { category: 'Coupons accepted offer', type: 'click' }
                     );

--- a/ecommerce/static/js/utils/analytics_utils.js
+++ b/ecommerce/static/js/utils/analytics_utils.js
@@ -6,7 +6,6 @@ define([
         'utils/utils',
         'models/user_model',
         'models/tracking_model',
-        'models/course_model',
         'views/clickable_view',
         'views/analytics_view'
     ],
@@ -17,28 +16,24 @@ define([
               Utils,
               UserModel,
               TrackingModel,
-              CourseModel,
               ClickableView,
               AnalyticsView) {
         'use strict';
 
         return {
             analyticsSetUp: function () {
-                var courseModel = new CourseModel(),
-                    trackingModel = new TrackingModel(),
+                var trackingModel = new TrackingModel(),
                     userModel = new UserModel();
 
                 /* jshint ignore:start */
                 // initModelData is set by the Django template at render time.
                 trackingModel.set(initModelData.tracking);
                 userModel.set(initModelData.user);
-                courseModel.set(initModelData.course);
                 /* jshint ignore:end */
 
                 new AnalyticsView({
                     model: trackingModel,
-                    userModel: userModel,
-                    courseModel: courseModel
+                    userModel: userModel
                 });
 
                 // instrument the click events

--- a/ecommerce/static/js/views/analytics_view.js
+++ b/ecommerce/static/js/views/analytics_view.js
@@ -1,9 +1,8 @@
 define([
         'jquery',
-        'backbone',
-        'underscore'
+        'backbone'
     ],
-    function ($, Backbone, _) {
+    function ($, Backbone) {
         'use strict';
 
         /**
@@ -42,7 +41,7 @@ define([
                     // kick off segment
                     this.initSegment(trackId);
                     this.logUser();
-                    this.recordPageData();
+                    analytics.page();
 
                     // now segment has been loaded, we can track events
                     this.listenTo(this.model, 'segment:track', this.track);
@@ -68,19 +67,6 @@ define([
             },
 
             /**
-             * Get data for initializing segment and record the initial page load.
-             */
-            recordPageData: function () {
-                var pageData = {};
-
-                if (this.options.courseModel.get('courseId')) {
-                    pageData = this.buildCourseProperties();
-                }
-
-                analytics.page(pageData);
-            },
-
-            /**
              * Log the user.
              */
             logUser: function () {
@@ -102,31 +88,16 @@ define([
                 );
             },
 
-            buildCourseProperties: function() {
-                var course = {};
-
-                if (this.options.courseModel) {
-                    course.courseId = this.options.courseModel.get('courseId');
-                }
-
-                if (this.model.has('page')) {
-                    course.label = this.model.get('page');
-                }
-
-                return course;
-            },
-
-            /**
-             * Catch 'segment:track' events and create events and send
-             * to Segment.
-             *
-             * @param eventType String event type.
-             */
+          /**
+           * Catch 'segment:track' events and create events and send
+           * to Segment.
+           *
+           * @param eventType String event type.
+           * @param properties Event properties.
+           */
             track: function (eventType, properties) {
-                var course = this.buildCourseProperties();
-
-                // send event to segment including the course ID
-                analytics.track(eventType, _.extend(course, properties));
+                // https://segment.com/docs/sources/website/analytics.js/#track
+                analytics.track(eventType, properties);
             }
         });
     }


### PR DESCRIPTION
Prior to this change course ID was treated special compared to other
event properties. This change treats the course ID as any other
property. Given that we have no course-centric pages, course ID will
almost never be included in the event properties going forward.

LEARNER-278