### PR TITLE
[ENT-640] Remove references to "enterprise_customer_users".

### DIFF
--- a/ecommerce/enterprise/api.py
+++ b/ecommerce/enterprise/api.py
@@ -89,9 +89,6 @@ def fetch_enterprise_learner_data(site, user):
                             },
                             "enable_data_sharing_consent": true,
                             "enforce_data_sharing_consent": "at_login",
-                            "enterprise_customer_users": [
-                                1
-                            ],
                             "branding_configuration": {
                                 "enterprise_customer": "cf246b88-d5f6-4908-a522-fc307e0b0c59",
                                 "logo": "https://open.edx.org/sites/all/themes/edx_open/logo.png"

--- a/ecommerce/enterprise/tests/mixins.py
+++ b/ecommerce/enterprise/tests/mixins.py
@@ -35,9 +35,6 @@ class EnterpriseServiceMockMixin(object):
             },
             'enable_data_sharing_consent': True,
             'enforce_data_sharing_consent': 'at_login',
-            'enterprise_customer_users': [
-                1
-            ],
             'branding_configuration': {
                 'enterprise_customer': 'cf246b88-d5f6-4908-a522-fc307e0b0c59',
                 'logo': 'https://open.edx.org/sites/all/themes/edx_open/logo.png'
@@ -86,9 +83,6 @@ class EnterpriseServiceMockMixin(object):
             },
             'enable_data_sharing_consent': consent_enabled,
             'enforce_data_sharing_consent': 'at_login',
-            'enterprise_customer_users': [
-                1
-            ],
             'branding_configuration': {
                 'enterprise_customer': 'cf246b88-d5f6-4908-a522-fc307e0b0c59',
                 'logo': 'https://open.edx.org/sites/all/themes/edx_open/logo.png'
@@ -157,9 +151,6 @@ class EnterpriseServiceMockMixin(object):
                         },
                         'enable_data_sharing_consent': consent_enabled,
                         'enforce_data_sharing_consent': 'at_login',
-                        'enterprise_customer_users': [
-                            1
-                        ],
                         'branding_configuration': {
                             'enterprise_customer': enterprise_customer_uuid,
                             'logo': 'https://open.edx.org/sites/all/themes/edx_open/logo.png'


### PR DESCRIPTION
As of https://github.com/edx/edx-enterprise/pull/193, responses from the Enterprise API no longer include this field.

CC @UmanShahzad @douglashall 