### PR TITLE
Price value prefix checking

### DIFF
--- a/ecommerce/static/js/test/specs/pages/basket_page_spec.js
+++ b/ecommerce/static/js/test/specs/pages/basket_page_spec.js
@@ -617,10 +617,23 @@ define([
             describe('generateLocalPriceText', function() {
                 it('should replace USD values', function() {
                     spyOn(BasketPage, 'formatToLocalPrice').and.returnValue('foo');
-                    expect('Replace foo and foo with foo')
-                        .toEqual(BasketPage.generateLocalPriceText('Replace $12.34 and $56.78 with foo'));
+                    expect('foo')
+                        .toEqual(BasketPage.generateLocalPriceText('USD12.34'));
                     expect(BasketPage.formatToLocalPrice).toHaveBeenCalledWith('12.34');
-                    expect(BasketPage.formatToLocalPrice).toHaveBeenCalledWith('56.78');
+                });
+
+                it('should replace $ values', function() {
+                    spyOn(BasketPage, 'formatToLocalPrice').and.returnValue('foo');
+                    expect('foo')
+                        .toEqual(BasketPage.generateLocalPriceText('$12.34'));
+                    expect(BasketPage.formatToLocalPrice).toHaveBeenCalledWith('12.34');
+                });
+
+                it('should replace negative values', function() {
+                    spyOn(BasketPage, 'formatToLocalPrice').and.returnValue('foo');
+                    expect('foo')
+                        .toEqual(BasketPage.generateLocalPriceText('-$12.34'));
+                    expect(BasketPage.formatToLocalPrice).toHaveBeenCalledWith('-12.34');
                 });
 
                 it('should not replace text without USD values', function() {


### PR DESCRIPTION
# Introduction

When attempting local currency translation we look at the value of all HTML elements where the class name is `.price` or `.voucher`. However, not all values start with `$` - when the local language selection is Spanish the prefix is `USD`

<img width="1589" alt="spanish" src="https://user-images.githubusercontent.com/8136030/32001297-5ec2ca8c-b967-11e7-89ae-8f2c65669913.png">

# Discussion

The initial idea was to add a data attribute in the [client side checkout basket HTML template](https://github.com/edx/ecommerce/blob/master/ecommerce/templates/oscar/basket/partials/client_side_checkout_basket.html#L48), however, it turns out when you do that, the `basket.total_incl_tax_excl_discounts` value is locale formatted.

<img width="1913" alt="spanish_locale_format" src="https://user-images.githubusercontent.com/8136030/32001416-bf9e6c76-b967-11e7-888e-445c38592ecc.png">

## Price Formatting When the Selected Language Is...

### Spanish (`es-419`)

<img width="1589" alt="spanish" src="https://user-images.githubusercontent.com/8136030/32001528-10d24130-b968-11e7-98d7-1557594fadd6.png">

### Arabic (`ar`)

<img width="1919" alt="arabic" src="https://user-images.githubusercontent.com/8136030/32001543-172e5f5a-b968-11e7-9e30-f5549c45d149.png">

### French (`fr`)

<img width="944" alt="french" src="https://user-images.githubusercontent.com/8136030/32001567-1ef2b5ce-b968-11e7-9a33-51c571591938.png">

### Simplified Chinese (`zh-cn`)

<img width="1916" alt="chinese" src="https://user-images.githubusercontent.com/8136030/32001573-28e7206a-b968-11e7-901b-cfecb701b1f1.png">

Since it seems there are currently only two variants for price formatting (`$` prefixed and `USD` prefixed) for all our language options, modify the existing currency conversion logic to take into account these prefixes, and if either of these prefixes don't exist, fallback to the existing value.

![image](https://user-images.githubusercontent.com/8136030/32014407-0299b854-b98c-11e7-9a5e-cc4308f372bf.png)
