### PR TITLE
Stop thawing baskets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,15 +21,15 @@ before_install:
   - docker-compose -f ./.travis/docker-compose-travis.yml up -d
 
 install:
-  - docker exec -t ecommerce_testing  bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/ && make requirements'
+  - docker exec -t ecommerce_testing bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/ && make requirements'
 
 script:
-  - docker exec -t ecommerce_testing  bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/docs && make html'
-  - docker exec -t ecommerce_testing  bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/ && DJANGO_SETTINGS_MODULE=ecommerce.settings.test make validate_translations'
-  - docker exec -t ecommerce_testing  bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/ && DJANGO_SETTINGS_MODULE=ecommerce.settings.test make clean_static'
-  - docker exec -t ecommerce_testing  bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/ && DJANGO_SETTINGS_MODULE=ecommerce.settings.test make static'
-  - docker exec -t ecommerce_testing  bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/ && DJANGO_SETTINGS_MODULE=ecommerce.settings.test TRAVIS=1 xvfb-run make validate_python'
-  - docker exec -t ecommerce_testing  bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/ && DJANGO_SETTINGS_MODULE=ecommerce.settings.test xvfb-run make validate_js'
+  - docker exec -t ecommerce_testing bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/docs && make html'
+  - docker exec -t ecommerce_testing bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/ && DJANGO_SETTINGS_MODULE=ecommerce.settings.test make validate_translations'
+  - docker exec -t ecommerce_testing bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/ && DJANGO_SETTINGS_MODULE=ecommerce.settings.test make clean_static'
+  - docker exec -t ecommerce_testing bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/ && DJANGO_SETTINGS_MODULE=ecommerce.settings.test make static'
+  - docker exec -t ecommerce_testing bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/ && DJANGO_SETTINGS_MODULE=ecommerce.settings.test TRAVIS=1 xvfb-run make validate_python'
+  - docker exec -t ecommerce_testing bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/ && DJANGO_SETTINGS_MODULE=ecommerce.settings.test xvfb-run make validate_js'
 
 after_success:
   - pip install -U codecov

