### PR TITLE
Only send US formatted order value number to tracking LEARNER-964

### DIFF
--- a/ecommerce/extensions/checkout/tests/test_views.py
+++ b/ecommerce/extensions/checkout/tests/test_views.py
@@ -304,3 +304,13 @@ class ReceiptResponseViewTests(CourseCatalogMockMixin, LmsApiMockMixin, RefundTe
         body['course_key'] = seat.attr.course_key
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.context_data['display_credit_messaging'])
+
+    @httpretty.activate
+    def test_order_value_unlocalized_for_tracking(self):
+        order = self._create_order_for_receipt(self.user)
+        self.client.cookies.load({settings.LANGUAGE_COOKIE_NAME: 'fr'})
+        response = self._get_receipt_response(order.number)
+
+        self.assertEqual(response.status_code, 200)
+        order_value_string = 'data-total-amount="{}"'.format(order.total_incl_tax)
+        self.assertContains(response, order_value_string)

--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -2,6 +2,7 @@
 {% load core_extras %}
 {% load currency_filters %}
 {% load i18n %}
+{% load l10n %}
 {% load offer_tags %}
 {% load staticfiles %}
 
@@ -24,7 +25,7 @@
        class="receipt container content-container"
        data-currency="{{ order.currency }}"
        data-order-id="{{ order.number }}"
-       data-total-amount="{{ order.total_incl_tax }}">
+       data-total-amount="{{ order.total_incl_tax | unlocalize }}">
       <h2 class="thank-you">{% trans "Thank you for your order!" %}</h2>
 
       <div class="list-info">


### PR DESCRIPTION
Use the international API on javascript to format the order number for tracking consistently.

Please review @mjfrey @clintonb 