### PR TITLE
Check for previous purchase before adding to basket

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -21,7 +21,6 @@ from slumber.exceptions import HttpNotFoundError, SlumberBaseException
 
 from ecommerce.core.url_utils import get_lms_url
 from ecommerce.core.utils import log_message_and_raise_validation_error
-from ecommerce.courses.utils import mode_for_seat
 from ecommerce.extensions.payment.exceptions import ProcessorNotFoundError
 from ecommerce.extensions.payment.helpers import get_processor_class, get_processor_class_by_name
 
@@ -412,44 +411,6 @@ class User(AbstractUser):
 
     def get_full_name(self):
         return self.full_name or super(User, self).get_full_name()
-
-    def is_user_already_enrolled(self, request, seat):
-        """
-        Check if a user is already enrolled in the course.
-        Calls the LMS enrollment API endpoint and sends the course ID and username query parameters
-        and returns the status of the user's enrollment in the course.
-
-        Arguments:
-            request (WSGIRequest): the request from which the LMS enrollment API endpoint is created.
-            seat (Product): the seat for which the check is done if the user is enrolled in.
-
-        Returns:
-            A boolean value if the user is enrolled in the course or not.
-
-        Raises:
-            ConnectionError, SlumberBaseException and Timeout for failures in establishing a
-            connection with the LMS enrollment API endpoint.
-        """
-        course_key = seat.attr.course_key
-        try:
-            api = EdxRestApiClient(
-                request.site.siteconfiguration.build_lms_url('/api/enrollment/v1'),
-                oauth_access_token=self.access_token,
-                append_slash=False
-            )
-            status = api.enrollment(','.join([self.username, course_key])).get()
-        except (ConnectionError, SlumberBaseException, Timeout):
-            log.exception(
-                'Failed to retrieve enrollment details for [%s] in course [%s]',
-                self.username,
-                course_key
-            )
-            raise
-
-        seat_type = mode_for_seat(seat)
-        if status and status.get('mode') == seat_type and status.get('is_active'):
-            return True
-        return False
 
     def account_details(self, request):
         """ Returns the account details from LMS.

--- a/ecommerce/core/tests/test_models.py
+++ b/ecommerce/core/tests/test_models.py
@@ -71,27 +71,6 @@ class UserTests(CourseCatalogTestMixin, LmsApiMockMixin, TestCase):
         self.assertEquals(user.get_full_name(), full_name)
 
     @httpretty.activate
-    @ddt.data(('verified', False), ('professional', True), ('no-id-professional', False))
-    @ddt.unpack
-    def test_is_user_enrolled(self, mode, id_verification):
-        """ Verify check for user enrollment in a course. """
-        user = self.create_user()
-        self.request.user = user
-        course_id1 = 'course-v1:test+test+test'
-        __, enrolled_seat = self.create_course_and_seat(
-            course_id=course_id1, seat_type=mode, id_verification=id_verification
-        )
-        self.mock_enrollment_api(self.request, user, course_id1, mode=mode)
-        self.assertTrue(user.is_user_already_enrolled(self.request, enrolled_seat))
-
-        course_id2 = 'course-v1:not+enrolled+here'
-        __, not_enrolled_seat = self.create_course_and_seat(
-            course_id=course_id2, seat_type=mode, id_verification=id_verification
-        )
-        self.mock_enrollment_api(self.request, user, course_id2, is_active=False, mode=mode)
-        self.assertFalse(user.is_user_already_enrolled(self.request, not_enrolled_seat))
-
-    @httpretty.activate
     def test_user_details(self):
         """ Verify user details are returned. """
         user = self.create_user()

--- a/ecommerce/extensions/order/exceptions.py
+++ b/ecommerce/extensions/order/exceptions.py
@@ -1,0 +1,10 @@
+"""
+Exceptions used by the Order app.
+"""
+
+
+class AlreadyPlacedOrderException(Exception):
+    """
+    Exception for user if he has already placed an order for course
+    """
+    pass

--- a/ecommerce/extensions/order/tests/test_utils.py
+++ b/ecommerce/extensions/order/tests/test_utils.py
@@ -1,14 +1,18 @@
 """Test Order Utility classes """
 import logging
 
+import ddt
 import mock
 from django.test.client import RequestFactory
-from oscar.core.loading import get_class
+from oscar.core.loading import get_class, get_model
 from oscar.test.factories import create_basket as oscar_create_basket
+from oscar.test.factories import create_order
 from oscar.test.newfactories import BasketFactory
 from testfixtures import LogCapture
 
 from ecommerce.extensions.fulfillment.status import ORDER
+from ecommerce.extensions.order.utils import UserAlreadyPlacedOrder
+from ecommerce.extensions.refund.tests.factories import RefundFactory
 from ecommerce.referrals.models import Referral
 from ecommerce.tests.factories import PartnerFactory, SiteConfigurationFactory
 from ecommerce.tests.testcases import TestCase
@@ -20,6 +24,8 @@ NoShippingRequired = get_class('shipping.methods', 'NoShippingRequired')
 OrderCreator = get_class('order.utils', 'OrderCreator')
 OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
 OrderTotalCalculator = get_class('checkout.calculators', 'OrderTotalCalculator')
+OrderLine = get_model('order', 'Line')
+RefundLine = get_model('refund', 'RefundLine')
 ShippingAddress = get_class('order.models', 'ShippingAddress')
 
 
@@ -169,3 +175,63 @@ class OrderCreatorTests(TestCase):
             order = self.create_order_model(basket)
             message = 'Referral for Order [{order_id}] failed to save.'.format(order_id=order.id)
             l.check((LOGGER_NAME, 'ERROR', message))
+
+
+@ddt.ddt
+class UserAlreadyPlacedOrderTests(TestCase):
+    """
+    Tests for Util class UserAlreadyPlacedOrder
+    """
+    def setUp(self):
+        super(UserAlreadyPlacedOrderTests, self).setUp()
+        self.user = self.create_user()
+        self.order = create_order(user=self.user)
+        self.product = self.get_order_product()
+
+    def get_order_product(self, order=None):
+        """
+        Args:
+            order: if no order given uses self.order
+        Returns:
+            the product order was placed for
+        """
+        order = self.order if not order else order
+        return OrderLine.objects.get(order=order).product
+
+    def test_already_have_not_refunded_order(self):
+        """
+        Test the case that user have a non refunded order for the product.
+        """
+        self.assertTrue(UserAlreadyPlacedOrder.user_already_placed_order(user=self.user, product=self.product))
+
+    def test_no_previous_order(self):
+        """
+        Test the case that user do not have any previous order for the product.
+        """
+        user = self.create_user()
+        self.assertFalse(UserAlreadyPlacedOrder.user_already_placed_order(user=user, product=self.product))
+
+    def test_already_have_refunded_order(self):
+        """
+        Test the case that user have a refunded order for the product.
+        """
+        user = self.create_user()
+        refund = RefundFactory(user=user)
+        refund_line = RefundLine.objects.get(refund=refund)
+        refund_line.status = 'Complete'
+        refund_line.save()
+        product = self.get_order_product(order=refund.order)
+        self.assertFalse(UserAlreadyPlacedOrder.user_already_placed_order(user=user, product=product))
+
+    @ddt.data(('Open', False), ('Revocation Error', False), ('Denied', False), ('Complete', True))
+    @ddt.unpack
+    def test_is_order_line_refunded(self, refund_line_status, is_refunded):
+        """
+        Tests the functionality of is_order_line_refunded method.
+        """
+        user = self.create_user()
+        refund = RefundFactory(user=user)
+        refund_line = RefundLine.objects.get(refund=refund)
+        refund_line.status = refund_line_status
+        refund_line.save()
+        self.assertEqual(UserAlreadyPlacedOrder.is_order_line_refunded(refund_line.order_line), is_refunded)

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -334,28 +334,6 @@ class LmsApiMockMixin(object):
         course_url = get_lms_url('api/courses/v1/courses/{}/'.format(course_id))
         httpretty.register_uri(httpretty.GET, course_url, body=course_info_json, content_type=CONTENT_TYPE)
 
-    def mock_enrollment_api(self, request, user, course_id, is_active=True, mode='audit'):
-        """ Returns a successful response indicating self.user is enrolled in the specified course mode. """
-        url = '{host}/enrollment/{username},{course_id}'.format(
-            host=request.site.siteconfiguration.build_lms_url('/api/enrollment/v1'),
-            username=user.username,
-            course_id=course_id
-        )
-        body = json.dumps({'mode': mode, 'is_active': is_active})
-        httpretty.register_uri(httpretty.GET, url, body=body, content_type=CONTENT_TYPE)
-
-    def mock_enrollment_api_error(self, request, user, course_id, error):
-        """ Mock Enrollment api call which raises error when called """
-        def callback(request, uri, headers):  # pylint: disable=unused-argument
-            raise error
-
-        url = '{host}/enrollment/{username},{course_id}'.format(
-            host=request.site.siteconfiguration.build_lms_url('/api/enrollment/v1'),
-            username=user.username,
-            course_id=course_id
-        )
-        httpretty.register_uri(httpretty.GET, url, body=callback, content_type=CONTENT_TYPE)
-
     def mock_account_api(self, request, username, data):
         """ Mock the account LMS API endpoint for a user.
 


