### PR TITLE
Add logging to CyberSource submit view

### DIFF
--- a/ecommerce/extensions/api/v2/views/checkout.py
+++ b/ecommerce/extensions/api/v2/views/checkout.py
@@ -25,6 +25,11 @@ class CheckoutView(APIView):
         basket_id = request.data['basket_id']
         payment_processor_name = request.data['payment_processor']
 
+        logger.info(
+            'Checkout view called for basket [%s].',
+            basket_id
+        )
+
         # Get the basket, and make sure it belongs to the current user.
         try:
             basket = request.user.baskets.get(id=basket_id)


### PR DESCRIPTION
These log messages are meant to help verify that this view is being hit consistently by users' browsers.

LEARNER-1671