--- a/Makefile
+++ b/Makefile
@@ -56,27 +56,25 @@ clean:
 clean_static:
 	rm -rf assets/* ecommerce/static/build/*
 
+quality:
+	isort --check-only --recursive e2e/ ecommerce/
+	pep8 --config=.pep8 ecommerce e2e
+	pylint --rcfile=pylintrc ecommerce e2e
+
 validate_js:
 	rm -rf coverage
 	$(NODE_BIN)/gulp test
 	$(NODE_BIN)/gulp lint
 	$(NODE_BIN)/gulp jscs
 
-validate_python: clean
+validate_python: clean quality
 	PATH=$$PATH:$(NODE_BIN) REUSE_DB=1 coverage run --branch --source=ecommerce ./manage.py test ecommerce \
 	--settings=ecommerce.settings.test --with-ignore-docstrings --logging-level=DEBUG
 	coverage report
-	make quality
 
-fast_validate_python: clean
+fast_validate_python: clean quality
 	REUSE_DB=1 DISABLE_ACCEPTANCE_TESTS=True ./manage.py test ecommerce \
 	--settings=ecommerce.settings.test --processes=4 --with-ignore-docstrings --logging-level=DEBUG
-	make quality
-
-quality:
-	isort --check-only --recursive e2e/ ecommerce/
-	pep8 --config=.pep8 ecommerce e2e
-	pylint --rcfile=pylintrc ecommerce e2e
 
 validate: validate_python validate_js
 

--- a/ecommerce/extensions/checkout/mixins.py
+++ b/ecommerce/extensions/checkout/mixins.py
@@ -101,25 +101,22 @@ class EdxOrderPlacementMixin(OrderPlacementMixin):
         and basket submission in a transaction. Should be used only in
         the context of an exception handler.
         """
-        try:
-            return Order.objects.get(number=order_number)
-        except Order.DoesNotExist:
-            with transaction.atomic():
-                order = self.place_order(
-                    order_number=order_number,
-                    user=user,
-                    basket=basket,
-                    shipping_address=shipping_address,
-                    shipping_method=shipping_method,
-                    shipping_charge=shipping_charge,
-                    order_total=order_total,
-                    billing_address=billing_address,
-                    **kwargs
-                )
+        with transaction.atomic():
+            order = self.place_order(
+                order_number=order_number,
+                user=user,
+                basket=basket,
+                shipping_address=shipping_address,
+                shipping_method=shipping_method,
+                shipping_charge=shipping_charge,
+                order_total=order_total,
+                billing_address=billing_address,
+                **kwargs
+            )
 
-                basket.submit()
+            basket.submit()
 
-            return self.handle_successful_order(order, request)
+        return self.handle_successful_order(order, request)
 
     def handle_successful_order(self, order, request=None):  # pylint: disable=arguments-differ
         """Send a signal so that receivers can perform relevant tasks (e.g., fulfill the order)."""

--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import logging
 
 import six
-from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
@@ -307,17 +306,6 @@ class CybersourceInterstitialView(CybersourceNotificationMixin, View):
         try:
             notification = request.POST.dict()
             basket = self.validate_notification(notification)
-        except (InvalidBasketError, InvalidSignatureError):
-            return redirect(reverse('payment_error'))
-        except (UserCancelled, TransactionDeclined, PaymentError):
-            order_number = request.POST.get('req_reference_number')
-            basket_id = OrderNumberGenerator().basket_id(order_number)
-            basket = self._get_basket(basket_id)
-            if basket:
-                basket.thaw()
-
-            messages.error(request, _('Your payment has been canceled.'))
-            return redirect(reverse('basket:summary'))
         except:  # pylint: disable=bare-except
             return redirect(reverse('payment_error'))
 

--- a/ecommerce/templates/oscar/checkout/payment_error.html
+++ b/ecommerce/templates/oscar/checkout/payment_error.html
@@ -14,13 +14,13 @@
   <div class="container content-wrapper receipt-cancel-error">
     <h1>{% trans "Payment Failed" %}</h1>
     <p>
-      {% blocktrans %}
-        A system error occurred while processing your payment. <strong>You have not been charged.</strong>
+      {% blocktrans trimmed %}
+        An error occurred while processing your payment. <strong>You have not been charged.</strong>
       {% endblocktrans %}</p>
 
     <p>
       {% with "<a class='nav-link' href='mailto:"|add:payment_support_email|add:"'>"|safe as start_link %}
-        {% blocktrans with end_link="</a>"|safe %}
+        {% blocktrans trimmed with end_link="</a>"|safe %}
           Please wait a few minutes and then try again. For help, contact {{ start_link }}{{ payment_support_email }}{{ end_link }}.
         {% endblocktrans %}
       {% endwith %}
@@ -28,8 +28,8 @@
 
     <p>
       {% with "<a class='nav-link' href='"|add:basket_url|add:"'>"|safe as start_link %}
-        {% blocktrans with end_link="</a>"|safe %}
-          To try again, visit the {{ start_link }}basket page{{ end_link }}.
+        {% blocktrans trimmed with end_link="</a>"|safe %}
+          To try again, visit the {{ start_link }}checkout page{{ end_link }}.
         {% endblocktrans %}
       {% endwith %}
     </p>


### PR DESCRIPTION
Thawing the user's basket when there's a problem handling their CyberSource payment causes that basket to be re-used when making subsequent payments. This thaw can be triggered when CyberSource, seemingly unprompted, sends the service an error response soon after a successful payment.

The response contains error code 104, indicating that payment processing failed because the "merchant reference code" (i.e., order number) matches a reference code sent in the last 15 minutes. After this happens, the user's basket is left open. The next time they try to check out, the basket middleware retrieves this open basket. Although we do re-freeze the basket at this point, we will silently fail to place a new order because an order with the number corresponding to the now-frozen basket already exists. If the user is attempting to pay for something at this point, we'll charge them, but they won't receive the product they paid for and we'll show them a receipt page corresponding to their most recently placed order. Since we're re-freezing the basket, the user will be able to place a new order the next time they try to do so (the middleware will create a new basket for them).

This change prevents us from thawing the user's basket when errors occur while handling CyberSource payments. As a result, a new basket should be used for every attempted order, preventing order number collisions. This change also prevents order number collisions from causing order placement to fail silently.

LEARNER-867

@edx/learner FYI.