### PR TITLE
There is no benefit type for program coupons

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -18,6 +18,7 @@ from ecommerce.core.constants import COURSE_ID_REGEX, ENROLLMENT_CODE_SWITCH, IS
 from ecommerce.core.url_utils import get_ecommerce_url
 from ecommerce.courses.models import Course
 from ecommerce.invoice.models import Invoice
+from ecommerce.programs.constants import BENEFIT_PROXY_CLASS_MAP
 
 logger = logging.getLogger(__name__)
 
@@ -575,7 +576,7 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
     voucher_type = serializers.SerializerMethodField()
 
     def get_benefit_type(self, obj):
-        return retrieve_benefit(obj).type
+        return retrieve_benefit(obj).type or BENEFIT_PROXY_CLASS_MAP[retrieve_benefit(obj).proxy_class]
 
     def get_benefit_value(self, obj):
         return retrieve_benefit(obj).value

--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -1112,6 +1112,19 @@ class CouponViewSetFunctionalTest(CouponMixin, CourseCatalogTestMixin, CourseCat
         )
         self.assertEqual(response_data['benefit_value'], edited_benefit_value)
 
+    @ddt.data(Benefit.PERCENTAGE, Benefit.FIXED)
+    def test_program_coupon_benefit_type(self, benefit_type):
+        """Verify that the coupon serializer returns benefit type for program coupons."""
+        self.data.update({
+            'benefit_type': benefit_type,
+            'program_uuid': str(uuid4()),
+            'title': 'Test Program Coupon Benefit Type',
+            'enterprise_customer': None,
+            'stock_record_ids': [],
+        })
+        details = self._create_and_get_coupon_details()
+        self.assertEqual(details['benefit_type'], benefit_type)
+
 
 class CouponCategoriesListViewTests(TestCase):
     """ Tests for the coupon category list view. """

--- a/ecommerce/extensions/offer/tests/test_utils.py
+++ b/ecommerce/extensions/offer/tests/test_utils.py
@@ -2,12 +2,12 @@ from decimal import Decimal
 
 import ddt
 from oscar.core.loading import get_model
-from oscar.test.factories import *  # pylint:disable=wildcard-import,unused-wildcard-import
 
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
 from ecommerce.extensions.checkout.utils import add_currency
 from ecommerce.extensions.offer.utils import _remove_exponent_and_trailing_zeros, format_benefit_value
+from ecommerce.extensions.test.factories import *  # pylint:disable=wildcard-import,unused-wildcard-import
 from ecommerce.tests.testcases import TestCase
 
 Benefit = get_model('offer', 'Benefit')
@@ -35,6 +35,17 @@ class UtilTests(CourseCatalogTestMixin, TestCase):
         benefit_value = format_benefit_value(self.value_benefit)
         expected_benefit = add_currency(Decimal((self.seat_price - 10)))
         self.assertEqual(benefit_value, '${expected_benefit}'.format(expected_benefit=expected_benefit))
+
+    def test_format_program_benefit_value(self):
+        """ format_benefit_value(program_benefit) should format benefit value based on proxy class. """
+        percentage_benefit = PercentageDiscountBenefitWithoutRangeFactory()
+        benefit_value = format_benefit_value(percentage_benefit)
+        self.assertEqual(benefit_value, '{}%'.format(percentage_benefit.value))
+
+        absolute_benefit = AbsoluteDiscountBenefitWithoutRangeFactory()
+        benefit_value = format_benefit_value(absolute_benefit)
+        expected_value = add_currency(Decimal(absolute_benefit.value))
+        self.assertEqual(benefit_value, '${}'.format(expected_value))
 
     @ddt.data(
         ('1.0', '1'),

--- a/ecommerce/extensions/offer/utils.py
+++ b/ecommerce/extensions/offer/utils.py
@@ -56,8 +56,16 @@ def format_benefit_value(benefit):
     Returns:
         benefit_value (str): String value containing formatted benefit value and type.
     """
+
+    # TODO: Find a better way to format benefit value so we can remove this import.
+    # Techdebt ticket: LEARNER-1317
+    # Import is here because of a circular dependency.
+    from ecommerce.programs.constants import BENEFIT_PROXY_CLASS_MAP
+
     benefit_value = _remove_exponent_and_trailing_zeros(Decimal(str(benefit.value)))
-    if benefit.type == Benefit.PERCENTAGE:
+    benefit_type = benefit.type or BENEFIT_PROXY_CLASS_MAP[benefit.proxy_class]
+
+    if benefit_type == Benefit.PERCENTAGE:
         benefit_value = _('{benefit_value}%'.format(benefit_value=benefit_value))
     else:
         converted_benefit = add_currency(Decimal(benefit.value))


### PR DESCRIPTION
There is no discount/benefit type for program coupons since we use
proxy_class to determine the type. This commit should take care of
displaying the proper benefit type on coupon details/edit page and
basket page.

LEARNER-1087