### PR TITLE
Upgrading DRF to 3.6.4 and removing swagger.

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -278,6 +278,7 @@ class RefundSerializer(serializers.ModelSerializer):
 
     class Meta(object):
         model = Refund
+        fields = '__all__'
 
 
 class CourseSerializer(serializers.HyperlinkedModelSerializer):
@@ -708,6 +709,7 @@ class CheckoutSerializer(serializers.Serializer):  # pylint: disable=abstract-me
 class InvoiceSerializer(serializers.ModelSerializer):
     class Meta(object):
         model = Invoice
+        fields = '__all__'
 
 
 class ProviderSerializer(serializers.Serializer):  # pylint: disable=abstract-method

--- a/ecommerce/extensions/api/v2/views/baskets.py
+++ b/ecommerce/extensions/api/v2/views/baskets.py
@@ -45,6 +45,9 @@ class BasketCreateView(EdxOrderPlacementMixin, generics.CreateAPIView):
     """
     permission_classes = (IsAuthenticated,)
 
+    def get_serializer(self):
+        pass
+
     # Disable atomicity for the view. Otherwise, we'd be unable to commit to the database
     # until the request had concluded; Django will refuse to commit when an atomic() block
     # is active, since that would break atomicity. Without an order present in the database

--- a/ecommerce/extensions/api/v2/views/courses.py
+++ b/ecommerce/extensions/api/v2/views/courses.py
@@ -73,7 +73,7 @@ class CourseViewSet(NonDestroyableModelViewSet):
 
     def get_serializer_context(self):
         context = super(CourseViewSet, self).get_serializer_context()
-        context['include_products'] = bool(self.request.GET.get('include_products', False))
+        context['include_products'] = bool(self.request.GET.get('include_products', False)) if self.request else False
         return context
 
     @detail_route(methods=['post'])

--- a/ecommerce/extensions/api/v2/views/publication.py
+++ b/ecommerce/extensions/api/v2/views/publication.py
@@ -17,7 +17,7 @@ class AtomicPublicationView(generics.CreateAPIView, generics.UpdateAPIView):
 
     def get_serializer_context(self):
         context = super(AtomicPublicationView, self).get_serializer_context()
-        context['access_token'] = self.request.user.access_token
+        context['access_token'] = self.request.user.access_token if self.request else None
         context['partner'] = get_partner_for_site(self.request)
         return context
 

--- a/ecommerce/extensions/api/v2/views/refunds.py
+++ b/ecommerce/extensions/api/v2/views/refunds.py
@@ -36,6 +36,9 @@ class RefundCreateView(generics.CreateAPIView):
     """
     permission_classes = (IsAuthenticated, CanActForUser)
 
+    def get_serializer(self):
+        pass
+
     def create(self, request, *args, **kwargs):
         """ Creates refunds, if eligible orders exist. """
         course_id = request.data.get('course_id')

--- a/ecommerce/extensions/api/v2/views/stockrecords.py
+++ b/ecommerce/extensions/api/v2/views/stockrecords.py
@@ -18,7 +18,7 @@ class StockRecordViewSet(viewsets.ModelViewSet):
     def get_serializer_class(self):
         serializer_class = self.serializer_class
 
-        if self.request.method == 'PUT':
+        if self.request and self.request.method == 'PUT':
             serializer_class = serializers.PartialStockRecordSerializerForUpdate
 
         return serializer_class

--- a/ecommerce/extensions/partner/shortcuts.py
+++ b/ecommerce/extensions/partner/shortcuts.py
@@ -1,3 +1,6 @@
 def get_partner_for_site(request):
     """ Returns the Partner associated with the request. """
