### PR TITLE
Fix the BasketCalculateView so it does not throw an error when used.

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_baskets.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_baskets.py
@@ -38,6 +38,7 @@ Order = get_model('order', 'Order')
 ShippingEventType = get_model('order', 'ShippingEventType')
 Refund = get_model('refund', 'Refund')
 User = get_user_model()
+Voucher = get_model('voucher', 'Voucher')
 
 LOGGER_NAME = 'ecommerce.extensions.api.v2.views.baskets'
 
@@ -448,7 +449,9 @@ class BasketCalculateViewTests(ProgramTestMixin, TestCase):
         """ Verify successful basket calculation considering Enterprise entitlement vouchers """
 
         discount = 5
-        voucher, _ = prepare_voucher(_range=self.range, benefit_type=Benefit.FIXED, benefit_value=discount)
+        # Using ONCE_PER_CUSTOMER usage here because it fully excercises the Oscar Applicator code.
+        voucher, _ = prepare_voucher(_range=self.range, benefit_type=Benefit.FIXED, benefit_value=discount,
+                                     usage=Voucher.ONCE_PER_CUSTOMER)
         mock_get_entitlement_voucher.return_value = voucher
 
         # If the list of sku's contains more than one product no entitlement voucher is applied

--- a/ecommerce/extensions/api/v2/views/baskets.py
+++ b/ecommerce/extensions/api/v2/views/baskets.py
@@ -383,7 +383,7 @@ class BasketCalculateView(generics.GenericAPIView):
                     basket.vouchers.add(voucher)
 
                 # Calculate any discounts on the basket.
-                Applicator().apply(basket, request)
+                Applicator().apply(basket, user=request.user, request=request)
 
                 discounts = []
 


### PR DESCRIPTION
The method [signature](https://github.com/django-oscar/django-oscar/blame/1.4/src/oscar/apps/offer/applicator.py#L19) of the Applicator apply method is Applicator.apply(self, basket, user=None, request=None).
We were calling this method from the [BasketCalculateView](https://github.com/edx/ecommerce/blame/master/ecommerce/extensions/api/v2/views/baskets.py#L386) with Applicator().apply(basket, request) causing
a Request object to be used when a user object was expected.

This bug is only surfaced when this view is working with a basket that has a voucher applied to it. If a voucher is not applied to the basket the Oscar code never uses the second parameter passed to Applicator.apply method. The enterprise entitlement feature applies a voucher within the BasketCalculateView if the basket qualifies for an enterprise entitlement so this is the only current use case which would have surfaced this bug.