### PR TITLE
Only cache enrollments for 30 seconds.

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -252,7 +252,7 @@ PROVIDER_DATA_PROCESSING_TIMEOUT = 15  # Value is in seconds.
 CREDIT_PROVIDER_CACHE_TIMEOUT = 600
 
 # Enrollment API settings used for fetching information from LMS
-ENROLLMENT_API_CACHE_TIMEOUT = 3600  # Value is in seconds.
+ENROLLMENT_API_CACHE_TIMEOUT = 30  # Value is in seconds.
 # END URL CONFIGURATION
 
 VOUCHER_CACHE_TIMEOUT = 10  # Value is in seconds.


### PR DESCRIPTION
Only cache user enrollments for 30 seconds as apposed to an hour.

This should reduce the size of memcache and make gets faster.
