### PR TITLE
Deprecated optional.txt

### DIFF
--- a/requirements/monitoring/requirements.txt
+++ b/requirements/monitoring/requirements.txt
@@ -7,7 +7,6 @@
 -r ../base.txt
 -r ../docs.txt
 -r ../local.txt
--r ../optional.txt
 -r ../production.txt
 -r ../test.txt
 -r ../../e2e/requirements.txt

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,2 +1,1 @@
-# Optional packages
-newrelic==2.88.1.73
+# DEPRECATED: Place requirements in production.txt.

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -9,6 +9,7 @@ gevent==1.0.2
 
 gunicorn==19.7.1
 MySQL-python==1.2.5
+newrelic==2.90.0.75
 python-memcached==1.58
 PyYAML==3.12
 nodeenv==1.1.1


### PR DESCRIPTION
The New Relic package has been upgraded and moved to production.txt. As we move toward consolidating Ansible configuration, we are adopting best practices from more recent IDAs here in this repo. We no longer use optional.txt. The cost of installing the optional package is minimal relative to the administrative overhead of optionally installing it, thus it will always be installed. However, the code will not be active on servers that are not running the New Relic agent.

LEARNER-818