### PR TITLE
ENT-734 Add ability to apply a voucher to a basket with an Enterprise Offer.

### DIFF
--- a/ecommerce/enterprise/forms.py
+++ b/ecommerce/enterprise/forms.py
@@ -8,6 +8,7 @@ from oscar.core.loading import get_model
 from ecommerce.enterprise.conditions import EnterpriseCustomerCondition
 from ecommerce.enterprise.constants import BENEFIT_MAP, BENEFIT_TYPE_CHOICES
 from ecommerce.enterprise.utils import get_enterprise_customer
+from ecommerce.extensions.offer.models import OFFER_PRIORITY_ENTERPRISE
 from ecommerce.programs.custom import class_path, create_condition
 
 Benefit = get_model('offer', 'Benefit')
@@ -101,7 +102,7 @@ class EnterpriseOfferForm(forms.ModelForm):
         self.instance.offer_type = ConditionalOffer.SITE
         self.instance.max_basket_applications = 1
         self.instance.site = site
-        self.instance.priority = 10  # This will ensure that Enterprise Offers are applied before Program Offers.
+        self.instance.priority = OFFER_PRIORITY_ENTERPRISE
 
         if commit:
             benefit = getattr(self.instance, 'benefit', Benefit())

--- a/ecommerce/enterprise/tests/test_forms.py
+++ b/ecommerce/enterprise/tests/test_forms.py
@@ -7,6 +7,7 @@ from oscar.core.loading import get_model
 from ecommerce.enterprise.constants import BENEFIT_MAP
 from ecommerce.enterprise.forms import EnterpriseOfferForm
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
+from ecommerce.extensions.offer.models import OFFER_PRIORITY_ENTERPRISE
 from ecommerce.extensions.test import factories
 from ecommerce.programs.custom import class_path
 from ecommerce.tests.testcases import TestCase
@@ -36,6 +37,7 @@ class EnterpriseOfferFormTests(EnterpriseServiceMockMixin, TestCase):
         self.assertEqual(offer.status, ConditionalOffer.OPEN)
         self.assertEqual(offer.max_basket_applications, 1)
         self.assertEqual(offer.site, self.site)
+        self.assertEqual(offer.priority, OFFER_PRIORITY_ENTERPRISE)
         self.assertEqual(offer.condition.enterprise_customer_uuid, enterprise_customer_uuid)
         self.assertEqual(offer.condition.enterprise_customer_name, enterprise_customer_name)
         self.assertEqual(offer.condition.enterprise_customer_catalog_uuid, enterprise_customer_catalog_uuid)

--- a/ecommerce/extensions/offer/models.py
+++ b/ecommerce/extensions/offer/models.py
@@ -19,6 +19,10 @@ from threadlocals.threadlocals import get_current_request
 from ecommerce.core.utils import get_cache_key, log_message_and_raise_validation_error
 
 
+OFFER_PRIORITY_ENTERPRISE = 10
+OFFER_PRIORITY_VOUCHER = 20
+
+
 class Benefit(AbstractBenefit):
     def save(self, *args, **kwargs):
         self.clean()

--- a/ecommerce/extensions/test/factories.py
+++ b/ecommerce/extensions/test/factories.py
@@ -9,6 +9,7 @@ from oscar.test.factories import *  # pylint:disable=wildcard-import,unused-wild
 
 from ecommerce.enterprise.benefits import EnterpriseAbsoluteDiscountBenefit, EnterprisePercentageDiscountBenefit
 from ecommerce.enterprise.conditions import EnterpriseCustomerCondition
+from ecommerce.extensions.offer.models import OFFER_PRIORITY_VOUCHER
 from ecommerce.programs.benefits import AbsoluteDiscountBenefitWithoutRange, PercentageDiscountBenefitWithoutRange
 from ecommerce.programs.conditions import ProgramCourseRunSeatsCondition
 from ecommerce.programs.custom import class_path