### PR DESCRIPTION
**ECOM-7646**

**Description:**
As the Enrollment check was reverted in   ECOM-7349 MERGED  . Which use to prevent audit multiple order and audit multiple payment issues. We started facing those issues again. We need to get some more appropriate solution for those two issues.

**Steps to Reproduce:**
1. Go to stage
2. Enroll in a verified course as an audit student
3. Go to Dashboard
4. Open checkout page (by clicking on the upgrade to verified button) in new tab and pay for course
5. Go back to your dashboard tab (which should have been open this whole time)
6. Open checkout page in new tab (again by clicking the upgrade button) and pay for course again
7. You'll see you've created two orders for the same course

**Work:**
1. Add new order check to prevent multiple order issue
2. Remove Existing Enrollment Check
3. Update basket and coupon views to use Order check and write tests

**Expected behaviour:**
Students should not be able to pay for single course seat twice.

**Actual behaviour:** 
Students can pay for single course seat twice.

**Testing:**
[Sandbox](https://order-check.sandbox.edx.org)
<img width="1435" alt="screen shot 2017-05-22 at 1 39 16 pm" src="https://cloud.githubusercontent.com/assets/7721119/26299447/4e4321c2-3ef4-11e7-99a2-0a3aa73cb7cf.png">

**Reviewers:**
Style and readability review: @noraiz-anwar 
Code Review: @schenedx 
Code Review: @bderusha 

**Post-review:**
Rebase and squash commits.