### PR TITLE
Reporting coverage for all JS files

### DIFF
--- a/ecommerce/static/js/collections/category_collection.js
+++ b/ecommerce/static/js/collections/category_collection.js
@@ -1,3 +1,4 @@
+/* istanbul ignore next */
 define([
     'collections/paginated_collection',
     'models/category'

--- a/ecommerce/static/js/collections/enterprise_customer_collection.js
+++ b/ecommerce/static/js/collections/enterprise_customer_collection.js
@@ -1,3 +1,4 @@
+/* istanbul ignore next */
 define([
     'collections/paginated_collection',
     'models/enterprise_customer_model'

--- a/ecommerce/static/js/models/category.js
+++ b/ecommerce/static/js/models/category.js
@@ -1,3 +1,4 @@
+/* istanbul ignore next */
 define([
     'backbone',
     'backbone.relational'

--- a/ecommerce/static/js/models/enterprise_customer_model.js
+++ b/ecommerce/static/js/models/enterprise_customer_model.js
@@ -1,3 +1,4 @@
+/* istanbul ignore next */
 define([
     'backbone',
     'backbone.relational'

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,7 +2,12 @@
 // Generated on Tue Jul 21 2015 10:10:16 GMT-0400 (EDT)
 
 module.exports = function(config) {
-  config.set({
+    const coveragePath = 'ecommerce/static/js/!(test)/**/*.js';
+    var preprocessors = {};
+
+    preprocessors[coveragePath] = ['coverage'];
+
+    config.set({
 
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: '',
@@ -29,9 +34,7 @@ module.exports = function(config) {
 
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
-    preprocessors: {
-        'ecommerce/static/js/!(test)/**/*.js': ['coverage']
-    },
+    preprocessors: preprocessors,
 
     // enabled plugins
     plugins:[
@@ -39,6 +42,7 @@ module.exports = function(config) {
        'karma-jasmine',
        'karma-requirejs',
        'karma-firefox-launcher',
+       'karma-coverage-allsources',
        'karma-coverage',
        'karma-spec-reporter',
        'karma-sinon'
@@ -46,6 +50,7 @@ module.exports = function(config) {
 
     // Karma coverage config
     coverageReporter: {
+        include: coveragePath,
         reporters: [
             {type: 'text'},
             { type: 'lcov', subdir: 'report-lcov' }
@@ -55,7 +60,7 @@ module.exports = function(config) {
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['spec', 'coverage'],
+    reporters: ['spec', 'coverage-allsources', 'coverage'],
 
     // web server port
     port: 9876,

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "jasmine-jquery": "2.1.1",
     "karma": "1.5.0",
     "karma-coverage": "1.1.1",
+    "karma-coverage-allsources": "0.0.4",
     "karma-firefox-launcher": "1.0.1",
     "karma-jasmine": "1.1.0",
     "karma-jasmine-jquery": "0.1.1",


### PR DESCRIPTION
Our current coverage reports are invalid because they exclude JS files that are not loaded by the tests. These files have 0% coverage, thus our reports over-estimate test coverage.