### PR TITLE
Standardize product expiration date value.

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -180,6 +180,7 @@ class ProductSerializer(ProductPaymentInfoMixin, serializers.HyperlinkedModelSer
     product_class = serializers.SerializerMethodField()
     is_available_to_buy = serializers.SerializerMethodField()
     stockrecords = StockRecordSerializer(many=True, read_only=True)
+    expires = serializers.SerializerMethodField()
 
     def get_attribute_values(self, product):
         request = self.context.get('request')
@@ -197,6 +198,11 @@ class ProductSerializer(ProductPaymentInfoMixin, serializers.HyperlinkedModelSer
     def get_is_available_to_buy(self, product):
         info = self._get_info(product)
         return info.availability.is_available_to_buy
+
+    def get_expires(self, product):
+        if product.expires:
+            return product.expires.strftime(ISO_8601_FORMAT)
+        return None
 
     class Meta(object):
         model = Product

--- a/ecommerce/extensions/api/v2/tests/views/test_products.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_products.py
@@ -3,9 +3,9 @@ from __future__ import unicode_literals
 import datetime
 import json
 
-import pytz
 from django.core.urlresolvers import reverse
 from django.test import RequestFactory
+from django.utils.timezone import now
 from oscar.core.loading import get_model
 
 from ecommerce.core.constants import COUPON_PRODUCT_CLASS_NAME
@@ -33,8 +33,7 @@ class ProductViewSetBase(ProductSerializerMixin, CourseCatalogTestMixin, TestCas
         self.client.login(username=self.user.username, password=self.password)
         self.course = CourseFactory(id='edX/DemoX/Demo_Course', name='Test Course', site=self.site)
 
-        # TODO Update the expiration date by 2099-12-31
-        expires = datetime.datetime(2100, 1, 1, tzinfo=pytz.UTC)
+        expires = now() + datetime.timedelta(days=1)
         self.seat = self.course.create_or_update_seat('honor', False, 0, self.partner, expires=expires)
 
 


### PR DESCRIPTION
There was a discrepancy between the product expiration date outputs. The tests format the expiration date according to the ISO 8601 standard while the `ProductSerializer` would print out the `datetime` object (which included milliseconds which aren't part of the standard).
Instead of changing the way the tests' serializer outputs the value, I've changed the way the `ProductSerializer` outputs the expiration date value.

@edx/helio please review.