### PR TITLE
[ENT-720] Fix error when trying to apply a voucher.

### DIFF
--- a/ecommerce/extensions/basket/tests/test_views.py
+++ b/ecommerce/extensions/basket/tests/test_views.py
@@ -769,12 +769,14 @@ class VoucherAddViewTests(LmsApiMockMixin, TestCase):
 
     def test_no_voucher_error_msg(self):
         """ Verify correct error message is returned when voucher can't be found. """
+        self.basket.add_product(ProductFactory())
         self.assert_form_valid_message("Coupon code '{code}' does not exist.".format(code=COUPON_CODE))
 
     def test_voucher_already_in_basket_error_msg(self):
         """ Verify correct error message is returned when voucher already in basket. """
-        voucher = factories.VoucherFactory(code=COUPON_CODE)
+        voucher, product = prepare_voucher(code=COUPON_CODE)
         self.basket.vouchers.add(voucher)
+        self.basket.add_product(product)
         self.assert_form_valid_message(
             "You have already added coupon code '{code}' to your basket.".format(code=COUPON_CODE))
 

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -464,7 +464,7 @@ class VoucherAddView(BaseVoucherAddView):  # pylint: disable=function-redefined
 
     def form_valid(self, form):
         code = form.cleaned_data['code']
-        if not self.request.basket.id:
+        if self.request.basket.is_empty:
             return redirect_to_referrer(self.request, 'basket:summary')
         if self.request.basket.contains_voucher(code):
             messages.error(


### PR DESCRIPTION
Without this, there are cases where people try to apply a coupon on the basket page and because there are no lines in the basket, they get an error since some code assumes there's always at least one line. So we just ensure lines exist in the basket before accessing them.

**JIRA tickets**: [ENT-720](https://openedx.atlassian.net/browse/ENT-720)

**Merge deadline**: End of sprint.

**Testing instructions**:

I don't know how to get into a situation where the basket has no lines when trying to apply the coupon -- sorry, just lack of eCommerce knowledge here :\ Tried looking but couldn't figure it out. @douglashall ?
