### PR TITLE
Call isort on codebase

### DIFF
--- a/ecommerce/core/migrations/0033_auto_20170606_0539.py
+++ b/ecommerce/core/migrations/0033_auto_20170606_0539.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations
+
 from ecommerce.core.constants import USER_LIST_VIEW_SWITCH
 
 

--- a/ecommerce/core/tests/test_generate_courses.py
+++ b/ecommerce/core/tests/test_generate_courses.py
@@ -1,4 +1,5 @@
 import json
+
 import ddt
 import httpretty
 import mock

--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -17,7 +17,8 @@ from ecommerce.coupons.tests.mixins import CouponMixin, DiscoveryMockMixin
 from ecommerce.coupons.views import voucher_is_valid
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
 from ecommerce.enterprise.utils import (
-    get_enterprise_course_consent_url, get_enterprise_customer_data_sharing_consent_token
+    get_enterprise_course_consent_url,
+    get_enterprise_customer_data_sharing_consent_token
 )
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin

--- a/ecommerce/courses/models.py
+++ b/ecommerce/courses/models.py
@@ -12,7 +12,10 @@ from oscar.core.loading import get_class, get_model
 from simple_history.models import HistoricalRecords
 
 from ecommerce.core.constants import (
-    ENROLLMENT_CODE_PRODUCT_CLASS_NAME, ENROLLMENT_CODE_SEAT_TYPES, ENROLLMENT_CODE_SWITCH, SEAT_PRODUCT_CLASS_NAME
+    ENROLLMENT_CODE_PRODUCT_CLASS_NAME,
+    ENROLLMENT_CODE_SEAT_TYPES,
+    ENROLLMENT_CODE_SWITCH,
+    SEAT_PRODUCT_CLASS_NAME
 )
 from ecommerce.courses.publishers import LMSPublisher
 from ecommerce.extensions.catalogue.utils import generate_sku

--- a/ecommerce/courses/tests/test_utils.py
+++ b/ecommerce/courses/tests/test_utils.py
@@ -10,7 +10,10 @@ from ecommerce.core.tests import toggle_switch
 from ecommerce.coupons.tests.mixins import DiscoveryMockMixin
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.courses.utils import (
-    get_certificate_type_display_value, get_course_catalogs, get_course_info_from_catalog, mode_for_seat
+    get_certificate_type_display_value,
+    get_course_catalogs,
+    get_course_info_from_catalog,
+    mode_for_seat
 )
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
 from ecommerce.tests.testcases import TestCase

--- a/ecommerce/enterprise/tests/test_entitlements.py
+++ b/ecommerce/enterprise/tests/test_entitlements.py
@@ -11,7 +11,9 @@ from ecommerce.core.tests import toggle_switch
 from ecommerce.coupons.tests.mixins import CouponMixin, DiscoveryMockMixin
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.enterprise.entitlements import (
-    get_course_entitlements_for_learner, get_course_vouchers_for_learner, get_entitlement_voucher,
+    get_course_entitlements_for_learner,
+    get_course_vouchers_for_learner,
+    get_entitlement_voucher,
     is_course_in_enterprise_catalog
 )
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin

--- a/ecommerce/extensions/analytics/tests/test_utils.py
+++ b/ecommerce/extensions/analytics/tests/test_utils.py
@@ -7,7 +7,10 @@ from oscar.test import factories
 
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.analytics.utils import (
-    parse_tracking_context, prepare_analytics_data, track_segment_event, translate_basket_line_for_segment
+    parse_tracking_context,
+    prepare_analytics_data,
+    track_segment_event,
+    translate_basket_line_for_segment
 )
 from ecommerce.extensions.basket.tests.mixins import BasketMixin
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin

--- a/ecommerce/extensions/api/v2/tests/views/test_baskets.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_baskets.py
@@ -24,9 +24,12 @@ from ecommerce.extensions.api.v2.tests.views import JSON_CONTENT_TYPE, OrderDeta
 from ecommerce.extensions.api.v2.views.baskets import BasketCreateView
 from ecommerce.extensions.payment import exceptions as payment_exceptions
 from ecommerce.extensions.payment.processors.cybersource import Cybersource
