### PR TITLE
Updated Program Conditional Offer logic to allow for partial programs

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -423,6 +423,10 @@ class SiteConfiguration(models.Model):
     def credit_api_client(self):
         return EdxRestApiClient(self.build_lms_url('/api/credit/v1/'), jwt=self.access_token)
 
+    @cached_property
+    def enrollment_api_client(self):
+        return EdxRestApiClient(self.build_lms_url('/api/enrollment/v1/'), jwt=self.access_token, append_slash=False)
+
 
 class User(AbstractUser):
     """Custom user model for use with OIDC."""

--- a/ecommerce/core/tests/test_models.py
+++ b/ecommerce/core/tests/test_models.py
@@ -341,3 +341,15 @@ class SiteConfigurationTests(TestCase):
         self.assertEqual(client_store['base_url'], 'https://fake.domain.com/api/v1/')
         self.assertIsInstance(client_auth, SuppliedJwtAuth)
         self.assertEqual(client_auth.token, token)
+
+    @httpretty.activate
+    def test_enrollment_api_client(self):
+        """ Verify the property an Enrollment API client."""
+        token = self.mock_access_token_response()
+        client = self.site.siteconfiguration.enrollment_api_client
+        client_store = client._store  # pylint: disable=protected-access
+        client_auth = client_store['session'].auth
+
+        self.assertEqual(client_store['base_url'], self.site_configuration.enrollment_api_url)
+        self.assertIsInstance(client_auth, SuppliedJwtAuth)
+        self.assertEqual(client_auth.token, token)

--- a/ecommerce/courses/utils.py
+++ b/ecommerce/courses/utils.py
@@ -1,10 +1,13 @@
 import hashlib
+import logging
 
 from django.conf import settings
 from django.core.cache import cache
 from django.utils.translation import ugettext_lazy as _
 
 from ecommerce.core.utils import traverse_pagination
+
+logger = logging.getLogger(__name__)
 
 
 def mode_for_seat(product):

--- a/ecommerce/extensions/api/v2/tests/views/test_baskets.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_baskets.py
@@ -378,6 +378,7 @@ class BasketCalculateViewTests(ProgramTestMixin, TestCase):
         offer = ProgramOfferFactory(benefit=PercentageDiscountBenefitWithoutRangeFactory(value=100))
         program_uuid = offer.condition.program_uuid
         self.mock_program_detail_endpoint(program_uuid, self.site_configuration.discovery_api_url)
