### PR TITLE
Use GA clientId from request cookie on all analytics events instead of DB.

### DIFF
--- a/ecommerce/extensions/analytics/middleware.py
+++ b/ecommerce/extensions/analytics/middleware.py
@@ -1,0 +1,23 @@
+"""
+Middleware for analytics app to parse GA cookie.
+"""
+
+from ecommerce.extensions.analytics.utils import get_google_analytics_client_id
+
+
+class TrackingMiddleware(object):
+    """
+    Middleware that parse `_ga` cookie and save/update in user tracking context.
+    """
+
+    def process_request(self, request):
+        user = request.user
+        if user.is_authenticated():
+            tracking_context = user.tracking_context or {}
+            old_client_id = tracking_context.get('ga_client_id')
+            ga_client_id = get_google_analytics_client_id(request)
+
+            if ga_client_id and ga_client_id != old_client_id:
+                tracking_context['ga_client_id'] = ga_client_id
+                user.tracking_context = tracking_context
+                user.save()

--- a/ecommerce/extensions/analytics/tests/test_middleware.py
+++ b/ecommerce/extensions/analytics/tests/test_middleware.py
@@ -1,0 +1,30 @@
+from django.test.client import RequestFactory
+
+from ecommerce.extensions.analytics import middleware
+from ecommerce.tests.testcases import TestCase
+
+
+class TrackingMiddlewareTests(TestCase):
+    """ Test for TrackingMiddleware. """
+    def setUp(self):
+        super(TrackingMiddlewareTests, self).setUp()
+        self.middleware = middleware.TrackingMiddleware()
+        self.request_factory = RequestFactory()
+        self.user = self.create_user()
+
+    def _assert_ga_client_id(self, ga_client_id):
+        self.request_factory.cookies['_ga'] = 'GA1.2.{}'.format(ga_client_id)
+        request = self.request_factory.get('/')
+        request.user = self.user
+        self.middleware.process_request(request)
+        expected_client_id = self.user.tracking_context.get('ga_client_id')
+        self.assertEqual(ga_client_id, expected_client_id)
+
+    def test_process_request(self):
+        """ Test that middleware save/update GA client id in user tracking context. """
+        self.assertIsNone(self.user.tracking_context)
+        self._assert_ga_client_id('test-client-id')
+
+        updated_client_id = 'updated-client-id'
+        self.assertNotEqual(updated_client_id, self.user.tracking_context.get('ga_client_id'))
+        self._assert_ga_client_id(updated_client_id)

--- a/ecommerce/extensions/analytics/utils.py
+++ b/ecommerce/extensions/analytics/utils.py
@@ -14,7 +14,7 @@ def parse_tracking_context(user):
         user (User): An instance of the User model.
 
     Returns:
-        Tuple of strings: user_tracking_id, lms_client_id, lms_ip
+        Tuple of strings: user_tracking_id, ga_client_id, lms_ip
     """
     tracking_context = user.tracking_context or {}
 
@@ -26,10 +26,10 @@ def parse_tracking_context(user):
         # at some point.
         user_tracking_id = 'ecommerce-{}'.format(user.id)
 
-    lms_client_id = tracking_context.get('lms_client_id')
     lms_ip = tracking_context.get('lms_ip')
+    ga_client_id = tracking_context.get('ga_client_id')
 
-    return user_tracking_id, lms_client_id, lms_ip
+    return user_tracking_id, ga_client_id, lms_ip
 
 
 def silence_exceptions(msg):
@@ -118,7 +118,7 @@ def prepare_analytics_data(user, segment_key):
     return json.dumps(data)
 
 
-def track_segment_event(site, user, event, properties, ga_client_id=None):
+def track_segment_event(site, user, event, properties):
     """ Fire a tracking event via Segment.
 
     Args:
@@ -126,7 +126,6 @@ def track_segment_event(site, user, event, properties, ga_client_id=None):
         user (User): User to which the event should be associated.
         event (str): Event name.
         properties (dict): Event properties.
