### PR TITLE
ENT-530: Coupon code gets valid for 'all the courses' if an enterprise customer is selected during coupon creation.

### DIFF
--- a/ecommerce/coupons/tests/test_utils.py
+++ b/ecommerce/coupons/tests/test_utils.py
@@ -1,11 +1,23 @@
 import ddt
+from oscar.test.factories import ProductFactory, RangeFactory, VoucherFactory
 
-from ecommerce.coupons.utils import prepare_course_seat_types
+from ecommerce.coupons.utils import is_voucher_applied, prepare_course_seat_types
+from ecommerce.extensions.basket.utils import prepare_basket
+from ecommerce.extensions.test.factories import prepare_voucher
 from ecommerce.tests.testcases import TestCase
 
 
 @ddt.ddt
 class CouponAppViewTests(TestCase):
+
+    def setUp(self):
+        """
+        Setup variables for test cases.
+        """
+        super(CouponAppViewTests, self).setUp()
+
+        self.user = self.create_user(email='test@tester.fake')
+        self.request.user = self.user
 
     @ddt.data(
         (['verIfiEd', 'profeSSional'], 'verified,professional'),
@@ -15,3 +27,20 @@ class CouponAppViewTests(TestCase):
     def test_prepare_course_seat_types(self, course_seat_types, expected_result):
         """Verify prepare course seat types return correct value."""
         self.assertEqual(prepare_course_seat_types(course_seat_types), expected_result)
+
+    def test_is_voucher_applied(self):
+        """
+        Verify is_voucher_applied return correct value.
+        """
+        product = ProductFactory(stockrecords__price_excl_tax=100)
+        voucher, product = prepare_voucher(
+            _range=RangeFactory(products=[product]),
+            benefit_value=10
+        )
+        basket = prepare_basket(self.request, [product], voucher)
+
+        # Verify is_voucher_applied returns True when voucher is applied to the basket.
+        self.assertTrue(is_voucher_applied(basket, voucher))
+
+        # Verify is_voucher_applied returns False when voucher can not be applied to the basket.
+        self.assertFalse(is_voucher_applied(basket, VoucherFactory()))

--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -13,7 +13,7 @@ from oscar.core.loading import get_class, get_model
 from oscar.test.factories import OrderFactory, OrderLineFactory, RangeFactory, VoucherFactory
 
 from ecommerce.core.url_utils import get_lms_url
-from ecommerce.coupons.tests.mixins import CouponMixin
+from ecommerce.coupons.tests.mixins import CouponMixin, DiscoveryMockMixin
 from ecommerce.coupons.views import voucher_is_valid
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
 from ecommerce.enterprise.utils import (
@@ -298,7 +298,7 @@ class CouponOfferViewTests(ApiMockMixin, CouponMixin, DiscoveryTestMixin, Enterp
 
 @ddt.ddt
 class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, EnterpriseServiceMockMixin,
-                            TestCase):
+                            TestCase, DiscoveryMockMixin):
     redeem_url = reverse('coupons:redeem')
 
     def setUp(self):
@@ -331,16 +331,20 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
             benefit_value=90,
             code=COUPON_CODE,
             email_domains=None,
-            enterprise_customer=None
+            enterprise_customer=None,
+            course_id=None,
+            catalog=None
     ):
         """ Creates coupon and returns code. """
         coupon = self.create_coupon(
             benefit_value=benefit_value,
-            catalog=self.catalog,
+            catalog=catalog,
             code=code,
             email_domains=email_domains,
             enterprise_customer=enterprise_customer
         )
+        coupon.course_id = course_id
+        coupon.save()
         coupon_code = coupon.attr.coupon_vouchers.vouchers.first().code
         self.assertEqual(Voucher.objects.filter(code=coupon_code).count(), 1)
         return coupon_code
@@ -394,7 +398,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
 
     def test_no_product(self):
         """ Verify an error is returned when a stock record for the provided SKU doesn't exist. """
-        self.create_coupon_and_get_code()
+        self.create_coupon_and_get_code(catalog=self.catalog)
         url = format_url(base=self.redeem_url, params={'code': COUPON_CODE, 'sku': 'INVALID'})
         response = self.client.get(url)
         self.assertEqual(response.context['error'], 'The product does not exist.')
@@ -427,7 +431,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
     @httpretty.activate
     def test_basket_redirect_enrollment_code(self):
         """ Verify the view redirects to the receipt page when an enrollment code is provided. """
-        code = self.create_coupon_and_get_code(benefit_value=100, code='')
+        code = self.create_coupon_and_get_code(benefit_value=100, code='', catalog=self.catalog)
         self.mock_account_api(self.request, self.user.username, data={'is_active': True})
         self.mock_access_token_response()
 
@@ -437,7 +441,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
     @mock.patch.object(EdxOrderPlacementMixin, 'place_free_order')
     def test_basket_redirect_enrollment_code_error(self, place_free_order):
         """ Verify the view redirects to checkout error page when an order hasn't completed. """
