### PR TITLE
Do not tell sailthru about multi-product baskets 

### DIFF
--- a/ecommerce/extensions/api/v2/views/baskets.py
+++ b/ecommerce/extensions/api/v2/views/baskets.py
@@ -149,6 +149,7 @@ class BasketCreateView(EdxOrderPlacementMixin, generics.CreateAPIView):
 
             requested_products = request.data.get('products')
             if requested_products:
+                is_multi_product_basket = True if len(requested_products) > 1 else False
                 for requested_product in requested_products:
                     # Ensure the requested products exist
                     sku = requested_product.get('sku')
@@ -182,8 +183,8 @@ class BasketCreateView(EdxOrderPlacementMixin, generics.CreateAPIView):
 
                     # Call signal handler to notify listeners that something has been added to the basket
                     basket_addition = get_class('basket.signals', 'basket_addition')
-                    basket_addition.send(sender=basket_addition, product=product, user=request.user,
-                                         request=request, basket=basket)
+                    basket_addition.send(sender=basket_addition, product=product, user=request.user, request=request,
+                                         basket=basket, is_multi_product_basket=is_multi_product_basket)
             else:
                 # If no products were included in the request, we cannot checkout.
                 return self._report_bad_request(

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -85,13 +85,14 @@ def prepare_basket(request, products, voucher=None):
             )
             return basket
 
+    is_multi_product_basket = True if len(products) > 1 else False
     for product in products:
         if product.is_enrollment_code_product or \
                 not UserAlreadyPlacedOrder.user_already_placed_order(request.user, product):
             basket.add_product(product, 1)
             # Call signal handler to notify listeners that something has been added to the basket
             basket_addition.send(sender=basket_addition, product=product, user=request.user, request=request,
-                                 basket=basket)
+                                 basket=basket, is_multi_product_basket=is_multi_product_basket)
         else:
             already_purchased_products.append(product)
             logger.warning(


### PR DESCRIPTION
It seems we already do this for some things like coupons.
Sailthru is not currently used for bundles.
Product has determined that we want to implement the abandoned cart email for now only for courses and have a separate effort to implement it for bundles (programs).