### PR TITLE
[WIP] Add management command to create a set of courses from json

### DIFF
--- a/ecommerce/core/management/commands/generate_courses.py
+++ b/ecommerce/core/management/commands/generate_courses.py
@@ -1,0 +1,136 @@
+"""
+Django management command to generate a test course for a given course id on LMS
+"""
+import datetime
+import json
+import logging
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import timezone
+from oscar.core.loading import get_model
+from waffle.models import Flag
+
+from ecommerce.courses.models import Course
+
+Partner = get_model('partner', 'Partner')
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+
+    help = 'Generate courses on ecommerce from a json list of courses. Should only be run in development environments!'
+
+    valid_seat_types = ["audit", "verified", "honor", "professional"]
+    default_verified_price = 100
+    default_professional_price = 1000
+    default_upgrade_deadline = timezone.now() + datetime.timedelta(days=365)
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'courses',
+            help='courses to create in JSON format'  # TODO - link test-course JSON format
+        )
+
+    def handle(self, *args, **options):
+        if not settings.DEBUG:
+            # DEBUG is turned on in development settings and off in production settings
+            raise CommandError("Command should only be run in development environments")
+        try:
+            logger.info("Attempting to create course from the following json object: %s", options["courses"])
+            arg = json.loads(options["courses"])
+        except ValueError:
+            raise CommandError("Invalid JSON object")
+        try:
+            courses = arg["courses"]
+        except KeyError:
+            raise CommandError("JSON object is missing courses field")
+
+        partner = Partner.objects.get(short_code='edx')
+        site = partner.siteconfiguration.site
+        Flag.objects.update_or_create(name='enable_client_side_checkout', defaults={'everyone': True})
+
+        for course_settings in courses:
+            if not self._course_is_valid(course_settings):
+                logger.warning("Can't create course, proceeding to next course")
+                continue
+
+            # Create the course
+            org = course_settings["organization"]
+            num = course_settings["number"]
+            run = course_settings["run"]
+            course_name = course_settings["fields"]["display_name"]
+            course_id = "course-v1:{org}+{num}+{run}".format(org=org, num=num, run=run)
+            defaults = {'name': course_name}
+            course, __ = Course.objects.update_or_create(id=course_id, site=site, defaults=defaults)
+            logger.info("Created course with id %s", course.id)
+
+            # Create seats
+            for seat in course_settings["seats"]:
+                self._create_seat(course, seat, partner)
+
+            # Publish the data to the LMS
+            course.publish_to_lms()
+
+    def _course_is_valid(self, course):
+        """ Returns true if the course is properly formatted and contains acceptable values """
+        is_valid = True
+
+        # Check course settings
+        missing_settings = []
+        if "organization" not in course:
+            missing_settings.append("organization")
+        if "number" not in course:
+            missing_settings.append("number")
+        if "run" not in course:
+            missing_settings.append("run")
+        if "fields" not in course:
+            missing_settings.append("fields")
+        if "seats" not in course:
+            missing_settings.append("seats")
+        if missing_settings:
+            logger.warning("Course json is missing the following fields: " + str(missing_settings))
+            is_valid = False
+
+        # Check fields settings
+        if ("fields" in course) and ("display_name" not in course["fields"]):
+            logger.warning("Fields json is missing display_name")
+            is_valid = False
+
+        # Check seats types
+        if "seats" in course:
+            for seat in course["seats"]:
+                if ("seat_type" not in seat) or (seat["seat_type"] not in self.valid_seat_types):
+                    logger.warning("Seat type must be one of " + str(self.valid_seat_types))
+                    is_valid = False
+                    break
+
+        return is_valid
+
+    def _create_seat(self, course, seat, partner):
+        """ Add the specified seat to the course """
+        seat_type = seat["seat_type"]
+        if seat_type == "audit":
+            course.create_or_update_seat("", False, 0, partner)
+        elif seat_type == "verified":
+            course.create_or_update_seat(
+                "verified",
+                True,
+                self.default_verified_price,
+                partner,
+                expires=self.default_upgrade_deadline
+            )
+        elif seat_type == "honor":
+            course.create_or_update_seat("honor", False, 0, partner)
+        elif seat_type == "professional":
+            if "id_verification_required" in seat:
+                id_verification_required = seat["id_verification_required"]
+            else:
+                id_verification_required = True
+            course.create_or_update_seat(
+                "professional",
+                id_verification_required,
+                self.default_professional_price,
+                partner
+            )
+        logger.info("Created %s seat for course %s", seat_type, course.id)

