### PR TITLE
Filter Program Offers to only show offers for the current site

### DIFF
--- a/ecommerce/extensions/dashboard/offers/__init__.py
+++ b/ecommerce/extensions/dashboard/offers/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'ecommerce.extensions.dashboard.offers.config.OffersDashboardConfig'

--- a/ecommerce/extensions/dashboard/offers/config.py
+++ b/ecommerce/extensions/dashboard/offers/config.py
@@ -1,0 +1,5 @@
+from oscar.apps.dashboard.offers import config
+
+
+class OffersDashboardConfig(config.OffersDashboardConfig):
+    name = 'ecommerce.extensions.dashboard.offers'

--- a/ecommerce/extensions/dashboard/offers/forms.py
+++ b/ecommerce/extensions/dashboard/offers/forms.py
@@ -1,0 +1,12 @@
+from django.contrib.sites.models import Site
+from django.forms import ModelChoiceField
+from oscar.apps.dashboard.offers.forms import MetaDataForm as CoreMetaDataForm
+from oscar.core.loading import get_model
+
+
+class MetaDataForm(CoreMetaDataForm):
+    site = ModelChoiceField(queryset=Site.objects.all(), required=True)
+
+    class Meta(object):
+        model = get_model('offer', 'ConditionalOffer')
+        fields = ('name', 'description', 'site')

--- a/ecommerce/extensions/dashboard/offers/tests/test_views.py
+++ b/ecommerce/extensions/dashboard/offers/tests/test_views.py
@@ -1,0 +1,77 @@
+from __future__ import unicode_literals
+
+import json
+
+from django.urls import reverse
+from oscar.core.loading import get_model
+from oscar.test.factories import RangeFactory
+
+from ecommerce.tests.factories import SiteFactory
+from ecommerce.tests.testcases import TestCase
+
+Benefit = get_model('offer', 'Benefit')
+Condition = get_model('offer', 'Condition')
+ConditionalOffer = get_model('offer', 'ConditionalOffer')
+
+
+class OfferWizardTests(TestCase):
+    def test_site(self):
+        """ Verify the site is stored in the session. """
+        user = self.create_user(is_staff=True)
+        self.client.login(username=user.username, password=self.password)
+        site = SiteFactory()
+
+        self.assertEqual(ConditionalOffer.objects.count(), 0)
+
+        # Start creating the offer by defining by setting the name and site
+        metadata = {
+            'name': 'Test Offer',
+            'description': 'Blah!',
+            'site': site.id,
+        }
+        metadata_url = reverse('dashboard:offer-metadata')
+        response = self.client.post(metadata_url, metadata)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], reverse('dashboard:offer-benefit'))
+
+        # Ensure the Site ID is stored in the session
+        actual = json.loads(self.client.session['offer_wizard']['metadata'])['data']['site_id']
+        self.assertEqual(actual, site.id)
+
+        # Set the offer benfit data
+        offer_range = RangeFactory()
+        data = {
+            'range': offer_range.id,
+            'type': Benefit.PERCENTAGE,
+            'value': 100
+        }
+        response = self.client.post(response['Location'], data)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], reverse('dashboard:offer-condition'))
+
+        # Set the restrictions on the offer
+        restrictions_url = reverse('dashboard:offer-restrictions')
+        data = {
+            'range': offer_range.id,
+            'type': Condition.COUNT,
+            'value': 1
+        }
+        response = self.client.post(response['Location'], data)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], restrictions_url)
+
+        # Reload the first page to exercise _fetch_form_kwargs, which should pull the site from the session
+        response = self.client.get(metadata_url)
+        self.assertEqual(response.status_code, 200)
+
+        # Finish saving the offer
+        data = {}
+        response = self.client.post(restrictions_url, data)
+        self.assertEqual(response.status_code, 302)
+
+        self.assertEqual(ConditionalOffer.objects.count(), 1)
+        offer = ConditionalOffer.objects.first()
+        self.assertEqual(response['Location'], reverse('dashboard:offer-detail', kwargs={'pk': offer.pk}))
+
+        # Ensure the offer is associated to the site set in the first step of the wizard
+        self.assertEqual(offer.site, site)

