### PR TITLE
[ENT-497] Update user-facing consent view to reflect new data model

### DIFF
--- a/ecommerce/enterprise/api.py
+++ b/ecommerce/enterprise/api.py
@@ -110,11 +110,14 @@ def fetch_enterprise_learner_data(site, user):
                             "is_active": true,
                             "date_joined": "2016-09-01T19:18:26.026495Z"
                         },
-                        "data_sharing_consent": [
+                        "data_sharing_consent_records": [
                             {
-                                "user": 1,
-                                "state": "enabled",
-                                "enabled": true
+                                "username": "staff",
+                                "enterprise_customer_uuid": "cf246b88-d5f6-4908-a522-fc307e0b0c59",
+                                "exists": true,
+                                "consent_provided": true,
+                                "consent_required": false,
+                                "course_id": "course-v1:edX DemoX Demo_Course",
                             }
                         ]
                     }

--- a/ecommerce/enterprise/tests/mixins.py
+++ b/ecommerce/enterprise/tests/mixins.py
@@ -172,11 +172,14 @@ class EnterpriseServiceMockMixin(object):
                         'is_active': True,
                         'date_joined': '2016-09-01T19:18:26.026495Z'
                     },
-                    'data_sharing_consent': [
+                    'data_sharing_consent_records': [
                         {
-                            'user': 1,
-                            'state': 'enabled' if consent_provided else 'disabled',
-                            'enabled': consent_provided
+                            "username": "verified",
+                            "enterprise_customer_uuid": enterprise_customer_uuid,
+                            "exists": True,
+                            "consent_provided": consent_provided,
+                            "consent_required": consent_enabled and not consent_provided,
+                            "course_id": "course-v1:edX DemoX Demo_Course",
                         }
                     ]
                 }

--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -271,10 +271,14 @@ def get_enterprise_course_consent_url(
     )
     request_params = {
         'course_id': course_id,
-        'enterprise_id': enterprise_customer_uuid,
-        'enrollment_deferred': True,
+        'enterprise_customer_uuid': enterprise_customer_uuid,
+        'defer_creation': True,
         'next': callback_url,
         'failure_url': failure_url,
+        # TODO: Erase these 2 keys when edx-platform/ecommerce are both deployed to be using
+        # 'enterprise_customer_uuid' and 'defer_creation' rather than these.
+        'enterprise_id': enterprise_customer_uuid,
+        'enrollment_deferred': True,
     }
     redirect_url = '{base}?{params}'.format(
         base=site.siteconfiguration.enterprise_grant_data_sharing_url,
@@ -290,9 +294,9 @@ def get_enterprise_customer_data_sharing_consent_token(access_token, course_id, 
     """
     consent_token_hmac = hmac.new(
         str(access_token),
-        '{course_id}_{enterprise_uuid}'.format(
+        '{course_id}_{enterprise_customer_uuid}'.format(
             course_id=course_id,
-            enterprise_uuid=enterprise_customer_uuid,
+            enterprise_customer_uuid=enterprise_customer_uuid,
         ),
         digestmod=hashlib.sha256,
     )


### PR DESCRIPTION
**Description:** This PR updates any variables in code/mocks/docs that point to the user-facing data sharing consent view from edx-enterprise that may be changed as part of https://github.com/edx/edx-enterprise/pull/207.

**JIRA:** [ENT-497](https://openedx.atlassian.net/browse/ENT-497)

**Dependencies**: https://github.com/edx/edx-enterprise/pull/207 & https://github.com/edx/edx-platform/pull/16136 (I believe these edx-platform PR must be released together with this to prevent any discrepancies).

**Merge deadline**: End of week.

**Testing instructions**:

Copied from https://github.com/edx/ecommerce/pull/1426:

1. Create a premium course
2. Create a coupon attached to an EnterpriseCustomer
3. Ensure that the premium course is included in the catalog linked to the EnterpriseCustomer
4. Verify that the EnterpriseCustomer is configured to require data sharing consent 
5. Create a new user and go to the coupon redemption link
6. Verify that you're prompted for data sharing consent as expected.

**Reviewers**
- [ ] @haikuginger 
- [ ] @brittneyexline @douglashall 

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```