### PR TITLE
LEARNER-2594 course names discrepancy for coupon redemption

### DIFF
--- a/ecommerce/extensions/api/v2/views/vouchers.py
+++ b/ecommerce/extensions/api/v2/views/vouchers.py
@@ -286,6 +286,6 @@ class VoucherViewSet(NonDestroyableModelViewSet):
             'credit_provider_price': credit_provider_price,
             'seat_type': product.attr.certificate_type,
             'stockrecords': serializers.StockRecordSerializer(stock_record).data,
-            'title': course.name,
+            'title': course_info.get('title', course.name),
             'voucher_end_date': voucher.end_datetime
         }


### PR DESCRIPTION
[**LEARNER-2594**](https://openedx.atlassian.net/browse/LEARNER-2594)
Updated code to use the course title from the discovery. If unable to find it than use the old one. 