### PR TITLE
Track programs or other bundles associated with a completed order

### DIFF
--- a/ecommerce/coupons/tests/mixins.py
+++ b/ecommerce/coupons/tests/mixins.py
@@ -402,6 +402,7 @@ class CouponMixin(object):
         request.site = self.site
         request.user = factories.UserFactory()
         request.COOKIES = {}
+        request.GET = {}
 
         self.basket = prepare_basket(request, [coupon])
 

--- a/ecommerce/coupons/tests/test_utils.py
+++ b/ecommerce/coupons/tests/test_utils.py
@@ -18,6 +18,7 @@ class CouponAppViewTests(TestCase):
 
         self.user = self.create_user(email='test@tester.fake')
         self.request.user = self.user
+        self.request.GET = {}
 
     @ddt.data(
         (['verIfiEd', 'profeSSional'], 'verified,professional'),

--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -90,6 +90,7 @@ class CouponViewSetTest(CouponMixin, DiscoveryTestMixin, TestCase):
         request.data = self.coupon_data
         request.site = self.site
         request.COOKIES = {}
+        request.GET = {}
         return request
 
     def test_create(self):

--- a/ecommerce/extensions/basket/tests/test_utils.py
+++ b/ecommerce/extensions/basket/tests/test_utils.py
@@ -25,6 +25,9 @@ from ecommerce.tests.testcases import TestCase, TransactionTestCase
 
 Benefit = get_model('offer', 'Benefit')
 Basket = get_model('basket', 'Basket')
+BasketAttribute = get_model('basket', 'BasketAttribute')
+BasketAttributeType = get_model('basket', 'BasketAttributeType')
+BUNDLE = 'bundle_identifier'
 Product = get_model('catalogue', 'Product')
 
 
@@ -358,6 +361,20 @@ class BasketUtilsTests(DiscoveryTestMixin, TestCase):
         with mock.patch.object(UserAlreadyPlacedOrder, 'user_already_placed_order', return_value=True):
             basket = prepare_basket(self.request, [enrollment_code])
             self.assertIsNotNone(basket)
+
+    def test_prepare_basket_with_bundle(self):
+        """
+        Test prepare_basket updates or creates a basket attribute for the associated bundle
+        """
+        product = ProductFactory()
+        request = self.request
+        basket = prepare_basket(request, [product])
+        with self.assertRaises(BasketAttribute.DoesNotExist):
+            BasketAttribute.objects.get(basket=basket, attribute_type__name=BUNDLE)
+        request.GET = {'bundle': 'test_bundle'}
+        basket = prepare_basket(request, [product])
+        bundle_id = BasketAttribute.objects.get(basket=basket, attribute_type__name=BUNDLE).value_text
+        self.assertEqual(bundle_id, 'test_bundle')
 
 
 class BasketUtilsTransactionTests(TransactionTestCase):

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -18,6 +18,9 @@ from ecommerce.referrals.models import Referral
 
 Applicator = get_class('offer.utils', 'Applicator')
 Basket = get_model('basket', 'Basket')
+BasketAttribute = get_model('basket', 'BasketAttribute')
+BasketAttributeType = get_model('basket', 'BasketAttributeType')
+BUNDLE = 'bundle_identifier'
 StockRecord = get_model('partner', 'StockRecord')
 OrderLine = get_model('order', 'Line')
 Refund = get_model('refund', 'Refund')
@@ -59,6 +62,14 @@ def prepare_basket(request, products, voucher=None):
     basket.save()
     basket_addition = get_class('basket.signals', 'basket_addition')
     already_purchased_products = []
+    bundle = request.GET.get('bundle')
+
+    if bundle:
+        BasketAttribute.objects.update_or_create(
+            basket=basket,
+            attribute_type=BasketAttributeType.objects.get(name=BUNDLE),
+            value_text=bundle
+        )
 
     if request.site.siteconfiguration.enable_embargo_check:
         if not embargo_check(request.user, request.site, products):

--- a/ecommerce/programs/migrations/0002_add_basket_attribute_type.py
+++ b/ecommerce/programs/migrations/0002_add_basket_attribute_type.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+from ecommerce.extensions.checkout.signals import BUNDLE
+
+
+def create_attribute(apps, schema_editor):
+    BasketAttributeType = apps.get_model('basket', 'BasketAttributeType')
+
+    BasketAttributeType.objects.create(name=BUNDLE)
+
+
+def delete_attribute(apps, schema_editor):
+    BasketAttributeType = apps.get_model('basket', 'BasketAttributeType')
+    try:
+        BasketAttributeType.objects.get(name=BUNDLE).delete()
+    except BasketAttributeType.DoesNotExist:
+        pass
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('programs', '0001_initial'),
+        ('basket', '0007_auto_20160907_2040')
+    ]
+
+    operations = [
+        migrations.RunPython(create_attribute, delete_attribute)
+    ]

