### PR TITLE
Add name attribute as a sequence to ProgramOfferFactory.

### DIFF
--- a/ecommerce/extensions/test/factories.py
+++ b/ecommerce/extensions/test/factories.py
@@ -108,7 +108,7 @@ class VoucherFactory(BaseVoucherFactory):  # pylint: disable=function-redefined
 
 
 class ConditionalOfferFactory(BaseConditionalOfferFactory):  # pylint: disable=function-redefined
-    name = factory.Faker('word')
+    name = factory.Sequence(lambda n: 'ConditionalOffer {number}'.format(number=n))
 
 
 class AbsoluteDiscountBenefitWithoutRangeFactory(BenefitFactory):


### PR DESCRIPTION
Flaky errors like [this one](https://gist.github.com/vkaracic/1e7cfae4e1d65dda8a3d15c4f042d012) have become way too common on Travis. Using a sequence instead of relying on `Faker` to always pick a new word from Lorem Ipsum is a better solution.

FYI @edx/helio 