-        code = self.create_coupon_and_get_code(benefit_value=100, code='')
+        code = self.create_coupon_and_get_code(benefit_value=100, code='', catalog=self.catalog)
         self.mock_account_api(self.request, self.user.username, data={'is_active': True})
         self.mock_access_token_response()
         place_free_order.return_value = Exception
@@ -450,12 +454,15 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
             )
             self.assertTrue(mock_logger.called)
 
-    def prepare_enterprise_data(self, benefit_value=100, consent_enabled=True, consent_provided=False):
+    def prepare_enterprise_data(self, benefit_value=100, consent_enabled=True, consent_provided=False, course_id=None,
+                                catalog=None):
         """Creates an enterprise coupon and mocks enterprise endpoints."""
         code = self.create_coupon_and_get_code(
             benefit_value=benefit_value,
             code='',
-            enterprise_customer=ENTERPRISE_CUSTOMER
+            enterprise_customer=ENTERPRISE_CUSTOMER,
+            course_id=course_id,
+            catalog=catalog
         )
         self.request.user = self.user
         self.mock_enterprise_learner_api(consent_enabled=consent_enabled, consent_provided=consent_provided)
@@ -468,7 +475,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
     @httpretty.activate
     def test_enterprise_customer_redirect_no_consent(self):
         """ Verify the view redirects to LMS when an enrollment code is provided. """
