### PR TITLE
Fix eslint errors.

### DIFF
--- a/ecommerce/static/js/pages/basket_page.js
+++ b/ecommerce/static/js/pages/basket_page.js
@@ -1,7 +1,3 @@
-/**
- * Basket page scripts.
- **/
-
 define([
     'jquery',
     'underscore',

--- a/ecommerce/static/js/pages/receipt_page.js
+++ b/ecommerce/static/js/pages/receipt_page.js
@@ -1,7 +1,3 @@
-/**
- * Basket page scripts.
- **/
-
 define([
     'jquery'
 ],


### PR DESCRIPTION
ESLint was complaining about missing whitespace in comments at the
beginning of a couple of files. I am removing those comments because
they do not offer any value.