### PR TITLE
[ENT-357] Display course run price with entitlement on Landing page & course description modal

### DIFF
--- a/ecommerce/extensions/api/v2/views/baskets.py
+++ b/ecommerce/extensions/api/v2/views/baskets.py
@@ -14,6 +14,7 @@ from rest_framework import generics, status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
+from ecommerce.enterprise.entitlements import get_entitlement_voucher
 from ecommerce.extensions.analytics.utils import audit_log
 from ecommerce.extensions.api import data as data_api
 from ecommerce.extensions.api import exceptions as api_exceptions
@@ -334,7 +335,9 @@ class BasketCalculateView(generics.GenericAPIView):
         """ Calculate basket totals given a list of sku's
 
         Create a temporary basket add the sku's and apply an optional voucher code.
-        Then calculate the total proce less discounts.
+        Then calculate the total price less discounts. If a voucher code is not
+        provided apply a voucher in the Enterprise entitlements available
+        to the user.
 
         Arguments:
             sku (string): A list of sku(s) to calculate
@@ -361,6 +364,10 @@ class BasketCalculateView(generics.GenericAPIView):
         products = Product.objects.filter(stockrecords__partner=partner, stockrecords__partner_sku__in=skus)
         if not products:
             return HttpResponseBadRequest(_('Products with SKU(s) [{skus}] do not exist.').format(skus=', '.join(skus)))
+
+        # If there is only one product apply an Enterprise entitlement voucher
+        if not voucher and len(products) == 1:
+            voucher = get_entitlement_voucher(request, products[0])
 
         # We wrap this in an atomic operation so we never commit this to the db.
         # This is to avoid merging this temporary basket with a real user basket.


### PR DESCRIPTION
This PR modifies the `/api/v2/baskets/calculate` endpoint to look for vouchers in the Enterprise entitlements available to the user when a vocher code is not provided.

Related edx-enterprise PR: https://github.com/edx/edx-enterprise/pull/118