--- a/ecommerce/extensions/dashboard/offers/views.py
+++ b/ecommerce/extensions/dashboard/offers/views.py
@@ -1,0 +1,47 @@
+import json
+
+from django.contrib.sites.models import Site
+from django.core.serializers.json import DjangoJSONEncoder
+from oscar.apps.dashboard.offers.views import OfferMetaDataView as CoreOfferMetaDataView
+from oscar.apps.dashboard.offers.views import OfferRestrictionsView as CoreOfferRestrictionsView
+
+
+class OfferMetaDataView(CoreOfferMetaDataView):
+
+    def _store_form_kwargs(self, form):
+        session_data = self.request.session.setdefault(self.wizard_name, {})
+
+        # Adjust kwargs to save site_id rather than site which can't be serialized in the session
+        form_data = form.cleaned_data.copy()
+        site = form_data['site']
+        form_data['site_id'] = site.id
+        del form_data['site']
+        form_kwargs = {'data': form_data}
+        json_data = json.dumps(form_kwargs, cls=DjangoJSONEncoder)
+        session_data[self._key()] = json_data
+        self.request.session.save()
+
+    def _fetch_form_kwargs(self, step_name=None):
+
+        if not step_name:
+            step_name = self.step_name
+        session_data = self.request.session.setdefault(self.wizard_name, {})
+        json_data = session_data.get(self._key(step_name), None)
+        if json_data:
+            form_kwargs = json.loads(json_data)
+            form_kwargs['data']['site'] = Site.objects.get(pk=form_kwargs['data']['site_id'])
+            del form_kwargs['data']['site_id']
+            return form_kwargs
+
+        return {}
+
+
+class OfferRestrictionsView(CoreOfferRestrictionsView):
+
+    def form_valid(self, form):
+        offer = form.save(commit=False)
+
+        # Make sure to save offer.site from the session_offer
+        session_offer = self._fetch_session_offer()
+        offer.site = session_offer.site
+        return self.save_offer(offer)

--- a/ecommerce/programs/tests/test_views.py
+++ b/ecommerce/programs/tests/test_views.py
@@ -69,7 +69,7 @@ class ProgramOfferListViewTests(ProgramTestMixin, ViewTestMixin, TestCase):
         # These should be ignored since their associated Condition objects do NOT have a program UUID.
         factories.ConditionalOfferFactory.create_batch(3)
 
-        program_offers = factories.ProgramOfferFactory.create_batch(4)
+        program_offers = factories.ProgramOfferFactory.create_batch(4, site=self.site)
 
         for offer in program_offers:
             self.mock_program_detail_endpoint(offer.condition.program_uuid, self.site_configuration.discovery_api_url)
@@ -86,11 +86,17 @@ class ProgramOfferListViewTests(ProgramTestMixin, ViewTestMixin, TestCase):
         """ Should return only Conditional Offers with Site offer type. """
 
         # Conditional Offer should contain a condition with program uuid set in order to be returned
-        site_conditional_offer = factories.ProgramOfferFactory()
+        site_conditional_offer = factories.ProgramOfferFactory(site=self.site)
+
+        # Conditional Offer with null Site or non-matching Site should not be returned
+        null_site_offer = factories.ProgramOfferFactory()
+        different_site_offer = factories.ProgramOfferFactory(site=factories.SiteConfigurationFactory().site)
         program_offers = [
             site_conditional_offer,
             factories.ProgramOfferFactory(offer_type=ConditionalOffer.VOUCHER),
-            factories.ConditionalOfferFactory(offer_type=ConditionalOffer.SITE)
+            factories.ConditionalOfferFactory(offer_type=ConditionalOffer.SITE),
+            null_site_offer,
+            different_site_offer
         ]
 
         for offer in program_offers:
@@ -103,7 +109,7 @@ class ProgramOfferListViewTests(ProgramTestMixin, ViewTestMixin, TestCase):
 class ProgramOfferUpdateViewTests(ProgramTestMixin, ViewTestMixin, TestCase):
     def setUp(self):
         super(ProgramOfferUpdateViewTests, self).setUp()
-        self.program_offer = factories.ProgramOfferFactory()
+        self.program_offer = factories.ProgramOfferFactory(site=self.site)
         self.path = reverse('programs:offers:edit', kwargs={'pk': self.program_offer.pk})
 
         # NOTE: We activate httpretty here so that we don't have to decorate every test method.

--- a/ecommerce/programs/views.py
+++ b/ecommerce/programs/views.py
@@ -25,6 +25,7 @@ class ProgramOfferViewMixin(StaffOnlyMixin):
 
     def get_queryset(self):
         return super(ProgramOfferViewMixin, self).get_queryset().filter(
+            site=self.request.site.id,
             condition__program_uuid__isnull=False,
             offer_type=ConditionalOffer.SITE
         )

