### PR TITLE
Truncate voucher names when they are longer than model allows

### DIFF
--- a/ecommerce/extensions/voucher/tests/test_utils.py
+++ b/ecommerce/extensions/voucher/tests/test_utils.py
@@ -206,6 +206,21 @@ class UtilTests(CouponMixin, DiscoveryMockMixin, DiscoveryTestMixin, LmsApiMockM
         self.assertEqual(voucher.start_datetime, self.data['start_datetime'])
         self.assertEqual(voucher.usage, Voucher.SINGLE_USE)
 
+    def test_create_voucher_with_long_name(self):
+        self.data.update({
+            'name': (
+                'This Is A Really Really Really Really Really Really Long '
+                'Voucher Name That Needs To Be Trimmed To Fit Into The Name Column Of The DB'
+            )
+        })
+        trimmed = (
+            'This Is A Really Really Really Really Really Really Long '
+            'Voucher Name That Needs To Be Trimmed To Fit Into The Name Column Of Th'
+        )
+        vouchers = create_vouchers(**self.data)
+        voucher = vouchers[0]
+        self.assertEqual(voucher.name, trimmed)
+
     @ddt.data(
         {'end_datetime': ''},
         {'end_datetime': 3},

--- a/ecommerce/extensions/voucher/utils.py
+++ b/ecommerce/extensions/voucher/utils.py
@@ -452,7 +452,7 @@ def _create_new_voucher(code, end_datetime, name, offer, start_datetime, voucher
             )
 
     voucher = Voucher.objects.create(
-        name=name,
+        name=name[:128],
         code=voucher_code,
         usage=voucher_type,
         start_datetime=start_datetime,


### PR DESCRIPTION
Long course names are breaking saving of vouchers. This truncates voucher names so they always fit.

[WL-1326]