### PR TITLE
LEARNER-2355 Make address, suite, state and zip optional

### DIFF
--- a/ecommerce/extensions/payment/tests/test_forms.py
+++ b/ecommerce/extensions/payment/tests/test_forms.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import ddt
 import pycountry
+from waffle.models import Switch
 
 from ecommerce.extensions.payment.forms import PaymentForm
 from ecommerce.extensions.test.factories import create_basket
@@ -91,6 +92,37 @@ class PaymentFormTests(TestCase):
 
         invalid_postal_code = ''.join(['a' for __ in range(0, 11)])
         self.assert_form_not_valid(country='IN', postal_code=invalid_postal_code)
+
+    # Temporarily add this test for codecov for the feature flag added for this test
+    # https://openedx.atlassian.net/browse/LEARNER-2355
+    # This code will be removed after this test is done
+    def test_state_validation_with_optional_location_fields(self):
+        """ Verify the state field is limited to 2 characters when the country is set to the U.S. or Canada. """
+        switch, __ = Switch.objects.get_or_create(name='optional_location_fields')
+        switch.active = True
+        switch.save()
+        self.assert_form_valid(country='US', state='CA')
+        self.assert_form_not_valid(country='US', state='ZZ')
+        self.assert_form_valid(country='US', state=None)
+        self.assert_form_valid(country='US', state=None, address_line1=None)
+        switch.active = False
+        switch.save()
+        self.assert_form_not_valid(country='US', state=None)
+        self.assert_form_not_valid(country='US', state='CA', address_line1=None)
+
+    # Temporarily add this test for codecov for the feature flag added for this test
+    # https://openedx.atlassian.net/browse/LEARNER-2355
+    # This code will be removed after this test is done
+    def test_postal_code_validation_optional_location_fields(self):
+        """ Verify the postal code is limited to 9 characters when the country is set to the U.S. or Canada. """
+        switch, __ = Switch.objects.get_or_create(name='optional_location_fields')
+        switch.active = True
+        switch.save()
+        self.assert_form_valid(country='US', state='CA', postal_code='90210')
+        self.assert_form_valid(country='US', state='CA', postal_code='902102938')
+        self.assert_form_not_valid(country='US', state='CA', postal_code='1234567890')
+        switch.active = False
+        switch.save()
 
     def test_countries_sorting(self):
         """ Verify the country choices are sorted by country name. """

--- a/ecommerce/static/js/pages/basket_page.js
+++ b/ecommerce/static/js/pages/basket_page.js
@@ -75,15 +75,20 @@ define([
 
         function cardHolderInfoValidation(event) {
             var requiredFields = [
-                'input[name=first_name]',
-                'input[name=last_name]',
-                'input[name=address_line1]',
-                'input[name=city]',
-                'select[name=country]'
-            ];
-
-            if (['US', 'CA'].indexOf($('select[name=country]').val()) > -1) {
-                requiredFields.push('select[name=state]');
+                    'input[name=first_name]',
+                    'input[name=last_name]',
+                    'input[name=city]',
+                    'select[name=country]'
+                ],
+                experiments = window.experimentVariables || {};
+            // Only require address and state if we are not in the hide location fields variation of this experiment
+            // https://openedx.atlassian.net/browse/LEARNER-2355
+            if (!(experiments && experiments.hide_location_fields)) {
+                requiredFields.push('input[name=address_line1]');
+                if (['US', 'CA'].indexOf($('select[name=country]').val()) > -1) {
+                    requiredFields.push('select[name=state]');
+                    requiredFields.push('input[name=postal_code]');
+                }
             }
 
             _.each(requiredFields, function(field) {
@@ -348,14 +353,18 @@ define([
                             Saskatchewan: 'SK',
                             Yukon: 'YT'
                         }
-                    };
+                    },
+                    experiments = window.experimentVariables || {},
+                    selectorRequired = 'aria-required="true" required',
+                    stateSelector = '<select name="state" class="select form-control" id="id_state"';
 
                 if (country === 'US' || country === 'CA') {
                     $($inputDiv).empty();
-                    $($inputDiv).append(
-                        '<select name="state" class="select form-control" id="id_state"' +
-                        'aria-required="true" required></select>'
-                    );
+                    // Only require state if we are not in the hide location fields variation of this experiment
+                    // https://openedx.atlassian.net/browse/LEARNER-2355
+                    stateSelector += !(experiments && experiments.hide_location_fields) ? selectorRequired : '';
+                    stateSelector += '></select>';
+                    $($inputDiv).append(stateSelector);
                     $('#id_state').append($('<option>', {value: '', text: gettext('<Choose state/province>')}));
                     $('#div_id_state').find('label').text(gettext('State/Province (required)'));
 


### PR DESCRIPTION
**Background**
We have consulted with cybersource and internally with enterprise/finance/legal and a number of other teams about those 4 fields on the checkout form.
We determined there is some use for them, especially reducing risk of fraud and credit card declines, but we also believe there is a potentially greater benefit of increased revenue. We know how to measure the revenue and declined cards and want to a/b test a new checkout page that would all fit on one desktop screen with fewer fields against our current page.

**This PR**
This PR would enable the variation that will make these fields optional to not pass them, while preserving current behavior for the other variation.

An optimizely flag would result in the same behavior for half the users by preserving the client side validation.
(Only question is zip code. Currently it is required server side if US/CA is selected, but is not marked as required client side and there is no client side validation. If necessary, I can add a client side requirement for it when US/CA are selected like is currently done for state)

**Optimizely**
The optimizely test would look roughly like [this.](https://app.optimizely.com/v2/projects/1743970571/experiments/8728653307)
Of course we would test further first before turning on