### PR TITLE
BasketCalculateView supports username parameter

### DIFF
--- a/ecommerce/extensions/api/v2/views/baskets.py
+++ b/ecommerce/extensions/api/v2/views/baskets.py
@@ -4,8 +4,9 @@ from __future__ import unicode_literals
 import logging
 import warnings
 
+from django.contrib.auth import get_user_model
 from django.db import transaction
-from django.http import HttpResponseBadRequest
+from django.http import HttpResponseBadRequest, HttpResponseForbidden
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from edx_rest_framework_extensions.permissions import IsSuperuser
@@ -32,6 +33,7 @@ Order = get_model('order', 'Order')
 OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
 Product = get_model('catalogue', 'Product')
 Selector = get_class('partner.strategy', 'Selector')
+User = get_user_model()
 Voucher = get_model('voucher', 'Voucher')
 
 
@@ -342,6 +344,7 @@ class BasketCalculateView(generics.GenericAPIView):
         Arguments:
             sku (string): A list of sku(s) to calculate
             code (string): Optional voucher code to apply to the basket.
+            username (string): Optional username of a user for which to caclulate the basket.
 
         Returns:
             JSON: {
@@ -369,12 +372,24 @@ class BasketCalculateView(generics.GenericAPIView):
         if not voucher and len(products) == 1:
             voucher = get_entitlement_voucher(request, products[0])
 
+        username = request.GET.get('username', default='')
+        user = request.user
+        # If a username is passed in, validate that the user has staff access or is the same user.
+        if username:
+            if user.is_staff or (user.username.lower() == username.lower()):
+                try:
+                    user = User.objects.get(username=username)
+                except User.DoesNotExist:
+                    logger.debug('Request username: [%s] does not exist', username)
+            else:
+                return HttpResponseForbidden('Unauthorized user credentials')
+
         # We wrap this in an atomic operation so we never commit this to the db.
         # This is to avoid merging this temporary basket with a real user basket.
         try:
             with transaction.atomic():
-                basket = Basket(owner=request.user, site=request.site)
-                basket.strategy = Selector().strategy(user=request.user)
+                basket = Basket(owner=user, site=request.site)
+                basket.strategy = Selector().strategy(user=user)
 
                 for product in products:
                     basket.add_product(product, 1)
@@ -383,10 +398,9 @@ class BasketCalculateView(generics.GenericAPIView):
                     basket.vouchers.add(voucher)
 
                 # Calculate any discounts on the basket.
-                Applicator().apply(basket, user=request.user, request=request)
+                Applicator().apply(basket, user=user, request=request)
 
                 discounts = []
-
                 if basket.offer_discounts:
                     discounts = basket.offer_discounts
                 if basket.voucher_discounts:


### PR DESCRIPTION
 BasketCalculateView supports username parameter

In order to support Drupal site accessing user data the
BasketCalculateView must take a username as a parameter.
Additionally, protections are put in place to make sure
that unpriviledged users are not allowed to access other
user's data by passing in a different username.

LEARNER-1875