### PR TITLE
Mloturco/learner 2196

### DIFF
--- a/ecommerce/programs/forms.py
+++ b/ecommerce/programs/forms.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from django import forms
 from django.forms.utils import ErrorList
 from django.utils.translation import ugettext_lazy as _
@@ -82,7 +83,7 @@ class ProgramOfferForm(forms.ModelForm):
 
         client = ProgramsApiClient(site.siteconfiguration.discovery_api_client, site.domain)
         program = client.get_program(program_uuid)
-        offer_name = _('Discount for the {program_title} {program_type} Program'.format(
+        offer_name = _(u'Discount for the {program_title} {program_type} Program'.format(
             program_title=program['title'],
             program_type=program['type']
         ))

--- a/ecommerce/programs/tests/mixins.py
+++ b/ecommerce/programs/tests/mixins.py
@@ -10,7 +10,7 @@ from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
 
 
 class ProgramTestMixin(DiscoveryTestMixin):
-    def mock_program_detail_endpoint(self, program_uuid, discovery_api_url, empty=False):
+    def mock_program_detail_endpoint(self, program_uuid, discovery_api_url, empty=False, title='Test Program'):
         """ Mocks the program detail endpoint on the Catalog API.
         Args:
             program_uuid (uuid): UUID of the mocked program.
@@ -42,7 +42,7 @@ class ProgramTestMixin(DiscoveryTestMixin):
             program_uuid = str(program_uuid)
             data = {
                 'uuid': program_uuid,
-                'title': 'Test Program',
+                'title': title,
                 'type': 'MicroMockers',
                 'courses': courses,
                 'applicable_seat_types': [


### PR DESCRIPTION
Previously, trying to create a program offer in CAT for a program with a special (non-ascii) character caused a bug, this properly handles unicode strings to allow for program offers for programs with non-ascii characters in their name.  

Learner-2196