### PR TITLE
[LEARNER-489] Fix discount data text overlap on the receipt page

### DIFF
--- a/ecommerce/static/sass/partials/views/_receipt.scss
+++ b/ecommerce/static/sass/partials/views/_receipt.scss
@@ -306,7 +306,7 @@
         }
 
         .order-total {
-            margin-left: 60%;
+            margin-left: 50%;
 
             padding: 20px 0;
 
@@ -334,7 +334,7 @@
             .price {
                 float: right;
 
-                margin-right: 12%;
+                margin-right: 10%;
 
                 color: black;
             }
@@ -343,6 +343,14 @@
 
     .wrapper-content-main {
         margin-bottom: 20px;
+    }
+}
+
+/* Medium devices (laptop, 1200px and lower) */
+@media (max-width: $screen-md-max) {
+    .discount {
+        display: block;
+        margin-top: 10px;
     }
 }
 

--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -101,12 +101,15 @@
 
                     {% if discount.voucher_code %}
                       {% with voucher=discount.voucher %}
-                        {% blocktrans trimmed with voucher_code=voucher.code voucher_discount_amount=voucher.benefit|benefit_discount %}
-                          {{ voucher_code }} {{ voucher_discount_amount }} off
-                        {% endblocktrans %}
+                        <span class="discount">{{ voucher.code }}</span>
+                        <span class="discount">
+                          {% blocktrans trimmed with voucher_code=voucher.code voucher_discount_amount=voucher.benefit|benefit_discount %}
+                            {{ voucher_discount_amount }} off
+                          {% endblocktrans %}
+                        </span>
                       {% endwith %}
                     {% else %}
-                      {{ discount.offer_name }}
+                      <span class="discount">{{ discount.offer_name }}</span>
                     {% endif %}
 
                   </div>


### PR DESCRIPTION
Reviewers:
@edx/helio 

JIRA ticket:
[Fix discount data text overlap on the receipt page](https://openedx.atlassian.net/browse/LEARNER-489)

Screenshot:
![screencapture-ecommerce-coupons-sandbox-edx-org-checkout-receipt-1491486436996](https://cloud.githubusercontent.com/assets/6833568/24757742/6027266e-1ae0-11e7-864f-2f6cf0afca81.png)
Mobile:
![mobile](https://cloud.githubusercontent.com/assets/6833568/24799921/1e6d6d32-1b9e-11e7-9c59-f19d718a3171.png)
