### PR TITLE
Added temporary switch to disable non-order-related events

### DIFF
--- a/ecommerce/extensions/analytics/tests/test_utils.py
+++ b/ecommerce/extensions/analytics/tests/test_utils.py
@@ -4,6 +4,7 @@ from analytics import Client
 from django.contrib.auth.models import AnonymousUser
 from oscar.test import factories
 
+from ecommerce.core.tests import toggle_switch
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.analytics.utils import (
     parse_tracking_context, prepare_analytics_data, track_segment_event, translate_basket_line_for_segment
@@ -16,6 +17,10 @@ from ecommerce.tests.testcases import TestCase
 
 class UtilsTest(CourseCatalogTestMixin, BasketMixin, TestCase):
     """ Tests for the analytics utils. """
+
+    def setUp(self):
+        super(UtilsTest, self).setUp()
+        toggle_switch('fire_non_order_events', True)
 
     def test_prepare_analytics_data(self):
         """ Verify the function returns correct analytics data for a logged in user."""

--- a/ecommerce/extensions/analytics/utils.py
+++ b/ecommerce/extensions/analytics/utils.py
@@ -2,6 +2,8 @@ import json
 import logging
 from functools import wraps
 
+import waffle
+
 from ecommerce.courses.utils import mode_for_seat
 
 logger = logging.getLogger(__name__)
@@ -131,6 +133,9 @@ def track_segment_event(site, user, event, properties):
         (success, msg): Tuple indicating the success of enqueuing the event on the message queue.
             This can be safely ignored unless needed for debugging purposes.
     """
+
+    if not (event in ('Order Completed', 'Order Refunded',) or waffle.switch_is_active('fire_non_order_events')):
+        return False, ''
 
     site_configuration = site.siteconfiguration
     if not site_configuration.segment_key:

--- a/ecommerce/extensions/basket/tests/test_models.py
+++ b/ecommerce/extensions/basket/tests/test_models.py
@@ -5,8 +5,10 @@ from analytics import Client
 from oscar.core.loading import get_class, get_model
 from oscar.test import factories
 
+from ecommerce.core.tests import toggle_switch
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.analytics.utils import parse_tracking_context, translate_basket_line_for_segment
+from ecommerce.extensions.api.v2.tests.views.mixins import CatalogMixin
 from ecommerce.extensions.basket.models import Basket
 from ecommerce.extensions.basket.tests.mixins import BasketMixin
 from ecommerce.extensions.test.factories import create_basket
@@ -17,9 +19,10 @@ Basket = get_model('basket', 'Basket')
 OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
 
 
-class BasketTests(BasketMixin, TestCase):
+class BasketTests(CatalogMixin, BasketMixin, TestCase):
     def setUp(self):
         super(BasketTests, self).setUp()
+        toggle_switch('fire_non_order_events', True)
         self.site1 = SiteConfigurationFactory().site
         self.site2 = SiteConfigurationFactory().site
 

--- a/ecommerce/extensions/checkout/tests/test_mixins.py
+++ b/ecommerce/extensions/checkout/tests/test_mixins.py
@@ -10,6 +10,7 @@ from testfixtures import LogCapture
 from waffle.models import Sample
 
 from ecommerce.core.models import SegmentClient
+from ecommerce.core.tests import toggle_switch
 from ecommerce.extensions.analytics.utils import parse_tracking_context, translate_basket_line_for_segment
 from ecommerce.extensions.checkout.exceptions import BasketNotFreeError
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
@@ -38,6 +39,7 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin,
 
     def setUp(self):
         super(EdxOrderPlacementMixinTests, self).setUp()
+        toggle_switch('fire_non_order_events', True)
 
         self.user = UserFactory()
         self.order = self.create_order(status=ORDER.OPEN)

--- a/ecommerce/extensions/refund/tests/test_signals.py
+++ b/ecommerce/extensions/refund/tests/test_signals.py
@@ -2,6 +2,7 @@ from mock import patch
 from oscar.test.newfactories import UserFactory
 
 from ecommerce.core.models import SegmentClient
+from ecommerce.core.tests import toggle_switch
 from ecommerce.extensions.refund.api import create_refunds
 from ecommerce.extensions.refund.tests.mixins import RefundTestMixin
 from ecommerce.tests.testcases import TestCase
@@ -13,6 +14,7 @@ class RefundTrackingTests(RefundTestMixin, TestCase):
 
     def setUp(self):
         super(RefundTrackingTests, self).setUp()
+        toggle_switch('fire_non_order_events', True)
 
         self.user = UserFactory()
         self.refund = create_refunds([self.create_order()], self.course.id)[0]


### PR DESCRIPTION
This is an attempt to determine if these new events are the cause of the increased CPU utilization in production.