--- a/ecommerce/settings/_oscar.py
+++ b/ecommerce/settings/_oscar.py
@@ -25,6 +25,7 @@ OSCAR_APPS = [
     'ecommerce.extensions.checkout',
     'ecommerce.extensions.customer',
     'ecommerce.extensions.dashboard',
+    'ecommerce.extensions.dashboard.offers',
     'ecommerce.extensions.dashboard.orders',
     'ecommerce.extensions.dashboard.users',
     'ecommerce.extensions.offer',

--- a/ecommerce/templates/oscar/dashboard/offers/offer_detail.html
+++ b/ecommerce/templates/oscar/dashboard/offers/offer_detail.html
@@ -1,0 +1,117 @@
+{% extends 'dashboard/layout.html' %}
+{% load currency_filters %}
+{% load i18n %}
+
+{% block title %}
+    {% blocktrans with name=offer.name %}
+        {{ name }} | Offers
+    {% endblocktrans %} | {{ block.super }}
+{% endblock %}
+
+{% block breadcrumbs %}
+<ul class="breadcrumb">
+    <li>
+        <a href="{% url 'dashboard:index' %}">{% trans "Dashboard" %}</a>
+    </li>
+    <li>
+        <a href="{% url 'dashboard:offer-list' %}">{% trans "Offers" %}</a>
+    </li>
+    <li class="active">{{ offer.name }}</li>
+</ul>
+{% endblock %}
+
+{% block header %}
+<div class="page-header">
+    <form id="status_form" class="pull-right" method="post" action=".">
+        {% csrf_token %} {% if offer.is_suspended %}
+        <button type="submit" class="btn btn-success" name="unsuspend" data-loading-text="{% trans 'Reinstating...' %}">{% trans "Reinstate offer" %}</button> {% else %}
+        <button type="submit" class="btn btn-default" name="suspend" data-loading-text="{% trans 'Suspending...' %}">{% trans "Suspend offer" %}</button> {% endif %}
+        <a class="btn btn-danger" href="{% url 'dashboard:offer-delete' pk=offer.pk %}">{% trans "Delete offer" %}</a>
+    </form>
+    <h1>{{ offer.name }}</h1>
+</div>
+{% endblock header %}
+
+{% block dashboard_content %}
+<table class="table table-bordered">
+    <tr>
+        <td>
+            {% if offer.is_available %}
+            <span class="label label-success">{% trans "Offer currently available" %}</span> {% else %}
+            <span class="label label-danger">{% trans "Offer not available due to restrictions!" %}</span> {% endif %}
+        </td>
+        <td>{% trans "Total cost:" %} <strong>{{ offer.total_discount|currency }}</strong></td>
+        <td>{% trans "Number of orders:" %} <strong>{{ offer.num_orders }}</strong></td>
+        <td>{% trans "Number of uses:" %} <strong>{{ offer.num_applications }}</strong></td>
+    </tr>
+</table>
+
+<div class="table-header">
+    <div class="pull-right" style="font-weight: normal">{% trans "Date created:" %} {{ offer.date_created }}</div>
+    <h2>{% trans "Offer details" %}</h2>
+</div>
+<table class="table table-striped table-bordered">
+    <tbody>
+        <tr>
+            <th>{% trans "Name" %}</th>
+            <td>{{ offer.name }}</td>
+            <td rowspan="3"><a id="edit_metadata" href="{% url 'dashboard:offer-metadata' pk=offer.pk %}" class="btn btn-default">{% trans "Edit" %}</a></td>
+        </tr>
+        <tr>
+            <th>{% trans "Description" %}</th>
+            <td>{{ offer.description|safe|default:"-" }}</td>
+        </tr>
+        <tr>
+            <th>{% trans "Site" %}</th>
+            <td>{{ offer.site|safe|default:"-" }}</td>
+        </tr>
+        <tr>
+            <th>{% trans "Incentive" %}</th>
+            <td>{{ offer.benefit.description|safe }}</td>
+            <td><a href="{% url 'dashboard:offer-benefit' pk=offer.pk %}" class="btn btn-default">{% trans "Edit" %}</a></td>
+        </tr>
+        <tr>
+            <th>{% trans "Condition" %}</th>
+            <td>{{ offer.condition.description|safe }}</td>
+            <td><a href="{% url 'dashboard:offer-condition' pk=offer.pk %}" class="btn btn-default">{% trans "Edit" %}</a></td>
+        </tr>
+        <tr>
+            <th>{% trans "Restrictions" %}</th>
+            <td>
+                {% for restriction in offer.availability_restrictions %} {% if not restriction.is_satisfied %}
+                <span class="label label-danger">
+                                {{ restriction.description }}
+                            </span><br/> {% else %} {{ restriction.description }}</br>
+                {% endif %} {% endfor %}
+            </td>
+            <td><a href="{% url 'dashboard:offer-restrictions' pk=offer.pk %}" class="btn btn-default">{% trans "Edit" %}</a></td>
+        </tr>
+    </tbody>
+</table>
+
+{% if order_discounts %}
+<div class="table-header">
+    <a class="pull-right btn" href=".?format=csv">{% trans "Export to CSV" %}</a>
+    <h2>{% trans "Orders that used this offer" %}</h2>
+</div>
+<table class="table table-bordered table-striped">
+    <thead>
+        <th>{% trans "Order number" %}</th>
+        <th>{% trans "Order date" %}</th>
+        <th>{% trans "Order total" %}</th>
+        <th>{% trans "Cost" %}</th>
+    </thead>
+    <tbody>
+        {% for discount in order_discounts %} {% with order=discount.order %}
+        <tr>
+            <td><a href="{% url 'dashboard:order-detail' number=order.number %}">{{ order.number }}</a></td>
+            <td>{{ order.date_placed }}</td>
+            <td>{{ order.total_incl_tax|currency }}</td>
+            <td>{{ discount.amount|currency }}</td>
+        </tr>
+        {% endwith %} {% endfor %}
+    </tbody>
+</table>
+{% include 'dashboard/partials/pagination.html' %}
+{% endif %}
+{% endblock dashboard_content %}

--- a/ecommerce/templates/oscar/dashboard/offers/summary.html
+++ b/ecommerce/templates/oscar/dashboard/offers/summary.html
@@ -1,0 +1,41 @@
+{% load i18n %}
+
+<div class="table-header">
+    <h3>{% trans "Offer summary" %}</h3>
+</div>
+<div class="well-stacked">
+    {% if session_offer.name %}
+    <div class="well">
+        <a href="{% if session_offer.pk %}{% url 'dashboard:offer-metadata' pk=session_offer.pk %}{% else %}{% url 'dashboard:offer-metadata' %}{% endif %}" class="btn btn-default pull-right">{% trans "Edit" %}</a>
+        <p><strong>{% trans "Name" %}:</strong><br /> {{ session_offer.name }}</p>
+        {% if session_offer.description %}
+        <p><strong>{% trans "Description" %}:</strong><br /> {{ session_offer.description|safe|striptags|truncatewords:8 }}</p>
+        {% endif %} {% if session_offer.site %}
+        <p><strong>{% trans "Site" %}:</strong><br /> {{ session_offer.site }}</p>
+        {% endif %}
+    </div>
+    {% endif %} {% if session_offer.benefit %}
+    <div class="well">
+        <a href="{% if session_offer.pk %}{% url 'dashboard:offer-benefit' pk=session_offer.pk %}{% else %}{% url 'dashboard:offer-benefit' %}{% endif %}" class="btn btn-default pull-right">{% trans "Edit" %}</a>
+        <p><strong>{% trans "Incentive" %}:</strong><br /> {{ session_offer.benefit.description|safe }}</p>
+
+    </div>
+    {% endif %} {% if session_offer.condition %}
+    <div class="well">
+        <a href="{% if session_offer.pk %}{% url 'dashboard:offer-condition' pk=session_offer.pk %}{% else %}{% url 'dashboard:offer-condition' %}{% endif %}" class="btn btn-default pull-right">{% trans "Edit" %}</a>
+        <p><strong>{% trans "Condition" %}:</strong><br/>{{ session_offer.condition.description|safe }}</p>
+    </div>
+    {% endif %} {% if session_offer.pk %}
+    <div class="well">
+        <a href="{% if session_offer.pk %}{% url 'dashboard:offer-restrictions' pk=session_offer.pk %}{% else %}{% url 'dashboard:offer-restrictions' %}{% endif %}" class="btn btn-default pull-right">{% trans "Edit" %}</a>
+        <p><strong>{% trans "Restrictions" %}:</strong> <br/> {% if offer.availability_restrictions %}</p>
+
+        <ul>
+            {% for restriction in offer.availability_restrictions %}
+            <li>{{ restriction.description }}</li>
+            {% endfor %}
+        </ul>
+        {% else %} - {% endif %}
+    </div>
+    {% endif %}
+</div>


### PR DESCRIPTION
Program Offers are now site-aware and the view is filtered to only show
offers for the current site. Site field also added to dashboard/offers
UI when creating/displaying offers from the dashboard.

WL-1152