### PR TITLE
[ENT-493] New data sharing consent API

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -409,6 +409,10 @@ class SiteConfiguration(models.Model):
         return EdxRestApiClient(self.enterprise_api_url, jwt=self.access_token)
 
     @cached_property
+    def consent_api_client(self):
+        return EdxRestApiClient(self.build_lms_url('/consent/api/v1/'), jwt=self.access_token, append_slash=False)
+
+    @cached_property
     def user_api_client(self):
         """
         Returns the API client to access the user API endpoint on LMS.

--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -465,8 +465,14 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
             catalog=catalog
         )
         self.request.user = self.user
-        self.mock_enterprise_learner_api(consent_enabled=consent_enabled, consent_provided=consent_provided)
-        self.mock_enterprise_course_enrollment_api(results_present=False)
+        self.mock_consent_response(
+            self.user.username,
+            course_id,
+            ENTERPRISE_CUSTOMER,
+            granted=consent_provided,
+            required=(consent_enabled and not consent_provided),
+            exists=(not consent_provided),
+        )
         self.mock_account_api(self.request, self.user.username, data={'is_active': True})
         self.mock_access_token_response()
         self.mock_specific_enterprise_customer_api(uuid=ENTERPRISE_CUSTOMER, consent_enabled=consent_enabled)

--- a/ecommerce/enterprise/tests/mixins.py
+++ b/ecommerce/enterprise/tests/mixins.py
@@ -420,3 +420,57 @@ class EnterpriseServiceMockMixin(object):
             body=enterprise_enrollment_api_response_json,
             content_type='application/json'
         )
+
+    def mock_consent_response(
+            self,
+            username,
+            course_id,
+            ec_uuid,
+            method=httpretty.GET,
+            granted=True,
+            required=False,
+            exists=True,
+            response_code=None
+    ):
+        response_body = {
+            'username': username,
+            'course_id': course_id,
+            'enterprise_customer_uuid': ec_uuid,
+            'consent_provided': granted,
+            'consent_required': required,
+            'exists': exists,
+        }
+        httpretty.register_uri(
+            method=method,
+            uri=self.site.siteconfiguration.build_lms_url('/consent/api/v1/data_sharing_consent'),
+            content_type='application/json',
+            body=json.dumps(response_body),
+            status=response_code or 200,
+        )
+
+    def mock_consent_get(self, username, course_id, ec_uuid):
+        self.mock_consent_response(
+            username,
+            course_id,
+            ec_uuid
+        )
+
+    def mock_consent_missing(self, username, course_id, ec_uuid):
+        self.mock_consent_response(
+            username,
+            course_id,
+            ec_uuid,
+            exists=False,
+            granted=False,
+            required=True,
+        )
+
+    def mock_consent_not_required(self, username, course_id, ec_uuid):
+        self.mock_consent_response(
+            username,
+            course_id,
+            ec_uuid,
+            exists=False,
+            granted=False,
+            required=False,
+        )

--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -147,7 +147,7 @@ class EnrollmentFulfillmentModule(BaseFulfillmentModule):
                 pass
 
             if enterprise_customer_uuid is not None:
-                data['enterprise_course_consent'] = True
+                data['linked_enterprise_customer'] = str(enterprise_customer_uuid)
                 break
 
         # If an EnterpriseCustomer UUID is associated with the coupon, create an EnterpriseCustomerUser


### PR DESCRIPTION
This pull request updates ecommerce to use the new generic data sharing consent API, as well as adopt a different format for communicating the linked enterprise to the LMS for use in consent creation.

Depends on edx/edx-platform#15706.

Testing instructions:

1. Create a premium course
2. Create a coupon attached to an EnterpriseCustomer
3. Ensure that the premium course is included in the catalog linked to the EnterpriseCustomer
4. Verify that the EnterpriseCustomer is configured to require data sharing consent 
5. Create a new user and go to the coupon redemption link
6. Verify that you're prompted for data sharing consent as expected.