### PR TITLE
Passing SKU to ecom_worker for sailthru calls.

### DIFF
--- a/ecommerce/sailthru/signals.py
+++ b/ecommerce/sailthru/signals.py
@@ -55,6 +55,7 @@ def process_checkout_complete(sender, order=None, user=None, request=None,  # py
 
         # get product
         product = line.product
+        sku = line.partner_sku
 
         # ignore everything except course seats.  no support for coupons as of yet
         if product.is_seat_product:
@@ -65,7 +66,8 @@ def process_checkout_complete(sender, order=None, user=None, request=None,  # py
             update_course_enrollment.delay(order.user.email, _build_course_url(course_id),
                                            False, mode_for_seat(product),
                                            unit_cost=price, course_id=course_id, currency=order.currency,
-                                           site_code=site_configuration.partner.short_code, message_id=message_id)
+                                           site_code=site_configuration.partner.short_code, message_id=message_id,
+                                           sku=sku)
 
 
 @receiver(basket_addition)

--- a/ecommerce/sailthru/tests/test_signals.py
+++ b/ecommerce/sailthru/tests/test_signals.py
@@ -97,7 +97,8 @@ class SailthruSignalTests(CouponMixin, CourseCatalogTestMixin, TestCase):
             currency=order.currency,
             message_id=CAMPAIGN_COOKIE,
             site_code=self.partner.short_code,
-            unit_cost=order.total_excl_tax
+            unit_cost=order.total_excl_tax,
+            sku=order.lines.first().partner_sku
         )
 
     @patch('ecommerce_worker.sailthru.v1.tasks.update_course_enrollment.delay')
@@ -116,7 +117,8 @@ class SailthruSignalTests(CouponMixin, CourseCatalogTestMixin, TestCase):
             currency=order.currency,
             message_id=None,
             site_code=self.partner.short_code,
-            unit_cost=order.total_excl_tax
+            unit_cost=order.total_excl_tax,
+            sku=order.lines.first().partner_sku
         )
 
     @patch('ecommerce_worker.sailthru.v1.tasks.update_course_enrollment.delay')
@@ -177,7 +179,8 @@ class SailthruSignalTests(CouponMixin, CourseCatalogTestMixin, TestCase):
             currency=order.currency,
             message_id=CAMPAIGN_COOKIE,
             site_code=self.partner.short_code,
-            unit_cost=order.total_excl_tax
+            unit_cost=order.total_excl_tax,
+            sku=order.lines.first().partner_sku
         )
 
     def test_basket_attribute_update_with_existing_attribute(self):
@@ -217,7 +220,8 @@ class SailthruSignalTests(CouponMixin, CourseCatalogTestMixin, TestCase):
             currency=order.currency,
             message_id=CAMPAIGN_COOKIE,
             site_code=self.partner.short_code,
-            unit_cost=order.total_excl_tax
+            unit_cost=order.total_excl_tax,
+            sku=order.lines.first().partner_sku
         )
 
     def _create_order(self, price, mode='verified'):


### PR DESCRIPTION
LEARNER-1378 - Subtask for LEARNER-1193

This explicit passing would simplify ecom-worker implementation. Ecom-worker instead of using ecom-api for fetching sku, it would get this from ecommerce as part of signal handling code.