### PR TITLE
Rename course entitlement product title.

### DIFF
--- a/ecommerce/core/url_utils.py
+++ b/ecommerce/core/url_utils.py
@@ -47,7 +47,7 @@ def get_lms_enrollment_api_url():
 
 def get_lms_entitlement_api_url():
     """ Returns the base lms entitlement api url. """
-    return get_lms_url('/api/entitlements/v1/entitlements/')
+    return get_lms_url('/api/entitlements/v1/')
 
 
 def get_lms_enrollment_base_api_url():

--- a/ecommerce/entitlements/tests/test_utils.py
+++ b/ecommerce/entitlements/tests/test_utils.py
@@ -18,7 +18,7 @@ class TestCourseEntitlementProductCreation(TestCase):
 
         product = create_or_update_course_entitlement(
             'verified', 100, self.partner, 'foo-bar', 'Foo Bar Entitlement')
-        self.assertEqual(product.title, 'Course Entitlement for Foo Bar Entitlement')
+        self.assertEqual(product.title, 'Course Foo Bar Entitlement')
         self.assertEqual(product.attr.UUID, 'foo-bar')
 
         stock_record = StockRecord.objects.get(product=product, partner=self.partner)
@@ -32,7 +32,7 @@ class TestCourseEntitlementProductCreation(TestCase):
         stock_record = StockRecord.objects.get(product=product, partner=self.partner)
 
         self.assertEqual(stock_record.price_excl_tax, 100)
-        self.assertEqual(product.title, 'Course Entitlement for Foo Bar Entitlement')
+        self.assertEqual(product.title, 'Course Foo Bar Entitlement')
 
         product = create_or_update_course_entitlement('verified', 200, partner, 'foo-bar', 'Foo Bar Entitlement')
 

--- a/ecommerce/entitlements/utils.py
+++ b/ecommerce/entitlements/utils.py
@@ -22,6 +22,7 @@ def create_parent_course_entitlement(name, UUID):
     parent, created = Product.objects.get_or_create(
         structure=Product.PARENT,
         product_class=ProductClass.objects.get(name=COURSE_ENTITLEMENT_PRODUCT_CLASS_NAME),
+        title='Parent Course Entitlement for {}'.format(name),
     )
 
     if created:
@@ -46,7 +47,7 @@ def create_or_update_course_entitlement(certificate_type, price, partner, UUID, 
     entitlement_class = ProductClass.objects.get(name=COURSE_ENTITLEMENT_PRODUCT_CLASS_NAME)
 
     certificate_type_query = Q(
-        title='Course Entitlement for {}'.format(name),
+        title='Course {}'.format(name),
         attributes__name='certificate_type',
         attribute_values__value_text=certificate_type,
         product_class=entitlement_class
@@ -61,7 +62,7 @@ def create_or_update_course_entitlement(certificate_type, price, partner, UUID, 
 
     course_entitlement.structure = Product.CHILD
     course_entitlement.is_discountable = True
-    course_entitlement.title = 'Course Entitlement for {}'.format(name)
+    course_entitlement.title = 'Course {}'.format(name)
     course_entitlement.attr.certificate_type = certificate_type
     course_entitlement.attr.UUID = UUID
     course_entitlement.parent = parent_entitlement
@@ -80,7 +81,7 @@ def create_or_update_course_entitlement(certificate_type, price, partner, UUID, 
     )
 
     logger.info(
-        'Course course entitlement product stock record with certificate type [%s] for [%s] does not exist. '
+        'Course entitlement product stock record with certificate type [%s] for [%s] does not exist. '
         'Instantiated a new instance.',
         certificate_type,
         UUID

--- a/ecommerce/programs/tests/mixins.py
+++ b/ecommerce/programs/tests/mixins.py
@@ -88,7 +88,7 @@ class ProgramTestMixin(DiscoveryTestMixin):
         if mocked_api == 'enrollments':
             api_url = get_lms_enrollment_api_url()
         else:
-            api_url = get_lms_entitlement_api_url()
+            api_url = get_lms_entitlement_api_url() + 'entitlements/'
         httpretty.register_uri(
             method=httpretty.GET,
             uri='{}?user={}'.format(api_url, username),


### PR DESCRIPTION
Do not use the word entitlement in product title.