### PR TITLE
Link to the dashboard from the payment error page

### DIFF
--- a/ecommerce/extensions/payment/tests/views/test_cybersource.py
+++ b/ecommerce/extensions/payment/tests/views/test_cybersource.py
@@ -12,6 +12,7 @@ from oscar.apps.payment.exceptions import TransactionDeclined
 from oscar.core.loading import get_class, get_model
 from oscar.test import factories
 
+from ecommerce.core.url_utils import get_lms_url
 from ecommerce.extensions.payment.exceptions import InvalidBasketError, InvalidSignatureError
 from ecommerce.extensions.payment.tests.mixins import CybersourceMixin, CybersourceNotificationTestsMixin
 from ecommerce.extensions.payment.views.cybersource import CybersourceInterstitialView
@@ -182,7 +183,7 @@ class CybersourceInterstitialViewTests(CybersourceNotificationTestsMixin, TestCa
         response = self.client.get(reverse('payment_error'))
         self.assertDictContainsSubset(
             {
-                'basket_url': reverse('basket:summary'),
+                'dashboard_url': get_lms_url(),
                 'payment_support_email': self.site.siteconfiguration.payment_support_email
             },
             response.context

--- a/ecommerce/extensions/payment/views/__init__.py
+++ b/ecommerce/extensions/payment/views/__init__.py
@@ -1,5 +1,6 @@
-from django.core.urlresolvers import reverse
 from django.views.generic import TemplateView
+
+from ecommerce.core.url_utils import get_lms_url
 
 
 class PaymentFailedView(TemplateView):
@@ -8,7 +9,7 @@ class PaymentFailedView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super(PaymentFailedView, self).get_context_data(**kwargs)
         context.update({
-            'basket_url': reverse('basket:summary'),
+            'dashboard_url': get_lms_url(),
             'payment_support_email': self.request.site.siteconfiguration.payment_support_email
         })
         return context

--- a/ecommerce/templates/oscar/basket/basket.html
+++ b/ecommerce/templates/oscar/basket/basket.html
@@ -45,7 +45,7 @@
                             {% endcaptureas %}
 
                             {% blocktrans with link_end="</a>" %}
-                                If you have attempted to do a purchase, you have not been charged. Return to your {{ dashboard_link_start }}dashboard{{ link_end }} to try
+                                If you attempted to make a purchase, you have not been charged. Return to your {{ dashboard_link_start }}dashboard{{ link_end }} to try
                                 again, or {{ support_link_start }}contact {{ platform_name }} Support{{ link_end }}.
                             {% endblocktrans %}
                         </div>

--- a/ecommerce/templates/oscar/checkout/payment_error.html
+++ b/ecommerce/templates/oscar/checkout/payment_error.html
@@ -27,9 +27,9 @@
     </p>
 
     <p>
-      {% with "<a class='nav-link' href='"|add:basket_url|add:"'>"|safe as start_link %}
+      {% with "<a class='nav-link' href='"|add:dashboard_url|add:"'>"|safe as start_link %}
         {% blocktrans trimmed with end_link="</a>"|safe %}
-          To try again, visit the {{ start_link }}checkout page{{ end_link }}.
+          To try again, return to your {{ start_link }}dashboard{{ end_link }}.
         {% endblocktrans %}
       {% endwith %}
     </p>


### PR DESCRIPTION
Users seeing the payment error page will be given a new, empty basket. Returning them to the basket page with an empty basket isn't helpful and forces them to make an extra click to get back to their dashboard.

LEARNER-867

This a follow-up to https://github.com/edx/ecommerce/pull/1338.