### PR TITLE
ENT-276: Display multiline large course name on offers page's course cards

### DIFF
--- a/ecommerce/static/sass/partials/utilities/_mixins.scss
+++ b/ecommerce/static/sass/partials/utilities/_mixins.scss
@@ -21,3 +21,29 @@
   transform: translateY(-50%);
   vertical-align: middle;
 }
+
+// Truncate overflow text with ellipses in multi-line format
+@mixin multiline-ellipsis($lineHeight: 1.2em, $lineCount: 1){
+  overflow: hidden;
+  width: 100%;
+  position: relative;
+  line-height: $lineHeight;
+  max-height: $lineHeight * $lineCount;
+  margin-right: -1em;
+  padding-right: 1em;
+  &:before {
+    content: '...';
+    position: absolute;
+    right: 0;
+    bottom: 0;
+  }
+  &:after {
+    content: '';
+    position: absolute;
+    right: 0;
+    width: 1em;
+    height: 1em;
+    margin-top: 0.2em;
+    background: white;
+  }
+}

--- a/ecommerce/static/sass/partials/views/_coupon_offer.scss
+++ b/ecommerce/static/sass/partials/views/_coupon_offer.scss
@@ -1,3 +1,5 @@
+@import "utilities/mixins";
+
 #offer {
     .container {
         padding-top: $container-padding-top;
@@ -148,13 +150,9 @@
                 }
                 .course-name {
                     margin: 0 0 5px 0;
-                    max-height: 28px;
-                    overflow: hidden;
-                    white-space: nowrap;
-                    text-overflow: ellipsis;
-                    font-size: 1.25em;
-                    line-height: 1.35;
+                    font-size: 1.1em;
                     font-weight: 600;
+                    @include multiline-ellipsis($lineHeight: 1.35em, $lineCount: 2);
                 }
                 .course-org {
                     font-size: 1em;


### PR DESCRIPTION
ENT-276

@asadiqbal08 @saleem-latif @mattdrayer 
Update course cards on offers page to display multi-line (2 lines) course name for large course names. So now only those course names will be truncated with ellipses (**...**) which are larger than 2 lines.
You can check that only last course with title/name `"A Dummy Course for QA Testing and Manual Verification of Stories"` is truncated with ellipses. This is achieved by using a css mixin `multiLine-ellipsis`.

<img width="1191" alt="screen shot 2017-04-03 at 11 32 15 am" src="https://cloud.githubusercontent.com/assets/5072991/24597789/4e5af63a-1861-11e7-8b5b-c2d582bbc3f7.png">

 
**Previously** the course name on course cards was truncated with ellipses, e.g. the course name `"Wind Mill Manufacturing and Energy Course"` with be `"Wind Mill Manufacturing an..."`.
<img width="1171" alt="screen shot 2017-03-29 at 1 57 36 pm" src="https://cloud.githubusercontent.com/assets/5072991/24446820/516662c4-1488-11e7-9eff-dd73cc0438d7.png">
