### PR TITLE
Decreased Codecov threshold to 94%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,4 +6,4 @@ coverage:
         target: 95
     project:
       default:
-        target: 95
+        target: 94


### PR DESCRIPTION
The recent change reporting all JS files lead to an overall decrease in coverage. Dropping Codecov's threshold so that open PRs are not penalized for code that is not relevant to those PRs.