### PR TITLE
Corrected paths for social-core

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -218,7 +218,7 @@ MIDDLEWARE_CLASSES = (
     # MUST appear AFTER CurrentSiteMiddleware.
     'ecommerce.extensions.basket.middleware.BasketMiddleware',
     'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
-    'social.apps.django_app.middleware.SocialAuthExceptionMiddleware',
+    'social_django.middleware.SocialAuthExceptionMiddleware',
     'simple_history.middleware.HistoryRequestMiddleware',
     'threadlocals.middleware.ThreadLocalMiddleware',
     'ecommerce.theming.middleware.CurrentSiteThemeMiddleware',
@@ -266,6 +266,7 @@ DJANGO_APPS = [
     'release_util',
     'crispy_forms',
     'solo',
+    'social_django',
 ]
 
 # Apps specific to this project go here.
@@ -407,8 +408,6 @@ ENABLE_AUTO_AUTH = False
 # Prefix for auto auth usernames. This value must be set in order for auto-auth to function.
 # If it were not set, we would be unable to automatically remove all auto-auth users.
 AUTO_AUTH_USERNAME_PREFIX = 'AUTO_AUTH_'
-
-INSTALLED_APPS += ['social.apps.django_app.default']
 
 AUTHENTICATION_BACKENDS = ('auth_backends.backends.EdXOpenIdConnect',) + AUTHENTICATION_BACKENDS
 

--- a/ecommerce/social_auth/tests/test_strategies.py
+++ b/ecommerce/social_auth/tests/test_strategies.py
@@ -1,6 +1,6 @@
 """Tests of social auth strategies."""
 from django.conf import settings
-from social.apps.django_app.default.models import DjangoStorage
+from social_django.models import DjangoStorage
 
 from ecommerce.social_auth.strategies import CurrentSiteDjangoStrategy
 from ecommerce.tests.testcases import TestCase

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -16,7 +16,7 @@ from mock import patch
 from oscar.core.loading import get_class, get_model
 from oscar.test import factories
 from oscar.test.utils import RequestFactory
-from social.apps.django_app.default.models import UserSocialAuth
+from social_django.models import UserSocialAuth
 from threadlocals.threadlocals import set_thread_variable
 
 from ecommerce.core.url_utils import get_lms_url

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ django-waffle==0.11.1
 djangorestframework==3.3.3
 djangorestframework-jwt==1.8.0
 drf-extensions==0.3.1
-edx-auth-backends==1.0.2
+edx-auth-backends==1.0.3
 edx-django-release-util==0.3.0
 edx-django-sites-extensions==1.0.0
 edx-drf-extensions==1.2.2


### PR DESCRIPTION
Python Social Auth paths have been corrected to social_core and social_django.

LEARNER-693