### PR TITLE
Do not include the footer on the checkout page

### DIFF
--- a/ecommerce/templates/oscar/basket/basket.html
+++ b/ecommerce/templates/oscar/basket/basket.html
@@ -68,3 +68,7 @@
     {% include client_side_payment_processor.get_template_name %}
   {% endif %}
 {% endblock %}
+
+{% block footer %}
+<!--Do not include the footer.-->
+{% endblock footer %}


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LEARNER-1271

**How to test:**
The footer on devstack is included from https://github.com/edx/ecommerce/blob/master/ecommerce/templates/edx/footer.html

Type some thing in there and it should show up in the footer. With this PR, nothing should show up on the checkout page.

Before: 
<img width="500" alt="screen shot 2017-06-26 at 2 43 04 pm" src="https://user-images.githubusercontent.com/7101723/27554918-098605e0-5a7e-11e7-95b5-54e3537a3f13.png">
After: 
<img width="500" alt="screen shot 2017-06-26 at 2 42 25 pm" src="https://user-images.githubusercontent.com/7101723/27554903-fe77970e-5a7d-11e7-82b1-5bc0b6e41014.png">
