### PR TITLE
Setup internationalize on checkout and paypal page

### DIFF
--- a/ecommerce/extensions/payment/constants.py
+++ b/ecommerce/extensions/payment/constants.py
@@ -29,3 +29,12 @@ CYBERSOURCE_CARD_TYPE_MAP = {
 }
 
 CLIENT_SIDE_CHECKOUT_FLAG_NAME = 'enable_client_side_checkout'
+
+# Paypal only supports 4 languages, which are prioritized by country.
+# https://developer.paypal.com/docs/classic/api/locale_codes/
+PAYPAL_LOCALES = {
+    'zh': 'CN',
+    'fr': 'FR',
+    'en': 'US',
+    'es': 'MX',
+}

--- a/ecommerce/extensions/payment/forms.py
+++ b/ecommerce/extensions/payment/forms.py
@@ -7,7 +7,7 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import HTML, Div, Layout
 from django import forms
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from oscar.core.loading import get_model
 
 logger = logging.getLogger(__name__)

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -6,6 +6,8 @@ from logging.handlers import SysLogHandler
 from os.path import basename, normpath
 from sys import path
 
+from django.utils.translation import ugettext_lazy as _
+
 from oscar import OSCAR_MAIN_TEMPLATE_DIR
 
 from ecommerce.settings._oscar import *
@@ -66,7 +68,8 @@ DATABASES = {
 TIME_ZONE = 'America/New_York'
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#language-code
-LANGUAGE_CODE = 'en-us'
+# http://www.i18nguy.com/unicode/language-identifiers.html
+LANGUAGE_CODE = 'en'
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#site-id
 # This needs to be set to None in order to support multitenancy
@@ -77,6 +80,12 @@ DEFAULT_SITE_ID = 1
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#use-i18n
 USE_I18N = True
+
+LANGUAGES = (
+    ('en', _('English')),
+    ('es', _('Spanish')),
+    ('es-419', _('Spanish (Latin American)')),
+)
 
 LOCALE_PATHS = (
     join(DJANGO_ROOT, 'conf', 'locale'),

--- a/ecommerce/settings/devstack.py
+++ b/ecommerce/settings/devstack.py
@@ -54,6 +54,9 @@ PAYMENT_PROCESSOR_CONFIG = {
 }
 # END PAYMENT PROCESSING
 
+# Language cookie
+LANGUAGE_COOKIE_NAME = 'openedx-language-preference'
+
 #####################################################################
 # Lastly, see if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):

--- a/ecommerce/templates/edx/base.html
+++ b/ecommerce/templates/edx/base.html
@@ -6,7 +6,7 @@
 {% load staticfiles %}
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang={{ LANGUAGE_CODE }}>
 <head>
     <link rel="shortcut icon" href="{% static 'images/favicon.ico' %}"/>
     <meta charset="UTF-8">


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LEARNER-1278
https://openedx.atlassian.net/browse/LEARNER-914

Goals:
* Enable django language cookie
* Verify i18n on checkout page'
* Send user's language to paypal


@edx/learner Please review

https://github.com/edx/configuration/pull/3950
https://github.com/edx/ecommerce/pull/1345/
https://github.com/edx/edx-internal/pull/115