-from ecommerce.extensions.test.factories import (PercentageDiscountBenefitWithoutRangeFactory,
-                                                 ProgramCourseRunSeatsConditionFactory,
-                                                 ProgramOfferFactory, prepare_voucher)
+from ecommerce.extensions.test.factories import (
+    PercentageDiscountBenefitWithoutRangeFactory,
+    ProgramCourseRunSeatsConditionFactory,
+    ProgramOfferFactory,
+    prepare_voucher
+)
 from ecommerce.programs.tests.mixins import ProgramTestMixin
 from ecommerce.tests.factories import ProductFactory
 from ecommerce.tests.mixins import BasketCreationMixin, ThrottlingMixin

--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import httpretty
 import mock
-
 from django.core.urlresolvers import reverse
 
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin

--- a/ecommerce/extensions/api/v2/tests/views/test_publication.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_publication.py
@@ -10,7 +10,10 @@ from freezegun import freeze_time
 from oscar.core.loading import get_model
 
 from ecommerce.core.constants import (
-    ENROLLMENT_CODE_PRODUCT_CLASS_NAME, ENROLLMENT_CODE_SWITCH, ISO_8601_FORMAT, SEAT_PRODUCT_CLASS_NAME
+    ENROLLMENT_CODE_PRODUCT_CLASS_NAME,
+    ENROLLMENT_CODE_SWITCH,
+    ISO_8601_FORMAT,
+    SEAT_PRODUCT_CLASS_NAME
 )
 from ecommerce.core.tests import toggle_switch
 from ecommerce.courses.models import Course

--- a/ecommerce/extensions/basket/models.py
+++ b/ecommerce/extensions/basket/models.py
@@ -5,7 +5,6 @@ from oscar.core.loading import get_class
 
 from ecommerce.extensions.analytics.utils import track_segment_event, translate_basket_line_for_segment
 
-
 OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
 Selector = get_class('partner.strategy', 'Selector')
 

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -23,7 +23,9 @@ from ecommerce.courses.utils import get_certificate_type_display_value, get_cour
 from ecommerce.enterprise.entitlements import get_enterprise_code_redemption_redirect
 from ecommerce.enterprise.utils import CONSENT_FAILED_PARAM, get_enterprise_customer_from_voucher
 from ecommerce.extensions.analytics.utils import (
-    prepare_analytics_data, track_segment_event, translate_basket_line_for_segment
+    prepare_analytics_data,
+    track_segment_event,
+    translate_basket_line_for_segment
 )
 from ecommerce.extensions.basket.utils import add_utm_params_to_url, get_basket_switch_data, prepare_basket
 from ecommerce.extensions.offer.utils import format_benefit_value, render_email_confirmation_if_required

--- a/ecommerce/extensions/catalogue/models.py
+++ b/ecommerce/extensions/catalogue/models.py
@@ -6,7 +6,9 @@ from oscar.apps.catalogue.abstract_models import AbstractProduct, AbstractProduc
 from simple_history.models import HistoricalRecords
 
 from ecommerce.core.constants import (
-    COUPON_PRODUCT_CLASS_NAME, ENROLLMENT_CODE_PRODUCT_CLASS_NAME, SEAT_PRODUCT_CLASS_NAME
+    COUPON_PRODUCT_CLASS_NAME,
+    ENROLLMENT_CODE_PRODUCT_CLASS_NAME,
+    SEAT_PRODUCT_CLASS_NAME
 )
 from ecommerce.core.utils import log_message_and_raise_validation_error
 

--- a/ecommerce/extensions/catalogue/tests/mixins.py
+++ b/ecommerce/extensions/catalogue/tests/mixins.py
@@ -7,7 +7,9 @@ from oscar.core.utils import slugify
 from oscar.test import factories
 
 from ecommerce.core.constants import (
-    ENROLLMENT_CODE_PRODUCT_CLASS_NAME, ENROLLMENT_CODE_SWITCH, SEAT_PRODUCT_CLASS_NAME
+    ENROLLMENT_CODE_PRODUCT_CLASS_NAME,
+    ENROLLMENT_CODE_SWITCH,
+    SEAT_PRODUCT_CLASS_NAME
 )
 from ecommerce.core.tests import toggle_switch
 from ecommerce.courses.tests.factories import CourseFactory

--- a/ecommerce/extensions/fulfillment/tests/test_api.py
+++ b/ecommerce/extensions/fulfillment/tests/test_api.py
@@ -6,8 +6,11 @@ from nose.tools import raises
 from testfixtures import LogCapture
 
 from ecommerce.extensions.fulfillment import api, exceptions
