### PR TITLE
jbradley/learner 2413 Add Geolocation-Based Local Currency To Basket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ node_modules/
 ecommerce/static/bower_components/
 ecommerce/static/build/
 npm-debug.log
+package-lock.json
 
 # Unit test / coverage reports
 coverage/

--- a/ecommerce/static/js/pages/basket_page.js
+++ b/ecommerce/static/js/pages/basket_page.js
@@ -16,452 +16,492 @@ define([
               Cookies) {
         'use strict';
 
-        function hideVoucherForm() {
-            $('#voucher_form_container').hide();
-            $('#voucher_form_link').show();
-        }
+        var BasketPage = {
+            hideVoucherForm: function() {
+                $('#voucher_form_container').hide();
+                $('#voucher_form_link').show();
+            },
 
-        function onFail() {
-            var message = gettext('Problem occurred during checkout. Please contact support');
-            $('#messages').html(_s.sprintf('<div class="alert alert-error">%s</div>', message));
-        }
+            onFail: function() {
+                var message = gettext('Problem occurred during checkout. Please contact support.');
+                $('#messages').html(_s.sprintf('<div class="alert alert-error">%s</div>', message));
+            },
 
-        function onSuccess(data) {
-            var $form = $('<form>', {
-                class: 'hidden',
-                action: data.payment_page_url,
-                method: 'POST',
-                'accept-method': 'UTF-8'
-            });
+            onSuccess: function(data) {
+                var $form = $('<form>', {
+                    class: 'hidden',
+                    action: data.payment_page_url,
+                    method: 'POST',
+                    'accept-method': 'UTF-8'
+                });
 
-            _.each(data.payment_form_data, function(value, key) {
-                $('<input>').attr({
-                    type: 'hidden',
-                    name: key,
-                    value: value
-                }).appendTo($form);
-            });
+                _.each(data.payment_form_data, function(value, key) {
+                    $('<input>').attr({
+                        type: 'hidden',
+                        name: key,
+                        value: value
+                    }).appendTo($form);
+                });
 
-            $form.appendTo('body').submit();
-        }
+                $form.appendTo('body').submit();
+            },
 
-        function checkoutPayment(data) {
-            $.ajax({
-                url: '/api/v2/checkout/',
-                method: 'POST',
-                contentType: 'application/json; charset=utf-8',
-                dataType: 'json',
-                headers: {
-                    'X-CSRFToken': Cookies.get('ecommerce_csrftoken')
-                },
-                data: JSON.stringify(data),
-                success: onSuccess,
-                error: onFail
-            });
-        }
+            checkoutPayment: function(data) {
+                $.ajax({
+                    url: '/api/v2/checkout/',
+                    method: 'POST',
+                    contentType: 'application/json; charset=utf-8',
+                    dataType: 'json',
+                    headers: {
+                        'X-CSRFToken': Cookies.get('ecommerce_csrftoken')
+                    },
+                    data: JSON.stringify(data),
+                    success: BasketPage.onSuccess,
+                    error: BasketPage.onFail
+                });
+            },
 
-        function appendCardValidationErrorMsg(event, field, msg) {
-            field.find('~.help-block').append('<span>' + msg + '</span>');
-            field.focus();
-            event.preventDefault();
-            $('.payment-form').attr('data-has-error', true);
-        }
+            appendCardValidationErrorMsg: function(event, field, msg) {
+                event.preventDefault();
+                field.find('~.help-block').append('<span>' + msg + '</span>');
+                field.focus();
+                $('.payment-form').attr('data-has-error', true);
+            },
 
-        function appendCardHolderValidationErrorMsg(field, msg) {
-            field.parentsUntil('form-item').find('~.help-block').append(
-                '<span>' + msg + '</span>'
-            );
-        }
+            appendCardHolderValidationErrorMsg: function(field, msg) {
+                field.parentsUntil('form-item').find('~.help-block').append(
+                    '<span>' + msg + '</span>'
+                );
+            },
 
-        function cardHolderInfoValidation(event) {
-            var requiredFields = [
-                    'input[name=first_name]',
-                    'input[name=last_name]',
-                    'input[name=city]',
-                    'select[name=country]'
-                ],
-                experiments = window.experimentVariables || {};
-            // Only require address and state if we are not in the hide location fields variation of this experiment
-            // https://openedx.atlassian.net/browse/LEARNER-2355
-            if (!(experiments && experiments.hide_location_fields)) {
-                requiredFields.push('input[name=address_line1]');
-                if (['US', 'CA'].indexOf($('select[name=country]').val()) > -1) {
-                    requiredFields.push('select[name=state]');
-                    requiredFields.push('input[name=postal_code]');
+            cardHolderInfoValidation: function(event) {
+                var requiredFields = [
+                        'input[name=first_name]',
+                        'input[name=last_name]',
+                        'input[name=city]',
+                        'select[name=country]'
+                    ],
+                    countriesWithRequiredStateAndPostalCodeValues = ['US', 'CA'],
+                    experiments = window.experimentVariables || {};
+                // Only require address and state if we are not in the hide location fields variation of this experiment
+                // https://openedx.atlassian.net/browse/LEARNER-2355
+                if (!(experiments && experiments.hide_location_fields)) {
+                    requiredFields.push('input[name=address_line1]');
+                    if (countriesWithRequiredStateAndPostalCodeValues.indexOf($('select[name=country]').val()) > -1) {
+                        requiredFields.push('select[name=state]');
+                        requiredFields.push('input[name=postal_code]');
+                    }
                 }
-            }
 
-            _.each(requiredFields, function(field) {
-                if ($(field).val() === '') {
-                    event.preventDefault();
-                    appendCardHolderValidationErrorMsg($(field), gettext('This field is required'));
-                    $('.payment-form').attr('data-has-error', true);
-                }
-            });
+                _.each(requiredFields, function(field) {
+                    if ($(field).val() === '') {
+                        event.preventDefault();
+                        BasketPage.appendCardHolderValidationErrorMsg($(field), gettext('This field is required'));
+                        $('.payment-form').attr('data-has-error', true);
+                    }
+                });
 
-            // Focus the first element that has an error message.
-            $('.help-block > span')
-            .first().parentsUntil('fieldset').last()
-            .find('input')
-            .focus();
-        }
+                // Focus the first element that has an error message.
+                $('.help-block > span')
+                .first().parentsUntil('fieldset').last()
+                .find('input')
+                .focus();
+            },
 
-        function isCardTypeSupported(cardType) {
-            return $.inArray(cardType, ['amex', 'discover', 'mastercard', 'visa']) > -1;
-        }
+            isCardTypeSupported: function(cardType) {
+                return $.inArray(cardType, ['amex', 'discover', 'mastercard', 'visa']) > -1;
+            },
 
-        function cardInfoValidation(event) {
-            var cardType,
-                // We are adding 1 here because month in js style date-time starts with 0
-                // i.e. 0 for JAN, 1 for FEB etc. However, credit card expiry months start with 1
-                // i.e 1 for JAN, 2 for FEB etc.
-                currentMonth = new Date().getMonth() + 1,
-                currentYear = new Date().getFullYear(),
-                $number = $('#card-number'),
-                $cvn = $('#card-cvn'),
-                $expMonth = $('#card-expiry-month'),
-                $expYear = $('#card-expiry-year'),
-                cardNumber = $number.val(),
-                cvnNumber = $cvn.val(),
-                cardExpiryMonth = $expMonth.val(),
-                cardExpiryYear = $expYear.val();
+            cardInfoValidation: function(event) {
+                var cardType,
+                    // We are adding 1 here because month in js style date-time starts with 0
+                    // i.e. 0 for JAN, 1 for FEB etc. However, credit card expiry months start with 1
+                    // i.e 1 for JAN, 2 for FEB etc.
+                    currentMonth = new Date().getMonth() + 1,
+                    currentYear = new Date().getFullYear(),
+                    $number = $('#card-number'),
+                    $cvn = $('#card-cvn'),
+                    $expMonth = $('#card-expiry-month'),
+                    $expYear = $('#card-expiry-year'),
+                    cardNumber = $number.val(),
+                    cvnNumber = $cvn.val(),
+                    cardExpiryMonth = $expMonth.val(),
+                    cardExpiryYear = $expYear.val();
 
-            cardType = CreditCardUtils.getCreditCardType(cardNumber);
-
-            if (!CreditCardUtils.isValidCardNumber(cardNumber)) {
-                appendCardValidationErrorMsg(event, $number, gettext('Invalid card number'));
-            } else if (_.isUndefined(cardType) || !isCardTypeSupported(cardType.name)) {
-                appendCardValidationErrorMsg(event, $number, gettext('Unsupported card type'));
-            } else if (cvnNumber.length !== cardType.cvnLength || !Number.isInteger(Number(cvnNumber))) {
-                appendCardValidationErrorMsg(event, $cvn, gettext('Invalid security number'));
-            }
-
-            if (!Number.isInteger(Number(cardExpiryMonth)) ||
-                Number(cardExpiryMonth) > 12 || Number(cardExpiryMonth) < 1) {
-                appendCardValidationErrorMsg(event, $expMonth, gettext('Invalid month'));
-            } else if (!Number.isInteger(Number(cardExpiryYear)) || Number(cardExpiryYear) < currentYear) {
-                appendCardValidationErrorMsg(event, $expYear, gettext('Invalid year'));
-            } else if (Number(cardExpiryMonth) < currentMonth && Number(cardExpiryYear) === currentYear) {
-                appendCardValidationErrorMsg(event, $expMonth, gettext('Card expired'));
-            }
-        }
-
-        function detectCreditCard() {
-            var card,
-                $input = $('#card-number'),
-                cardNumber = $input.val().replace(/\s+/g, ''),
-                iconPath = '/static/images/credit_cards/';
-
-            if (cardNumber.length > 12) {
-                card = CreditCardUtils.getCreditCardType(cardNumber);
+                cardType = CreditCardUtils.getCreditCardType(cardNumber);
 
                 if (!CreditCardUtils.isValidCardNumber(cardNumber)) {
-                    $('.card-type-icon').attr('src', '').addClass('hidden');
-                    return;
+                    BasketPage.appendCardValidationErrorMsg(event, $number, gettext('Invalid card number'));
+                } else if (_.isUndefined(cardType) || !BasketPage.isCardTypeSupported(cardType.name)) {
+                    BasketPage.appendCardValidationErrorMsg(event, $number, gettext('Unsupported card type'));
+                } else if (cvnNumber.length !== cardType.cvnLength || !Number.isInteger(Number(cvnNumber))) {
+                    BasketPage.appendCardValidationErrorMsg(event, $cvn, gettext('Invalid security number'));
                 }
 
-                if (typeof card !== 'undefined') {
-                    $('.card-type-icon').attr(
-                        'src',
-                        iconPath + card.name + '.png'
-                    ).removeClass('hidden');
-                    $input.trigger('cardType:detected', {type: card.name});
+                if (!Number.isInteger(Number(cardExpiryMonth)) ||
+                    Number(cardExpiryMonth) > 12 || Number(cardExpiryMonth) < 1) {
+                    BasketPage.appendCardValidationErrorMsg(event, $expMonth, gettext('Invalid month'));
+                } else if (!Number.isInteger(Number(cardExpiryYear)) || Number(cardExpiryYear) < currentYear) {
+                    BasketPage.appendCardValidationErrorMsg(event, $expYear, gettext('Invalid year'));
+                } else if (Number(cardExpiryMonth) < currentMonth && Number(cardExpiryYear) === currentYear) {
+                    BasketPage.appendCardValidationErrorMsg(event, $expMonth, gettext('Card expired'));
+                }
+            },
+
+            detectCreditCard: function() {
+                var card,
+                    $input = $('#card-number'),
+                    cardNumber = $input.val().replace(/\s+/g, ''),
+                    iconPath = '/static/images/credit_cards/';
+
+                if (cardNumber.length > 12) {
+                    card = CreditCardUtils.getCreditCardType(cardNumber);
+
+                    if (!CreditCardUtils.isValidCardNumber(cardNumber)) {
+                        $('.card-type-icon').attr('src', '').addClass('hidden');
+                        return;
+                    }
+
+                    if (typeof card !== 'undefined') {
+                        $('.card-type-icon').attr(
+                            'src',
+                            iconPath + card.name + '.png'
+                        ).removeClass('hidden');
+                        $input.trigger('cardType:detected', {type: card.name});
+                    } else {
+                        $('.card-type-icon').attr('src', '').addClass('hidden');
+                    }
                 } else {
                     $('.card-type-icon').attr('src', '').addClass('hidden');
                 }
-            } else {
-                $('.card-type-icon').attr('src', '').addClass('hidden');
-            }
-        }
+            },
 
-        function sdnCheck(event) {
-            var firstName = $('input[name=first_name]').val(),
-                lastName = $('input[name=last_name]').val(),
-                city = $('input[name=city]').val(),
-                country = $('select[name=country]').val();
+            sdnCheck: function(event) {
+                var firstName = $('input[name=first_name]').val(),
+                    lastName = $('input[name=last_name]').val(),
+                    city = $('input[name=city]').val(),
+                    country = $('select[name=country]').val();
 
-            $.ajax({
-                url: '/api/v2/sdn/search/',
-                method: 'POST',
-                contentType: 'application/json; charset=utf-8',
-                dataType: 'json',
-                headers: {
-                    'X-CSRFToken': Cookies.get('ecommerce_csrftoken')
-                },
-                data: JSON.stringify({
-                    name: _s.sprintf('%s %s', firstName, lastName),
-                    city: city,
-                    country: country
-                }),
-                async: false,
-                success: function(data) {
-                    if (data.hits > 0) {
-                        event.preventDefault();
-                        Utils.redirect('/payment/sdn/failure/');
-                    }
-                }
-            });
-        }
-
-        function showVoucherForm() {
-            $('#voucher_form_container').show();
-            $('#voucher_form_link').hide();
-            $('#id_code').focus();
-        }
-
-        function showCvvTooltip() {
-            $('#cvvtooltip').show();
-            $('#card-cvn-help').attr('aria-haspopup', 'false');
-            $('#card-cvn-help').attr('aria-expanded', 'true');
-        }
-
-        function hideCvvTooltip() {
-            $('#cvvtooltip').hide();
-            $('#card-cvn-help').attr('aria-haspopup', 'true');
-            $('#card-cvn-help').attr('aria-expanded', 'false');
-        }
-
-        function toggleCvvTooltip() {
-            var $cvnHelpButton = $('#card-cvn-help');
-            $('#cvvtooltip').toggle();
-            $cvnHelpButton.attr(
-                'aria-haspopup',
-                $cvnHelpButton.attr('aria-haspopup') === 'true' ? 'false' : 'true'
-            );
-            $cvnHelpButton.attr(
-                'aria-expanded',
-                $cvnHelpButton.attr('aria-expanded') === 'true' ? 'false' : 'true'
-            );
-        }
-
-        function onReady() {
-            var $paymentButtons = $('.payment-buttons'),
-                basketId = $paymentButtons.data('basket-id');
-
-            Utils.toogleMobileMenuClickEvent();
-
-            $(document).keyup(function(e) {
-                switch (e.which) {
-                case KeyCodes.Escape:
-                    hideCvvTooltip();
-                    break;
-                case KeyCodes.Tab:
-                    if ($('#card-cvn-help').is(':focus')) {
-                        showCvvTooltip();
-                    }
-                    break;
-                default:
-                    break;
-                }
-            });
-
-            $('#card-cvn-help').on('click touchstart', function(event) {
-                event.preventDefault();
-                toggleCvvTooltip();
-            });
-
-            $('#card-cvn-help').blur(hideCvvTooltip);
-            $('#card-cvn-help').hover(showCvvTooltip, hideCvvTooltip);
-
-            $('#voucher_form_link').on('click', function(event) {
-                event.preventDefault();
-                showVoucherForm();
-            });
-
-            $('#voucher_form_cancel').on('click', function(event) {
-                event.preventDefault();
-                hideVoucherForm();
-            });
-
-            $('select[name=country]').on('change', function() {
-                var country = $('select[name=country]').val(),
-                    $inputDiv = $('#div_id_state .controls'),
-                    states = {
-                        US: {
-                            Alabama: 'AL',
-                            Alaska: 'AK',
-                            American: 'AS',
-                            Arizona: 'AZ',
-                            Arkansas: 'AR',
-                            California: 'CA',
-                            Colorado: 'CO',
-                            Connecticut: 'CT',
-                            Delaware: 'DE',
-                            'Dist. of Columbia': 'DC',
-                            Florida: 'FL',
-                            Georgia: 'GA',
-                            Guam: 'GU',
-                            Hawaii: 'HI',
-                            Idaho: 'ID',
-                            Illinois: 'IL',
-                            Indiana: 'IN',
-                            Iowa: 'IA',
-                            Kansas: 'KS',
-                            Kentucky: 'KY',
-                            Louisiana: 'LA',
-                            Maine: 'ME',
-                            Maryland: 'MD',
-                            'Marshall Islands': 'MH',
-                            Massachusetts: 'MA',
-                            Michigan: 'MI',
-                            Micronesia: 'FM',
-                            Minnesota: 'MN',
-                            Mississippi: 'MS',
-                            Missouri: 'MO',
-                            Montana: 'MT',
-                            Nebraska: 'NE',
-                            Nevada: 'NV',
-                            'New Hampshire': 'NH',
-                            'New Jersey': 'NJ',
-                            'New Mexico': 'NM',
-                            'New York': 'NY',
-                            'North Carolina': 'NC',
-                            'North Dakota': 'ND',
-                            'Northern Marianas': 'MP',
-                            Ohio: 'OH',
-                            Oklahoma: 'OK',
-                            Oregon: 'OR',
-                            Palau: 'PW',
-                            Pennsylvania: 'PA',
-                            'Puerto Rico': 'PR',
-                            'Rhode Island': 'RI',
-                            'South Carolina': 'SC',
-                            'South Dakota': 'SD',
-                            Tennessee: 'TN',
-                            Texas: 'TX',
-                            Utah: 'UT',
-                            Vermont: 'VT',
-                            Virginia: 'VA',
-                            'Virgin Islands': 'VI',
-                            Washington: 'WA',
-                            'West Virginia': 'WV',
-                            Wisconsin: 'WI',
-                            Wyoming: 'WY'
-                        },
-                        CA: {
-                            Alberta: 'AB',
-                            'British Columbia': 'BC',
-                            Manitoba: 'MB',
-                            'New Brunswick': 'NB',
-                            'Newfoundland and Labrador': 'NL',
-                            'Northwest Territories': 'NT',
-                            'Nova Scotia': 'NS',
-                            Nunavut: 'NU',
-                            Ontario: 'ON',
-                            'Prince Edward Island': 'PE',
-                            Quebec: 'QC',
-                            Saskatchewan: 'SK',
-                            Yukon: 'YT'
-                        }
+                $.ajax({
+                    url: '/api/v2/sdn/search/',
+                    method: 'POST',
+                    contentType: 'application/json; charset=utf-8',
+                    dataType: 'json',
+                    headers: {
+                        'X-CSRFToken': Cookies.get('ecommerce_csrftoken')
                     },
-                    experiments = window.experimentVariables || {},
-                    selectorRequired = 'aria-required="true" required',
-                    stateSelector = '<select name="state" class="select form-control" id="id_state"';
+                    data: JSON.stringify({
+                        name: _s.sprintf('%s %s', firstName, lastName),
+                        city: city,
+                        country: country
+                    }),
+                    async: false,
+                    success: function(data) {
+                        if (data.hits > 0) {
+                            event.preventDefault();
+                            Utils.redirect('/payment/sdn/failure/');
+                        }
+                    }
+                });
+            },
 
-                if (country === 'US' || country === 'CA') {
-                    $($inputDiv).empty();
-                    // Only require state if we are not in the hide location fields variation of this experiment
-                    // https://openedx.atlassian.net/browse/LEARNER-2355
-                    stateSelector += !(experiments && experiments.hide_location_fields) ? selectorRequired : '';
-                    stateSelector += '></select>';
-                    $($inputDiv).append(stateSelector);
-                    $('#id_state').append($('<option>', {value: '', text: gettext('<Choose state/province>')}));
-                    $('#div_id_state').find('label').text(gettext('State/Province (required)'));
+            showVoucherForm: function() {
+                $('#voucher_form_container').show();
+                $('#voucher_form_link').hide();
+                $('#id_code').focus();
+            },
 
-                    _.each(states[country], function(value, key) {
-                        $('#id_state').append($('<option>', {value: value, text: key}));
+            showCvvTooltip: function() {
+                $('#cvvtooltip').show();
+                $('#card-cvn-help').attr({
+                    'aria-haspopup': 'false',
+                    'aria-expanded': 'true'
+                });
+            },
+
+            hideCvvTooltip: function() {
+                $('#cvvtooltip').hide();
+                $('#card-cvn-help').attr({
+                    'aria-haspopup': 'true',
+                    'aria-expanded': 'false'
+                });
+            },
+
+            toggleCvvTooltip: function() {
+                var $cvnHelpButton = $('#card-cvn-help');
+                $('#cvvtooltip').toggle();
+                $cvnHelpButton.attr({
+                    'aria-haspopup': $cvnHelpButton.attr('aria-haspopup') === 'true' ? 'false' : 'true',
+                    'aria-expanded': $cvnHelpButton.attr('aria-expanded') === 'true' ? 'false' : 'true'
+                });
+            },
+
+            addPriceDisclaimer: function() {
+                var price = $('#basket-total').find('> .price').text(),
+                    countryData = Cookies.getJSON('edx-price-l10n');
+                if (countryData && countryData.countryCode !== 'USA') {
+                    $('<span>').attr('class', 'price-disclaimer')
+                        .text('* This total contains an approximate conversion. You will be charged ' + price + ' USD.')
+                        .appendTo('div[aria-labelledby="order-details-region"]');
+                }
+            },
+
+            formatToLocalPrice: function(priceInUsd) {
+                var countryData = Cookies.getJSON('edx-price-l10n');
+
+                // Default to USD when the exchange rate cookie doesn't exist
+                if (countryData && countryData.countryCode !== 'USA') {
+                    return countryData.symbol + Math.round(priceInUsd * countryData.rate) + ' '
+                        + countryData.code + ' *';
+                } else {
+                    return '$' + priceInUsd;
+                }
+            },
+
+            generateLocalPriceText: function(usdPriceText) {
+                var localPriceText = usdPriceText;
+                // Matches on all $ab.cd strings
+                usdPriceText.match(/\$[0-9]+\.[0-9]+/g).forEach(function(value) {
+                    localPriceText = localPriceText.replace(value, BasketPage.formatToLocalPrice(value.substring(1)));
+                });
+                return localPriceText;
+            },
+
+            translateElementToLocalPrices: function(element) {
+                var priceText = element.text(),
+                    localPriceText = BasketPage.generateLocalPriceText(priceText);
+                if (priceText !== localPriceText) {
+                    element.text(localPriceText);
+                }
+            },
+
+            translateToLocalPrices: function() {
+                $('.price').each(function() {
+                    BasketPage.translateElementToLocalPrices($(this));
+                });
+
+                $('.voucher').each(function() {
+                    BasketPage.translateElementToLocalPrices($(this));
+                });
+            },
+
+            onReady: function() {
+                var $paymentButtons = $('.payment-buttons'),
+                    basketId = $paymentButtons.data('basket-id');
+
+                BasketPage.addPriceDisclaimer();
+                BasketPage.translateToLocalPrices();
+                Utils.toogleMobileMenuClickEvent();
+
+                $(document).keyup(function(e) {
+                    switch (e.which) {
+                    case KeyCodes.Escape:
+                        BasketPage.hideCvvTooltip();
+                        break;
+                    case KeyCodes.Tab:
+                        if ($('#card-cvn-help').is(':focus')) {
+                            BasketPage.showCvvTooltip();
+                        }
+                        break;
+                    default:
+                        break;
+                    }
+                });
+
+                $('#card-cvn-help').on('click touchstart', function(event) {
+                    event.preventDefault();
+                    BasketPage.toggleCvvTooltip();
+                });
+
+                $('#card-cvn-help').blur(BasketPage.hideCvvTooltip)
+                    .hover(BasketPage.showCvvTooltip, BasketPage.hideCvvTooltip);
+
+                $('#voucher_form_link').on('click', function(event) {
+                    event.preventDefault();
+                    BasketPage.showVoucherForm();
+                });
+
+                $('#voucher_form_cancel').on('click', function(event) {
+                    event.preventDefault();
+                    BasketPage.hideVoucherForm();
+                });
+
+                $('select[name=country]').on('change', function() {
+                    var country = $('select[name=country]').val(),
+                        $inputDiv = $('#div_id_state .controls'),
+                        states = {
+                            US: {
+                                Alabama: 'AL',
+                                Alaska: 'AK',
+                                American: 'AS',
+                                Arizona: 'AZ',
+                                Arkansas: 'AR',
+                                California: 'CA',
+                                Colorado: 'CO',
+                                Connecticut: 'CT',
+                                Delaware: 'DE',
+                                'Dist. of Columbia': 'DC',
+                                Florida: 'FL',
+                                Georgia: 'GA',
+                                Guam: 'GU',
+                                Hawaii: 'HI',
+                                Idaho: 'ID',
+                                Illinois: 'IL',
+                                Indiana: 'IN',
+                                Iowa: 'IA',
+                                Kansas: 'KS',
+                                Kentucky: 'KY',
+                                Louisiana: 'LA',
+                                Maine: 'ME',
+                                Maryland: 'MD',
+                                'Marshall Islands': 'MH',
+                                Massachusetts: 'MA',
+                                Michigan: 'MI',
+                                Micronesia: 'FM',
+                                Minnesota: 'MN',
+                                Mississippi: 'MS',
+                                Missouri: 'MO',
+                                Montana: 'MT',
+                                Nebraska: 'NE',
+                                Nevada: 'NV',
+                                'New Hampshire': 'NH',
+                                'New Jersey': 'NJ',
+                                'New Mexico': 'NM',
+                                'New York': 'NY',
+                                'North Carolina': 'NC',
+                                'North Dakota': 'ND',
+                                'Northern Marianas': 'MP',
+                                Ohio: 'OH',
+                                Oklahoma: 'OK',
+                                Oregon: 'OR',
+                                Palau: 'PW',
+                                Pennsylvania: 'PA',
+                                'Puerto Rico': 'PR',
+                                'Rhode Island': 'RI',
+                                'South Carolina': 'SC',
+                                'South Dakota': 'SD',
+                                Tennessee: 'TN',
+                                Texas: 'TX',
+                                Utah: 'UT',
+                                Vermont: 'VT',
+                                Virginia: 'VA',
+                                'Virgin Islands': 'VI',
+                                Washington: 'WA',
+                                'West Virginia': 'WV',
+                                Wisconsin: 'WI',
+                                Wyoming: 'WY'
+                            },
+                            CA: {
+                                Alberta: 'AB',
+                                'British Columbia': 'BC',
+                                Manitoba: 'MB',
+                                'New Brunswick': 'NB',
+                                'Newfoundland and Labrador': 'NL',
+                                'Northwest Territories': 'NT',
+                                'Nova Scotia': 'NS',
+                                Nunavut: 'NU',
+                                Ontario: 'ON',
+                                'Prince Edward Island': 'PE',
+                                Quebec: 'QC',
+                                Saskatchewan: 'SK',
+                                Yukon: 'YT'
+                            }
+                        },
+                        experiments = window.experimentVariables || {},
+                        selectorRequired = 'aria-required="true" required',
+                        stateSelector = '<select name="state" class="select form-control" id="id_state"';
+
+                    if (country === 'US' || country === 'CA') {
+                        $($inputDiv).empty();
+                        // Only require state if we are not in the hide location fields variation of this experiment
+                        // https://openedx.atlassian.net/browse/LEARNER-2355
+                        stateSelector += !(experiments && experiments.hide_location_fields) ? selectorRequired : '';
+                        stateSelector += '></select>';
+                        $($inputDiv).append(stateSelector);
+                        $('#id_state').append($('<option>', {value: '', text: gettext('<Choose state/province>')}));
+                        $('#div_id_state').find('label').text(gettext('State/Province (required)'));
+
+                        _.each(states[country], function(value, key) {
+                            $('#id_state').append($('<option>', {value: value, text: key}));
+                        });
+                    } else {
+                        $($inputDiv).empty();
+                        $('#div_id_state').find('label').text('State/Province');
+                        // In order to change the maxlength attribute, the same needs to be changed in the Django form.
+                        $($inputDiv).append(
+                            '<input class="textinput textInput form-control" id="id_state"' +
+                            'maxlength="60" name="state" type="text">'
+                        );
+                    }
+                });
+
+                $('#card-number').on('input', function() {
+                    BasketPage.detectCreditCard();
+                });
+
+                $('#payment-button').click(function(e) {
+                    _.each($('.help-block'), function(errorMsg) {
+                        $(errorMsg).empty();  // Clear existing validation error messages.
                     });
-                } else {
-                    $($inputDiv).empty();
-                    $('#div_id_state').find('label').text('State/Province');
-                    // In order to change the maxlength attribute, the same needs to be changed in the Django form.
-                    $($inputDiv).append(
-                        '<input class="textinput textInput form-control" id="id_state"' +
-                        'maxlength="60" name="state" type="text">'
-                    );
-                }
-            });
-
-            $('#card-number').on('input', function() {
-                detectCreditCard();
-            });
-
-            $('#payment-button').click(function(e) {
-                _.each($('.help-block'), function(errorMsg) {
-                    $(errorMsg).empty();  // Clear existing validation error messages.
+                    $('.payment-form').attr('data-has-error', false);
+                    if ($('#card-number').val()) {
+                        BasketPage.detectCreditCard();
+                    }
+                    BasketPage.cardInfoValidation(e);
+                    BasketPage.cardHolderInfoValidation(e);
+                    if ($('input[name=sdn-check]').val() === 'enabled' && !$('.payment-form').data('has-error')) {
+                        BasketPage.sdnCheck(e);
+                    }
                 });
-                $('.payment-form').attr('data-has-error', false);
-                if ($('#card-number').val()) {
-                    detectCreditCard();
-                }
-                cardInfoValidation(e);
-                cardHolderInfoValidation(e);
-                if ($('input[name=sdn-check]').val() === 'enabled' && !$('.payment-form').data('has-error')) {
-                    sdnCheck(e);
-                }
-            });
 
-            // NOTE: We only include buttons that have a data-processor-name attribute because we don't want to
-            // go through the standard checkout process for some payment methods (e.g. Apple Pay).
-            $paymentButtons.find('.payment-button[data-processor-name]').click(function(e) {
-                var $btn = $(e.target),
-                    deferred = new $.Deferred(),
-                    promise = deferred.promise(),
-                    paymentProcessor = $btn.data('processor-name'),
-                    data = {
-                        basket_id: basketId,
-                        payment_processor: paymentProcessor
-                    };
+                // NOTE: We only include buttons that have a data-processor-name attribute because we don't want to
+                // go through the standard checkout process for some payment methods (e.g. Apple Pay).
+                $paymentButtons.find('.payment-button[data-processor-name]').click(function(e) {
+                    var $btn = $(e.target),
+                        deferred = new $.Deferred(),
+                        promise = deferred.promise(),
+                        paymentProcessor = $btn.data('processor-name'),
+                        data = {
+                            basket_id: basketId,
+                            payment_processor: paymentProcessor
+                        };
 
-                Utils.disableElementWhileRunning($btn, function() {
-                    return promise;
+                    Utils.disableElementWhileRunning($btn, function() {
+                        return promise;
+                    });
+                    BasketPage.checkoutPayment(data);
                 });
-                checkoutPayment(data);
-            });
 
-            // Increment the quantity field until max
-            $('.spinner .btn:first-of-type').on('click', function() {
-                var $btn = $(this),
-                    input = $btn.closest('.spinner').find('input'),
-                    max = input.attr('max');
+                // Increment the quantity field until max
+                $('.spinner .btn:first-of-type').on('click', function() {
+                    var $btn = $(this),
+                        input = $btn.closest('.spinner').find('input'),
+                        max = input.attr('max');
 
-                // Stop if max attribute is defined and value is reached to given max value
-                if (_.isUndefined(max) || parseInt(input.val(), 10) < parseInt(max, 10)) {
-                    input.val(parseInt(input.val(), 10) + 1);
-                } else {
-                    $btn.next('disabled', true);
-                }
-            });
+                    // Stop if max attribute is defined and value is reached to given max value
+                    if (_.isUndefined(max) || parseInt(input.val(), 10) < parseInt(max, 10)) {
+                        input.val(parseInt(input.val(), 10) + 1);
+                    } else {
+                        $btn.next('disabled', true);
+                    }
+                });
 
-            // Decrement the quantity field until min
-            $('.spinner .btn:last-of-type').on('click', function() {
-                var $btn = $(this),
-                    input = $btn.closest('.spinner').find('input'),
-                    min = input.attr('min');
+                // Decrement the quantity field until min
+                $('.spinner .btn:last-of-type').on('click', function() {
+                    var $btn = $(this),
+                        input = $btn.closest('.spinner').find('input'),
+                        min = input.attr('min');
 
-                // Stop if min attribute is defined and value is reached to given min value
-                if (_.isUndefined(min) || parseInt(input.val(), 10) > parseInt(min, 10)) {
-                    input.val(parseInt(input.val(), 10) - 1);
-                } else {
-                    $btn.prev('disabled', true);
-                }
-            });
-        }
-
-        return {
-            appendCardHolderValidationErrorMsg: appendCardHolderValidationErrorMsg,
-            cardInfoValidation: cardInfoValidation,
-            checkoutPayment: checkoutPayment,
-            hideCvvTooltip: hideCvvTooltip,
-            hideVoucherForm: hideVoucherForm,
-            isCardTypeSupported: isCardTypeSupported,
-            onFail: onFail,
-            onReady: onReady,
-            onSuccess: onSuccess,
-            sdnCheck: sdnCheck,
-            showCvvTooltip: showCvvTooltip,
-            showVoucherForm: showVoucherForm,
-            toggleCvvTooltip: toggleCvvTooltip
+                    // Stop if min attribute is defined and value is reached to given min value
+                    if (_.isUndefined(min) || parseInt(input.val(), 10) > parseInt(min, 10)) {
+                        input.val(parseInt(input.val(), 10) - 1);
+                    } else {
+                        $btn.prev('disabled', true);
+                    }
+                });
+            }
         };
+
+        return BasketPage;
     }
 );

--- a/ecommerce/static/js/test/fixtures/basket.html
+++ b/ecommerce/static/js/test/fixtures/basket.html
@@ -1,3 +1,29 @@
+<div id="line-price" class="amount row">
+    <span class="price">$123.45</span>
+</div>
+
+<div id="line-discount" class="amount row">
+  <span class="price">$56.78</span>
+</div>
+
+<div id="basket-total" class="row">
+    <span class="price">$9.10</span>
+</div>
+
+<div id="voucher-1" class="amount row">
+    <span class="voucher">$123.45</span>
+</div>
+
+<div id="voucher-2" class="amount row">
+  <span class="voucher">$56.78</span>
+</div>
+
+<div id="voucher-3" class="row">
+    <span class="voucher">$9.10</span>
+</div>
+
+<div aria-labelledby="order-details-region"></div>
+
 <div class="spinner">
   <input class="quantity" id="id_form-0-quantity" min="1" max="10" name="form-0-quantity" type="number" value="1">
 

--- a/ecommerce/static/js/test/specs/pages/basket_page_spec.js
+++ b/ecommerce/static/js/test/specs/pages/basket_page_spec.js
@@ -492,7 +492,7 @@ define([
                     $errorMessagesDiv = $('#messages');
                     BasketPage.onFail();
                     expect($errorMessagesDiv.text()).toEqual(
-                        'Problem occurred during checkout. Please contact support'
+                        'Problem occurred during checkout. Please contact support.'
                     );
                 });
             });
@@ -552,6 +552,124 @@ define([
                         .appendTo('body');
                     AnalyticsUtils.analyticsSetUp();
                     expect(window.analytics.page).toHaveBeenCalled();
+                });
+            });
+
+            describe('formatToLocalPrice', function() {
+                var EDX_PRICE_LOCATION_COOKIE_NAME = 'edx-price-l10n',
+                    USD_VALUE = 100.25,
+                    EXPECTED_USD_PRICE = '$100.25',
+                    COOKIE_VALUES = {countryCode: 'FOO', rate: 2, code: 'BAR', symbol: 'BAZ'};
+
+                beforeEach(function() {
+                    Cookies.remove(EDX_PRICE_LOCATION_COOKIE_NAME);
+                });
+
+                afterAll(function() {
+                    Cookies.remove(EDX_PRICE_LOCATION_COOKIE_NAME);
+                });
+
+                it('should return USD price when cookie does not exist', function() {
+                    expect(BasketPage.formatToLocalPrice(USD_VALUE)).toEqual(EXPECTED_USD_PRICE);
+                });
+
+                it('should return USD price when country code is USA', function() {
+                    Cookies.set(EDX_PRICE_LOCATION_COOKIE_NAME, {countryCode: 'USA'});
+                    expect(BasketPage.formatToLocalPrice(USD_VALUE)).toEqual(EXPECTED_USD_PRICE);
+                });
+
+                it('should return formatted USD when non-US cookie exists', function() {
+                    Cookies.set(EDX_PRICE_LOCATION_COOKIE_NAME, COOKIE_VALUES);
+                    expect(BasketPage.formatToLocalPrice(USD_VALUE)).toEqual('BAZ201 BAR *');
+                });
+            });
+
+            describe('generateLocalPriceText', function() {
+                it('should replace USD values', function() {
+                    spyOn(BasketPage, 'formatToLocalPrice').and.returnValue('foo');
+                    expect('Replace foo and foo with foo')
+                        .toEqual(BasketPage.generateLocalPriceText('Replace $12.34 and $56.78 with foo'));
+                    expect(BasketPage.formatToLocalPrice).toHaveBeenCalledWith('12.34');
+                    expect(BasketPage.formatToLocalPrice).toHaveBeenCalledWith('56.78');
+                });
+            });
+
+            describe('translateElementToLocalPrices', function() {
+                it('should replace price when local price text does not match price text', function() {
+                    var $element = $('<div />');
+                    spyOn(BasketPage, 'generateLocalPriceText').and.callFake(function(priceText) {
+                        return 'localprice' + priceText;
+                    });
+                    spyOn($element, 'text').and.returnValue('foobar');
+
+                    BasketPage.translateElementToLocalPrices($element);
+
+                    expect($element.text.calls.count()).toEqual(2);
+                    expect($element.text).toHaveBeenCalledWith('localpricefoobar');
+                });
+
+                it('should replace not replace price when local price text matches', function() {
+                    var $element = $('<div />'),
+                        priceText = 'someprice';
+                    spyOn(BasketPage, 'generateLocalPriceText').and.returnValue(priceText);
+                    spyOn($element, 'text').and.returnValue(priceText);
+
+                    BasketPage.translateElementToLocalPrices($element);
+
+                    expect($element.text.calls.count()).toEqual(1);
+                    expect($element.text).not.toHaveBeenCalledWith(priceText);
+                });
+            });
+
+            describe('translateToLocalPrices', function() {
+                it('should replace prices', function() {
+                    spyOn(BasketPage, 'translateElementToLocalPrices');
+
+                    BasketPage.translateToLocalPrices();
+
+                    // 3 .price elements + 3 .voucher elements
+                    expect(BasketPage.translateElementToLocalPrices.calls.count()).toEqual(6);
+
+                    // check to make sure the method was called
+                    $('.price').each(function() {
+                        expect(BasketPage.translateElementToLocalPrices).toHaveBeenCalledWith($(this));
+                    });
+                    $('.voucher').each(function() {
+                        expect(BasketPage.translateElementToLocalPrices).toHaveBeenCalledWith($(this));
+                    });
+                });
+            });
+
+            describe('addPriceDisclaimer', function() {
+                var EDX_PRICE_LOCATION_COOKIE_NAME = 'edx-price-l10n';
+                var COOKIE_VALUES = {countryCode: 'FOO', rate: 2, code: 'BAR', symbol: 'BAZ'};
+
+                beforeEach(function() {
+                    Cookies.remove(EDX_PRICE_LOCATION_COOKIE_NAME);
+                });
+
+                afterAll(function() {
+                    Cookies.remove(EDX_PRICE_LOCATION_COOKIE_NAME);
+                });
+
+                it('should not add disclaimer when cookie does not exist', function() {
+                    BasketPage.addPriceDisclaimer();
+                    expect(0).toEqual($('.price-disclaimer').length);
+                });
+
+                it('should return USD price when country code is USA', function() {
+                    Cookies.set(EDX_PRICE_LOCATION_COOKIE_NAME, {countryCode: 'USA'});
+                    BasketPage.addPriceDisclaimer();
+                    expect($('.price-disclaimer').length).toEqual(0);
+                });
+
+                it('should return formatted USD when non-US cookie exists', function() {
+                    Cookies.set(EDX_PRICE_LOCATION_COOKIE_NAME, COOKIE_VALUES);
+                    BasketPage.addPriceDisclaimer();
+
+                    // eslint-disable-next-line max-len
+                    expect('* This total contains an approximate conversion. You will be charged $9.10 USD.')
+                        .toEqual($('.price-disclaimer').text());
                 });
             });
         });

--- a/ecommerce/static/sass/partials/views/_basket.scss
+++ b/ecommerce/static/sass/partials/views/_basket.scss
@@ -598,6 +598,10 @@
             #order-details {
                 margin: 50px 0;
             }
+
+            .price-disclaimer {
+                font-style: italic;
+            }
         }
     }
 }


### PR DESCRIPTION
## Purpose

[JIRA](https://openedx.atlassian.net/browse/LEARNER-2413)

Translate basket prices into local currency. Local currency is defined by information stored in the `edx-price-l10n` cookie, which should be set beforehand.

cc: @MatthewPiatetsky @AlasdairSwan @mikedikan 

## Example

### Before
![image](https://user-images.githubusercontent.com/8136030/31198962-ffe422de-a923-11e7-9b7a-cf5024e64d14.png)

### No Cookie
![image](https://user-images.githubusercontent.com/8136030/31199271-d65bde42-a924-11e7-999e-1e5c02315851.png)

### With Cookie (But `USA` Country Code)
![image](https://user-images.githubusercontent.com/8136030/31199226-b5b6cfbc-a924-11e7-9b1a-5380586db32d.png)

### Cookie With Chinese Yen Values
![image](https://user-images.githubusercontent.com/8136030/31199344-17d8afc6-a925-11e7-937d-f7e369c747af.png)

## To Do
- [x] Check what happens when coupon is added
- [x] Update spec
- [x] Check about warning text on conversion accuracy
- [x] Squash commits

