### PR TITLE
Upgrade management commands excluding paypal to Django 1.9+

### DIFF
--- a/ecommerce/courses/management/commands/publish_to_lms.py
+++ b/ecommerce/courses/management/commands/publish_to_lms.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 import logging
 import os
-from optparse import make_option
 
 from django.core.management import BaseCommand, CommandError
 
@@ -16,15 +15,13 @@ class Command(BaseCommand):
     """Publish the courses to LMS."""
 
     help = 'Publish the courses to LMS'
-    option_list = BaseCommand.option_list + (
-        make_option(
-            '--course_ids_file',
-            action='store',
-            dest='course_ids_file',
-            default=None,
-            help='Path to file to read courses from.'
-        ),
-    )
+
+    def add_arguments(self, parser):
+        parser.add_argument('--course_ids_file',
+                            action='store',
+                            dest='course_ids_file',
+                            default=None,
+                            help='Path to file to read courses from.')
 
     ch = logging.StreamHandler()
     ch.setLevel(logging.DEBUG)

--- a/ecommerce/extensions/catalogue/management/commands/convert_course.py
+++ b/ecommerce/extensions/catalogue/management/commands/convert_course.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 import logging
-from optparse import make_option
 
 from django.core.management import BaseCommand
 from django.db import transaction
@@ -27,43 +26,36 @@ class Command(BaseCommand):
     help = 'Convert a list of courses from honor to audit, or vice versa. For use with courses '
     'which already have enrollments.'
 
-    option_list = BaseCommand.option_list + (
-        make_option(
-            '--access_token',
-            action='store',
-            dest='access_token',
-            default=None,
-            help='OAuth2 access token used to authenticate against the LMS APIs.'
-        ),
-        make_option(
-            '--commit',
-            action='store_true',
-            dest='commit',
-            default=False,
-            help='Save the changes to the database. If this is not set,'
-            ' migrated data will NOT be saved to the database.'
-        ),
-        make_option(
-            '--partner',
-            action='store',
-            dest='partner',
-            default=None,
-            help='Partner code for the site whose courses should be updated.'
-        ),
-        make_option(
-            '--direction',
-            action='store',
-            dest='direction',
-            type='choice',
-            choices=(HONOR_TO_AUDIT, AUDIT_TO_HONOR),
-            default=HONOR_TO_AUDIT,
-            help='Which direction to convert the courses. Options are honor_to_audit, or audit_to_honor.'
-        )
-    )
+    def add_arguments(self, parser):
+        parser.add_argument('course_ids', nargs='+', type=str)
+
+        parser.add_argument('--access_token',
+                            action='store',
+                            dest='access_token',
+                            default=None,
+                            help='OAuth2 access token used to authenticate against the LMS APIs.')
+        parser.add_argument('--commit',
+                            action='store_true',
+                            dest='commit',
+                            default=False,
+                            help='Save the changes to the database. If this is not set,'
+                                 ' migrated data will NOT be saved to the database.')
+        parser.add_argument('--partner',
+                            action='store',
+                            dest='partner',
+                            default=None,
+                            help='Partner code for the site whose courses should be updated.')
+        parser.add_argument('--direction',
+                            action='store',
+                            dest='direction',
+                            choices=(HONOR_TO_AUDIT, AUDIT_TO_HONOR),
+                            default=HONOR_TO_AUDIT,
+                            help='Which direction to convert the courses. Options are honor_to_audit, or audit_to_'
+                                 'honor.')
 
     def handle(self, *args, **options):
         self.options = options  # pylint: disable=attribute-defined-outside-init
-        course_ids = map(unicode, args)
+        course_ids = map(unicode, self.options.get('course_ids', []))
 
         self.access_token = options.get('access_token')  # pylint: disable=attribute-defined-outside-init
         if not self.access_token:

--- a/ecommerce/extensions/catalogue/management/commands/migrate_course.py
+++ b/ecommerce/extensions/catalogue/management/commands/migrate_course.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 import logging
-from optparse import make_option
 
 import requests
 import waffle