+        self.mock_enrollment_api(self.user.username)
 
         response = self.client.get(self.url)
         expected = {

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -431,6 +431,7 @@ class EnrollmentFulfillmentModuleTests(ProgramTestMixin, DiscoveryTestMixin, Ful
         self.create_seat_and_order(certificate_type='credit', provider='MIT')
         program_uuid = uuid.uuid4()
         self.mock_program_detail_endpoint(program_uuid, self.site_configuration.discovery_api_url)
+        self.mock_enrollment_api(self.user.username)
         self.prepare_basket_with_voucher(program_uuid=program_uuid)
         __, lines = EnrollmentFulfillmentModule().fulfill_product(self.order, list(self.order.lines.all()))
         # No exceptions should be raised and the order should be fulfilled

--- a/ecommerce/programs/tests/test_conditions.py
+++ b/ecommerce/programs/tests/test_conditions.py
@@ -13,6 +13,7 @@ from ecommerce.tests.factories import ProductFactory
 from ecommerce.tests.testcases import TestCase
 
 Product = get_model('catalogue', 'Product')
+LOGGER_NAME = 'ecommerce.programs.conditions'
 
 
 @ddt.ddt
@@ -42,7 +43,7 @@ class ProgramCourseRunSeatsConditionTests(ProgramTestMixin, TestCase):
         self.assertEqual(self.condition.get_program(self.site.siteconfiguration), data)
 
     @httpretty.activate
-    def test_is_satisfied(self):
+    def test_is_satisfied_no_enrollments(self):
         """ The method should return True if the basket contains one course run seat corresponding to each
         course in the program. """
         offer = factories.ProgramOfferFactory(condition=self.condition)
@@ -63,6 +64,7 @@ class ProgramCourseRunSeatsConditionTests(ProgramTestMixin, TestCase):
                 else:
                     audit_seats.append(seat)
 
+        self.mock_enrollment_api(basket.owner.username)
         # Empty baskets should never be satisfied
         basket.flush()
         self.assertTrue(basket.is_empty)
@@ -77,12 +79,52 @@ class ProgramCourseRunSeatsConditionTests(ProgramTestMixin, TestCase):
         # All courses must be represented in the basket.
         # NOTE: We add all but the first verified seat to ensure complete branch coverage of the method.
         basket.flush()
-        for verified_seat in verified_seats[:len(verified_seats) - 1]:
+        for verified_seat in verified_seats[1:len(verified_seats)]:
             basket.add_product(verified_seat)
         self.assertFalse(self.condition.is_satisfied(offer, basket))
 
         # The condition should be satisfied if one valid course run from each course is in the basket.
-        basket.add_product(verified_seats[len(verified_seats) - 1])
+        basket.add_product(verified_seats[0])
+        self.assertTrue(self.condition.is_satisfied(offer, basket))
+
+        # If the user is enrolled with the wrong seat type for courses missing from their basket that are
+        # needed for the program, the condition should NOT be satisfied
+        basket.flush()
+        for verified_seat in verified_seats[1:len(verified_seats)]:
+            basket.add_product(verified_seat)
+        self.assertFalse(self.condition.is_satisfied(offer, basket))
+
+    @httpretty.activate
+    def test_is_satisfied_with_enrollments(self):
+        """ The condition should be satisfied if one valid course run from each course is in either the
+        basket or the user's enrolled courses. """
+        offer = factories.ProgramOfferFactory(condition=self.condition)
+        basket = factories.BasketFactory(site=self.site, owner=factories.UserFactory())
+        program = self.mock_program_detail_endpoint(
+            self.condition.program_uuid, self.site_configuration.discovery_api_url
+        )
+        enrollments = [{'mode': 'verified', 'course_details': {'course_id': 'course-v1:test-org+course+1'}},
+                       {'mode': 'verified', 'course_details': {'course_id': 'course-v1:test-org+course+2'}}]
+
+        # Extract one verified seat for each course
+        verified_seats = []
+        for course in program['courses']:
+            course_run = Course.objects.get(id=course['course_runs'][0]['key'])
+            for seat in course_run.seat_products:
+                if seat.attr.id_verification_required:
+                    verified_seats.append(seat)
+
+        self.mock_enrollment_api(basket.owner.username, enrollments=enrollments)
+        # If the user has not added all of the remaining courses in program to their basket,
+        # the condition should not be satisfied
+        basket.flush()
+        for seat in verified_seats[2:len(verified_seats) - 1]:
+            basket.add_product(seat)
+        self.assertFalse(self.condition.is_satisfied(offer, basket))
+
+        # When all courses in the program that the user is not already enrolled in are in their basket,
+        # the condition should be satisfied
+        basket.add_product(verified_seats[-1])
         self.assertTrue(self.condition.is_satisfied(offer, basket))
 
     @ddt.data(HttpNotFoundError, SlumberBaseException, Timeout)

--- a/ecommerce/programs/tests/test_offer.py
+++ b/ecommerce/programs/tests/test_offer.py
@@ -23,6 +23,7 @@ class ProgramOfferTests(ProgramTestMixin, TestCase):
 
         program_uuid = offer.condition.program_uuid
         program = self.mock_program_detail_endpoint(program_uuid, self.site_configuration.discovery_api_url)
+        self.mock_enrollment_api(basket.owner.username)
 
         # Add one course run seat from each course to the basket.
         for course in program['courses']:


### PR DESCRIPTION
ProgramCourseRunSeatsCondition model's is_satisfied method checks enrollments and items in basket  for condition satisfaction, allowing for discount application on remaining courses in a program when a user is already enrolled in some of the program courses.

**Test**
Add two course products in ecommerce.
Create corresponding courses with verified seats in CAT.
Create a program offer with these two courses.
Enroll a user in a verified seat of one course.
Add the verified seat for the other course to the basket.
Discount should appear for the one course.

LEARNER-1901