### PR TITLE
Update program offer logic to account for entitlements

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -434,6 +434,10 @@ class SiteConfiguration(models.Model):
     def enrollment_api_client(self):
         return EdxRestApiClient(self.build_lms_url('/api/enrollment/v1/'), jwt=self.access_token, append_slash=False)
 
+    @cached_property
+    def entitlement_api_client(self):
+        return EdxRestApiClient(self.build_lms_url('/api/entitlements/v1/'), jwt=self.access_token)
+
 
 class User(AbstractUser):
     """Custom user model for use with OIDC."""

--- a/ecommerce/core/url_utils.py
+++ b/ecommerce/core/url_utils.py
@@ -47,7 +47,7 @@ def get_lms_enrollment_api_url():
 
 def get_lms_entitlement_api_url():
     """ Returns the base lms entitlement api url. """
-    return get_lms_url('/api/entitlements/v1/')
+    return get_lms_url('/api/entitlements/v1/entitlements/')
 
 
 def get_lms_enrollment_base_api_url():

--- a/ecommerce/entitlements/utils.py
+++ b/ecommerce/entitlements/utils.py
@@ -43,11 +43,13 @@ def create_or_update_course_entitlement(certificate_type, price, partner, UUID, 
 
     certificate_type = certificate_type.lower()
     UUID = unicode(UUID)
+    entitlement_class = ProductClass.objects.get(name=COURSE_ENTITLEMENT_PRODUCT_CLASS_NAME)
 
     certificate_type_query = Q(
         title='Course Entitlement for {}'.format(name),
         attributes__name='certificate_type',
-        attribute_values__value_text=certificate_type
+        attribute_values__value_text=certificate_type,
+        product_class=entitlement_class
     )
 
     try:
@@ -63,6 +65,7 @@ def create_or_update_course_entitlement(certificate_type, price, partner, UUID, 
     course_entitlement.attr.certificate_type = certificate_type
     course_entitlement.attr.UUID = UUID
     course_entitlement.parent = parent_entitlement
+    course_entitlement.product_class = entitlement_class
     course_entitlement.save()
 
     StockRecord.objects.update_or_create(

--- a/ecommerce/extensions/api/v2/tests/views/test_baskets.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_baskets.py
@@ -388,7 +388,7 @@ class BasketCalculateViewTests(ProgramTestMixin, TestCase):
         )
         program_uuid = offer.condition.program_uuid
         self.mock_program_detail_endpoint(program_uuid, self.site_configuration.discovery_api_url)
-        self.mock_enrollment_api(self.user.username)
+        self.mock_user_data(self.user.username)
 
         response = self.client.get(self.url)
         expected = {
@@ -473,7 +473,7 @@ class BasketCalculateViewTests(ProgramTestMixin, TestCase):
         products = self._get_program_verified_seats(program)
         url = self._generate_sku_username_url(products, differentuser.username)
         enrollment = [{'mode': 'verified', 'course_details': {'course_id': program['courses'][0]['key']}}]
-        self.mock_enrollment_api(differentuser.username, enrollment)
+        self.mock_user_data(differentuser.username, owned_products=enrollment)
 
         expected = {
             'total_incl_tax_excl_discounts': sum(product.stockrecords.first().price_excl_tax
@@ -505,7 +505,7 @@ class BasketCalculateViewTests(ProgramTestMixin, TestCase):
         products = self._get_program_verified_seats(program)
         url = self._generate_sku_username_url(products, 'invalidusername')
         enrollment = [{'mode': 'verified', 'course_details': {'course_id': program['courses'][0]['key']}}]
-        self.mock_enrollment_api(differentuser.username, enrollment)
+        self.mock_user_data(differentuser.username, enrollment)
 
         expected = {
             'total_incl_tax_excl_discounts': sum(product.stockrecords.first().price_excl_tax

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -434,7 +434,7 @@ class EnrollmentFulfillmentModuleTests(ProgramTestMixin, DiscoveryTestMixin, Ful
         self.create_seat_and_order(certificate_type='credit', provider='MIT')
         program_uuid = uuid.uuid4()
         self.mock_program_detail_endpoint(program_uuid, self.site_configuration.discovery_api_url)
-        self.mock_enrollment_api(self.user.username)
+        self.mock_user_data(self.user.username)
         self.prepare_basket_with_voucher(program_uuid=program_uuid)
         __, lines = EnrollmentFulfillmentModule().fulfill_product(self.order, list(self.order.lines.all()))
         # No exceptions should be raised and the order should be fulfilled

--- a/ecommerce/programs/conditions.py
+++ b/ecommerce/programs/conditions.py
@@ -10,7 +10,7 @@ from oscar.core.loading import get_model
 from requests.exceptions import ConnectionError, Timeout
 from slumber.exceptions import HttpNotFoundError, SlumberBaseException
 
-from ecommerce.core.utils import get_cache_key
+from ecommerce.core.utils import get_cache_key, traverse_pagination
 from ecommerce.extensions.offer.decorators import check_condition_applicability
 from ecommerce.extensions.offer.mixins import SingleItemConsumptionConditionMixin
 from ecommerce.programs.utils import get_program
@@ -30,18 +30,65 @@ class ProgramCourseRunSeatsCondition(SingleItemConsumptionConditionMixin, Condit
 
     def get_applicable_skus(self, site_configuration):
         """ SKUs to which this condition applies. """
-        program_course_run_skus = set()
+        program_skus = set()
         program = get_program(self.program_uuid, site_configuration)
         if program:
             applicable_seat_types = program['applicable_seat_types']
 
             for course in program['courses']:
                 for course_run in course['course_runs']:
-                    program_course_run_skus.update(
+                    program_skus.update(
                         set([seat['sku'] for seat in course_run['seats'] if seat['type'] in applicable_seat_types])
                     )
+                for entitlement in course['entitlements']:
+                    if entitlement['mode'].lower() in applicable_seat_types:
+                        program_skus.add(entitlement['sku'])
+        return program_skus
 
-        return program_course_run_skus
+    def get_lms_resource(self, basket, resource_name, endpoint):
+        cache_key = get_cache_key(
+            site_domain=basket.site.domain,
+            resource=resource_name,
+            username=basket.owner.username,
+        )
+        data_list = cache.get(cache_key)
+        if not data_list:
+            user = basket.owner.username
+            try:
+                data_list = endpoint.get(user=user)
+                cache.set(cache_key, data_list, settings.ENROLLMENT_API_CACHE_TIMEOUT)
+            except (ConnectionError, SlumberBaseException, Timeout) as exc:
+                logger.error('Failed to retrieve %s : %s', resource_name, str(exc))
+        return data_list if data_list else []
+
+    def get_user_ownership_data(self, basket, retrieve_entitlements=False):
+        """
+        Retrieves existing enrollments and entitlements for a user from LMS
+        """
+        enrollments = []
+        entitlements = []
+        site_configuration = basket.site.siteconfiguration
+        if site_configuration.enable_partial_program:
+            enrollments = self.get_lms_resource(
+                basket, 'enrollments', site_configuration.enrollment_api_client.enrollment)
+            if retrieve_entitlements:
+                response = self.get_lms_resource(
+                    basket, 'entitlements', site_configuration.entitlement_api_client.entitlements
+                )
+                if isinstance(response, dict):
+                    entitlements = traverse_pagination(response, site_configuration.entitlement_api_client.entitlements)
+                else:
+                    entitlements = response
+        return enrollments, entitlements
+
+    def has_entitlements(self, program):
+        """
+        Determines whether an entitlement product exists for any course in the program.
+        """
+        for course in program['courses']:
+            if course['entitlements']:
+                return True
+        return False
 
     @check_condition_applicability()
     def is_satisfied(self, offer, basket):  # pylint: disable=unused-argument
@@ -55,7 +102,6 @@ class ProgramCourseRunSeatsCondition(SingleItemConsumptionConditionMixin, Condit
         Returns:
             bool
         """
-
         basket_skus = set([line.stockrecord.partner_sku for line in basket.all_lines()])
         try:
             program = get_program(self.program_uuid, basket.site.siteconfiguration)
@@ -67,28 +113,16 @@ class ProgramCourseRunSeatsCondition(SingleItemConsumptionConditionMixin, Condit
         else:
             return False
 
-        enrollments = []
-        if basket.site.siteconfiguration.enable_partial_program:
-            api_resource = 'enrollments'
-            cache_key = get_cache_key(
-                site_domain=basket.site.domain,
-                resource=api_resource,
-                username=basket.owner.username,
-            )
-            enrollments = cache.get(cache_key, [])
-            if not enrollments:
-                api = basket.site.siteconfiguration.enrollment_api_client
-                user = basket.owner.username
-                try:
-                    enrollments = api.enrollment.get(user=user)
-                    cache.set(cache_key, enrollments, settings.ENROLLMENT_API_CACHE_TIMEOUT)
-                except (ConnectionError, SlumberBaseException, Timeout) as exc:
-                    logger.error('Failed to retrieve enrollments: %s', str(exc))
+        retrieve_entitlements = self.has_entitlements(program)
+        enrollments, entitlements = self.get_user_ownership_data(basket, retrieve_entitlements)
 
         for course in program['courses']:
             # If the user is already enrolled in a course, we do not need to check their basket for it
             if any(course['key'] in enrollment['course_details']['course_id'] and
                    enrollment['mode'] in applicable_seat_types for enrollment in enrollments):
+                continue
+            if any(course['uuid'] in entitlement['course_uuid'] and
+                   entitlement['mode'] in applicable_seat_types for entitlement in entitlements):
                 continue
 
             # If the  basket has no SKUs left, but we still have courses over which
@@ -100,6 +134,9 @@ class ProgramCourseRunSeatsCondition(SingleItemConsumptionConditionMixin, Condit
             skus = set()
             for course_run in course['course_runs']:
                 skus.update(set([seat['sku'] for seat in course_run['seats'] if seat['type'] in applicable_seat_types]))
+            for entitlement in course['entitlements']:
+                if entitlement['mode'].lower() in applicable_seat_types:
+                    skus.add(entitlement['sku'])
 
             # The lack of a difference in the set of SKUs in the basket and the course indicates that
             # that there is no intersection. Therefore, the basket contains no SKUs for the current course.

--- a/ecommerce/programs/tests/mixins.py
+++ b/ecommerce/programs/tests/mixins.py
@@ -3,14 +3,17 @@ from decimal import Decimal
 
 import httpretty
 
-from ecommerce.core.url_utils import get_lms_enrollment_api_url
+from ecommerce.core.url_utils import get_lms_enrollment_api_url, get_lms_entitlement_api_url
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.courses.utils import mode_for_product
+from ecommerce.entitlements.utils import create_or_update_course_entitlement
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
+from ecommerce.tests.factories import PartnerFactory
 
 
 class ProgramTestMixin(DiscoveryTestMixin):
-    def mock_program_detail_endpoint(self, program_uuid, discovery_api_url, empty=False, title='Test Program'):
+    def mock_program_detail_endpoint(self, program_uuid, discovery_api_url, empty=False, title='Test Program',
+                                     include_entitlements=True):
         """ Mocks the program detail endpoint on the Catalog API.
         Args:
             program_uuid (uuid): UUID of the mocked program.
@@ -18,10 +21,23 @@ class ProgramTestMixin(DiscoveryTestMixin):
         Returns:
             dict: Mocked program data.
         """
+        partner = PartnerFactory()
         data = None
         if not empty:
             courses = []
             for i in range(1, 5):
+                uuid = '268afbfc-cc1e-415b-a5d8-c58d955bcfc' + str(i)
+                entitlement = create_or_update_course_entitlement('verified', 10, partner, uuid, uuid)
+                entitlements = []
+                if include_entitlements:
+                    entitlements.append(
+                        {
+                            "mode": "verified",
+                            "price": "10.00",
+                            "currency": "USD",
+                            "sku": entitlement.stockrecords.first().partner_sku
+                        }
+                    )
                 key = 'course-v1:test-org+course+' + str(i)
                 course_runs = []
                 for __ in range(1, 4):
@@ -37,7 +53,7 @@ class ProgramTestMixin(DiscoveryTestMixin):
                         } for seat in course_run.seat_products]
                     })
 
-                courses.append({'key': key, 'course_runs': course_runs, })
+                courses.append({'key': key, 'uuid': uuid, 'course_runs': course_runs, 'entitlements': entitlements, })
 
             program_uuid = str(program_uuid)
             data = {
@@ -63,17 +79,21 @@ class ProgramTestMixin(DiscoveryTestMixin):
         )
         return data
 
-    def mock_enrollment_api(self, username, enrollments=None, response_code=200):
-        """ Mocks enrollment retrieval from LMS
+    def mock_user_data(self, username, mocked_api='enrollments', owned_products=None, response_code=200):
+        """ Mocks user ownership data retrieval from LMS
         Returns:
-            list: Mocked enrollment data
+            list: Mocked entitlement or enrollment data
         """
         self.mock_access_token_response()
+        if mocked_api == 'enrollments':
+            api_url = get_lms_enrollment_api_url()
+        else:
+            api_url = get_lms_entitlement_api_url()
         httpretty.register_uri(
             method=httpretty.GET,
-            uri='{}?user={}'.format(get_lms_enrollment_api_url(), username),
-            body=json.dumps([] if enrollments is None else enrollments),
+            uri='{}?user={}'.format(api_url, username),
+            body=json.dumps([] if owned_products is None else owned_products),
             status=response_code,
             content_type='application/json'
         )
-        return enrollments
+        return owned_products

--- a/ecommerce/programs/tests/test_offer.py
+++ b/ecommerce/programs/tests/test_offer.py
@@ -27,7 +27,7 @@ class ProgramOfferTests(ProgramTestMixin, TestCase):
 
         program_uuid = offer.condition.program_uuid
         program = self.mock_program_detail_endpoint(program_uuid, self.site_configuration.discovery_api_url)
-        self.mock_enrollment_api(basket.owner.username)
+        self.mock_user_data(basket.owner.username)
 
         # Add one course run seat from each course to the basket.
         products = []


### PR DESCRIPTION
Take existing user entitlements into account for partial program offers and calculate offers for programs with course entitlement products.

[LEARNER-2659](https://openedx.atlassian.net/browse/LEARNER-2659)