### PR TITLE
LEARNER-1184 Disable enrollment code product revocation in refund process

### DIFF
--- a/ecommerce/extensions/refund/models.py
+++ b/ecommerce/extensions/refund/models.py
@@ -128,13 +128,16 @@ class Refund(StatusMixin, TimeStampedModel):
 
             status = getattr(settings, 'OSCAR_INITIAL_REFUND_LINE_STATUS', REFUND_LINE.OPEN)
             for line in unrefunded_lines:
-                RefundLine.objects.create(
-                    refund=refund,
-                    order_line=line,
-                    line_credit_excl_tax=line.line_price_excl_tax,
-                    quantity=line.quantity,
-                    status=status
-                )
+                # LEARNER-1184 Disabling refund line creation for enrollment code, Because
+                # it causes Multiple Refunds errors.
+                if not line.product.is_enrollment_code_product:
+                    RefundLine.objects.create(
+                        refund=refund,
+                        order_line=line,
+                        line_credit_excl_tax=line.line_price_excl_tax,
+                        quantity=line.quantity,
+                        status=status
+                    )
 
             if total_credit_excl_tax == 0:
                 refund.approve(notify_purchaser=False)


### PR DESCRIPTION
[Learner-1184](https://openedx.atlassian.net/browse/LEARNER-1184)

Description:
Refund revocataion process was breaking for enrollment codes because of no enrollment for user. Currently do not have proper rules for implementation so bypassing it. People were able to get multiple refunds for single orders. This pr will disable that functionality. 