### PR TITLE
[ENT-303] Allow coupon API to be filtered by EnterpriseCustomer UUID; allow catalog-based coupons to be linked to EnterpriseCustomers

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -476,38 +476,49 @@ class CouponViewSetFunctionalTest(CouponMixin, CourseCatalogTestMixin, CourseCat
         response = self.client.get(COUPONS_LINK)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         coupon_data = json.loads(response.content)['results'][0]
-        self.assertEqual(coupon_data['title'], self.data['title'])
-        self.assertEqual(coupon_data['category']['name'], self.data['category']['name'])
-        self.assertEqual(coupon_data['client'], self.data['client'])
+        self.assert_coupon_data(coupon_data)
 
     def test_list_coupons_by_enterprise_customer(self):
         """
         Test the behavior of the coupon list view when filtering by EnterpriseCustomer UUID
         """
         ec_uuid = 'ec1f642c-3e5f-4e30-bdba-2d683d7bcba9'
+
         # First, test that when we filter by a UUID that isn't present, we don't get a result.
         response = self.client.get(COUPONS_LINK, {'enterprise_customer': ec_uuid})
         self.assertEqual(len(json.loads(response.content)['results']), 0)
+        
         # Next, test that when we don't pass a real UUID, we don't attempt to filter.
         response = self.client.get(COUPONS_LINK, {'enterprise_customer': 'fake_uuid'})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json.loads(response.content)['results']), 1)
+        # Validate that the contents of that single coupon are what we expect
         coupon_data = json.loads(response.content)['results'][0]
-        self.assertEqual(coupon_data['title'], self.data['title'])
-        self.assertEqual(coupon_data['category']['name'], self.data['category']['name'])
-        self.assertEqual(coupon_data['client'], self.data['client'])
+        self.assert_coupon_data(coupon_data)
+        
         # Finally, add a new coupon that has that UUID, and test that we only get that back when filtering.
         self.data['enterprise_customer'] = {'id': ec_uuid}
+        # Create the coupon...
         self.client.post(COUPONS_LINK, json.dumps(self.data), 'application/json')
+        # Check that when we filter by EnterpriseCustomer, we get that single coupon
         response = self.client.get(COUPONS_LINK, {'enterprise_customer': ec_uuid})
         self.assertEqual(len(json.loads(response.content)['results']), 1)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # Validate the contents of that coupon to match what we created
         coupon_data = json.loads(response.content)['results'][0]
+        self.assert_coupon_data(coupon_data)
+        
+        # And test that without filtering, we get both coupons.
+        response = self.client.get(COUPONS_LINK)
+        self.assertEqual(len(json.loads(response.content)['results']), 2)
+
+    def assert_coupon_data(self, coupon_data):
+        """
+        Verify the coupon data matches what we have stored.
+        """
         self.assertEqual(coupon_data['title'], self.data['title'])
         self.assertEqual(coupon_data['category']['name'], self.data['category']['name'])
         self.assertEqual(coupon_data['client'], self.data['client'])
-        response = self.client.get(COUPONS_LINK)
-        # And test that without filtering, we get both coupons.
-        self.assertEqual(len(json.loads(response.content)['results']), 2)
 
     def test_list_and_details_endpoint_return_custom_code(self):
         """Test that the list and details endpoints return the correct code."""

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -59,7 +59,7 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
         Handle cases where we need to filter by fields that aren't
         natively supported on the Coupon object.
         """
-        ec_filter = self.request.GET.get('enterprise_customer', None)
+        ec_filter = self.request.GET.get('enterprise_customer')
         objs = super(CouponViewSet, self).get_queryset()
         if ec_filter is not None:
             try:

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import logging
+import uuid
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -52,6 +53,28 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
         if self.action == 'list':
             return CouponListSerializer
         return CouponSerializer
+
+    def get_queryset(self):
+        """
+        Handle cases where we need to filter by fields that aren't
+        natively supported on the Coupon object.
+        """
+        ec_filter = self.request.GET.get('enterprise_customer', None)
+        objs = super(CouponViewSet, self).get_queryset()
+        if ec_filter is not None:
+            try:
+                # Check to make sure we got a real UUID
+                uuid.UUID(ec_filter)
+            except ValueError:
+                # If we didn't get a valid UUID for enterprise_customer, then skip the filtration
+                pass
+            else:
+                # We got a valid, UUID-like argument for enterprise_customer, for which we
+                # have to do an excessively complicated query to filter on.
+                objs = objs.filter(
+                    coupon_vouchers__vouchers__offers__condition__range__enterprise_customer=ec_filter
+                ).distinct()
+        return objs
 
     def create(self, request, *args, **kwargs):
         """Adds coupon to the user's basket.