-from ecommerce.extensions.fulfillment.api import (get_fulfillment_modules, get_fulfillment_modules_for_line,
-                                                  revoke_fulfillment_for_refund)
+from ecommerce.extensions.fulfillment.api import (
+    get_fulfillment_modules,
+    get_fulfillment_modules_for_line,
+    revoke_fulfillment_for_refund
+)
 from ecommerce.extensions.fulfillment.status import LINE, ORDER
 from ecommerce.extensions.fulfillment.tests.mixins import FulfillmentTestMixin
 from ecommerce.extensions.fulfillment.tests.modules import FakeFulfillmentModule

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -13,16 +13,23 @@ from oscar.test.newfactories import BasketFactory, UserFactory
 from requests.exceptions import ConnectionError, Timeout
 from testfixtures import LogCapture
 
-from ecommerce.core.constants import (COUPON_PRODUCT_CLASS_NAME, ENROLLMENT_CODE_PRODUCT_CLASS_NAME,
-                                      ENROLLMENT_CODE_SWITCH, SEAT_PRODUCT_CLASS_NAME)
+from ecommerce.core.constants import (
+    COUPON_PRODUCT_CLASS_NAME,
+    ENROLLMENT_CODE_PRODUCT_CLASS_NAME,
+    ENROLLMENT_CODE_SWITCH,
+    SEAT_PRODUCT_CLASS_NAME
+)
 from ecommerce.core.tests import toggle_switch
 from ecommerce.core.url_utils import get_lms_enrollment_api_url
 from ecommerce.coupons.tests.mixins import CouponMixin
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.courses.utils import mode_for_seat
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
-from ecommerce.extensions.fulfillment.modules import (CouponFulfillmentModule, EnrollmentCodeFulfillmentModule,
-                                                      EnrollmentFulfillmentModule)
+from ecommerce.extensions.fulfillment.modules import (
+    CouponFulfillmentModule,
+    EnrollmentCodeFulfillmentModule,
+    EnrollmentFulfillmentModule
+)
 from ecommerce.extensions.fulfillment.status import LINE
 from ecommerce.extensions.fulfillment.tests.mixins import FulfillmentTestMixin
 from ecommerce.extensions.test.factories import create_order

--- a/ecommerce/extensions/offer/models.py
+++ b/ecommerce/extensions/offer/models.py
@@ -7,7 +7,10 @@ from django.core.cache import cache
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from oscar.apps.offer.abstract_models import (
-    AbstractBenefit, AbstractCondition, AbstractConditionalOffer, AbstractRange
+    AbstractBenefit,
+    AbstractCondition,
+    AbstractConditionalOffer,
+    AbstractRange
 )
 from requests.exceptions import ConnectionError, Timeout
 from slumber.exceptions import SlumberBaseException

--- a/ecommerce/extensions/order/migrations/0014_auto_20170606_0535.py
+++ b/ecommerce/extensions/order/migrations/0014_auto_20170606_0535.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations
+
 from ecommerce.extensions.order.constants import ORDER_LIST_VIEW_SWITCH
 
 

--- a/ecommerce/extensions/payment/management/commands/paypal_profile.py
+++ b/ecommerce/extensions/payment/management/commands/paypal_profile.py
@@ -5,7 +5,7 @@ import paypalrestsdk
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.db.utils import IntegrityError
-from paypalrestsdk import WebProfile    # pylint: disable=ungrouped-imports
+from paypalrestsdk import WebProfile  # pylint: disable=ungrouped-imports
 
 from ecommerce.extensions.payment.models import PaypalWebProfile
 

--- a/ecommerce/extensions/payment/processors/cybersource.py
+++ b/ecommerce/extensions/payment/processors/cybersource.py
@@ -21,8 +21,12 @@ from ecommerce.core.url_utils import get_ecommerce_url
 from ecommerce.extensions.checkout.utils import get_receipt_page_url
 from ecommerce.extensions.payment.constants import APPLE_PAY_CYBERSOURCE_CARD_TYPE_MAP, CYBERSOURCE_CARD_TYPE_MAP
 from ecommerce.extensions.payment.exceptions import (
-    DuplicateReferenceNumber, InvalidCybersourceDecision, InvalidSignatureError, PartialAuthorizationError,
-    PCIViolation, ProcessorMisconfiguredError
+    DuplicateReferenceNumber,
+    InvalidCybersourceDecision,
+    InvalidSignatureError,
+    PartialAuthorizationError,
+    PCIViolation,
+    ProcessorMisconfiguredError
 )
 from ecommerce.extensions.payment.helpers import sign
 from ecommerce.extensions.payment.processors import BaseClientSidePaymentProcessor, HandledProcessorResponse

