### PR TITLE
Change voucher factory code attribute to a sequence.

### DIFF
--- a/ecommerce/extensions/test/factories.py
+++ b/ecommerce/extensions/test/factories.py
@@ -104,7 +104,7 @@ def prepare_voucher(code='COUPONTEST', _range=None, start_datetime=None, end_dat
 
 class VoucherFactory(BaseVoucherFactory):  # pylint: disable=function-redefined
     name = factory.Faker('word')
-    code = factory.Faker('word')
+    code = factory.Sequence(lambda n: 'VOUCHERCODE{number}'.format(number=n))
 
 
 class ConditionalOfferFactory(BaseConditionalOfferFactory):  # pylint: disable=function-redefined


### PR DESCRIPTION
Same issue as here: https://github.com/edx/ecommerce/pull/1296 happens for the `VoucherFactory.code` attribute. I couldn't find anymore unique attributes in our test factories so we should be fine after this change.

FYI @edx/helio 