### PR TITLE
ENT-310: Display Coupon Creation date on Otto coupon dashboard

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -541,7 +541,7 @@ class CouponListSerializer(serializers.ModelSerializer):
 
     class Meta(object):
         model = Product
-        fields = ('category', 'client', 'code', 'id', 'title')
+        fields = ('category', 'client', 'code', 'id', 'title', 'date_created')
 
 
 class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):

--- a/ecommerce/extensions/voucher/models.py
+++ b/ecommerce/extensions/voucher/models.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 
 from django.db import models
-from oscar.apps.voucher.abstract_models import AbstractVoucher
+from oscar.apps.voucher.abstract_models import AbstractVoucher  # pylint: disable=ungrouped-imports
 
 from ecommerce.core.utils import log_message_and_raise_validation_error
 
@@ -63,4 +63,4 @@ class Voucher(AbstractVoucher):
             return False
 
 
-from oscar.apps.voucher.models import *  # noqa isort:skip pylint: disable=wildcard-import,unused-wildcard-import,wrong-import-position,wrong-import-order
+from oscar.apps.voucher.models import *  # noqa isort:skip pylint: disable=wildcard-import,unused-wildcard-import,wrong-import-position,wrong-import-order,ungrouped-imports

--- a/ecommerce/static/js/test/specs/views/coupon_list_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/coupon_list_view_spec.js
@@ -1,0 +1,67 @@
+define([
+        'jquery',
+        'views/coupon_list_view',
+        'collections/coupon_collection'
+    ],
+    function ($, CouponListView, CouponCollection) {
+        'use strict';
+
+        describe('coupon list view', function () {
+            var view,
+                collection,
+                coupons = [
+                    {
+                        category: {id: 3, name: 'Affiliate Promotion'},
+                        code: 'G7SL19ZZ26PL07E',
+                        course_seats: [],
+                        course_seat_types: [],
+                        id: 1,
+                        max_uses: 2,
+                        price: 10,
+                        quantity: 1,
+                        seats: [],
+                        stock_record_ids: [],
+                        total_value: 10,
+                        date_created: new Date()
+                    },
+                    {
+                        category: {id: 3, name: 'Affiliate Promotion'},
+                        code: 'G7SL19ZZ26PL07E',
+                        course_seats: [],
+                        course_seat_types: [],
+                        id: 1,
+                        max_uses: 2,
+                        price: 10,
+                        quantity: 2,
+                        seats: [],
+                        stock_record_ids: [],
+                        total_value: 20,
+                        date_created: new Date()
+                    }
+                ];
+
+            beforeEach(function () {
+                collection = new CouponCollection();
+                collection.set(coupons);
+
+                view = new CouponListView({collection: collection}).render();
+            });
+
+            it('should change the default filter placeholder for coupon search field to a custom string', function () {
+                expect(view.$el.find('#couponTable_filter input[type=search]').attr('placeholder')).toBe('Search...');
+            });
+
+            it('should adjust the style of the coupon filter textbox', function () {
+                var $tableInput = view.$el.find('#couponTable_filter input');
+
+                expect($tableInput.hasClass('field-input input-text')).toBeTruthy();
+                expect($tableInput.hasClass('form-control input-sm')).toBeFalsy();
+            });
+
+            it('should populate the table based on the coupon collection', function () {
+                var tableData = view.$el.find('#couponTable').DataTable().data();
+                expect(tableData.data().length).toBe(collection.length);
+            });
+        });
+    }
+);

--- a/ecommerce/static/js/views/coupon_list_view.js
+++ b/ecommerce/static/js/views/coupon_list_view.js
@@ -39,7 +39,8 @@ define([
                     client: coupon.get('client'),
                     code: coupon.get('code'),
                     id: coupon.get('id'),
-                    title: coupon.get('title')
+                    title: coupon.get('title'),
+                    dateCreated: moment(coupon.get('date_created')).format('MMMM DD, YYYY, h:mm A')
                 };
             },
 
@@ -78,6 +79,10 @@ define([
                                 }, this)
                             },
                             {
+                                title: gettext('Created'),
+                                data: 'dateCreated'
+                            },
+                            {
                                 title: gettext('Custom Code'),
                                 data: 'code'
                             },
@@ -96,7 +101,7 @@ define([
                                     $(nTd).html(this.downloadTpl(oData));
                                 }, this),
                                 orderable: false
-                             }
+                            }
                         ]
                     });
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -13,7 +13,7 @@ mock==1.3.0
 mock-django==0.6.9
 nose-ignore-docstring==0.2
 pep8==1.6.2
-pylint==1.5.0
+pylint==1.6.4
 selenium>=3.0.1
 testfixtures==4.5.0
 diff-cover==0.9.6


### PR DESCRIPTION
Hi @zubair-arbi , @mattdrayer , @brittneyexline 

Please review this PR, I have added coupon creation date column in coupon admin page.

__Description of ENT-310:__
On the coupon dashboard screen, there is no "date created" field displayed. This makes it difficult to manage/sort, so the Marketing team resorts to adding the date to the title of the coupon... not a good practice. Better to display the Date Created field.

__Acceptance Criteria__
1. On the Coupon dashboard screen, add a new column for Date Created. 
2. Enable Sort by Date Created
3. Make sure meets A11y standards