### PR TITLE
Updated Travis to build an image for testing

### DIFF
--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -1,0 +1,7 @@
+FROM edxops/ecommerce:latest
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        firefox \
+        xvfb \
+    && rm -rf /var/lib/apt/lists/*

--- a/.travis/docker-compose-travis.yml
+++ b/.travis/docker-compose-travis.yml
@@ -13,8 +13,9 @@ services:
       MYSQL_PASSWORD: "password"
       MYSQL_DATABASE: "ecommerce"
   ecommerce:
-    image: edxops/ecommerce:latest
+    image: edxops/ecommerce:test
     container_name: ecommerce_testing
+    build: .
     volumes:
       - ..:/edx/app/ecommerce/ecommerce
       - $HOME/.cache/pip:/edx/app/ecommerce/.cache/pip


### PR DESCRIPTION
Previously we relied on the firefox and xvfb packages living in our images. This is no longer the case as these packages are not needed for production-like environments. We now create a new image, with the "test" tag, that includes these packages.

LEARNER-818