### PR TITLE
Fix creating program offer when coupon with the same uuid already exists

### DIFF
--- a/ecommerce/programs/forms.py
+++ b/ecommerce/programs/forms.py
@@ -57,7 +57,12 @@ class ProgramOfferForm(forms.ModelForm):
         program_uuid = cleaned_data.get('program_uuid')
 
         if not self.instance.pk and program_uuid:
-            if ProgramCourseRunSeatsCondition.objects.filter(program_uuid=program_uuid).exists():
+            program_offer_exists = ConditionalOffer.objects.filter(
+                offer_type=ConditionalOffer.SITE,
+                condition__program_uuid=program_uuid
+            ).exists()
+
+            if program_offer_exists:
                 self.add_error('program_uuid', _('An offer already exists for this program.'))
 
         if cleaned_data['benefit_type'] == Benefit.PERCENTAGE and cleaned_data.get('benefit_value') > 100:

--- a/ecommerce/programs/tests/test_forms.py
+++ b/ecommerce/programs/tests/test_forms.py
@@ -114,3 +114,15 @@ class ProgramOfferFormTests(ProgramTestMixin, TestCase):
         form.is_valid()
         offer = form.save()
         self.assert_program_offer_conditions(offer, data['program_uuid'], data['benefit_value'], data['benefit_type'])
+
+    def test_create_when_conditional_offer_with_uuid_exists(self):
+        """
+        Verify a program offer can be created if a conditional offer with different type and same uuid already exists.
+        """
+        data = self.generate_data()
+        factories.ProgramOfferFactory(
+            condition__program_uuid=data['program_uuid'],
+            offer_type=ConditionalOffer.VOUCHER,
+        )
+        form = ProgramOfferForm(request=self.request, data=data)
+        self.assertTrue(form.is_valid())


### PR DESCRIPTION
LEARNER-1180

The goal is to enable creating program offers when a program coupon with the same uuid already exists.

@edx/helio please review.