### PR TITLE
Removed usage of SiteConfiguration.enable_otto_receipt_page

### DIFF
--- a/ecommerce/core/management/commands/create_or_update_site.py
+++ b/ecommerce/core/management/commands/create_or_update_site.py
@@ -137,7 +137,6 @@ class Command(BaseCommand):
         segment_key = options.get('segment_key')
         from_email = options.get('from_email')
         enable_enrollment_codes = True if options.get('enable_enrollment_codes') else False
-        enable_otto_receipt_page = not options.get('disable_otto_receipt_page')
         payment_support_email = options.get('payment_support_email', '')
         payment_support_url = options.get('payment_support_url', '')
         base_cookie_domain = options.get('base_cookie_domain', '')
@@ -169,7 +168,6 @@ class Command(BaseCommand):
             'segment_key': segment_key,
             'from_email': from_email,
             'enable_enrollment_codes': enable_enrollment_codes,
-            'enable_otto_receipt_page': enable_otto_receipt_page,
             'send_refund_notifications': options['send_refund_notifications'],
             'oauth_settings': {
                 'SOCIAL_AUTH_EDX_OIDC_URL_ROOT': '{lms_url_root}/oauth2'.format(lms_url_root=lms_url_root),

--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -117,6 +117,7 @@ class SiteConfiguration(models.Model):
         blank=True,
         default="",
     )
