### PR TITLE
Sort countries alphabetically by their full name.

### DIFF
--- a/ecommerce/extensions/payment/forms.py
+++ b/ecommerce/extensions/payment/forms.py
@@ -15,8 +15,13 @@ Basket = get_model('basket', 'Basket')
 
 
 def country_choices():
-    """ Returns a tuple of tuples, each containing an ISO 3166 country code. """
-    countries = [(country.alpha_2, country.name) for country in pycountry.countries]
+    """ Returns a tuple of tuples, each containing an ISO 3166 country code and the country name. """
+    countries = sorted(
+        [(country.alpha_2, country.name) for country in pycountry.countries],
+        key=lambda x: x[1]
+    )
+    # Inserting a placeholder here so that the first option
+    # when rendering the dropdown isn't a valid country.
     countries.insert(0, ('', _('<Choose country>')))
     return countries
 

--- a/ecommerce/extensions/payment/tests/test_forms.py
+++ b/ecommerce/extensions/payment/tests/test_forms.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import ddt
+import pycountry
 from oscar.test import factories
 
 from ecommerce.extensions.payment.forms import PaymentForm
@@ -8,9 +9,9 @@ from ecommerce.tests.testcases import TestCase
 
 
 @ddt.ddt
-class CyberSourceSubmitFormTests(TestCase):
+class PaymentFormTests(TestCase):
     def setUp(self):
-        super(CyberSourceSubmitFormTests, self).setUp()
+        super(PaymentFormTests, self).setUp()
         self.user = self.create_user()
         self.basket = factories.create_basket()
         self.basket.owner = self.user
@@ -92,3 +93,12 @@ class CyberSourceSubmitFormTests(TestCase):
 
         invalid_postal_code = ''.join(['a' for __ in range(0, 11)])
         self.assert_form_not_valid(country='IN', postal_code=invalid_postal_code)
+
+    def test_countries_sorting(self):
+        """ Verify the country choices are sorted by country name. """
+        data = self._generate_data()
+        form = PaymentForm(user=self.user, data=data)
+        expected = sorted([(country.alpha_2, country.name) for country in pycountry.countries], key=lambda x: x[1])
+        actual = list(form.fields['country'].choices)
+        actual.pop(0)   # Remove the "Choose country" placeholder
+        self.assertEqual(actual, expected)


### PR DESCRIPTION
After [updating](https://github.com/edx/ecommerce/commit/b78a6cbf60502c2f96d6feb5d53f58f68050d2fd) the ``pycountry`` package the country list wasn't in alphabetical order:
![screenshot from 2017-04-06 13-27-18](https://cloud.githubusercontent.com/assets/2808092/24752509/6c0bd2d4-1ace-11e7-808b-20ebccae19c3.png)

This PR sorts the countries back again:
![screenshot from 2017-04-06 13-35-50](https://cloud.githubusercontent.com/assets/2808092/24752533/8d8e777c-1ace-11e7-8252-91b60dbba4d8.png)
