### PR TITLE
ENT-367 Set max_age on Enterprise cookie.

### DIFF
--- a/ecommerce/enterprise/decorators.py
+++ b/ecommerce/enterprise/decorators.py
@@ -16,15 +16,23 @@ def set_enterprise_cookie(func):
     """
     @wraps(func)
     def _decorated(request, *args, **kwargs):
-        code, enterprise_customer_uuid = request.GET.get('code'), None
-        if code:
-            enterprise_customer_uuid = utils.get_enterprise_customer_uuid(code)
-
         response = func(request, *args, **kwargs)
 
         # Set enterprise customer cookie if enterprise customer uuid is available.
-        if enterprise_customer_uuid:
-            response = utils.set_enterprise_customer_cookie(request.site, response, enterprise_customer_uuid)
+        # The max_age of the cookie is set to a relatively short 60 seconds to
+        # maintain the Enterprise context across jumps over to other Open edX
+        # services, e.g. LMS, but also to ensure that the Enterprise context
+        # does not linger longer than it should.
+        code, enterprise_customer_uuid = request.GET.get('code'), None
+        if code:
+            enterprise_customer_uuid = utils.get_enterprise_customer_uuid(code)
+            if enterprise_customer_uuid:
+                response = utils.set_enterprise_customer_cookie(
+                    request.site,
+                    response,
+                    enterprise_customer_uuid,
+                    max_age=60
+                )
 
         return response
     return _decorated

--- a/ecommerce/enterprise/tests/test_decorators.py
+++ b/ecommerce/enterprise/tests/test_decorators.py
@@ -39,6 +39,7 @@ class EnterpriseDecoratorsTests(EnterpriseServiceMockMixin, TestCase):
 
         cookie = response.cookies[settings.ENTERPRISE_CUSTOMER_COOKIE_NAME]
         self.assertEqual(str(enterprise_customer_uuid), cookie.value)
+        self.assertEqual(60, cookie.get('max-age'))
 
     def test_set_enterprise_cookie_no_code(self):
         """

--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -393,7 +393,7 @@ def get_enterprise_customer_uuid(coupon_code):
     return offer.benefit.range.enterprise_customer
 
 
-def set_enterprise_customer_cookie(site, response, enterprise_customer_uuid):
+def set_enterprise_customer_cookie(site, response, enterprise_customer_uuid, max_age=None):
     """
     Set cookie for the enterprise customer with enterprise customer UUID.
 
@@ -403,6 +403,7 @@ def set_enterprise_customer_cookie(site, response, enterprise_customer_uuid):
         site (Site): Django site object.
         response (HttpResponse): Django HTTP response object.
         enterprise_customer_uuid (UUID): Enterprise customer UUID
+        max_age (int): Maximum age of the cookie (seconds), defaults to None (lasts only as long as browser session).
 
     Returns:
          response (HttpResponse): Django HTTP response object.
@@ -411,6 +412,7 @@ def set_enterprise_customer_cookie(site, response, enterprise_customer_uuid):
         response.set_cookie(
             settings.ENTERPRISE_CUSTOMER_COOKIE_NAME, enterprise_customer_uuid,
             domain=site.siteconfiguration.base_cookie_domain,
+            max_age=max_age,
         )
     else:
         log.warning(


### PR DESCRIPTION
We set a cookie which identifies a user as being associated with
a given enterprise based on how they navigated to the Open edX site.
This cookie gets shared across edX services, so that the enterprise
context can be maintained when navigating between UIs across these
services. This cookie needs to be short-lived so that the Enterprise
context does not linger longer than it should. This change sets a
60 second max age on the Enterprise cookie.

ENT-367