### PR TITLE
Updated rendering of Apple Pay button on mobile clients

### DIFF
--- a/ecommerce/static/sass/partials/views/_basket.scss
+++ b/ecommerce/static/sass/partials/views/_basket.scss
@@ -238,32 +238,27 @@
             }
 
             @supports (-webkit-appearance: -apple-pay-button) {
-                .apple-pay-set-up-button {
+                .apple-pay-button {
                     display: inline-block;
                     -webkit-appearance: -apple-pay-button;
-                    -apple-pay-button-type: set-up !important;
                 }
-
-                .apple-pay-button-with-text {
-                    display: inline-block;
-                    -webkit-appearance: -apple-pay-button;
-                    -apple-pay-button-type: buy;
-                    cursor: pointer;
-                }
-
-                .apple-pay-button-with-text > * {
-                    display: none;
-                }
-
-                .apple-pay-button-black-with-text {
+                .apple-pay-button-black {
                     -apple-pay-button-style: black;
                 }
+                .apple-pay-button-white {
+                    -apple-pay-button-style: white;
+                }
 
-                .apple-pay-button-with-text {
-                    --apple-pay-scale: 1; /* (height / 32) */
-                    display: inline-flex;
-                    justify-content: center;
-                    font-size: 12px;
+                .apple-pay-button-white-with-line {
+                    -apple-pay-button-style: white-outline;
+                }
+            }
+            @supports not (-webkit-appearance: -apple-pay-button) {
+                .apple-pay-button {
+                    display: inline-block;
+                    background-size: 100% 60%;
+                    background-repeat: no-repeat;
+                    background-position: 50% 50%;
                     border-radius: 5px;
                     padding: 0px;
                     box-sizing: border-box;
@@ -271,33 +266,18 @@
                     min-height: 32px;
                     max-height: 64px;
                 }
-
-                .apple-pay-button-black-with-text {
-                    background-color: black;
-                    color: white;
-                }
-
-                .apple-pay-button-with-text.apple-pay-button-black-with-text > .logo, {
+                .apple-pay-button-black {
                     background-image: -webkit-named-image(apple-pay-logo-white);
                     background-color: black;
                 }
-
-                .apple-pay-button-with-text > .text {
-                    font-family: -apple-system;
-                    font-size: calc(1em * var(--apple-pay-scale));
-                    font-weight: 300;
-                    align-self: center;
-                    margin-right: calc(2px * var(--apple-pay-scale));
+                .apple-pay-button-white {
+                    background-image: -webkit-named-image(apple-pay-logo-black);
+                    background-color: white;
                 }
-
-                .apple-pay-button-with-text > .logo {
-                    width: calc(35px * var(--scale));
-                    height: 100%;
-                    background-size: 100% 60%;
-                    background-repeat: no-repeat;
-                    background-position: 0 50%;
-                    margin-left: calc(2px * var(--apple-pay-scale));
-                    border: none;
+                .apple-pay-button-white-with-line {
+                    background-image: -webkit-named-image(apple-pay-logo-black);
+                    background-color: white;
+                    border: .5px solid black;
                 }
             }
         }
@@ -353,33 +333,6 @@
         color: red;
     }
 
-    .payment-methods {
-        padding-left: 0;
-    }
-
-    #payment-method {
-        #payment-method-image, button {
-            @include float(left);
-            border: 1px solid palette(grayscale, base);
-            border-radius: 5px;
-            height: 50px;
-        }
-
-        #payment-method-image {
-            border-bottom: 4px solid #337ab7;
-            width: 150px;
-            line-height: 40px;
-        }
-
-        button {
-            position: relative;
-            left: -1px;
-            background-color: white;
-            width: 100px;
-            color: gray;
-        }
-    }
-
     #payment-processor {
         .payment-button {
             border: 1px solid palette(grayscale, base);
@@ -390,12 +343,28 @@
             width: 120px;
             height: 50px;
             vertical-align: top;
+
             &.payment-processor-paypal {
                 background-image: url('/static/images/paypal_logo.png');
 
                 &:focus {
                     outline: dotted 1px #000;
                 }
+            }
+
+            &.credit-card {
+                @include float(left);
+                border: 1px solid palette(grayscale, base);
+                border-radius: 5px;
+                height: 50px;
+                border-bottom: 4px solid #337ab7;
+                width: 150px;
+                line-height: 40px;
+                padding: 0;
+                // NOTE: We are assuming a layout of credit card, PayPal, Apple Pay.
+                // The Apple Pay button has a margin equaly to 1/10th the button's height,
+                // so we are replicating that margin here for the credit card button.
+                @include margin-right(5px);
             }
         }
     }

