### PR TITLE
Handle declined attempts to pay for existing orders

### DIFF
--- a/ecommerce/extensions/payment/exceptions.py
+++ b/ecommerce/extensions/payment/exceptions.py
@@ -28,6 +28,16 @@ class InvalidCybersourceDecision(GatewayError):
     pass
 
 
+class DuplicateReferenceNumber(PaymentError):
+    """
+    CyberSource returned an error response with reason code 104, indicating that
+    a duplicate reference number (i.e., order number) was received in a 15 minute period.
+
+    See https://support.cybersource.com/cybskb/index?page=content&id=C156&pmv=print.
+    """
+    pass
+
+
 class PartialAuthorizationError(PaymentError):
     """The amount authorized by the payment processor differs from the requested amount."""
     pass

--- a/ecommerce/extensions/payment/tests/processors/test_cybersource.py
+++ b/ecommerce/extensions/payment/tests/processors/test_cybersource.py
@@ -17,8 +17,8 @@ from oscar.test import factories
 
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.payment.exceptions import (
-    InvalidCybersourceDecision, InvalidSignatureError, PartialAuthorizationError, PCIViolation,
-    ProcessorMisconfiguredError
+    DuplicateReferenceNumber, InvalidCybersourceDecision, InvalidSignatureError,
+    PartialAuthorizationError, PCIViolation, ProcessorMisconfiguredError
 )
 from ecommerce.extensions.payment.models import PaymentProcessorResponse
 from ecommerce.extensions.payment.processors.cybersource import Cybersource
@@ -197,6 +197,17 @@ class CybersourceTests(CybersourceMixin, PaymentProcessorTestCaseMixin, TestCase
 
         response = self.generate_notification(self.basket, decision=decision)
         self.assertRaises(exception, self.processor.handle_processor_response, response, basket=self.basket)
+
+    def test_handle_processor_response_duplicate_reference_number(self):
+        """
+        Verify that DuplicateReferenceNumber is raised when an ERROR decision with
+        reason code 104 is received.
+        """
+        response = self.generate_notification(self.basket, decision='ERROR', reason_code='104')
+        self.assertRaises(
+            DuplicateReferenceNumber,
+            self.processor.handle_processor_response, response, basket=self.basket
+        )
 
     def test_handle_processor_response_invalid_auth_amount(self):
         """


### PR DESCRIPTION
CyberSource may return an error response with reason code 104, indicating that a duplicate reference number (i.e., order number) was received in a 15 minute period. This is their way of telling us that they've declined an attempt to pay for an existing order. If this happens, we log appropriate INFO level messages and redirect the browser to the receipt page for the existing order. If CyberSource actually does agree to process a payment for an existing order, the order number collision will cause an exception to be raised on our end.

LEARNER-867

@edx/learner FYI