--- a/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
@@ -201,16 +201,6 @@ define([
             });
 
             describe('enterprise customers', function () {
-                it('enterprise customer dropdown should be hidden when a catalog is selected', function () {
-                    view.$('#single-course').prop('checked', true).trigger('change');
-                    expect(SpecUtils.formGroup(view, '[name=enterprise_customer]')).toBeVisible();
-
-                    view.$('#catalog').prop('checked', true).trigger('change');
-                    expect(SpecUtils.formGroup(view, '[name=enterprise_customer]')).not.toBeVisible();
-
-                    view.$('#multiple-courses').prop('checked', true).trigger('change');
-                    expect(SpecUtils.formGroup(view, '[name=enterprise_customer]')).toBeVisible();
-                });
 
                 it('enterprise customer is setting properly', function() {
                     view.$('#single-course').prop('checked', true).trigger('change');

--- a/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
@@ -201,6 +201,16 @@ define([
             });
 
             describe('enterprise customers', function () {
+                it('enterprise customer dropdown should be visible, no matter what coupon scope is selected', function () {
+                    view.$('#single-course').prop('checked', true).trigger('change');
+                    expect(SpecUtils.formGroup(view, '[name=enterprise_customer]')).toBeVisible();
+
+                    view.$('#catalog').prop('checked', true).trigger('change');
+                    expect(SpecUtils.formGroup(view, '[name=enterprise_customer]')).toBeVisible();
+
+                    view.$('#multiple-courses').prop('checked', true).trigger('change');
+                    expect(SpecUtils.formGroup(view, '[name=enterprise_customer]')).toBeVisible();
+                });
 
                 it('enterprise customer is setting properly', function() {
                     view.$('#single-course').prop('checked', true).trigger('change');

--- a/ecommerce/static/js/views/coupon_form_view.js
+++ b/ecommerce/static/js/views/coupon_form_view.js
@@ -474,14 +474,11 @@ define([
                     this.formGroup('[name=course_id]').removeClass(this.hiddenClass);
                     this.formGroup('[name=seat_type]').removeClass(this.hiddenClass);
                     this.formGroup('[name=course_catalog]').addClass(this.hiddenClass);
-                    this.formGroup('[name=enterprise_customer]').removeClass(this.hiddenClass);
                 } else if (this.model.get('catalog_type') === this.model.catalogTypes.catalog) {
                     this.model.unset('course_id');
                     this.model.unset('seat_type');
                     this.model.unset('stock_record_ids');
                     this.model.unset('catalog_query');
-                    this.formGroup('[name=enterprise_customer]').addClass(this.hiddenClass);
-                    this.model.unset('enterprise_customer');
                     this.formGroup('[name=catalog_query]').addClass(this.hiddenClass);
                     this.formGroup('[name=course_seat_types]').removeClass(this.hiddenClass);
                     this.formGroup('[name=course_id]').addClass(this.hiddenClass);
@@ -499,7 +496,6 @@ define([
                     this.formGroup('[name=course_id]').addClass(this.hiddenClass);
                     this.formGroup('[name=seat_type]').addClass(this.hiddenClass);
                     this.formGroup('[name=course_catalog]').addClass(this.hiddenClass);
-                    this.formGroup('[name=enterprise_customer]').removeClass(this.hiddenClass);
                     this.$('[name=seat_type] option').remove();
                     this.model.unset('course_id');
                     this.model.unset('seat_type');


### PR DESCRIPTION
**Description:**

This pull request adds two feature:

First, the ability to link a catalog-based coupon to an EnterpriseCustomer. We had initially disallowed this, but it's become apparent that this is a necessary use case, so this pull request removes the Javascript that disallowed it.

Second, the ability to filter, in the API, coupons by the EnterpriseCustomer that they're linked to. This is accomplished by passing an `enterprise_customer` query parameter containing the UUID of the EnterpriseCustomer in question.

**JIRA:** [ENT-303](https://openedx.atlassian.net/browse/ENT-303)

**Dependencies:** None

**Merge deadline:** 24 April 2017

**Installation instructions:** Standard ecommerce installation

**Testing instructions:**

1. In the coupon creation view, verify that you can create a coupon tied to a catalog that is also tied to an EnterpriseCustomer.
2. In the coupon list API view, verify that adding an `enterprise_customer` query parameter that is a valid UUID filters the coupons down to only those coupons that are linked to that EnterpriseCustomer.
