### PR TITLE
[ENT-587] More gracefully handle errors when hitting APIs

### DIFF
--- a/ecommerce/programs/tests/mixins.py
+++ b/ecommerce/programs/tests/mixins.py
@@ -63,7 +63,7 @@ class ProgramTestMixin(DiscoveryTestMixin):
         )
         return data
 
-    def mock_enrollment_api(self, username, enrollments=[]):  # pylint: disable=dangerous-default-value
+    def mock_enrollment_api(self, username, enrollments=None, response_code=200):
         """ Mocks enrollment retrieval from LMS
         Returns:
             list: Mocked enrollment data
@@ -72,7 +72,8 @@ class ProgramTestMixin(DiscoveryTestMixin):
         httpretty.register_uri(
             method=httpretty.GET,
             uri='{}?user={}'.format(get_lms_enrollment_api_url(), username),
-            body=json.dumps(enrollments),
+            body=json.dumps([] if enrollments is None else enrollments),
+            status=response_code,
             content_type='application/json'
         )
         return enrollments


### PR DESCRIPTION
This PR is meant to handle errors more gracefully in the codebase -- specifically those places where `edx/edx-enterprise` requires it.

**JIRA tickets**: [ENT-587](https://openedx.atlassian.net/browse/ENT-587)

**Merge deadline**: By the end of the week.

**Testing instructions**:

It's hard to test this because you'd need to force an error somehow. In many cases you can force the errors through over-throttling. But other than that, the tests should build the confidence you need.

But since this is meant primarily for the edx-enterprise's calls to ecommerce, know that edx-enterprise only makes calls to the basket calculation view. In that case, you can over-throttle /api/v2/baskets/calculate and see the result.

**Reviewers**
- [ ] @haikuginger 
- [ ] @douglashall @brittneyexline 