+    if not request:
+        return None
+
     return request.site.siteconfiguration.partner

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -275,7 +275,6 @@ DJANGO_APPS = [
     'simple_history',
     'waffle',
     'django_filters',
-    'rest_framework_swagger',
     'release_util',
     'crispy_forms',
     'solo',
@@ -463,19 +462,6 @@ REST_FRAMEWORK = {
     'TEST_REQUEST_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',
     ),
-}
-
-SWAGGER_SETTINGS = {
-    'info': {
-        'title': 'edX E-Commerce API',
-        'description': 'API for interacting with E-Commerce (Otto) orders, products, and associated resources.',
-    },
-    'doc_expansion': 'list',
-    'api_version': 'v2',
-
-    # Exclude the publication endpoint because its serializer requires context that rest-swagger does not
-    # supply. See https://github.com/marcgibbons/django-rest-swagger/issues/397
-    'exclude_namespaces': ['publication'],
 }
 # END DJANGO REST FRAMEWORK
 

--- a/ecommerce/tests/test_urls.py
+++ b/ecommerce/tests/test_urls.py
@@ -17,3 +17,12 @@ class TestUrls(TestCase):
         # Test client can't fetch external URLs, so fetch_redirect_response is set to
         # False to avoid loading the final page
         self.assertRedirects(response, get_lms_dashboard_url(), fetch_redirect_response=False)
+
+    def test_api_docs(self):
+        """
+        Verify that the API docs render.
+        """
+        path = reverse('api-docs:docs-index')
+        response = self.client.get(path)
+
+        assert response.status_code == 200

--- a/ecommerce/urls.py
+++ b/ecommerce/urls.py
@@ -10,6 +10,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.views.defaults import page_not_found, server_error
 from django.views.generic import TemplateView
 from django.views.i18n import JavaScriptCatalog
+from rest_framework.documentation import include_docs_urls
 
 from ecommerce.core import views as core_views
 from ecommerce.core.url_utils import get_lms_dashboard_url
@@ -53,7 +54,7 @@ urlpatterns = AUTH_URLS + WELL_KNOWN_URLS + [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),
     url(r'^api-auth/', include(AUTH_URLS, namespace='rest_framework')),
-    url(r'^api-docs/', include('rest_framework_swagger.urls')),
+    url(r'^api-docs/', include_docs_urls(title='Ecommerce API')),
     url(r'^courses/', include('ecommerce.courses.urls', namespace='courses')),
     url(r'^credit/', include('ecommerce.credit.urls', namespace='credit')),
     url(r'^coupons/', include('ecommerce.coupons.urls', namespace='coupons')),

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,5 @@
 analytics-python==1.2.7
+coreapi==2.3.1
 django==1.10.7
 django-compressor==2.2
 django-crispy-forms==1.6.1
@@ -6,12 +7,11 @@ django_extensions==1.9.0
 django-filter==1.0.4
 django-libsass==0.5
 django-oscar==1.4
-django-rest-swagger[reST]==0.3.10
 django-simple-history==1.8.2
 django-solo==1.1.2
 django-threadlocals==0.8
 django-waffle==0.12.0
-djangorestframework==3.3.3
+djangorestframework==3.6.4
 djangorestframework-jwt==1.11.0
 drf-extensions==0.3.1
 edx-auth-backends==1.1.2
@@ -23,11 +23,13 @@ edx-opaque-keys==0.3.1
 edx-rest-api-client==1.7.1
 jsonfield==1.0.3
 libsass==0.9.2
+markdown==2.6.9
 ndg-httpsclient==0.4.2
 path.py==7.2
 paypalrestsdk==1.11.5
 premailer==2.9.2
 pycountry==17.1.8
+pygments==2.2.0
 python-dateutil==2.4.2
 pytz==2016.10
 requests==2.18.1


### PR DESCRIPTION
3.6.4 includes built-in, interactive API documentation. We no longer
need django-rest-swagger.

LEARNER-1306
LEARNER-2632

![screenshot from 2017-09-28 14-05-28](https://user-images.githubusercontent.com/2851134/30958309-2674c4a8-a456-11e7-9dcb-34aec9608b9f.png)