### PR TITLE
Added logging to CurrentSiteDjangoStrategy

### DIFF
--- a/ecommerce/social_auth/strategies.py
+++ b/ecommerce/social_auth/strategies.py
@@ -1,4 +1,8 @@
+import logging
+
 from auth_backends.strategies import EdxDjangoStrategy
+
+logger = logging.getLogger(__name__)
 
 
 class CurrentSiteDjangoStrategy(EdxDjangoStrategy):
@@ -8,10 +12,15 @@ class CurrentSiteDjangoStrategy(EdxDjangoStrategy):
     """
 
     def get_setting(self, name):
-        # Check the request's associated SiteConfiguration for the setting
-        value = self.request.site.siteconfiguration.oauth_settings.get(name)
+        site = self.request.site
 
-        if not value:
+        # Check the request's associated SiteConfiguration for the setting
+        value = site.siteconfiguration.oauth_settings.get(name)
+
+        if value:
+            logger.info('Retrieved setting [%s] for site [%d] from SiteConfiguration', name, site.id)
+        else:
             value = super(CurrentSiteDjangoStrategy, self).get_setting(name)
+            logger.info('Retrieved setting [%s] for site [%d] from settings', name, site.id)
 
         return value

--- a/ecommerce/social_auth/tests/test_strategies.py
+++ b/ecommerce/social_auth/tests/test_strategies.py
@@ -4,6 +4,7 @@ import uuid
 from calendar import timegm
 
 import httpretty
+import mock
 from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 from django.test import override_settings
@@ -24,7 +25,8 @@ class CurrentSiteDjangoStrategyTests(TestCase):
         super(CurrentSiteDjangoStrategyTests, self).setUp()
         self.strategy = CurrentSiteDjangoStrategy(DjangoStorage, self.request)
 
-    def test_get_setting_from_siteconfiguration(self):
+    @mock.patch('ecommerce.social_auth.strategies.logger')
+    def test_get_setting_from_siteconfiguration(self, mock_logger):
         """Test that a setting can be retrieved from the site configuration."""
         setting_name = 'SOCIAL_AUTH_EDX_OIDC_KEY'
         expected = str(uuid.uuid4())
@@ -32,8 +34,11 @@ class CurrentSiteDjangoStrategyTests(TestCase):
         self.site.siteconfiguration.save()
 
         self.assertEqual(self.strategy.get_setting(setting_name), expected)
+        mock_logger.info.assert_called_once_with(
+            'Retrieved setting [%s] for site [%d] from SiteConfiguration', setting_name, self.site.id)
 
-    def test_get_setting_from_django_settings(self):
+    @mock.patch('ecommerce.social_auth.strategies.logger')
+    def test_get_setting_from_django_settings(self, mock_logger):
         """Test that a setting can be retrieved from django settings if it doesn't exist in site configuration."""
         setting_name = 'SOCIAL_AUTH_EDX_OIDC_SECRET'
         expected = str(uuid.uuid4())
@@ -44,6 +49,9 @@ class CurrentSiteDjangoStrategyTests(TestCase):
 
         with override_settings(**{setting_name: expected}):
             self.assertEqual(self.strategy.get_setting(setting_name), expected)
+
+        mock_logger.info.assert_called_once_with(
+            'Retrieved setting [%s] for site [%d] from settings', setting_name, self.site.id)
 
     def test_get_setting_raises_exception_on_missing_setting(self):
         """Test that a setting that does not exist raises exception."""


### PR DESCRIPTION
This will help us debug an issue with all sites being redirected to the same OAuth provider rather than the site-specific provider.

LEARNER-3079