### PR TITLE
Fix i18n config to enable auto-translation updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ compile_translations:
 fake_translations: extract_translations dummy_translations compile_translations
 
 pull_translations:
-	cd ecommerce && tx pull -af
+	cd ecommerce && tx pull -af --mode reviewed
 
 push_translations:
 	cd ecommerce && tx push -s

--- a/ecommerce/.tx/config
+++ b/ecommerce/.tx/config
@@ -2,13 +2,15 @@
 host = https://www.transifex.com
 
 [edx-platform.ecommerce]
-file_filter = conf/locale/<lang>/LC_MESSAGES/django-partial.po
-source_file = conf/locale/en/LC_MESSAGES/django-partial.po
-source_lang = en
+file_filter = conf/locale/<lang>/LC_MESSAGES/django.po
+source_file = conf/locale/en/LC_MESSAGES/django.po
+source_lang = en_US
 type = PO
+lang_map = en_US:en
 
 [edx-platform.ecommerce-js]
-file_filter = conf/locale/<lang>/LC_MESSAGES/djangojs-partial.po
-source_file = conf/locale/en/LC_MESSAGES/djangojs-partial.po
-source_lang = en
+file_filter = conf/locale/<lang>/LC_MESSAGES/djangojs.po
+source_file = conf/locale/en/LC_MESSAGES/djangojs.po
+source_lang = en_US
 type = PO
+lang_map = en_US:en


### PR DESCRIPTION
Fixes configuration issues that were preventing us from automatically updating translations for the ecommerce repo.

Summary:
- Removes *.po and *.mo from .gitignore. Their presence in the .gitignore file prevented the jenkins transifex/pull job from correctly detecting that translations had changed, and therefore it never attempted to open pull requests to update them.
- Fixes .tx/config so that the translation files are mapped with the correct names.
- adds `--mode reviewed` to the pull_translations command to ensure that only reviewed translations are merged to master.

@rlucioni 