-        ga_client_id (str): Google Analytics clientId.
 
     Returns:
         (success, msg): Tuple indicating the success of enqueuing the event on the message queue.
@@ -139,11 +138,11 @@ def track_segment_event(site, user, event, properties, ga_client_id=None):
         logger.debug(msg)
         return False, msg
 
-    user_tracking_id, lms_client_id, lms_ip = parse_tracking_context(user)
+    user_tracking_id, ga_client_id, lms_ip = parse_tracking_context(user)
     context = {
         'ip': lms_ip,
         'Google Analytics': {
-            'clientId': ga_client_id if ga_client_id else lms_client_id
+            'clientId': ga_client_id
         }
     }
     return site.siteconfiguration.segment_client.track(user_tracking_id, event, properties, context=context)

--- a/ecommerce/extensions/basket/tests/test_models.py
+++ b/ecommerce/extensions/basket/tests/test_models.py
@@ -123,11 +123,11 @@ class BasketTests(CatalogMixin, BasketMixin, TestCase):
         basket.add_product(seat)
 
         properties = translate_basket_line_for_segment(basket.lines.first())
-        user_tracking_id, lms_client_id, lms_ip = parse_tracking_context(basket.owner)
+        user_tracking_id, ga_client_id, lms_ip = parse_tracking_context(basket.owner)
         context = {
             'ip': lms_ip,
             'Google Analytics': {
-                'clientId': lms_client_id
+                'clientId': ga_client_id
             }
         }
 

--- a/ecommerce/extensions/checkout/signals.py
+++ b/ecommerce/extensions/checkout/signals.py
@@ -5,11 +5,7 @@ from django.dispatch import receiver
 from oscar.core.loading import get_class, get_model
 
 from ecommerce.courses.utils import mode_for_seat
-from ecommerce.extensions.analytics.utils import (
-    get_google_analytics_client_id,
-    silence_exceptions,
-    track_segment_event
-)
+from ecommerce.extensions.analytics.utils import silence_exceptions, track_segment_event
 from ecommerce.extensions.checkout.utils import get_credit_provider_details, get_receipt_page_url
 from ecommerce.notifications.notifications import send_notification
 from ecommerce.programs.utils import get_program
@@ -83,9 +79,7 @@ def track_completed_order(sender, order=None, **kwargs):  # pylint: disable=unus
     except BasketAttribute.DoesNotExist:
         logger.info('There is no program or bundle associated with order number %s', order.number)
 
-    ga_client_id = get_google_analytics_client_id(kwargs.get('request'))
-
-    track_segment_event(order.site, order.user, 'Order Completed', properties, ga_client_id=ga_client_id)
+    track_segment_event(order.site, order.user, 'Order Completed', properties)
 
 
 @receiver(post_checkout, dispatch_uid='send_completed_order_email')

