### PR TITLE
Updated Order Completed segment event to include Coupon data

### DIFF
--- a/ecommerce/extensions/checkout/signals.py
+++ b/ecommerce/extensions/checkout/signals.py
@@ -23,10 +23,15 @@ def track_completed_order(sender, order=None, **kwargs):  # pylint: disable=unus
     if order.total_excl_tax <= 0:
         return
 
+    voucher = order.basket_discounts.filter(voucher_id__isnull=False).first()
+    coupon = voucher.voucher_code if voucher else None
+
     properties = {
         'orderId': order.number,
         'total': str(order.total_excl_tax),
         'currency': order.currency,
+        'coupon': coupon,
+        'discount': str(order.total_discount_incl_tax),
         'products': [
             {
                 # For backwards-compatibility with older events the `sku` field is (ab)used to


### PR DESCRIPTION
Segment events were not tracking coupon or discount values, events fired now have include a coupon field containing the name of the coupon and a discount field containing the value of the discount they have received.

 [LEARNER-1918] cloned from [LEARNER-1568]