### PR TITLE
[LEARNER-1795] Allow order line description theming on the receipt page

### DIFF
--- a/ecommerce/templates/edx/checkout/_receipt_line_description.html
+++ b/ecommerce/templates/edx/checkout/_receipt_line_description.html
@@ -1,0 +1,1 @@
+<span>{{ line.description }}</span>

--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -80,7 +80,8 @@
                 <dd class="quantity">{{ line.quantity }}</dd>
                 <dt class="course-description sr">{% trans "Description:" %}</dt>
                 <dd class="course-description">
-                  <span>{{ line.description }}</span>
+                  {% include 'edx/checkout/_receipt_line_description.html' with line=line %}
+
                   {% if line.product.course %}
                     <p>{{ line.product.course.id|course_organization }}</p>
                   {% endif %}


### PR DESCRIPTION
JIRA story: https://openedx.atlassian.net/browse/LEARNER-1795

Continued work from https://github.com/edx/edx-themes/pull/525

Reviewers:
- [ ] @clintonb, please take a look since you were included in the discussion on the edx-themes PR
- [ ] @douglashall, @afzaledx, is this what you had in mind from theming standpoint?
- [ ] @edx/learner-helio (optional, just to keep the team in the loop)

The idea is to allow (WL) sites to provide a custom theme for the order line description present on the receipt page.

If this is acceptable, the next step will be adding a custom file to themes of those sites that have this requirement. I still need to know which sites are we talking about. If only one WL site needs this, we don't need to override this for the rest of them.