### PR TITLE
Use GA client id on order completed event instead from DB.

### DIFF
--- a/ecommerce/extensions/checkout/signals.py
+++ b/ecommerce/extensions/checkout/signals.py
@@ -5,7 +5,11 @@ from django.dispatch import receiver
 from oscar.core.loading import get_class, get_model
 
 from ecommerce.courses.utils import mode_for_seat
-from ecommerce.extensions.analytics.utils import silence_exceptions, track_segment_event
+from ecommerce.extensions.analytics.utils import (
+    get_google_analytics_client_id,
+    silence_exceptions,
+    track_segment_event
+)
 from ecommerce.extensions.checkout.utils import get_credit_provider_details, get_receipt_page_url
 from ecommerce.notifications.notifications import send_notification
 from ecommerce.programs.utils import get_program
@@ -79,7 +83,9 @@ def track_completed_order(sender, order=None, **kwargs):  # pylint: disable=unus
     except BasketAttribute.DoesNotExist:
         logger.info('There is no program or bundle associated with order number %s', order.number)
 
-    track_segment_event(order.site, order.user, 'Order Completed', properties)
+    ga_client_id = get_google_analytics_client_id(kwargs.get('request'))
+
+    track_segment_event(order.site, order.user, 'Order Completed', properties, ga_client_id=ga_client_id)
 
 
 @receiver(post_checkout, dispatch_uid='send_completed_order_email')


### PR DESCRIPTION
Our client ID is stored in ecommerce database, and that won't change anymore even if the user is moved to a different browse. We should not use the client ID from the database instead we should get the client ID from the cookie of the request.

**Testing:**
    Tested locally and working as expected.

LEARNER-2232