### PR TITLE
Disabled client-side tracking if Segment ID is empty

### DIFF
--- a/ecommerce/static/js/models/tracking_model.js
+++ b/ecommerce/static/js/models/tracking_model.js
@@ -12,7 +12,7 @@ define(['backbone', 'underscore'], function(Backbone, _) {
         isTracking: function() {
             var self = this,
                 trackId = self.get('segmentApplicationId');
-            return !_(trackId).isUndefined() && !_(trackId).isNull();
+            return !_(trackId).isUndefined() && !_(trackId).isNull() && !_(trackId).isEmpty();
         }
     });
 });


### PR DESCRIPTION
Tracking is now disabled if the Segment application ID is set to an empty string (e.g. the default for local development).

LEARNER-1668