### PR TITLE
Upgraded Segment client from 1.2.3 to 1.2.7

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -282,7 +282,7 @@ class SiteConfiguration(models.Model):
 
     @cached_property
     def segment_client(self):
-        return SegmentClient(self.segment_key, debug=settings.DEBUG)
+        return SegmentClient(self.segment_key, debug=settings.DEBUG, send=settings.SEND_SEGMENT_EVENTS)
 
     def save(self, *args, **kwargs):
         # Clear Site cache upon SiteConfiguration changed

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -607,3 +607,6 @@ if os.environ.get('ENABLE_DJANGO_TOOLBAR', False):
         'debug_toolbar.middleware.DebugToolbarMiddleware',
     )
 # END DJANGO DEBUG TOOLBAR CONFIGURATION
+
+# Determines if events are actually sent to Segment. This should only be set to False for testing purposes.
+SEND_SEGMENT_EVENTS = True

--- a/ecommerce/settings/test.py
+++ b/ecommerce/settings/test.py
@@ -150,3 +150,6 @@ COMPREHENSIVE_THEME_DIRS = [
 DEFAULT_SITE_THEME = "test-theme"
 
 ENTERPRISE_API_URL = urljoin(ENTERPRISE_SERVICE_URL, 'api/v1/')
+
+# Don't bother sending fake events to Segment. Doing so creates unnecessary threads.
+SEND_SEGMENT_EVENTS = False

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-analytics-python==1.2.3
+analytics-python==1.2.7
 django==1.10.7
 django-compressor==2.1.1
 django-crispy-forms==1.6.1


### PR DESCRIPTION
In addition to the upgrade we are no longer queueing events for tests. This should prevent the tests from spinning up unnecessary threads to fire fake events to a fake Segment property.

LEARNER-2076