### PR TITLE
[ENT-587] Don't cache invalid enrollment data on API error.

### DIFF
--- a/ecommerce/programs/conditions.py
+++ b/ecommerce/programs/conditions.py
@@ -84,10 +84,9 @@ class ProgramCourseRunSeatsCondition(Condition):
                 user = basket.owner.username
                 try:
                     enrollments = api.enrollment.get(user=user)
+                    cache.set(cache_key, enrollments, settings.ENROLLMENT_API_CACHE_TIMEOUT)
                 except (ConnectionError, SlumberBaseException, Timeout) as exc:
                     logger.error('Failed to retrieve enrollments: %s', str(exc))
-                else:
-                    cache.set(cache_key, enrollments, settings.ENROLLMENT_API_CACHE_TIMEOUT)
 
         for course in program['courses']:
             # If the user is already enrolled in a course, we do not need to check their basket for it


### PR DESCRIPTION
This is a quick fix of https://github.com/edx/ecommerce/pull/1468 to avoid caching invalid enrollment data if we get an API error.

See https://github.com/edx/ecommerce/pull/1468/files#r138332927 for original discussion.

@haikuginger @clintonb -- please double-check that this logic is fine.