### PR TITLE
Default to local price prefix instead of $

### DIFF
--- a/ecommerce/static/js/pages/basket_page.js
+++ b/ecommerce/static/js/pages/basket_page.js
@@ -256,7 +256,7 @@ define([
                 }
             },
 
-            formatToLocalPrice: function(priceInUsd) {
+            formatToLocalPrice: function(prefix, priceInUsd) {
                 var countryData = Cookies.getJSON('edx-price-l10n');
 
                 // Default to USD when the exchange rate cookie doesn't exist
@@ -264,7 +264,7 @@ define([
                     return countryData.symbol + Math.round(priceInUsd * countryData.rate) + ' '
                         + countryData.code + ' *';
                 } else {
-                    return '$' + priceInUsd;
+                    return prefix + priceInUsd;
                 }
             },
 
@@ -285,7 +285,7 @@ define([
 
                     if ($.isNumeric(priceValue)) {
                         localPriceText = localPriceText
-                            .replace(entireMatch, BasketPage.formatToLocalPrice(priceValue));
+                            .replace(entireMatch, BasketPage.formatToLocalPrice(groupMatch, priceValue));
                     }
                 }
 

--- a/ecommerce/static/js/test/specs/pages/basket_page_spec.js
+++ b/ecommerce/static/js/test/specs/pages/basket_page_spec.js
@@ -588,7 +588,8 @@ define([
             describe('formatToLocalPrice', function() {
                 var EDX_PRICE_LOCATION_COOKIE_NAME = 'edx-price-l10n',
                     USD_VALUE = 100.25,
-                    EXPECTED_USD_PRICE = '$100.25',
+                    PREFIX = 'PREFIX',
+                    EXPECTED_USD_PRICE = '100.25',
                     COOKIE_VALUES = {countryCode: 'FOO', rate: 2, code: 'BAR', symbol: 'BAZ'};
 
                 beforeEach(function() {
@@ -599,41 +600,38 @@ define([
                     Cookies.remove(EDX_PRICE_LOCATION_COOKIE_NAME);
                 });
 
-                it('should return USD price when cookie does not exist', function() {
-                    expect(BasketPage.formatToLocalPrice(USD_VALUE)).toEqual(EXPECTED_USD_PRICE);
+                it('should return prefixed price when cookie does not exist', function() {
+                    expect(BasketPage.formatToLocalPrice(PREFIX, USD_VALUE)).toEqual(PREFIX + EXPECTED_USD_PRICE);
                 });
 
-                it('should return USD price when country code is USA', function() {
+                it('should return prefixed price when country code is USA', function() {
                     Cookies.set(EDX_PRICE_LOCATION_COOKIE_NAME, {countryCode: 'USA'});
-                    expect(BasketPage.formatToLocalPrice(USD_VALUE)).toEqual(EXPECTED_USD_PRICE);
+                    expect(BasketPage.formatToLocalPrice(PREFIX, USD_VALUE)).toEqual(PREFIX + EXPECTED_USD_PRICE);
                 });
 
-                it('should return formatted USD when non-US cookie exists', function() {
+                it('should return formatted local price value when non-US cookie exists', function() {
                     Cookies.set(EDX_PRICE_LOCATION_COOKIE_NAME, COOKIE_VALUES);
-                    expect(BasketPage.formatToLocalPrice(USD_VALUE)).toEqual('BAZ201 BAR *');
+                    expect(BasketPage.formatToLocalPrice(PREFIX, USD_VALUE)).toEqual('BAZ201 BAR *');
                 });
             });
 
             describe('generateLocalPriceText', function() {
                 it('should replace USD values', function() {
                     spyOn(BasketPage, 'formatToLocalPrice').and.returnValue('foo');
-                    expect('foo')
-                        .toEqual(BasketPage.generateLocalPriceText('USD12.34'));
-                    expect(BasketPage.formatToLocalPrice).toHaveBeenCalledWith('12.34');
+                    expect('foo').toEqual(BasketPage.generateLocalPriceText('USD12.34'));
+                    expect(BasketPage.formatToLocalPrice).toHaveBeenCalledWith('USD', '12.34');
                 });
 
                 it('should replace $ values', function() {
                     spyOn(BasketPage, 'formatToLocalPrice').and.returnValue('foo');
-                    expect('foo')
-                        .toEqual(BasketPage.generateLocalPriceText('$12.34'));
-                    expect(BasketPage.formatToLocalPrice).toHaveBeenCalledWith('12.34');
+                    expect('foo').toEqual(BasketPage.generateLocalPriceText('$12.34'));
+                    expect(BasketPage.formatToLocalPrice).toHaveBeenCalledWith('$', '12.34');
                 });
 
                 it('should replace negative values', function() {
                     spyOn(BasketPage, 'formatToLocalPrice').and.returnValue('foo');
-                    expect('-foo')
-                        .toEqual(BasketPage.generateLocalPriceText('-$12.34'));
-                    expect(BasketPage.formatToLocalPrice).toHaveBeenCalledWith('12.34');
+                    expect('-foo').toEqual(BasketPage.generateLocalPriceText('-$12.34'));
+                    expect(BasketPage.formatToLocalPrice).toHaveBeenCalledWith('$', '12.34');
                 });
 
                 it('should not replace text without USD values', function() {


### PR DESCRIPTION
When a price has insufficient information to be currency converted (invalid currency cookie, for example) return the price value with a `$` prefix. However, for `es-419` users, the prefix for US dollars is `USD`.