### PR TITLE
Fix the bug on javascript won't run on receipt page

### DIFF
--- a/build.js
+++ b/build.js
@@ -37,7 +37,7 @@
             exclude: ['js/common']
         },
         {
-            name: 'js/pages/receipt_page',
+            name: 'js/apps/order_receipt_app',
             exclude: ['js/common']
         }
     ]

--- a/ecommerce/static/js/apps/order_receipt_app.js
+++ b/ecommerce/static/js/apps/order_receipt_app.js
@@ -1,0 +1,10 @@
+require([
+        'pages/receipt_page'
+    ],
+    function (ReceiptPage) {
+        'use strict';
+
+        new ReceiptPage();
+    }
+);
+

--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -12,7 +12,7 @@
 {% endblock title %}
 
 {% block javascript %}
-  <script src="{% static 'js/pages/receipt_page.js' %}"></script>
+  <script src="{% static 'js/apps/order_receipt_app.js' %}"></script>
 {% endblock javascript %}
 
 {% block navbar %}


### PR DESCRIPTION
ECOM-7716

@clintonb @AlasdairSwan @mjfrey Please review

With `define`, I found the javascript snippet here just won't run on the page.
Update it to `require` so it can run. I was able to verify this in the Chrome dev console on stage.
