### PR TITLE
Fire Payment Info Entered event after successful payment entry

### DIFF
--- a/ecommerce/courses/tests/test_models.py
+++ b/ecommerce/courses/tests/test_models.py
@@ -230,7 +230,7 @@ class CourseTests(CourseCatalogTestMixin, TestCase):
         professional_product_no_verification = course.create_or_update_seat('professional', False, 0, self.partner)
         self.assertEqual(course.products.count(), 2)
 
-        basket = BasketFactory(owner=user)
+        basket = BasketFactory(owner=user, site=self.site)
         basket.add_product(professional_product_no_verification)
         create_order(basket=basket, user=user)
         course.create_or_update_seat('professional', True, 0, self.partner)

--- a/ecommerce/extensions/checkout/mixins.py
+++ b/ecommerce/extensions/checkout/mixins.py
@@ -10,7 +10,7 @@ from ecommerce_worker.fulfillment.v1.tasks import fulfill_order
 from oscar.apps.checkout.mixins import OrderPlacementMixin
 from oscar.core.loading import get_class, get_model
 
-from ecommerce.extensions.analytics.utils import audit_log
+from ecommerce.extensions.analytics.utils import audit_log, track_segment_event
 from ecommerce.extensions.api import data as data_api
 from ecommerce.extensions.checkout.exceptions import BasketNotFreeError
 from ecommerce.extensions.customer.utils import Dispatcher
@@ -52,6 +52,7 @@ class EdxOrderPlacementMixin(OrderPlacementMixin):
         linked to the order when it is saved later on.
         """
         handled_processor_response = self.payment_processor.handle_processor_response(response, basket=basket)
+        track_segment_event(basket.site, basket.owner, 'Payment Info Entered', {'checkout_id': basket.order_number})
         source_type, __ = SourceType.objects.get_or_create(name=self.payment_processor.NAME)
         total = handled_processor_response.total
         reference = handled_processor_response.transaction_id

--- a/ecommerce/extensions/payment/tests/processors/mixins.py
+++ b/ecommerce/extensions/payment/tests/processors/mixins.py
@@ -36,6 +36,7 @@ class PaymentProcessorTestCaseMixin(RefundTestMixin, CourseCatalogTestMixin, Pay
 
         self.processor = self.processor_class(self.site)  # pylint: disable=not-callable
         self.basket = factories.create_basket(empty=True)
+        self.basket.site = self.site
         self.basket.add_product(self.product)
         self.basket.owner = factories.UserFactory()
         self.basket.save()


### PR DESCRIPTION
Updated handle_payment method in EdxOrderPlacementMixin to fire the segment analytic event 'Payment Info Entered' when payment information has been validated.