### PR TITLE
Make sure we have a voucher before attempting to get enterprise customer.

### DIFF
--- a/ecommerce/enterprise/templatetags/enterprise.py
+++ b/ecommerce/enterprise/templatetags/enterprise.py
@@ -14,7 +14,7 @@ def enterprise_customer_for_voucher(context, voucher):
     Raises:
         EnterpriseDoesNotExist: Voucher is not associated with any enterprise customer.
     """
-    if context and 'request' in context:
+    if voucher and context and 'request' in context:
         request = context['request']
     else:
         return None

--- a/ecommerce/enterprise/tests/test_templatetags.py
+++ b/ecommerce/enterprise/tests/test_templatetags.py
@@ -77,3 +77,17 @@ class EnterpriseTemplateTagsTests(EnterpriseServiceMockMixin, CouponMixin, TestC
         )
         result = template.render(Context({'voucher': voucher}))
         self.assertEquals(result, '')
+
+    def test_enterprise_customer_for_voucher_when_voucher_is_none(self):
+        """
+        Verify that enterprise_customer_for_voucher assignment tag returns None if
+        provided voucher is None.
+        """
+
+        template = Template(
+            "{% load enterprise %}"
+            "{% enterprise_customer_for_voucher voucher as enterprise_customer %}"
+            "{{ enterprise_customer.name }}"
+        )
+        result = template.render(Context({'voucher': None, 'request': self.request}))
+        self.assertEqual(result, '')


### PR DESCRIPTION
We previously created an enterprise [template tag](https://github.com/edx/ecommerce/pull/1335/files#diff-3aa5625f80dd97ba519afb4118998e70R10) which takes a voucher and
attempts to find an EnterpriseCustomer associated with that voucher.
The template tag should guard against [None being passed as the voucher
parameter](https://github.com/edx/ecommerce/pull/1335/files#diff-cfe5821c0f7876d15964704fe72e0218R120). This will happen during program purchase when there is a program offer in play since program offers do not have an associated voucher.

ENT-517