### PR TITLE
Disabled Product Added/Removed events for free items

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -188,12 +188,6 @@ class SiteConfiguration(models.Model):
         default='Order Completed, Order Refunded'
     )
 
-    @cached_property
-    def allowed_segment_events(self):
-        events = self._allowed_segment_events.split(',')
-        events = [event.strip() for event in events]
-        return events
-
     @property
     def payment_processors_set(self):
         """

--- a/ecommerce/extensions/analytics/tests/test_utils.py
+++ b/ecommerce/extensions/analytics/tests/test_utils.py
@@ -18,11 +18,6 @@ from ecommerce.tests.testcases import TestCase
 class UtilsTest(CourseCatalogTestMixin, BasketMixin, TestCase):
     """ Tests for the analytics utils. """
 
-    def setUp(self):
-        super(UtilsTest, self).setUp()
-        self.site_configuration._allowed_segment_events += ',foo'
-        self.site_configuration.save()
-
     def test_prepare_analytics_data(self):
         """ Verify the function returns correct analytics data for a logged in user."""
         user = self.create_user(

--- a/ecommerce/extensions/analytics/utils.py
+++ b/ecommerce/extensions/analytics/utils.py
@@ -133,12 +133,6 @@ def track_segment_event(site, user, event, properties):
     """
 
     site_configuration = site.siteconfiguration
-    if event not in site_configuration.allowed_segment_events:
-        msg = 'Event [{event}] was NOT fired because it is not permitted for site configuration [{site_id}]'.format(
-            event=event, site_id=site_configuration.pk)
-        logger.debug(msg)
-        return False, ''
-
     if not site_configuration.segment_key:
         msg = 'Event [{event}] was NOT fired because no Segment key is set for site configuration [{site_id}]'
         msg = msg.format(event=event, site_id=site_configuration.pk)

--- a/ecommerce/extensions/basket/tests/test_models.py
+++ b/ecommerce/extensions/basket/tests/test_models.py
@@ -153,3 +153,14 @@ class BasketTests(CatalogMixin, BasketMixin, TestCase):
             properties = translate_basket_line_for_segment(basket.lines.first())
             properties['cart_id'] = basket.id
             mock_track.assert_called_once_with(basket.site, basket.owner, 'Product Added', properties)
+
+    def test_product_events_with_free_items(self):
+        """ Product Added/Removed events should not be fired for free products. """
+        course = CourseFactory()
+        basket = create_basket(empty=True)
+        seat = course.create_or_update_seat('audit', False, 0, self.partner)
+
+        with mock.patch('ecommerce.extensions.basket.models.track_segment_event') as mock_track:
+            basket.add_product(seat)
+            basket.flush()
+            self.assertEqual(mock_track.call_count, 0)

--- a/ecommerce/extensions/basket/tests/test_models.py
+++ b/ecommerce/extensions/basket/tests/test_models.py
@@ -19,12 +19,6 @@ OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
 
 
 class BasketTests(CatalogMixin, BasketMixin, TestCase):
-    def setUp(self):
-        super(BasketTests, self).setUp()
-
-        self.site_configuration._allowed_segment_events += ',Product Removed, Product Added'
-        self.site_configuration.save()
-
     def assert_basket_state(self, basket, status, user, site):
         """ Verify the given basket's properties. """
         self.assertEqual(basket.status, status)

--- a/ecommerce/extensions/checkout/tests/test_mixins.py
+++ b/ecommerce/extensions/checkout/tests/test_mixins.py
@@ -39,10 +39,6 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin,
     def setUp(self):
         super(EdxOrderPlacementMixinTests, self).setUp()
         self.user = UserFactory()
-        self.site_configuration._allowed_segment_events += ' ,Product Removed, Product Added, Checkout Step Viewed, ' \
-                                                           'Checkout Step Completed, Payment Info Entered'
-        self.site_configuration.save()
-
         self.order = self.create_order(status=ORDER.OPEN)
 
     def test_handle_payment_logging(self, __):

--- a/ecommerce/extensions/checkout/tests/test_mixins.py
+++ b/ecommerce/extensions/checkout/tests/test_mixins.py
@@ -149,16 +149,6 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin,
                 )
             )
 
-    def test_handle_successful_free_order(self, mock_track):
-        """Verify that tracking events are not emitted for free orders."""
-        order = self.create_order(free=True, status=ORDER.OPEN)
-        EdxOrderPlacementMixin().handle_successful_order(order)
-
-        # Ensure that only 'Product Added' event is emitted (in order creation) and not 'Order Completion' event.
-        self.assertEqual(mock_track.call_count, 1)
-        event_name = mock_track.call_args[0][1]
-        self.assertEqual(event_name, 'Product Added')
-
     def test_handle_successful_order_no_context(self, mock_track):
         """
         Ensure that expected values are substituted when no tracking_context

--- a/ecommerce/extensions/refund/tests/test_signals.py
+++ b/ecommerce/extensions/refund/tests/test_signals.py
@@ -13,9 +13,6 @@ class RefundTrackingTests(RefundTestMixin, TestCase):
 
     def setUp(self):
         super(RefundTrackingTests, self).setUp()
-        self.site_configuration._allowed_segment_events += ' ,Product Added'
-        self.site_configuration.save()
-
         self.user = UserFactory()
         self.refund = create_refunds([self.create_order()], self.course.id)[0]
 

--- a/ecommerce/extensions/refund/tests/test_signals.py
+++ b/ecommerce/extensions/refund/tests/test_signals.py
@@ -51,19 +51,6 @@ class RefundTrackingTests(RefundTestMixin, TestCase):
 
         self.assert_refund_event_fired(mock_track, self.refund, tracking_context)
 
-    def test_successful_zero_dollar_refund_no_tracking(self, mock_track):
-        """
-        Verify that tracking events are not emitted for refunds corresponding
-        to a total credit of 0.
-        """
-        order = self.create_order(free=True)
-        create_refunds([order], self.course.id)
-
-        # Ensure that only 'Product Added' event is emitted (in order creation) and not 'Order Completion' event.
-        self.assertEqual(mock_track.call_count, 1)
-        event_name = mock_track.call_args[0][1]
-        self.assertEqual(event_name, 'Product Added')
-
     def test_successful_refund_tracking_without_context(self, mock_track):
         """Verify that a successfully placed refund is tracked, even if no tracking context is available."""
         self.approve(self.refund)


### PR DESCRIPTION
The volume we see for edX.org leads to a dramatic increase in CPU usage. Given that orders for free items are ignored, there is no need for these events.

LEARNER-2076