### PR TITLE
Refactor ecommerce course generator command

### DIFF
--- a/ecommerce/core/management/commands/generate_courses.py
+++ b/ecommerce/core/management/commands/generate_courses.py
@@ -1,11 +1,10 @@
 """
-Django management command to generate a test course for a given course id on LMS
+Django management command to generate a test course from a course config json
 """
 import datetime
 import json
 import logging
 
-from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.utils import timezone
 from oscar.core.loading import get_model
@@ -19,39 +18,46 @@ logger = logging.getLogger(__name__)
 
 class Command(BaseCommand):
 
-    help = 'Generate courses on ecommerce from a json list of courses. Should only be run in development environments!'
+    help = 'Generate courses on ecommerce from a json list of courses.'
 
-    valid_seat_types = ["audit", "verified", "honor", "professional"]
-    default_verified_price = 100
-    default_professional_price = 1000
+    course_enrollment_settings = [
+        "audit",
+        "verified",
+        "honor",
+        "professional_education",
+        "no_id_verification",
+        "credit",
+        "credit_provider"
+    ]
     default_upgrade_deadline = timezone.now() + datetime.timedelta(days=365)
 
     def add_arguments(self, parser):
         parser.add_argument(
-            'courses',
+            'courses_json',
             help='courses to create in JSON format'  # TODO - link test-course JSON format
         )
 
     def handle(self, *args, **options):
-        if not settings.DEBUG:
-            # DEBUG is turned on in development settings and off in production settings
-            raise CommandError("Command should only be run in development environments")
         try:
-            logger.info("Attempting to create course from the following json object: %s", options["courses"])
-            arg = json.loads(options["courses"])
+            courses = json.loads(options["courses_json"])["courses"]
         except ValueError:
             raise CommandError("Invalid JSON object")
-        try:
-            courses = arg["courses"]
         except KeyError:
-            raise CommandError("JSON object is missing courses field")
+            raise CommandError("JSON object is missing courses list")
 
-        partner = Partner.objects.get(short_code='edx')
-        site = partner.siteconfiguration.site
         Flag.objects.update_or_create(name='enable_client_side_checkout', defaults={'everyone': True})
-
         for course_settings in courses:
             if not self._course_is_valid(course_settings):
+                logger.warning("Can't create course, proceeding to next course")
+
+                continue
+
+            partner_code = course_settings["partner"]
+            try:
+                partner = Partner.objects.get(short_code=partner_code)
+                site = partner.siteconfiguration.site
+            except Partner.DoesNotExist:
+                logger.warning(partner_code + " partner does not exist")
                 logger.warning("Can't create course, proceeding to next course")
                 continue
 
@@ -66,71 +72,101 @@ class Command(BaseCommand):
             logger.info("Created course with id %s", course.id)
 
             # Create seats
-            for seat in course_settings["seats"]:
-                self._create_seat(course, seat, partner)
+            enrollment = course_settings["enrollment"]
+            self._create_seats(enrollment, course, partner)
 
             # Publish the data to the LMS
-            course.publish_to_lms()
+            if course.publish_to_lms():
+                logger.warning('An error occurred while attempting to publish [%s] to LMS', course_id)
+            else:
+                logger.info('Published course modes for [%s] to LMS', course_id)
 
     def _course_is_valid(self, course):
         """ Returns true if the course is properly formatted and contains acceptable values """
         is_valid = True
 
         # Check course settings
-        missing_settings = []
-        if "organization" not in course:
-            missing_settings.append("organization")
-        if "number" not in course:
-            missing_settings.append("number")
-        if "run" not in course:
-            missing_settings.append("run")
-        if "fields" not in course:
-            missing_settings.append("fields")
-        if "seats" not in course:
-            missing_settings.append("seats")
-        if missing_settings:
-            logger.warning("Course json is missing the following fields: " + str(missing_settings))
-            is_valid = False
+        required_course_settings = [
+            "organization",
+            "number",
+            "run",
+            "partner",
+            "fields",
+            "enrollment",
+        ]
+        for setting in required_course_settings:
+            if setting not in course:
+                logger.warning("Course json is missing " + setting)
+                is_valid = False
 
         # Check fields settings