--- a/ecommerce/templates/oscar/basket/partials/client_side_checkout_basket.html
+++ b/ecommerce/templates/oscar/basket/partials/client_side_checkout_basket.html
@@ -104,32 +104,28 @@
         <div id="payment-method-information" class="placeholder row">
             <div role="region" aria-labelledby="payment-method-region">
                 <h2 id="payment-method-region" class="title">{% trans "select payment method" %}</h2>
-                <div class="col-sm-12 payment-methods">
-                    <div id="payment-method" class="col-md-4 col-sm-7 col-xs-6">
-                        <a href="#payment-information" id="payment-method-image" title="{% trans "Pay with a Credit Card" %}" role="button"><img src="/static/images/credit_card_options.png" alt=""></a>
-                    </div>
-                    <div id="payment-processor" class="payment-buttons col-md-8 col-sm-5 col-xs-6" data-basket-id="{{ basket.id }}">
-                        {# Translators: Do NOT translate the name PayPal. #}
-                        <button data-track-type="click"
-                                data-track-event="edx.bi.ecommerce.basket.payment_selected"
-                                data-track-category="checkout"
-                                data-processor-name="paypal"
-                                class="btn payment-button payment-processor-paypal"
-                                value="paypal"
-                                title="{% trans "Pay with PayPal" %}"
-                                type="button">
-                        </button>
-                        <button id="applePayBtn" lang="{{ LANGUAGE_CODE|default:"en-us" }}" style="display:none"
-                                data-track-type="click"
-                                data-track-event="edx.bi.ecommerce.basket.payment_selected"
-                                data-track-category="checkout"
-                                class="payment-button apple-pay-button-with-text apple-pay-button-black-with-text apple-pay-button-with-text"
-                                title="{% trans "Pay with Apple Pay" %}" type="button">
-                          <span class="text"></span>
-                          <span class="logo"></span>
-                        </button>
-                    </div>
-                </div>
+                  <div id="payment-processor" class="payment-buttons col-sm-12" data-basket-id="{{ basket.id }}">
+                      <a href="#payment-information" class="payment-button credit-card" title="{% trans "Pay with a Credit Card" %}" role="button">
+                          <img src="/static/images/credit_card_options.png">
+                      </a>
+                      {# Translators: Do NOT translate the name PayPal. #}
+                      <button data-track-type="click"
+                              data-track-event="edx.bi.ecommerce.basket.payment_selected"
+                              data-track-category="checkout"
+                              data-processor-name="paypal"
+                              class="btn payment-button payment-processor-paypal"
+                              value="paypal"
+                              title="{% trans "Pay with PayPal" %}"
+                              type="button">
+                      </button>
+                      <button id="applePayBtn" lang="{{ LANGUAGE_CODE|default:"en-us" }}" style="display:none"
+                              data-track-type="click"
+                              data-track-event="edx.bi.ecommerce.basket.payment_selected"
+                              data-track-category="checkout"
+                              class="payment-button apple-pay-button apple-pay-button-black"
+                              title="{% trans "Pay with Apple Pay" %}" type="button">
+                      </button>
+                  </div>
             </div>
         </div>
         {% endif %}


### PR DESCRIPTION
All payment methods are now grouped together to avoid alignment issues on narrow windows. Additionally, we are now using the Apple Pay button without text. This style is slightly bolder and allows us to maintain a 120px width.

LEARNER-2002