+    # TODO Remove this field after all usages have been removed/released to production.
     enable_otto_receipt_page = models.BooleanField(
         verbose_name=_('Enable Otto receipt page'),
         help_text=_('Enable the usage of Otto receipt page.'),

--- a/ecommerce/core/tests/test_commands.py
+++ b/ecommerce/core/tests/test_commands.py
@@ -122,7 +122,6 @@ class CreateOrUpdateSiteCommandTests(TestCase):
         self._check_site_configuration(site, partner)
         self.assertFalse(site.siteconfiguration.enable_enrollment_codes)
         self.assertFalse(site.siteconfiguration.send_refund_notifications)
-        self.assertTrue(site.siteconfiguration.enable_otto_receipt_page)
         self.assertEqual(site.siteconfiguration.base_cookie_domain, '')
 
     def test_update_site(self):
@@ -164,7 +163,6 @@ class CreateOrUpdateSiteCommandTests(TestCase):
         self.assertEqual(site_configuration.payment_support_email, self.payment_support_email)
         self.assertEqual(site_configuration.payment_support_url, self.payment_support_url)
         self.assertTrue(site_configuration.send_refund_notifications)
-        self.assertFalse(site.siteconfiguration.enable_otto_receipt_page)
         self.assertEqual(site.siteconfiguration.base_cookie_domain, self.base_cookie_domain)
 
     @data(

--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -427,7 +427,6 @@ class CouponRedeemViewTests(CouponMixin, CourseCatalogTestMixin, LmsApiMockMixin
     @httpretty.activate
     def test_basket_redirect_enrollment_code(self):
         """ Verify the view redirects to the receipt page when an enrollment code is provided. """
-        self.toggle_ecommerce_receipt_page(True)
         code = self.create_coupon_and_get_code(benefit_value=100, code='')
         self.mock_account_api(self.request, self.user.username, data={'is_active': True})
         self.mock_access_token_response()
@@ -517,7 +516,6 @@ class CouponRedeemViewTests(CouponMixin, CourseCatalogTestMixin, LmsApiMockMixin
     @httpretty.activate
     def test_enterprise_customer_successful_redemption(self):
         """ Verify the view redirects to LMS when valid consent is provided. """
-        self.toggle_ecommerce_receipt_page(True)
         code = self.prepare_enterprise_data()
         self.mock_enterprise_learner_api_for_learner_with_no_enterprise()
         self.mock_enterprise_learner_post_api()
@@ -539,7 +537,6 @@ class CouponRedeemViewTests(CouponMixin, CourseCatalogTestMixin, LmsApiMockMixin
     @httpretty.activate
     def test_multiple_vouchers(self):
         """ Verify a redirect to LMS happens when a basket with already existing vouchers is used. """
-        self.toggle_ecommerce_receipt_page(True)
         code = self.create_coupon_and_get_code(benefit_value=100, code='')
         basket = Basket.get_basket(self.user, self.site)
         basket.vouchers.add(Voucher.objects.get(code=code))

--- a/ecommerce/extensions/checkout/tests/test_signals.py
+++ b/ecommerce/extensions/checkout/tests/test_signals.py
@@ -22,7 +22,6 @@ class SignalTests(CourseCatalogTestMixin, TestCase):
         super(SignalTests, self).setUp()
         self.user = self.create_user()
         self.request.user = self.user
-        self.toggle_ecommerce_receipt_page(True)
         toggle_switch('ENABLE_NOTIFICATIONS', True)
 
     def prepare_order(self, seat_type, credit_provider_id=None):

--- a/ecommerce/extensions/checkout/tests/test_views.py
+++ b/ecommerce/extensions/checkout/tests/test_views.py
@@ -27,7 +27,6 @@ class FreeCheckoutViewTests(TestCase):
         super(FreeCheckoutViewTests, self).setUp()
         self.user = self.create_user()
         self.client.login(username=self.user.username, password=self.password)
-        self.toggle_ecommerce_receipt_page(True)
 
     def prepare_basket(self, price):
         """ Helper function that creates a basket and adds a product with set price to it. """
@@ -62,20 +61,6 @@ class FreeCheckoutViewTests(TestCase):
             order_number=order.number,
             site_configuration=order.site.siteconfiguration
         )
-        self.assertRedirects(response, expected_url, fetch_redirect_response=False)
-
-    @httpretty.activate
-    def test_redirect_to_lms_receipt(self):
-        """ Verify that disabling the otto_receipt_page switch redirects to the LMS receipt page. """
-        self.toggle_ecommerce_receipt_page(False)
-        self.prepare_basket(0)
-        self.assertEqual(Order.objects.count(), 0)
-        receipt_page = self.site.siteconfiguration.build_lms_url('/commerce/checkout/receipt/')
-
-        response = self.client.get(self.path)
-        self.assertEqual(Order.objects.count(), 1)
-
-        expected_url = '{}?orderNum={}'.format(receipt_page, Order.objects.first().number)
         self.assertRedirects(response, expected_url, fetch_redirect_response=False)
 
 

--- a/ecommerce/extensions/checkout/utils.py
+++ b/ecommerce/extensions/checkout/utils.py
@@ -43,15 +43,11 @@ def get_receipt_page_url(site_configuration, order_number=None, override_url=Non
     Returns:
         str: Receipt page URL.
     """
-    if site_configuration.enable_otto_receipt_page:
-        if override_url:
-            return override_url
-        else:
-            base_url = site_configuration.build_ecommerce_url(reverse('checkout:receipt'))
-            params = urllib.urlencode({'order_number': order_number}) if order_number else ''
+    if override_url:
+        return override_url
     else:
-        base_url = site_configuration.build_lms_url('/commerce/checkout/receipt/')
-        params = urllib.urlencode({'orderNum': order_number}) if order_number else ''
+        base_url = site_configuration.build_ecommerce_url(reverse('checkout:receipt'))
+        params = urllib.urlencode({'order_number': order_number}) if order_number else ''
 
     return '{base_url}{params}'.format(
         base_url=base_url,

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -459,7 +459,6 @@ class EnrollmentCodeFulfillmentModuleTests(CourseCatalogTestMixin, TestCase):
     def setUp(self):
         super(EnrollmentCodeFulfillmentModuleTests, self).setUp()
         toggle_switch(ENROLLMENT_CODE_SWITCH, True)
-        self.toggle_ecommerce_receipt_page(True)
         course = CourseFactory()
         course.create_or_update_seat('verified', True, 50, self.partner, create_enrollment_code=True)
         enrollment_code = Product.objects.get(product_class__name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME)
@@ -487,16 +486,6 @@ class EnrollmentCodeFulfillmentModuleTests(CourseCatalogTestMixin, TestCase):
 
     def test_fulfill_product(self):
         """Test fulfilling an Enrollment code product."""
-        self.assertEqual(OrderLineVouchers.objects.count(), 0)
-        lines = self.order.lines.all()
-        __, completed_lines = EnrollmentCodeFulfillmentModule().fulfill_product(self.order, lines)
-        self.assertEqual(completed_lines[0].status, LINE.COMPLETE)
-        self.assertEqual(OrderLineVouchers.objects.count(), 1)
-        self.assertEqual(OrderLineVouchers.objects.first().vouchers.count(), self.QUANTITY)
-
-    def test_fulfill_product_with_lms_receipt_page(self):
-        """Test disabling otto_receipt_page switch still results in successfully fulfilling Enrollment code product."""
-        self.site.siteconfiguration.enable_otto_receipt_page = False
         self.assertEqual(OrderLineVouchers.objects.count(), 0)
         lines = self.order.lines.all()
         __, completed_lines = EnrollmentCodeFulfillmentModule().fulfill_product(self.order, lines)

--- a/ecommerce/extensions/payment/tests/mixins.py
+++ b/ecommerce/extensions/payment/tests/mixins.py
@@ -333,8 +333,6 @@ class CybersourceNotificationTestsMixin(CybersourceMixin):
     def setUp(self):
         super(CybersourceNotificationTestsMixin, self).setUp()
 
-        self.toggle_ecommerce_receipt_page(True)
-
         self.user = factories.UserFactory()
         self.billing_address = self.make_billing_address()
 

--- a/ecommerce/extensions/payment/tests/processors/test_cybersource.py
+++ b/ecommerce/extensions/payment/tests/processors/test_cybersource.py
@@ -35,7 +35,6 @@ class CybersourceTests(CybersourceMixin, PaymentProcessorTestCaseMixin, TestCase
 
     def setUp(self):
         super(CybersourceTests, self).setUp()
-        self.toggle_ecommerce_receipt_page(True)
         self.basket.site = self.site
 
     def assert_processor_response_recorded(self, processor_name, transaction_id, response, basket=None):

--- a/ecommerce/extensions/payment/tests/processors/test_paypal.py
+++ b/ecommerce/extensions/payment/tests/processors/test_paypal.py
@@ -173,23 +173,6 @@ class PaypalTests(PaypalMixin, PaymentProcessorTestCaseMixin, TestCase):
             'Creating PayPal payment for basket [{}] resulted in an exception. Will retry.'.format(self.basket.id)
         )
 
-    def test_switch_enabled_otto_url(self):
-        """
-        Ensures that when the otto_receipt_page waffle switch is enabled, the processor uses the new receipt page.
-        """
-        self.site.siteconfiguration.enable_otto_receipt_page = True
-        self.assertEqual(
-            self._get_receipt_url(),
-            self.site.siteconfiguration.build_ecommerce_url(settings.RECEIPT_PAGE_PATH)
-        )
-
-    def test_switch_disabled_lms_url(self):
-        """
-        Ensures that when the otto_receipt_page waffle switch is disabled, the processor uses the LMS receipt page.
-        """
-        self.site.siteconfiguration.enable_otto_receipt_page = False
-        assert self._get_receipt_url() == self.site.siteconfiguration.build_lms_url('/commerce/checkout/receipt/')
-
     @mock.patch('ecommerce.extensions.payment.processors.paypal.paypalrestsdk.Payment')
     @ddt.data(None, Paypal.DEFAULT_PROFILE_NAME, 'some-other-name')
     def test_dummy_web_profiles(self, enabled_profile_name, mock_payment):

--- a/ecommerce/extensions/payment/tests/views/test_cybersource.py
+++ b/ecommerce/extensions/payment/tests/views/test_cybersource.py
@@ -14,7 +14,7 @@ from oscar.test import factories
 
 from ecommerce.extensions.payment.exceptions import InvalidBasketError, InvalidSignatureError
 from ecommerce.extensions.payment.tests.mixins import CybersourceMixin, CybersourceNotificationTestsMixin
-from ecommerce.extensions.payment.views.cybersource import CybersourceInterstitialView, CybersourceNotifyView
+from ecommerce.extensions.payment.views.cybersource import CybersourceInterstitialView
 from ecommerce.tests.testcases import TestCase
 
 JSON = 'application/json'
@@ -30,28 +30,6 @@ post_checkout = get_class('checkout.signals', 'post_checkout')
 
 
 @ddt.ddt
-class CybersourceNotifyViewTests(CybersourceNotificationTestsMixin, TestCase):
-    """ Test processing of CyberSource notifications. """
-    path = reverse('cybersource:notify')
-    view = CybersourceNotifyView
-
-    def setUp(self):
-        super(CybersourceNotifyViewTests, self).setUp()
-        self.site.siteconfiguration.enable_otto_receipt_page = False
-        self.site.siteconfiguration.save()
-
-    def test_otto_receipt_page_enabled(self):
-        """
-        Verify that the Notify view returns HTTP response with 200 status
-        when the Otto hosted receipt page is enabled.
-        """
-        self.site.siteconfiguration.enable_otto_receipt_page = True
-        self.site.siteconfiguration.save()
-        response = self.client.post(self.path)
-        self.assertEqual(response.status_code, 200)
-
-
-@ddt.ddt
 class CybersourceSubmitViewTests(CybersourceMixin, TestCase):
     path = reverse('cybersource:submit')
 
@@ -59,8 +37,6 @@ class CybersourceSubmitViewTests(CybersourceMixin, TestCase):
         super(CybersourceSubmitViewTests, self).setUp()
         self.user = self.create_user()
         self.client.login(username=self.user.username, password=self.password)
-        self.site.siteconfiguration.enable_otto_receipt_page = True
-        self.site.siteconfiguration.save()
 
     def _generate_data(self, basket_id):
         return {

--- a/ecommerce/extensions/payment/tests/views/test_paypal.py
+++ b/ecommerce/extensions/payment/tests/views/test_paypal.py
@@ -105,8 +105,6 @@ class PaypalPaymentExecutionViewTests(PaypalMixin, PaymentEventsMixin, TestCase)
         """
         Verify redirection to LMS receipt page after attempted payment execution if the Otto receipt page is disabled.
         """
-        self.site_configuration.enable_otto_receipt_page = False
-        self.site_configuration.save()
         self.mock_oauth2_response()
 
         # Create a payment record the view can use to retrieve a basket

--- a/ecommerce/extensions/payment/urls.py
+++ b/ecommerce/extensions/payment/urls.py
@@ -3,7 +3,6 @@ from django.conf.urls import include, url
 from ecommerce.extensions.payment.views import PaymentFailedView, SDNFailure, cybersource, paypal
 
 CYBERSOURCE_URLS = [
-    url(r'^notify/$', cybersource.CybersourceNotifyView.as_view(), name='notify'),
     url(r'^redirect/$', cybersource.CybersourceInterstitialView.as_view(), name='redirect'),
     url(r'^submit/$', cybersource.CybersourceSubmitView.as_view(), name='submit'),
 ]

--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -7,7 +7,7 @@ from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
 from django.db import transaction
-from django.http import HttpResponse, JsonResponse
+from django.http import JsonResponse
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
@@ -268,34 +268,6 @@ class CybersourceNotificationMixin(EdxOrderPlacementMixin):
         except:  # pylint: disable=bare-except
             logger.exception(self.order_placement_failure_msg, basket.id)
             raise
-
-
-class CybersourceNotifyView(CybersourceNotificationMixin, View):
-    """ Validates a response from CyberSource and processes the associated basket/order appropriately. """
-
-    def post(self, request):
-        """Process a CyberSource merchant notification and place an order for paid products as appropriate."""
-
-        # If the Otto receipt page is enabled, CyberSource Interstitial View
-        # should handle the CyberSource response
-        if request.site.siteconfiguration.enable_otto_receipt_page:
-            return HttpResponse()
-
-        try:
-            notification = request.POST.dict()
-            basket = self.validate_notification(notification)
-        except (InvalidBasketError, InvalidSignatureError):
-            return HttpResponse(status=400)
-        except (UserCancelled, TransactionDeclined, PaymentError):
-            return HttpResponse()
-        except:  # pylint: disable=bare-except
-            return HttpResponse(status=500)
-
-        try:
-            self.create_order(request, basket, notification)
-            return HttpResponse()
-        except:  # pylint: disable=bare-except
-            return HttpResponse(status=500)
 
 
 class CybersourceInterstitialView(CybersourceNotificationMixin, View):

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -282,12 +282,6 @@ class SiteMixin(object):
 
         return token
 
-    def toggle_ecommerce_receipt_page(self, enable_otto_receipt_page):
-        """ Enables Ecommerce Receipt Page. """
-        site_configuration = self.site.siteconfiguration
-        site_configuration.enable_otto_receipt_page = enable_otto_receipt_page
-        site_configuration.save()
-
 
 class TestServerUrlMixin(object):
     def get_full_url(self, path, site=None):


### PR DESCRIPTION
Otto's receipt page is now the only receipt page we support. This field will be removed in a subsequent commit/release. Additionally, the `CybersourceNotifyView` (which relied on this field) has been removed. CyberSource payers should be redirected to the interstitial.

LEARNER-1528