--- a/ecommerce/extensions/payment/tests/processors/test_cybersource.py
+++ b/ecommerce/extensions/payment/tests/processors/test_cybersource.py
@@ -17,8 +17,12 @@ from oscar.test import factories
 
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.payment.exceptions import (
-    DuplicateReferenceNumber, InvalidCybersourceDecision, InvalidSignatureError,
-    PartialAuthorizationError, PCIViolation, ProcessorMisconfiguredError
+    DuplicateReferenceNumber,
+    InvalidCybersourceDecision,
+    InvalidSignatureError,
+    PartialAuthorizationError,
+    PCIViolation,
+    ProcessorMisconfiguredError
 )
 from ecommerce.extensions.payment.models import PaymentProcessorResponse
 from ecommerce.extensions.payment.processors.cybersource import Cybersource

--- a/ecommerce/extensions/voucher/tests/test_utils.py
+++ b/ecommerce/extensions/voucher/tests/test_utils.py
@@ -22,12 +22,14 @@ from ecommerce.extensions.fulfillment.modules import CouponFulfillmentModule
 from ecommerce.extensions.fulfillment.status import LINE
 from ecommerce.extensions.test.factories import create_order, prepare_voucher
 from ecommerce.extensions.voucher.utils import (
-    create_vouchers, generate_coupon_report, get_voucher_and_products_from_code,
-    get_voucher_discount_info, update_voucher_offer
+    create_vouchers,
+    generate_coupon_report,
+    get_voucher_and_products_from_code,
+    get_voucher_discount_info,
+    update_voucher_offer
 )
 from ecommerce.tests.mixins import LmsApiMockMixin
 from ecommerce.tests.testcases import TestCase
-
 
 Basket = get_model('basket', 'Basket')
 Benefit = get_model('offer', 'Benefit')

--- a/ecommerce/programs/tests/test_conditions.py
+++ b/ecommerce/programs/tests/test_conditions.py
@@ -2,7 +2,6 @@ import ddt
 import httpretty
 import mock
 from oscar.core.loading import get_model
-
 from requests import Timeout
 from slumber.exceptions import HttpNotFoundError, SlumberBaseException
 

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -7,7 +7,6 @@ from os.path import abspath, basename, dirname, join, normpath
 from sys import path
 
 from django.utils.translation import ugettext_lazy as _
-
 from oscar import OSCAR_MAIN_TEMPLATE_DIR
 
 from ecommerce.settings._oscar import *

--- a/ecommerce/tests/factories.py
+++ b/ecommerce/tests/factories.py
@@ -1,6 +1,6 @@
 import factory
 from django.contrib.sites.models import Site
-from factory.fuzzy import FuzzyText     # pylint: disable=ungrouped-imports
+from factory.fuzzy import FuzzyText  # pylint: disable=ungrouped-imports
 from faker import Faker
 from oscar.core.loading import get_model
 from oscar.test.factories import StockRecordFactory as OscarStockRecordFactory

--- a/ecommerce/theming/management/commands/tests/test_update_assets.py
+++ b/ecommerce/theming/management/commands/tests/test_update_assets.py
@@ -9,7 +9,10 @@ from path import Path
 
 from ecommerce.theming.helpers import get_themes
 from ecommerce.theming.management.commands.update_assets import (
-    SYSTEM_SASS_PATHS, Command, compile_sass, get_sass_directories
+    SYSTEM_SASS_PATHS,
+    Command,
+    compile_sass,
+    get_sass_directories
 )
 
 

--- a/ecommerce/theming/tests/test_helpers.py
+++ b/ecommerce/theming/tests/test_helpers.py
@@ -7,8 +7,13 @@ from mock import patch
 
 from ecommerce.tests.testcases import TestCase
 from ecommerce.theming.helpers import (
-    Theme, get_all_theme_template_dirs, get_current_site_theme, get_current_theme, get_theme_base_dir,
-    get_theme_base_dirs, get_themes
+    Theme,
+    get_all_theme_template_dirs,
+    get_current_site_theme,
+    get_current_theme,
+    get_theme_base_dir,
+    get_theme_base_dirs,
+    get_themes
 )
 from ecommerce.theming.test_utils import with_comprehensive_theme
 


### PR DESCRIPTION
We seem to do an isort check on the codebase as part of quality, but there are files that haven't actually been sorted.

This just calls it in a separate PR to make the diff easier to read.

P.S. This also adds an `isort` make target for future ease.