### PR TITLE
Dropped Promise return value for unsupported browsers

### DIFF
--- a/ecommerce/static/js/payment_processors/cybersource.js
+++ b/ecommerce/static/js/payment_processors/cybersource.js
@@ -159,9 +159,16 @@ define([
                 return promise;
             }
 
-            // Return an empty promise for callers expecting a promise.
-            // eslint-disable-next-line no-undef
-            return Promise.resolve();
+            // Return an empty promise for callers expecting a promise (e.g. tests). If Promise is not supported the
+            // browser (e.g. Internet Explorer), return nothing.
+            /* istanbul ignore next */
+            if (typeof Promise !== 'undefined') {
+                // eslint-disable-next-line no-undef
+                return Promise.resolve();
+            }
+
+            /* istanbul ignore next */
+            return null;
         },
 
         onApplePayButtonClicked: function(event) {


### PR DESCRIPTION
If the browser does not support Promises, an empty promise will NOT be
returned if Apple Pay is not supported. Users with browsers that support
the Promise feature will not be affected.

LEARNER-2218