### PR TITLE
Removed JWT decode handler override for devstack

### DIFF
--- a/ecommerce/settings/devstack.py
+++ b/ecommerce/settings/devstack.py
@@ -14,9 +14,6 @@ LOGGING['handlers']['local'] = {
 
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
 
-# TODO Remove this once we convert the E-Commerce service to use the latest JWT_ISSUERS configuration.
-JWT_AUTH['JWT_DECODE_HANDLER'] = 'edx_rest_framework_extensions.utils.jwt_decode_handler'
-
 # Allow live changes to JS and CSS
 COMPRESS_OFFLINE = False
 COMPRESS_ENABLED = False


### PR DESCRIPTION
E-Commerce must still use its custom decode handler until we change the configuration/settings to match the format of the other IDAs.

LEARNER-818