--- a/ecommerce/extensions/checkout/tests/test_mixins.py
+++ b/ecommerce/extensions/checkout/tests/test_mixins.py
@@ -114,7 +114,7 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin,
         Ensure that tracking events are fired with correct content when order
         placement event handling is invoked.
         """
-        tracking_context = {'lms_user_id': 'test-user-id', 'lms_client_id': 'test-client-id', 'lms_ip': '127.0.0.1'}
+        tracking_context = {'ga_client_id': 'test-client-id', 'lms_user_id': 'test-user-id', 'lms_ip': '127.0.0.1'}
         self.user.tracking_context = tracking_context
         self.user.save()
 
@@ -127,7 +127,7 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin,
                 mock_track,
                 self.order,
                 tracking_context['lms_user_id'],
-                tracking_context['lms_client_id'],
+                tracking_context['ga_client_id'],
                 tracking_context['lms_ip'],
                 self.order.number,
                 self.order.currency,
@@ -272,16 +272,20 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin,
         """
         Verify the "Payment Info Entered" Segment event is fired after payment info is validated
         """
+        tracking_context = {'ga_client_id': 'test-client-id', 'lms_user_id': 'test-user-id', 'lms_ip': '127.0.0.1'}
+        self.user.tracking_context = tracking_context
+        self.user.save()
+
         basket = create_basket(owner=self.user, site=self.site)
 
         mixin = EdxOrderPlacementMixin()
         mixin.payment_processor = DummyProcessor(self.site)
 
-        user_tracking_id, lms_client_id, lms_ip = parse_tracking_context(self.user)
+        user_tracking_id, ga_client_id, lms_ip = parse_tracking_context(self.user)
         context = {
             'ip': lms_ip,
             'Google Analytics': {
-                'clientId': lms_client_id
+                'clientId': ga_client_id
             }
         }
 

--- a/ecommerce/extensions/checkout/tests/test_signals.py
+++ b/ecommerce/extensions/checkout/tests/test_signals.py
@@ -3,7 +3,6 @@ import json
 import httpretty
 import mock
 from django.core import mail
-from django.test.client import RequestFactory
 from oscar.core.loading import get_class, get_model
 from oscar.test import factories
 from oscar.test.newfactories import BasketFactory
@@ -36,10 +35,6 @@ LOGGER_NAME = 'ecommerce.extensions.checkout.signals'
 class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
     def setUp(self):
         super(SignalTests, self).setUp()
-        self.ga_client_id = '1033501218.1368477899'
-        request_factory = RequestFactory()
-        request_factory.cookies['_ga'] = 'GA1.2.{}'.format(self.ga_client_id)
-        self.request = request_factory.get('/')
         self.user = self.create_user()
         self.request.user = self.user
         toggle_switch('ENABLE_NOTIFICATIONS', True)
@@ -178,20 +173,16 @@ class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
 
         with mock.patch('ecommerce.extensions.checkout.signals.track_segment_event') as mock_track:
             order = self.prepare_order('verified')
-            track_completed_order(None, order, request=self.request)
+            track_completed_order(None, order)
             properties = self._generate_event_properties(order)
-            mock_track.assert_called_once_with(
-                order.site, order.user, 'Order Completed', properties, ga_client_id=self.ga_client_id
-            )
+            mock_track.assert_called_once_with(order.site, order.user, 'Order Completed', properties)
 
             # We should be able to fire events even if the product is not related to a course.
             mock_track.reset_mock()
             order = create_order()
-            track_completed_order(None, order, request=self.request)
+            track_completed_order(None, order)
             properties = self._generate_event_properties(order)
-            mock_track.assert_called_once_with(
-                order.site, order.user, 'Order Completed', properties, ga_client_id=self.ga_client_id
-            )
+            mock_track.assert_called_once_with(order.site, order.user, 'Order Completed', properties)
 
     @mock.patch('ecommerce.extensions.checkout.signals.track_segment_event')
     def test_track_bundle_order(self, mock_track):
@@ -206,21 +197,17 @@ class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
         # Tracks a full bundle order
         with mock.patch('ecommerce.extensions.checkout.signals.get_program',
                         mock.Mock(return_value=self.mock_get_program_data(True))):
-            track_completed_order(None, order, request=self.request)
+            track_completed_order(None, order)
             properties = self._generate_event_properties(order, bundle_id='test_bundle', fullBundle=True)
-            mock_track.assert_called_once_with(
-                order.site, order.user, 'Order Completed', properties, ga_client_id=self.ga_client_id
-            )
+            mock_track.assert_called_once_with(order.site, order.user, 'Order Completed', properties)
 
         # Tracks a partial bundle order
         with mock.patch('ecommerce.extensions.checkout.signals.get_program',
                         mock.Mock(return_value=self.mock_get_program_data(False))):
             mock_track.reset_mock()
-            track_completed_order(None, order, request=self.request)
+            track_completed_order(None, order)
             properties = self._generate_event_properties(order, bundle_id='test_bundle')
-            mock_track.assert_called_once_with(
-                order.site, order.user, 'Order Completed', properties, ga_client_id=self.ga_client_id
-            )
+            mock_track.assert_called_once_with(order.site, order.user, 'Order Completed', properties)
 
     def test_track_completed_discounted_order_with_voucher(self):
         """ An event including coupon information should be sent to Segment"""
@@ -237,11 +224,9 @@ class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
             Applicator().apply(basket, user=basket.owner, request=self.request)
 
             order = factories.create_order(basket=basket, user=self.user)
-            track_completed_order(None, order, request=self.request)
+            track_completed_order(None, order)
             properties = self._generate_event_properties(order, voucher)
-            mock_track.assert_called_once_with(
-                order.site, order.user, 'Order Completed', properties, ga_client_id=self.ga_client_id
-            )
+            mock_track.assert_called_once_with(order.site, order.user, 'Order Completed', properties)
 
     def test_track_completed_discounted_order_with_voucher_with_offer(self):
         with mock.patch('ecommerce.extensions.checkout.signals.track_segment_event') as mock_track:
@@ -263,11 +248,9 @@ class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
             Applicator().apply(basket, user=basket.owner, request=self.request)
 
             order = factories.create_order(basket=basket, user=self.user)
-            track_completed_order(None, order, request=self.request)
+            track_completed_order(None, order)
             properties = self._generate_event_properties(order, voucher)
-            mock_track.assert_called_once_with(
-                order.site, order.user, 'Order Completed', properties, ga_client_id=self.ga_client_id
-            )
+            mock_track.assert_called_once_with(order.site, order.user, 'Order Completed', properties)
 
     def test_track_completed_discounted_order_with_offer(self):
         """ An event including a discount but no coupon should be sent to Segment"""
@@ -287,11 +270,9 @@ class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
             Applicator().apply_offers(basket, [site_offer])
 
             order = factories.create_order(basket=basket, user=self.user)
-            track_completed_order(None, order, request=self.request)
+            track_completed_order(None, order)
             properties = self._generate_event_properties(order)
-            mock_track.assert_called_once_with(
-                order.site, order.user, 'Order Completed', properties, ga_client_id=self.ga_client_id
-            )
+            mock_track.assert_called_once_with(order.site, order.user, 'Order Completed', properties)
 
     def test_track_completed_coupon_order(self):
         """ Make sure we do not send GA events for Coupon orders """

--- a/ecommerce/extensions/refund/tests/test_signals.py
+++ b/ecommerce/extensions/refund/tests/test_signals.py
@@ -27,7 +27,7 @@ class RefundTrackingTests(RefundTestMixin, TestCase):
         expected_context = {
             'ip': tracking_context.get('lms_ip'),
             'Google Analytics': {
-                'clientId': tracking_context.get('lms_client_id')
+                'clientId': tracking_context.get('ga_client_id')
             }
         }
         self.assertEqual(kwargs['context'], expected_context)
@@ -44,7 +44,7 @@ class RefundTrackingTests(RefundTestMixin, TestCase):
 
     def test_successful_refund_tracking(self, mock_track):
         """Verify that a successfully placed refund is tracked when Segment is enabled."""
-        tracking_context = {'lms_user_id': 'test-user-id', 'lms_client_id': 'test-client-id', 'lms_ip': '127.0.0.1'}
+        tracking_context = {'ga_client_id': 'test-client-id', 'lms_user_id': 'test-user-id', 'lms_ip': '127.0.0.1'}
         self.refund.user.tracking_context = tracking_context
         self.refund.user.save()
         self.approve(self.refund)

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -224,6 +224,7 @@ MIDDLEWARE_CLASSES = (
     'waffle.middleware.WaffleMiddleware',
     # NOTE: The overridden BasketMiddleware relies on request.site. This middleware
     # MUST appear AFTER CurrentSiteMiddleware.
+    'ecommerce.extensions.analytics.middleware.TrackingMiddleware',
     'ecommerce.extensions.basket.middleware.BasketMiddleware',
     'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
     'social_django.middleware.SocialAuthExceptionMiddleware',


### PR DESCRIPTION
Our client ID is stored in ecommerce database, and that won't change anymore even if the user is moved to a different browser. We should not use the client ID from the database instead we should get the client ID from the cookie of the request.

LEARNER-2596