@@ -104,7 +105,8 @@ def prepare_voucher(code='COUPONTEST', _range=None, start_datetime=None, end_dat
             benefit=benefit,
             condition=condition,
             max_global_applications=max_usage,
-            email_domains=email_domains
+            email_domains=email_domains,
+            priority=OFFER_PRIORITY_VOUCHER
         )
     else:
         offer = ConditionalOfferFactory(
@@ -112,7 +114,8 @@ def prepare_voucher(code='COUPONTEST', _range=None, start_datetime=None, end_dat
             benefit=benefit,
             condition=condition,
             email_domains=email_domains,
-            site=site
+            site=site,
+            priority=OFFER_PRIORITY_VOUCHER
         )
     voucher.offers.add(offer)
     return voucher, product

--- a/ecommerce/extensions/voucher/tests/test_utils.py
+++ b/ecommerce/extensions/voucher/tests/test_utils.py
@@ -20,6 +20,7 @@ from ecommerce.extensions.api import exceptions
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
 from ecommerce.extensions.fulfillment.modules import CouponFulfillmentModule
 from ecommerce.extensions.fulfillment.status import LINE
+from ecommerce.extensions.offer.models import OFFER_PRIORITY_VOUCHER
 from ecommerce.extensions.test.factories import create_order, prepare_voucher
 from ecommerce.extensions.voucher.utils import (
     create_vouchers,
@@ -199,6 +200,7 @@ class UtilTests(CouponMixin, DiscoveryMockMixin, DiscoveryTestMixin, LmsApiMockM
         self.assertEqual(voucher_offer.benefit.value, 100.00)
         self.assertEqual(voucher_offer.benefit.range.catalog, self.catalog)
         self.assertEqual(voucher_offer.email_domains, email_domains)
+        self.assertEqual(voucher_offer.priority, OFFER_PRIORITY_VOUCHER)
         self.assertEqual(len(coupon_voucher.vouchers.all()), 11)
         self.assertEqual(voucher.end_datetime, self.data['end_datetime'])
         self.assertEqual(voucher.start_datetime, self.data['start_datetime'])

--- a/ecommerce/extensions/voucher/utils.py
+++ b/ecommerce/extensions/voucher/utils.py
@@ -19,6 +19,7 @@ from oscar.templatetags.currency_filters import currency
 from ecommerce.core.url_utils import get_ecommerce_url
 from ecommerce.core.utils import log_message_and_raise_validation_error
 from ecommerce.extensions.api import exceptions
+from ecommerce.extensions.offer.models import OFFER_PRIORITY_VOUCHER
 from ecommerce.extensions.offer.utils import get_discount_percentage, get_discount_value
 from ecommerce.invoice.models import Invoice
 from ecommerce.programs.conditions import ProgramCourseRunSeatsCondition
@@ -377,7 +378,8 @@ def _get_or_create_offer(
         benefit=offer_benefit,
         max_global_applications=max_uses,
         email_domains=email_domains,
-        site=site
+        site=site,
+        priority=OFFER_PRIORITY_VOUCHER,
     )
 
     return offer


### PR DESCRIPTION
Voucher-based offers should take precedence over any other offers
that may be valid for a given basket. This change will set the
priority on new ConditionalOffers higher than Enterprise offers
or Program offers.

ENT-734

*Testing Instructions*
1. Visit https://business.sandbox.edx.org/enterprise/76afe510-a9fd-4b59-9ba1-49b537864205/course/course-v1:Microsoft+DAT206x+2017_T4/enroll/?catalog=a38ef858-9849-4e76-8624-55915d8d33ff&utm_medium=enterprise&utm_source=microsoft.
2. Sign in via TestShib.
3. Create account.
4. Selected Verified and click continue.
5. Grant consent to share data.
6. Apply code 20OFF to basket.
7. Verify the code discount is applied instead of the enterprise offer discount.