### PR TITLE
Create temp basket with site for calculation

### DIFF
--- a/ecommerce/extensions/api/v2/views/baskets.py
+++ b/ecommerce/extensions/api/v2/views/baskets.py
@@ -366,7 +366,7 @@ class BasketCalculateView(generics.GenericAPIView):
         # This is to avoid merging this temporary basket with a real user basket.
         try:
             with transaction.atomic():
-                basket = Basket(owner=request.user)
+                basket = Basket(owner=request.user, site=request.site)
                 basket.strategy = Selector().strategy(user=request.user)
 
                 for product in products:


### PR DESCRIPTION
When creating a temp basket used to calculate price / discount, we need to pass the site so things relying on it do not fail.