--- a/ecommerce/programs/tests/test_conditions.py
+++ b/ecommerce/programs/tests/test_conditions.py
@@ -31,19 +31,6 @@ class ProgramCourseRunSeatsConditionTests(ProgramTestMixin, TestCase):
         self.assertEqual(condition.name, expected)
 
     @httpretty.activate
-    def test_get_program(self):
-        """
-        The method should return data from the Discovery Service API.
-        Data should be cached for subsequent calls.
-        """
-        data = self.mock_program_detail_endpoint(self.condition.program_uuid, self.site_configuration.discovery_api_url)
-        self.assertEqual(self.condition.get_program(self.site.siteconfiguration), data)
-
-        # The program data should be cached
-        httpretty.disable()
-        self.assertEqual(self.condition.get_program(self.site.siteconfiguration), data)
-
-    @httpretty.activate
     def test_is_satisfied_no_enrollments(self):
         """ The method should return True if the basket contains one course run seat corresponding to each
         course in the program. """
@@ -136,7 +123,7 @@ class ProgramCourseRunSeatsConditionTests(ProgramTestMixin, TestCase):
         # Verify the user enrollments are cached
         basket.site.siteconfiguration.enable_partial_program = True
         httpretty.disable()
-        with mock.patch('ecommerce.programs.conditions.ProgramCourseRunSeatsCondition.get_program',
+        with mock.patch('ecommerce.programs.conditions.get_program',
                         return_value=program):
             self.assertTrue(self.condition.is_satisfied(offer, basket))
 
@@ -147,7 +134,7 @@ class ProgramCourseRunSeatsConditionTests(ProgramTestMixin, TestCase):
         basket = factories.BasketFactory(site=self.site, owner=factories.UserFactory())
         basket.add_product(self.test_product)
 
-        with mock.patch('ecommerce.programs.conditions.ProgramCourseRunSeatsCondition.get_program',
+        with mock.patch('ecommerce.programs.conditions.get_program',
                         side_effect=value):
             self.assertFalse(self.condition.is_satisfied(offer, basket))
 

--- a/ecommerce/programs/tests/test_utils.py
+++ b/ecommerce/programs/tests/test_utils.py
@@ -1,0 +1,26 @@
+import uuid
+
+import httpretty
+
+from ecommerce.programs.tests.mixins import ProgramTestMixin
+from ecommerce.programs.utils import get_program
+from ecommerce.tests.testcases import TestCase
+
+
+class UtilTests(ProgramTestMixin, TestCase):
+    def setUp(self):
+        super(UtilTests, self).setUp()
+
+    @httpretty.activate
+    def test_get_program(self):
+        """
+        The method should return data from the Discovery Service API.
+        Data should be cached for subsequent calls.
+        """
+        program_uuid = uuid.uuid4()
+        data = self.mock_program_detail_endpoint(program_uuid, self.site.siteconfiguration.discovery_api_url)
+        self.assertEqual(get_program(program_uuid, self.site.siteconfiguration), data)
+
+        # The program data should be cached
+        httpretty.disable()
+        self.assertEqual(get_program(program_uuid, self.site.siteconfiguration), data)

--- a/ecommerce/programs/utils.py
+++ b/ecommerce/programs/utils.py
@@ -1,0 +1,20 @@
+from ecommerce.programs.api import ProgramsApiClient
+
+
+def get_program(program_uuid, siteconfiguration):
+    """
+    Returns details for the program identified by the program_uuid.
+
+    Data is retrieved from the Discovery Service, and cached for ``settings.PROGRAM_CACHE_TIMEOUT`` seconds.
+
+    Args:
+        siteconfiguration (SiteConfiguration): Configuration containing the requisite parameters
+            to connect to the Discovery Service.
+
+        program_uuid (uuid): id to query the specified program
+
+    Returns:
+        dict
+    """
+    client = ProgramsApiClient(siteconfiguration.discovery_api_client, siteconfiguration.site.domain)
+    return client.get_program(str(program_uuid))


### PR DESCRIPTION
Track programs or other bundles associated with a completed order

prepare_basket creates a 'bundle' basket attribute if the request includes a bundle, and this is tracked along with the basket's products in the 'Order Completed' analytic event

[LEARNER-1721]
https://openedx.atlassian.net/browse/LEARNER-1721