### PR TITLE
LEARNER-1369 Update the order receipt frontend event for 'Completed Purchase'

### DIFF
--- a/ecommerce/static/js/pages/receipt_page.js
+++ b/ecommerce/static/js/pages/receipt_page.js
@@ -9,7 +9,7 @@ define([
         'use strict';
 
         function trackPurchase(orderId, totalAmount, currency) {
-            window.analytics.track('Order Completed', {
+            window.analytics.track('Completed Purchase', {
                 orderId: orderId,
                 total: totalAmount,
                 currency: currency


### PR DESCRIPTION
According to the Google Tag at https://tagmanager.google.com/?hl=en#/container/accounts/12009721/containers/652832/workspaces/80/triggers
we can update the front end trigger event name so we don't double count the order in GA

@mulby @clintonb Please help review

Once this gets deployed, I will make "API name" change in OptimizelyX "Order Completed" event 