### PR TITLE
Can't edit course two times

### DIFF
--- a/ecommerce/static/js/models/course_seats/course_seat.js
+++ b/ecommerce/static/js/models/course_seats/course_seat.js
@@ -30,7 +30,7 @@ define([
                 },
                 expires: function (value) {
                     var verificationDeadline,
-                        course = this.get('course');
+                        course = this.course || this.get('course');
 
                     // No validation is needed when the Seat is not linked to the course
                     if (!course || !course.get('id')) {

--- a/ecommerce/static/js/test/specs/models/course_seats/course_seat_spec.js
+++ b/ecommerce/static/js/test/specs/models/course_seats/course_seat_spec.js
@@ -39,6 +39,18 @@ define([
         });
 
         describe('Course seat model', function () {
+            describe('update model data', function() {
+                it('should be able to update seat data twice', function() {
+                    var model = CourseSeat.findOrCreate(data, {parse: true}),
+                        title1 = 'Changed title',
+                        title2 = 'Changed title 2';
+                    model.set({title: title1});
+                    expect(model.get('title')).toEqual(title1);
+                    model.set({title: title2});
+                    expect(model.get('title')).toEqual(title2);
+                });
+            });
+
             describe('getSeatType', function () {
                 it('should return a seat type corresponding to the certificate type', function () {
                     var mappings = {


### PR DESCRIPTION
LEARNER-1293

@edx/helio This should fix the issue of editing a course two times in a row. But a few flaky tests appeared after this fix (three to be precise). I don't want to merge until this is resolved but I didn't find a solution yet. I will fix other issues at hand and then return to this one if someone doesn't find a solution in the mean time.