### PR TITLE
Delete invalid basket attributes

### DIFF
--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -70,6 +70,8 @@ def prepare_basket(request, products, voucher=None):
             attribute_type=BasketAttributeType.objects.get(name=BUNDLE),
             defaults={'value_text': bundle}
         )
+    else:
+        BasketAttribute.objects.filter(basket=basket, attribute_type__name=BUNDLE).delete()
 
     if request.site.siteconfiguration.enable_embargo_check:
         if not embargo_check(request.user, request.site, products):


### PR DESCRIPTION
Updated prepare_basket method to remove old entries from the Basket Attribute table such that baskets are not mistakenly associated with bundle purchases in orders after a bundle purchase by the same user for single courses.