### PR TITLE
Added payment processor configuration for devstack

### DIFF
--- a/ecommerce/settings/devstack.py
+++ b/ecommerce/settings/devstack.py
@@ -1,5 +1,6 @@
 """Devstack settings"""
-from ecommerce.settings._debug_toolbar import *
+# noinspection PyUnresolvedReferences
+from ecommerce.settings._debug_toolbar import *  # isort:skip
 from ecommerce.settings.production import *
 
 DEBUG = True
@@ -23,22 +24,28 @@ COMPRESS_ENABLED = False
 # PAYMENT PROCESSING
 PAYMENT_PROCESSOR_CONFIG = {
     'edx': {
+        # NOTE: The same profile information is used here to appease the payment processor class.
+        # Only Silent Order POST is actually used.
         'cybersource': {
+            'merchant_id': 'edx_org',
+            'transaction_key': '/yIJJejEGoNNcecTyxC9ZD0wR2ZjkkKuOaZnq2BGMGIGQIOKA1rBR009OuvKbPW4J1KLb15BMlaoiUXoj/8/Fp6dy33/aHAU0+yGKcEMxyYXQOBPKjuoChIlMRVkrtWZqP9shGxw1jwHNovmGrvd2ULRIn21Rsq6YnHie7lLLRhXyY2MjnFXfv75eH2rFwfi4hBPbVPvx/r8PwgFIh5otAzsgyIlBjaKJkzbNXd5qCOdNFSBcPcJps3YgVH0ASleI/SZp+Ckuyotd+EhzK0tOehPJAm3L03lkPNeFX9lcemuRkeV53V3nvobn3GaX0td4FAEe8CZBn+IpFC2PoK0tw==',
             'soap_api_url': 'https://ics2wstest.ic3.com/commerce/1.x/transactionProcessor/CyberSourceTransaction_1.115.wsdl',
-            'merchant_id': 'fake-merchant-id',
-            'transaction_key': 'fake-transaction-key',
-            'profile_id': 'fake-profile-id',
-            'access_key': 'fake-access-key',
-            'secret_key': 'fake-secret-key',
+            'profile_id': '00D31C4B-4E8F-4E9F-A6B9-1DB8C7C86223',
+            'access_key': '90a39534dc513e8a81222b158378dda1',
+            'secret_key': 'ff09d545ddbe4f1e908cc47e3cceb30e4e9ff57a1fe0493392b69a0b75f8ac3df7840f89131d46faa4487071d53576d25047ebb39e9b4af18e9fb5ee1d4f1f66fdb711284c844c4c82bd24f168781e786ecf8b2d3dba4ab5b543c188ca5728e00b8ace43cca14cefbb605ecdc0706eda4cd50785d5754fd691426ddff03fcc7b',
             'payment_page_url': 'https://testsecureacceptance.cybersource.com/pay',
             'receipt_path': PAYMENT_PROCESSOR_RECEIPT_PATH,
             'cancel_checkout_path': PAYMENT_PROCESSOR_CANCEL_PATH,
             'send_level_2_3_details': True,
+            'sop_profile_id': '00D31C4B-4E8F-4E9F-A6B9-1DB8C7C86223',
+            'sop_access_key': '90a39534dc513e8a81222b158378dda1',
+            'sop_secret_key': 'ff09d545ddbe4f1e908cc47e3cceb30e4e9ff57a1fe0493392b69a0b75f8ac3df7840f89131d46faa4487071d53576d25047ebb39e9b4af18e9fb5ee1d4f1f66fdb711284c844c4c82bd24f168781e786ecf8b2d3dba4ab5b543c188ca5728e00b8ace43cca14cefbb605ecdc0706eda4cd50785d5754fd691426ddff03fcc7b',
+            'sop_payment_page_url': 'https://testsecureacceptance.cybersource.com/silent/pay',
         },
         'paypal': {
             'mode': 'sandbox',
-            'client_id': 'fake-client-id',
-            'client_secret': 'fake-client-secret',
+            'client_id': 'ATWMN3ZlgZl750ITtIEDZAqeyHIlRfrfaFBAnWpTHB8UDQE8Lrr6dgU6sE1Wz5cjmCxp4x8iRpIx-GXn',
+            'client_secret': 'EDE1bAVYDYEDlNW_iMNeMXP9T2LLPghMrsIqjMKi0Q3lmfgZUdgypkJhGnWesQD5E2AA_0mFgz6kckoc',
             'receipt_path': PAYMENT_PROCESSOR_RECEIPT_PATH,
             'cancel_checkout_path': PAYMENT_PROCESSOR_CANCEL_PATH,
             'error_path': PAYMENT_PROCESSOR_ERROR_PATH,
@@ -50,4 +57,5 @@ PAYMENT_PROCESSOR_CONFIG = {
 #####################################################################
 # Lastly, see if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
+    # noinspection PyUnresolvedReferences
     from .private import *  # pylint: disable=import-error


### PR DESCRIPTION
This change enables developers to quickly test payments without manual configuration.

LEARNER-1375