### PR TITLE
Updated offer satisfaction for efficiency

### DIFF
--- a/ecommerce/programs/tests/test_conditions.py
+++ b/ecommerce/programs/tests/test_conditions.py
@@ -155,8 +155,7 @@ class ProgramCourseRunSeatsConditionTests(ProgramTestMixin, TestCase):
         """ Ensure the basket returns False if the basket total is zero. """
         offer = factories.ProgramOfferFactory(condition=self.condition)
         basket = factories.BasketFactory(site=self.site, owner=factories.UserFactory())
-        basket.flush()
         test_product = factories.ProductFactory(stockrecords__price_excl_tax=0,
-                                                stockrecords__partner__short_code='McKenzieBruderWelter')
+                                                stockrecords__partner__short_code='test')
         basket.add_product(test_product)
         self.assertFalse(self.condition.is_satisfied(offer, basket))

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -250,6 +250,9 @@ PROGRAM_CACHE_TIMEOUT = 3600  # Value is in seconds.
 # PROVIDER DATA PROCESSING
 PROVIDER_DATA_PROCESSING_TIMEOUT = 15  # Value is in seconds.
 CREDIT_PROVIDER_CACHE_TIMEOUT = 600
+
+# Enrollment API settings used for fetching information from LMS
+ENROLLMENT_API_CACHE_TIMEOUT = 3600  # Value is in seconds.
 # END URL CONFIGURATION
 
 VOUCHER_CACHE_TIMEOUT = 10  # Value is in seconds.


### PR DESCRIPTION
Updated offer satisfaction check to only run on baskets with non-zero totals and to cache user enrollments for satisfaction checks on all possible offers