### PR TITLE
ENT-270: Add enterprise message to offers page

### DIFF
--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -234,6 +234,20 @@ class CouponOfferViewTests(ApiMockMixin, CouponMixin, CourseCatalogTestMixin, En
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
+    def test_offer_page_context_for_heading(self):
+        """
+        Verify the response context for logged in user and valid code, contains
+        expected heading and heading detail message.
+        """
+        url = self.prepare_url_for_credit_seat()
+        response = self.client.get(url)
+        expected_offer_page_heading = 'Welcome to edX'
+        expected_offer_page_heading_message = 'Please choose from the courses selected by your ' \
+                                              'organization to start learning.'
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['offer_app_page_heading'], expected_offer_page_heading)
+        self.assertEqual(response.context['offer_app_page_heading_message'], expected_offer_page_heading_message)
+
     def test_consent_failed_invalid(self):
         """ Verify that an error is returned if the consent_failed parameter is not a valid SKU. """
         url = '{}&consent_failed={}'.format(self.prepare_url_for_credit_seat(), 'INVALID')

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -120,6 +120,11 @@ class CouponOfferView(TemplateView):
         context_data.update(get_enterprise_customer_consent_failed_context_data(self.request, voucher))
 
         if context_data and 'error' not in context_data:
+            context_data.update({
+                'offer_app_page_heading': _('Welcome to edX'),
+                'offer_app_page_heading_message': _('Please choose from the courses selected by your '
+                                                    'organization to start learning.')
+            })
             self.template_name = 'coupons/offer.html'
 
         return context_data

--- a/ecommerce/static/js/views/offer_view.js
+++ b/ecommerce/static/js/views/offer_view.js
@@ -36,6 +36,8 @@ define([
                 this.$el.html(
                     this.template({
                         code: this.code,
+                        pageHeading: this.$el.closest('#offerApp').data('offerAppPageHeading'),
+                        pageHeadingMessage: this.$el.closest('#offerApp').data('offerAppPageHeadingMessage'),
                         courses: this.collection,
                         isCredit: this.isCredit,
                         isEnrollmentCode: this.isEnrollmentCode,
@@ -55,6 +57,8 @@ define([
                     this.$el.html(
                         this.template({
                             code: this.code,
+                            pageHeading: this.$el.closest('#offerApp').data('offerAppPageHeading'),
+                            pageHeadingMessage: this.$el.closest('#offerApp').data('offerAppPageHeadingMessage'),
                             courses: this.collection,
                             isCredit: this.isCredit,
                             isEnrollmentCode: this.isEnrollmentCode,

--- a/ecommerce/static/sass/partials/utilities/_variables.scss
+++ b/ecommerce/static/sass/partials/utilities/_variables.scss
@@ -40,6 +40,8 @@ $gray-color: #414141;
 
 // Offer landing page
 $gray-transparent: rgba(255, 255, 255, 0.5);
+$offer-page-blue: #0075b4;
+$offer-page-light-grey: #b1b2b4;
 $offer-page-price-blue: #0ea6ec;
 $offer-page-white: white;
 $offer-page-gray: gray;

--- a/ecommerce/static/sass/partials/views/_coupon_offer.scss
+++ b/ecommerce/static/sass/partials/views/_coupon_offer.scss
@@ -149,10 +149,14 @@
                     }
                 }
                 .course-name {
-                    margin: 0 0 5px 0;
-                    font-size: 1.1em;
-                    font-weight: 600;
-                    @include multiline-ellipsis($lineHeight: 1.35em, $lineCount: 2);
+                    min-height: 50px;
+
+                    p {
+                        margin: 0 0 5px 0;
+                        font-size: 1.1em;
+                        font-weight: 600;
+                        @include multiline-ellipsis($lineHeight: 1.35em, $lineCount: 2);
+                    }
                 }
                 .course-org {
                     font-size: 1em;
@@ -308,4 +312,19 @@
         color: #6B6969;
     }
 
+    .offer-page-heading {
+        padding: 0 0 15px;
+        margin: 0 15px 30px;
+        border-bottom: 1px solid $offer-page-light-grey;
+
+        .heading {
+            color: $offer-page-blue;
+            margin-bottom: 5px;
+        }
+
+        p {
+            font-size: 1rem;
+            margin-bottom: 0;
+        }
+    }
 }

--- a/ecommerce/static/templates/_offer_course_list.html
+++ b/ecommerce/static/templates/_offer_course_list.html
@@ -1,7 +1,10 @@
 <section class="col-xs-12 col-md-8 <% if (courses.length == 1) { %>col-lg-8 col-lg-offset-2<% }else { %>col-lg-12<% } %>">
 
     <% if (courses.length > 1) { %>
-    <h3 class="number-of-products-header col-xs-12"><%- gettext('Select one of the following courses.') %></h3>
+        <div class="offer-page-heading">
+            <h3 class="heading"><%= pageHeading %></h3>
+            <p><%= pageHeadingMessage %></p>
+        </div>
     <% } %>
 
     <% if (courses) { %>
@@ -31,7 +34,9 @@
                         </div>
                     </div>
                     <div class="col-sm-7 col-xs-12">
-                        <p class="course-name"><%= course.attributes.title %></p>
+                        <div class="course-name">
+                            <p><%= course.attributes.title %></p>
+                        </div>
 
                         <p class="course-org"><%= course.attributes.organization %></p>
 

--- a/ecommerce/templates/coupons/offer.html
+++ b/ecommerce/templates/coupons/offer.html
@@ -12,7 +12,7 @@
     <div id="offer">
         <div class="container">
             <div class="row">
-                <div id="offerApp">
+                <div id="offerApp" data-offer-app-page-heading="{{ offer_app_page_heading }}" data-offer-app-page-heading-message="{{ offer_app_page_heading_message }}">
                 </div>
                 <section class="verified-info col-xs-12 col-md-4 col-lg-12 hidden">
                     <p class="earn-verified-certificate col-xs-12 col-lg-5 pull-left-lg">{% trans "Earn a verified certificate in one of our popular courses to advance your career, showcase your accomplishments or enhance your college application." %}</p>


### PR DESCRIPTION
ENT-270
@asadiqbal08 @saleem-latif @mattdrayer 

Add/update the existing offers page heading message from "`Select one of the following courses.`" to "`Welcome to edX. Please choose from the courses selected by your organization to start learning.`" for **all users**.

<img width="1194" alt="screen shot 2017-04-05 at 5 30 21 pm" src="https://cloud.githubusercontent.com/assets/5072991/24705487/a05204fe-1a25-11e7-8101-92d620bee894.png">


**Previously:** 
<img width="1187" alt="screen shot 2017-03-28 at 3 25 37 pm" src="https://cloud.githubusercontent.com/assets/5072991/24602277/9005b96c-1875-11e7-8975-ff0974b4f089.png">