-        if ("fields" in course) and ("display_name" not in course["fields"]):
-            logger.warning("Fields json is missing display_name")
-            is_valid = False
-
-        # Check seats types
-        if "seats" in course:
-            for seat in course["seats"]:
-                if ("seat_type" not in seat) or (seat["seat_type"] not in self.valid_seat_types):
-                    logger.warning("Seat type must be one of " + str(self.valid_seat_types))
+        required_field_settings = [
+            "display_name"
+        ]
+        if "fields" in course:
+            for setting in required_field_settings:
+                if setting not in course["fields"]:
+                    logger.warning("Fields json is missing " + setting)
                     is_valid = False
-                    break
+
+        # Check enrollment settings
+        required_enrollment_settings = self.course_enrollment_settings
+        if "enrollment" in course:
+            for setting in required_enrollment_settings:
+                if setting not in course["enrollment"]:
+                    logger.warning("Enrollment json is missing " + setting)
+                    is_valid = False
 
         return is_valid
 
-    def _create_seat(self, course, seat, partner):
-        """ Add the specified seat to the course """
-        seat_type = seat["seat_type"]
-        if seat_type == "audit":
+    def _create_seats(self, enrollment, course, partner):
+        """ Create the seats for a given course based on the enrollment parameters """
+        for setting in enrollment:
+            if setting not in self.course_enrollment_settings:
+                logger.info(setting + " is not a recognized enrollment setting")
+            else:
+                logger.info(setting + " has been set to " + str(enrollment[setting]))
+
+        if enrollment["audit"]:
             course.create_or_update_seat("", False, 0, partner)
-        elif seat_type == "verified":
+            logger.info("Created audit seat for course %s", course.id)
+        if enrollment["honor"]:
+            course.create_or_update_seat("honor", False, 0, partner)
+            logger.info("Created honor seat for course %s", course.id)
+        if enrollment["verified"]:
             course.create_or_update_seat(
-                "verified",
-                True,
-                self.default_verified_price,
-                partner,
+                certificate_type="verified",
+                id_verification_required=True,
+                price=100,
+                partner=partner,
                 expires=self.default_upgrade_deadline
             )
-        elif seat_type == "honor":
-            course.create_or_update_seat("honor", False, 0, partner)
-        elif seat_type == "professional":
-            if "id_verification_required" in seat:
-                id_verification_required = seat["id_verification_required"]
-            else:
-                id_verification_required = True
+            logger.info("Created verified seat for course %s", course.id)
+        if enrollment["professional_education"]:
+            id_verification_required = not enrollment["no_id_verification"]
             course.create_or_update_seat(
-                "professional",
-                id_verification_required,
-                self.default_professional_price,
-                partner
+                certificate_type="professional",
+                id_verification_required=id_verification_required,
+                price=1000,
+                partner=partner
             )
-        logger.info("Created %s seat for course %s", seat_type, course.id)
+            logger.info(
+                "Created professional seat for course %s. ID verification requirement has been set to %s",
+                course.id,
+                id_verification_required
+            )
+        if enrollment["credit"]:
+            credit_provider = enrollment["credit_provider"]
+            course.create_or_update_seat(
+                certificate_type="credit",
+                id_verification_required=True,
+                price=2000,
+                partner=partner,
+                credit_provider=credit_provider,
+                credit_hours=100
+            )
+            logger.info(
+                "Created credit seat for course %s, with credit provider %s",
+                course.id,
+                credit_provider
+            )


### PR DESCRIPTION
LEARNER-2102
https://openedx.atlassian.net/browse/LEARNER-2102

Refactored generate_courses command and associated tests.
Updated the course seat handling logic.

Course json should at the minimum look like:
```
{
  "courses": [
    {
      "organization": "test-course-generator",
      "number": "1",
      "run": "1",
      "partner": "edx",
      "fields": {
        "display_name": "test-course",
      },
      "enrollment": {
        "audit": true,
        "honor": false,
        "verified": true,
        "professional_education": false,
        "no_id_verification": false,
        "credit": false,
        "credit_provider": null
      }
    }
  ]
}
```