@@ -153,27 +152,28 @@ class MigratedCourse(object):
 class Command(BaseCommand):
     help = 'Migrate course modes and pricing from LMS to Oscar.'
 
-    option_list = BaseCommand.option_list + (
-        make_option('--access_token',
-                    action='store',
-                    dest='access_token',
-                    default=None,
-                    help='OAuth2 access token used to authenticate against some LMS APIs.'),
-        make_option('--commit',
-                    action='store_true',
-                    dest='commit',
-                    default=False,
-                    help='Save the migrated data to the database. If this is not set, '
-                         'migrated data will NOT be saved to the database.'),
-        make_option('--site',
-                    action='store',
-                    dest='site_domain',
-                    default=None,
-                    help='Domain for the ecommerce site providing the course.'),
-    )
+    def add_arguments(self, parser):
+        parser.add_argument('course_ids', nargs='+', type=str)
+
+        parser.add_argument('--access_token',
+                            action='store',
+                            dest='access_token',
+                            default=None,
+                            help='OAuth2 access token used to authenticate against some LMS APIs.')
+        parser.add_argument('--commit',
+                            action='store_true',
+                            dest='commit',
+                            default=False,
+                            help='Save the migrated data to the database. If this is not set, '
+                                 'migrated data will NOT be saved to the database.')
+        parser.add_argument('--site',
+                            action='store',
+                            dest='site_domain',
+                            default=None,
+                            help='Domain for the ecommerce site providing the course.')
 
     def handle(self, *args, **options):
-        course_ids = args
+        course_ids = options.get('course_ids', [])
         access_token = options.get('access_token')
         site_domain = options.get('site_domain')
         if not access_token:

--- a/ecommerce/extensions/catalogue/management/commands/update_course_seat_expire.py
+++ b/ecommerce/extensions/catalogue/management/commands/update_course_seat_expire.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import logging
 import time
-from optparse import make_option
 
 from dateutil import parser
 from django.core.management import BaseCommand, CommandError
@@ -19,14 +18,14 @@ class Command(BaseCommand):
     """Update seat expire dates."""
 
     help = 'Update seat expire with the course enrollment end date.'
-    option_list = BaseCommand.option_list + (
-        make_option('--commit',
-                    action='store_true',
-                    dest='commit',
-                    default=False,
-                    help='Save the data to the database. If this is not set, '
-                         'expires date will not be updated'),
-    )
+
+    def add_arguments(self, par):
+        par.add_argument('--commit',
+                         action='store_true',
+                         dest='commit',
+                         default=False,
+                         help='Save the data to the database. If this is not set, '
+                              'expires date will not be updated')
 
     ch = logging.StreamHandler()
     ch.setLevel(logging.DEBUG)

--- a/ecommerce/extensions/voucher/tests/test_utils.py
+++ b/ecommerce/extensions/voucher/tests/test_utils.py
@@ -610,13 +610,12 @@ class UtilTests(CouponMixin, CourseCatalogMockMixin, CourseCatalogTestMixin, Lms
 
     def test_no_product(self):
         """ Verify that an exception is raised if there is no product. """
-        code = FuzzyText().fuzz()
-        voucher = VoucherFactory(code=code)
+        voucher = VoucherFactory()
         offer = ConditionalOfferFactory()
         voucher.offers.add(offer)
 
         with self.assertRaises(exceptions.ProductNotFoundError):
-            get_voucher_and_products_from_code(code=code)
+            get_voucher_and_products_from_code(code=voucher.code)
 
     def test_get_non_existing_voucher(self):
         """ Verify that get_voucher_and_products_from_code() raises exception for a non-existing voucher. """


### PR DESCRIPTION
LEARNER-1246
Subtask of LEARNER-480

Updating Management commands for Django >=1.9, by removing deprecated Django 1.8 features.