### PR TITLE
ENT-291 - Cannot  change Enterprise name when editing coupon

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -517,6 +517,22 @@ class CouponViewSetFunctionalTest(CouponMixin, CourseCatalogTestMixin, CourseCat
         self.assertEqual(response_data['title'], 'New title')
         self.assertIsNone(response_data['email_domains'])
 
+    def test_update_enterprise_with_catalog(self):
+        """Test updating a coupon enterprise and seat type."""
+        enterprise_customer_id = str(uuid4()).decode('utf-8')
+        response_data = self.get_response_json(
+            'PUT',
+            reverse('api:v2:coupons-detail', kwargs={'pk': self.coupon.id}),
+            data={
+                'catalog_query': 'key:*',
+                'course_catalog': None,
+                'course_seat_types': ['verified'],
+                'enterprise_customer': {'name': 'test enterprise', 'id': enterprise_customer_id}
+            }
+        )
+        self.assertEqual(response_data['id'], self.coupon.id)
+        self.assertEqual(response_data['enterprise_customer'], enterprise_customer_id)
+
     def test_update_name(self):
         """Test updating voucher name."""
         data = {

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -278,9 +278,17 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
             return None
 
         voucher_range = vouchers.first().offers.first().benefit.range
+        enterprise_customer_data = request.data.get('enterprise_customer')
+
         # Remove catalog if switching from single course to dynamic query
+        # In case of enterprise, range_data has enterprise data in it as enterprise is defined in UPDATABLE_RANGE_FIELDS
+        # so Catalog should not be None if there is an enterprise is associated with it.
         if voucher_range.catalog:
-            range_data['catalog'] = None
+            if not enterprise_customer_data:
+                range_data['catalog'] = None
+
+            if enterprise_customer_data and range_data.get('catalog_query'):
+                range_data['catalog'] = None
 
         course_catalog_data = request.data.get('course_catalog')
         if course_catalog_data:
@@ -293,7 +301,6 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
         else:
             range_data['course_catalog'] = None
 
-        enterprise_customer_data = request.data.get('enterprise_customer')
         if enterprise_customer_data:
             range_data['enterprise_customer'] = enterprise_customer_data.get('id')
         else:

--- a/ecommerce/static/js/models/coupon_model.js
+++ b/ecommerce/static/js/models/coupon_model.js
@@ -239,7 +239,7 @@ define([
                 this.set('catalog_type', catalogType);
 
                 if (this.get('catalog_type') === this.catalogTypes.single_course) {
-                    if (seats[0]) {
+                    if (seats !== null && seats[0]) {
                         seat_data = seats[0].attribute_values;
 
                         this.set('seat_type', this.getCertificateType(seat_data));


### PR DESCRIPTION
TASK : [ENT-291](https://openedx.atlassian.net/browse/ENT-291)


Steps to Reproduce
1. Go to ecommerce.edx.org/coupons and select Test_GE coupon
2. Click Edit
3. Change Enterprise from GE to Boeing

Expected Behavior
Enterprise change is accepted and saved

Actual Behavior
System hangs and doesn't save

##### NOTE: QA has tested this on sandbox and said working fine as expected after these changes. 