### PR TITLE
[LEARNER-618] Coupon discount should supersede base Program discount

### DIFF
--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -417,6 +417,8 @@ class VoucherAddView(BaseVoucherAddView):  # pylint: disable=function-redefined
 
             return
 
+        # Reset any site offers that are applied so that only one offer is active.
+        self.request.basket.reset_offer_applications()
         self.request.basket.vouchers.add(voucher)
 
         # Raise signal

--- a/ecommerce/extensions/test/factories.py
+++ b/ecommerce/extensions/test/factories.py
@@ -8,6 +8,7 @@ from oscar.test.factories import *  # pylint:disable=wildcard-import,unused-wild
 
 Benefit = get_model('offer', 'Benefit')
 Catalog = get_model('catalogue', 'Catalog')
+ConditionalOffer = get_model('offer', 'ConditionalOffer')
 Default = get_class('partner.strategy', 'Default')
 Voucher = get_model('voucher', 'Voucher')
 
@@ -81,13 +82,17 @@ def prepare_voucher(code='COUPONTEST', _range=None, start_datetime=None, end_dat
     condition = ConditionFactory(value=1, range=_range)
     if max_usage:
         offer = ConditionalOfferFactory(
-            name='PrepareVoucherOffer',
+            offer_type=ConditionalOffer.VOUCHER,
             benefit=benefit,
             condition=condition,
             max_global_applications=max_usage
         )
     else:
-        offer = ConditionalOfferFactory(name='PrepareVoucherOffer', benefit=benefit, condition=condition)
+        offer = ConditionalOfferFactory(
+            offer_type=ConditionalOffer.VOUCHER,
+            benefit=benefit,
+            condition=condition
+        )
     voucher.offers.add(offer)
     return voucher, product
 


### PR DESCRIPTION
Since we don't have official program discounts yet, I'm going with the assumption that they are going to be site-wide offers. I've created a 33% off site-wide offer and a 15% voucher offer, the way they behave after applying this PR is shown below:

![out-1](https://cloud.githubusercontent.com/assets/2808092/25658452/3662451a-3003-11e7-8584-d7b14152860c.gif)

FYI: @edx/helio 