-        code = self.prepare_enterprise_data()
+        code = self.prepare_enterprise_data(catalog=self.catalog)
         consent_token = get_enterprise_customer_data_sharing_consent_token(
             self.request.user.access_token,
             self.course.id,
@@ -490,7 +497,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
     @httpretty.activate
     def test_enterprise_customer_invalid_consent_token(self):
         """ Verify that the view renders an error when the consent token doesn't match. """
-        code = self.prepare_enterprise_data()
+        code = self.prepare_enterprise_data(catalog=self.catalog)
         self.request.user = self.user
         self.mock_account_api(self.request, self.user.username, data={'is_active': True})
         self.mock_access_token_response()
@@ -507,7 +514,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         Verify that a generic error is rendered when the corresponding EnterpriseCustomer doesn't exist
         on the Enterprise service.
         """
-        code = self.prepare_enterprise_data()
+        code = self.prepare_enterprise_data(catalog=self.catalog)
         self.mock_enterprise_customer_api_not_found(ENTERPRISE_CUSTOMER)
         self.mock_enterprise_learner_api_for_learner_with_no_enterprise()
         response = self.client.get(self.redeem_url_with_params(code=code))
@@ -516,7 +523,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
     @httpretty.activate
     def test_enterprise_customer_successful_redemption(self):
         """ Verify the view redirects to LMS when valid consent is provided. """
-        code = self.prepare_enterprise_data()
+        code = self.prepare_enterprise_data(catalog=self.catalog)
         self.mock_enterprise_learner_api_for_learner_with_no_enterprise()
         self.mock_enterprise_learner_post_api()
 
@@ -541,7 +548,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
 
         # Setting benefit value to a low amount to ensure the basket is not free,
         # and calls to the checkout page do not redirect away from the checkout page.
-        code = self.prepare_enterprise_data(benefit_value=5, consent_enabled=False)
+        code = self.prepare_enterprise_data(benefit_value=5, consent_enabled=False, catalog=self.catalog)
 
         self.mock_enterprise_learner_api_for_learner_with_no_enterprise()
         self.mock_enterprise_learner_post_api()
@@ -553,9 +560,37 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         self.assertEqual(messages[0].message, expected_message)
 
     @httpretty.activate
+    def test_enterprise_customer_coupon_redemption_for_invalid_course(self):
+        """ Verify the warning message appears on redemption if coupon does not belong to course. """
+        expected_message = 'This coupon code is not valid for this course. Try a different course.'
+
+        course, seat = self.create_course_and_seat()
+        stock_record = StockRecord.objects.get(product=seat)
+
+        # Setting benefit value to a low amount to ensure the basket is not free,
+        # and calls to the checkout page do not redirect away from the checkout page.
+        code = self.prepare_enterprise_data(benefit_value=5, consent_enabled=False, course_id=course.id)
+
+        self.mock_enterprise_learner_api_for_learner_with_no_enterprise()
+        self.mock_enterprise_learner_post_api()
+        self.mock_course_run_detail_endpoint(course, discovery_api_url=self.site_configuration.discovery_api_url)
+        params = {
+            'code': code,
+            'sku': stock_record.partner_sku,
+        }
+        response = self.client.get(
+            format_url(base=self.redeem_url, params=params),
+            follow=True,
+        )
+        messages = []
+        messages += response.context['messages']
+        self.assertEqual(messages[0].tags, 'warning')
+        self.assertEqual(messages[0].message, expected_message)
+
+    @httpretty.activate
     def test_multiple_vouchers(self):
         """ Verify a redirect to LMS happens when a basket with already existing vouchers is used. """
-        code = self.create_coupon_and_get_code(benefit_value=100, code='')
+        code = self.create_coupon_and_get_code(benefit_value=100, code='', catalog=self.catalog)
         basket = Basket.get_basket(self.user, self.site)
         basket.vouchers.add(Voucher.objects.get(code=code))
 
@@ -569,7 +604,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         """ Verify a user is rejected from redeeming a coupon for a course he's already enrolled in."""
         self.mock_account_api(self.request, self.user.username, data={'is_active': True})
         self.mock_access_token_response()
-        self.create_coupon_and_get_code()
+        self.create_coupon_and_get_code(catalog=self.catalog)
         with mock.patch.object(UserAlreadyPlacedOrder, 'user_already_placed_order', return_value=True):
             response = self.client.get(self.redeem_url_with_params())
             msg = 'You have already purchased {course} seat.'.format(course=self.course.name)
@@ -578,7 +613,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
     @httpretty.activate
     def test_invalid_email_domain_rejection(self):
         """ Verify a user with invalid email domain is rejected. """
-        self.create_coupon_and_get_code(email_domains='example.com')
+        self.create_coupon_and_get_code(email_domains='example.com', catalog=self.catalog)
         response = self.client.get(self.redeem_url_with_params())
         msg = 'You are not eligible to use this coupon.'
         self.assertEqual(response.context['error'], msg)
@@ -587,7 +622,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
     def test_inactive_user_rejection(self):
         """ Verify that a user who hasn't activated the account is rejected. """
         self.mock_account_api(self.request, self.user.username, data={'is_active': False})
-        self.create_coupon_and_get_code()
+        self.create_coupon_and_get_code(catalog=self.catalog)
         self.mock_access_token_response()
 
         response = self.client.get(self.redeem_url_with_params())

--- a/ecommerce/coupons/utils.py
+++ b/ecommerce/coupons/utils.py
@@ -163,3 +163,21 @@ def fetch_course_catalog(site, catalog_id):
 
     cache.set(cache_key, response, settings.COURSES_API_CACHE_TIMEOUT)
     return response
+
+
+def is_voucher_applied(basket, voucher):
+    """
+    Check if given voucher is applied to the given basket.
+
+    Arguments:
+        basket (Basket): oscar basket object to checked for discount voucher.
+        voucher (Voucher): Discount voucher.
+
+    Returns:
+         (bool): True if given voucher is applied to the basket, False otherwise
+    """
+    # Look for discounts from this new voucher
+    for discount in basket.offer_applications:
+        if discount['voucher'] and discount['voucher'] == voucher:
+            return True
+    return False

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -19,6 +19,7 @@ from oscar.core.loading import get_class, get_model
 from ecommerce.core.url_utils import get_ecommerce_url
 from ecommerce.core.views import StaffOnlyMixin
 from ecommerce.coupons.decorators import login_required_for_credit
+from ecommerce.coupons.utils import is_voucher_applied
 from ecommerce.enterprise.decorators import set_enterprise_cookie
 from ecommerce.enterprise.exceptions import EnterpriseDoesNotExist
 from ecommerce.enterprise.utils import (
@@ -140,6 +141,7 @@ class CouponOfferView(TemplateView):
 
 
 class CouponRedeemView(EdxOrderPlacementMixin, View):
+
     @method_decorator(set_enterprise_cookie)
     @method_decorator(login_required)
     def get(self, request):
@@ -244,11 +246,17 @@ class CouponRedeemView(EdxOrderPlacementMixin, View):
                 return HttpResponseRedirect(reverse('checkout:error'))
 
         if enterprise_customer:
-            message = _('A discount has been applied, courtesy of {enterprise_customer_name}.').format(
-                enterprise_customer_name=enterprise_customer.get('name')
-            )
-            message = '<i class="fa fa-info-circle"></i> {}'.format(message)
-            messages.info(self.request, message, extra_tags='safe')
+            if is_voucher_applied(basket, voucher):
+                message = _('A discount has been applied, courtesy of {enterprise_customer_name}.').format(
+                    enterprise_customer_name=enterprise_customer.get('name')
+                )
+                message = '<i class="fa fa-info-circle"></i> {}'.format(message)
+                messages.info(self.request, message, extra_tags='safe')
+            else:
+                messages.warning(
+                    self.request,
+                    _('This coupon code is not valid for this course. Try a different course.'))
+                self.request.basket.vouchers.remove(voucher)
 
         return HttpResponseRedirect(reverse('basket:summary'))
 


### PR DESCRIPTION
Hi @brittneyexline , @douglashall , @zubair-arbi , @asadiqbal08 

Please take a look at the changes, This PR updates error message when coupons is not applicable to the selected course.

__Steps To Reproduce:__
1. Open coupon creation form in ecommerce:
https://ecommerce-business.sandbox.edx.org/coupons/new/
2. Select "Single Course" radio button and enter course ID in "Course ID" field.
3. Select any enterprise customer from "Enterprise Customer" drop down.
4. Input all other required data and press "Create Coupon" button.
5. Download coupon code.
6. Login/Register to LMS with learner.
7. Select a course that is not linked with coupon. 
8. Click "Enroll in Course" button from course about page.
9. Copy coupon code from downloaded coupon file.
10. Paste coupon code in basket page.
11. Click apply button and view.

__Expected Result:__
Error message should appear as it is appearing for coupons that are created without enterprise customer "This coupon code is not valid for this course. Try a different course."
