### PR TITLE
Corrected event name

### DIFF
--- a/ecommerce/static/js/pages/receipt_page.js
+++ b/ecommerce/static/js/pages/receipt_page.js
@@ -9,7 +9,7 @@ define([
         'use strict';
 
         function trackPurchase(order_id, total_amount, currency) {
-            window.analytics.track('Completed Purchase', {
+            window.analytics.track('Completed Order', {
                 orderId: order_id,
                 total: total_amount,
                 currency: currency


### PR DESCRIPTION
The correct event name for completed orders is "Completed Order". "Completed Purchase" seems to have been copied from the old LMS-based receipt page, which has the wrong name.

LEARNER-414