--- a/ecommerce/core/tests/test_generate_courses.py
+++ b/ecommerce/core/tests/test_generate_courses.py
@@ -1,0 +1,140 @@
+import json
+import ddt
+import httpretty
+import mock
+from django.core.management import CommandError, call_command
+from django.test import override_settings
+
+from ecommerce.courses.models import Course
+from ecommerce.extensions.catalogue.tests.mixins import CourseCatalogTestMixin
+from ecommerce.tests.testcases import TestCase
+
+
+@ddt.ddt
+class GenerateCoursesTests(CourseCatalogTestMixin, TestCase):
+
+    default_verified_price = 100
+    default_professional_price = 1000
+
+    def test_invalid_env(self):
+        """
+        Test that running the command in a non-development environment will raise the appropriate command error
+        """
+        msg = "Command should only be run in development environments"
+        with self.assertRaisesRegexp(CommandError, msg):
+            arg = 'arg'
+            call_command("generate_courses", arg)
+
+    @override_settings(DEBUG=True)
+    def test_invalid_json(self):
+        """
+        Test that providing an invalid JSON object will raise the appropriate command error
+        """
+        msg = "Invalid JSON object"
+        with self.assertRaisesRegexp(CommandError, msg):
+            arg = 'invalid_json'
+            call_command("generate_courses", arg)
+
+    @override_settings(DEBUG=True)
+    def test_missing_courses_field(self):
+        """
+        Test that missing the courses key will raise the appropriate command error
+        """
+        msg = "JSON object is missing courses field"
+        with self.assertRaisesRegexp(CommandError, msg):
+            arg = ('{}')
+            call_command("generate_courses", arg)
+
+    @override_settings(DEBUG=True)
+    @mock.patch('ecommerce.core.management.commands.generate_courses.logger')
+    @ddt.data("organization", "number", "run", "fields", "seats")
+    def test_missing_course_setting(self, setting, mock_logger):
+        """
+        Test that missing settings in course JSON will result in the appropriate log messages
+        """
+        msg = "Course json is missing the following fields: " + str([setting])
+        settings = {"courses": [{
+            "store": "split",
+            "organization": "test-course-generator",
+            "number": "1",
+            "run": "1",
+            "fields": {"display_name": "test-course"},
+            "seats": []
+        }]}
+        del settings["courses"][0][setting]
+        arg = json.dumps(settings)
+        call_command("generate_courses", arg)
+        mock_logger.warning.assert_any_call(msg)
+
+    @override_settings(DEBUG=True)
+    @mock.patch('ecommerce.core.management.commands.generate_courses.logger')
+    def test_missing_course_name(self, mock_logger):
+        """
+        Test that missing course name in fields json will result in the appropriate log messages
+        """
+        msg = "Fields json is missing display_name"
+        settings = {"courses": [{
+            "store": "split",
+            "organization": "test-course-generator",
+            "number": "1",
+            "run": "1",
+            "fields": {},
+            "seats": []
+        }]}
+        arg = json.dumps(settings)
+        call_command("generate_courses", arg)
+        mock_logger.warning.assert_any_call(msg)
+
+    @override_settings(DEBUG=True)
+    @mock.patch('ecommerce.core.management.commands.generate_courses.logger')
+    def test_invalid_seat_type(self, mock_logger):
+        """
+        Test that an invalid seat type in seat JSON will result in the appropriate log messages
+        """
+        valid_seat_types = ["audit", "verified", "honor", "professional"]
+        msg = "Seat type must be one of %s" % (valid_seat_types)
+        settings = {"courses": [{
+            "store": "split",
+            "organization": "test-course-generator",
+            "number": "1",
+            "run": "1",
+            "fields": {"display_name": "test-course"},
+            "seats": [{"seat_type": "invalid_seat_type"}]
+        }]}
+        arg = json.dumps(settings)
+        call_command("generate_courses", arg)
+        mock_logger.warning.assert_any_call(msg)
+
+    @override_settings(DEBUG=True)
+    @httpretty.activate
+    @ddt.data("audit", "honor", "verified", "professional")
+    def test_create_seat(self, seat_type):
+        """
+        The command should create the demo course with a seat,
+        and publish that data to the LMS.
+        """
+        if seat_type == "verified":
+            price = self.default_verified_price
+        elif seat_type == "professional":
+            price = self.default_professional_price
+        else:
+            price = 0
+
+        self.mock_access_token_response()
+        settings = {"courses": [{
+            "store": "split",
+            "organization": "test-course-generator",
+            "number": "1",
+            "run": "1",
+            "fields": {"display_name": "test-course"},
+            "seats": [{"seat_type": seat_type}]
+        }]}
+        arg = json.dumps(settings)
+        with mock.patch.object(Course, 'publish_to_lms', return_value=None) as mock_publish:
+            call_command('generate_courses', arg)
+            mock_publish.assert_called_once_with()
+
+        course = Course.objects.get(id='course-v1:test-course-generator+1+1')
+        seats = course.seat_products
+        seat = seats[0]
+        self.assertEqual(seat.stockrecords.get(partner=self.partner).price_excl_tax, price)


### PR DESCRIPTION
LEARNER-1817
https://openedx.atlassian.net/browse/LEARNER-1817

This management command allows you to create a set of courses (e.g. course set containing all course types and valid course seat configurations) from properly-formatted json. Eventually, a provisioning script from docker devstack should be used to call this command, as opposed to using this command directly (It would be cumbersome to specify json directly on the command line)