### PR TITLE
Removed unnecessary validation from Benefit model

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -418,17 +418,20 @@ class CouponViewSetFunctionalTest(CouponMixin, CourseCatalogTestMixin, CourseCat
         self.assertEqual(response_data.status_code, status.HTTP_404_NOT_FOUND)
 
     @ddt.data(
-        ('benefit_type', ['', 'Incorrect benefit type']),
-        ('benefit_value', ['', 'Incorrect benefit value', -1, 101]),
-        ('category', [{'a': 'a', 'b': 'b'}]),
+        {'benefit_type': ''},
+        {'benefit_type': 'foo'},
+        {'benefit_value': ''},
+        {'benefit_value': 'foo'},
+        {'benefit_value': -1},
+        {'benefit_value': 121},
+        {'category': {'a': 'a', 'b': 'b'}},
     )
-    @ddt.unpack
-    def test_create_coupon_product_invalid_data(self, key, values):
+    def test_create_coupon_product_invalid_data(self, invalid_data):
         """Test creating coupon when provided data is invalid."""
-        for value in values:
-            self.data.update({key: value})
-            response_data = self.client.post(COUPONS_LINK, json.dumps(self.data), 'application/json')
-            self.assertEqual(response_data.status_code, status.HTTP_400_BAD_REQUEST)
+        self.data.update(invalid_data)
+        response_data = self.client.post(COUPONS_LINK, json.dumps(self.data), 'application/json')
+        self.assertEqual(response_data.status_code, 400,
+                         'Request should fail for invalid data: {}'.format(invalid_data))
 
     @ddt.data('benefit_type', 'benefit_value')
     def test_create_coupon_product_no_data_provided(self, key):

--- a/ecommerce/extensions/offer/models.py
+++ b/ecommerce/extensions/offer/models.py
@@ -15,22 +15,13 @@ from ecommerce.core.utils import get_cache_key, log_message_and_raise_validation
 
 
 class Benefit(AbstractBenefit):
-    VALID_BENEFIT_TYPES = [AbstractBenefit.PERCENTAGE, AbstractBenefit.FIXED]
-
     def save(self, *args, **kwargs):
         self.clean()
         super(Benefit, self).save(*args, **kwargs)  # pylint: disable=bad-super-call
 
     def clean(self):
-        self.clean_type()
         self.clean_value()
         super(Benefit, self).clean()  # pylint: disable=bad-super-call
-
-    def clean_type(self):
-        if self.type not in self.VALID_BENEFIT_TYPES:
-            log_message_and_raise_validation_error(
-                'Failed to create Benefit. Unrecognised benefit type [{type}]'.format(type=self.type)
-            )
 
     def clean_value(self):
         if self.value < 0:
@@ -45,12 +36,12 @@ class ConditionalOffer(AbstractConditionalOffer):
 
     def save(self, *args, **kwargs):
         self.clean()
-        super(ConditionalOffer, self).save(*args, **kwargs)   # pylint: disable=bad-super-call
+        super(ConditionalOffer, self).save(*args, **kwargs)  # pylint: disable=bad-super-call
 
     def clean(self):
         self.clean_email_domains()
         self.clean_max_global_applications()  # Our frontend uses the name max_uses instead of max_global_applications
-        super(ConditionalOffer, self).clean()   # pylint: disable=bad-super-call
+        super(ConditionalOffer, self).clean()  # pylint: disable=bad-super-call
 
     def clean_email_domains(self):
         if self.email_domains == '':


### PR DESCRIPTION
The benefit_type field’s artificial limits should not exist. Limits necessary for coupons should be enforced by the Coupons API endpoint. This change will enable the creation of custom benefits that specify a benefit type that is outside of “percentage” or “fixed”.

LEARNER-435