### PR TITLE
Update jshint "predef" options

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -126,6 +126,8 @@
         "expect",
         "waitsFor",
         "runs",
+        "beforeAll",
+        "afterAll",
 
         // jQuery-Jasmine library.
         "loadFixtures",


### PR DESCRIPTION
This update will allow us to use beforeAll and afterAll in
jasmine tests.

@clintonb since you're the only contributor to this file please review.