### PR TITLE
Added a timeout to e2e tests

### DIFF
--- a/e2e/pytest.ini
+++ b/e2e/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 addopts = --driver=Chrome
+# Each test must complete in less than 45 seconds
+timeout = 45

--- a/e2e/requirements.txt
+++ b/e2e/requirements.txt
@@ -4,5 +4,6 @@ edx-rest-api-client==1.7.1
 pytest==3.1.3
 pytest-random-order==0.5.4
 pytest-selenium==1.11.0
+pytest-timeout==1.2.0
 python-dotenv==0.6.4
 selenium==3.4.3


### PR DESCRIPTION
Each test now has a 45s timeout. This is one fix to help prevent
Jenkins jobs from running for hours.

LEARNER-1998