### PR TITLE
Always fire Order Completed tracking event

### DIFF
--- a/ecommerce/extensions/checkout/tests/test_views.py
+++ b/ecommerce/extensions/checkout/tests/test_views.py
@@ -254,7 +254,6 @@ class ReceiptResponseViewTests(CourseCatalogMockMixin, LmsApiMockMixin, RefundTe
         response = self._get_receipt_response(order.number)
         context_data = {
             'payment_method': None,
-            'fire_tracking_events': False,
             'display_credit_messaging': False,
             'verification_url': self.site.siteconfiguration.build_lms_url('verify_student/reverify'),
         }
@@ -270,7 +269,6 @@ class ReceiptResponseViewTests(CourseCatalogMockMixin, LmsApiMockMixin, RefundTe
         response = self._visit_receipt_page_with_another_user(order, staff_user)
         context_data = {
             'payment_method': None,
-            'fire_tracking_events': False,
             'display_credit_messaging': False,
         }
 

--- a/ecommerce/extensions/checkout/views.py
+++ b/ecommerce/extensions/checkout/views.py
@@ -147,7 +147,6 @@ class ReceiptResponseView(ThankYouView):
         order = context[self.context_object_name]
         context.update({
             'payment_method': self.get_payment_method(order),
-            'fire_tracking_events': self.request.session.pop('fire_tracking_events', False),
             'display_credit_messaging': self.order_contains_credit_seat(order),
         })
         context.update(self.get_order_verification_context(order))

--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -321,7 +321,6 @@ class CybersourceInterstitialView(CybersourceNotificationMixin, View):
                 order_number=notification.get('req_reference_number'),
                 site_configuration=self.request.site.siteconfiguration
             )
-            self.request.session['fire_tracking_events'] = True
             return redirect(receipt_page_url)
         except:  # pylint: disable=bare-except
             return redirect(reverse('payment_error'))

--- a/ecommerce/static/js/pages/receipt_page.js
+++ b/ecommerce/static/js/pages/receipt_page.js
@@ -19,10 +19,9 @@ define([
         function onReady() {
             var el = $('#receipt-container'),
                 order_id = el.data('order-id'),
-                fire_tracking_events = el.data('fire-tracking-events'),
                 total_amount = el.data('total-amount'),
                 currency = el.data('currency');
-            if (order_id && fire_tracking_events) {
+            if (order_id) {
                 trackPurchase(order_id, total_amount, currency);
             }
         }

--- a/ecommerce/static/js/test/specs/pages/receipt_page_spec.js
+++ b/ecommerce/static/js/test/specs/pages/receipt_page_spec.js
@@ -12,7 +12,7 @@ define([
             beforeEach(function () {
                 $('<script type="text/javascript">var initModelData = {};</script>').appendTo('body');
                 $(
-                    '<div id="receipt-container" data-fire-tracking-events="true" data-order-id="ORDER_ID"></div>'
+                    '<div id="receipt-container" data-order-id="ORDER_ID"></div>'
                 ).appendTo('body');
                 AnalyticsUtils.analyticsSetUp();
 

--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -23,7 +23,6 @@
   <div id="receipt-container"
        class="receipt container content-container"
        data-currency="{{ order.currency }}"
-       data-fire-tracking-events="{{ fire_tracking_events|yesno:"true,false" }}"
        data-order-id="{{ order.number }}"
        data-total-amount="{{ order.total_incl_tax }}">
       <h2 class="thank-you">{% trans "Thank you for your order!" %}</h2>


### PR DESCRIPTION
ECOM-7716
We should always fire the "Order Completed" javascript event on our new Otto based receipt page.

@clintonb @mjfrey Please review