### PR TITLE
LEARNER-2714 Fix for cat not saving credit hours.

### DIFF
--- a/ecommerce/courses/models.py
+++ b/ecommerce/courses/models.py
@@ -225,6 +225,8 @@ class Course(models.Model):
         seat.title = self.get_course_seat_name(certificate_type, id_verification_required)
         seat.expires = expires
 
+        seat.save()
+
         # If a ProductAttribute is saved with a value of None or the empty string, the ProductAttribute is deleted.
         # As a consequence, Seats derived from a migrated "audit" mode do not have a certificate_type attribute.
         seat.attr.certificate_type = certificate_type
@@ -241,7 +243,7 @@ class Course(models.Model):
         if credit_hours:
             seat.attr.credit_hours = credit_hours
 
-        seat.save()
+        seat.attr.save()
 
         try:
             stock_record = StockRecord.objects.get(product=seat, partner=partner)

--- a/ecommerce/courses/tests/test_models.py
+++ b/ecommerce/courses/tests/test_models.py
@@ -189,6 +189,44 @@ class CourseTests(DiscoveryTestMixin, TestCase):
         # Expected seat total, with one being the parent seat product.
         self.assertEqual(course.products.count(), len(credit_data) + 1)
 
+    def test_update_credit_seat(self):
+        """
+        Tests that model's seat update method updates the seat and attribute values
+        """
+        course = CourseFactory()
+        credit_provider = 'MIT'
+        credit_hours = 2
+        certificate_type = 'credit'
+        id_verification_required = True
+        price = 10
+        course.create_or_update_seat(
+            certificate_type,
+            id_verification_required,
+            price,
+            self.partner,
+            credit_provider=credit_provider,
+            credit_hours=credit_hours
+        )
+        credit_hours = 4
+        price = 100
+        credit_seat = course.create_or_update_seat(
+            certificate_type,
+            id_verification_required,
+            price,
+            self.partner,
+            credit_provider=credit_provider,
+            credit_hours=credit_hours
+        )
+        self.assert_course_seat_valid(
+            credit_seat,
+            course,
+            certificate_type,
+            id_verification_required,
+            price,
+            credit_provider=credit_provider,
+            credit_hours=credit_hours
+        )
+
     def test_collision_avoidance(self):
         """
         Sanity check verifying that course IDs which produced collisions due to a


### PR DESCRIPTION
[LEARNER-2714](https://openedx.atlassian.net/browse/LEARNER-2714):

**Current behavior**
When I attempt to edit the 'credit hours' field in the CAT/Ecomm instance for course run course run ASUx+CHM114x+2184C, the page won't save the change.

**Steps to reproduce**
Navigate to the CAT/Ecomm instance for course run ASUx+CHM114x+2184C (https://ecommerce.edx.org/courses/course-v1:ASUx+CHM114x+2184C).
Edit the page
Set the 'credit hours' field for course as '4' (currently has a value of '3')
Save the page

**Scope & Impact**
The current value of '3' misleads learners who are paying to convert this course to university credit.
Screenshots attached.
