### PR TITLE
Decrease Enterprise API cache timeout from 1 hour to 5 minutes.

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -577,7 +577,7 @@ CRISPY_TEMPLATE_PACK = 'bootstrap3'
 # URL for Enterprise service
 ENTERPRISE_SERVICE_URL = 'http://localhost:8000/enterprise/'
 # Cache enterprise response from Enterprise API.
-ENTERPRISE_API_CACHE_TIMEOUT = 3600  # Value is in seconds
+ENTERPRISE_API_CACHE_TIMEOUT = 300  # Value is in seconds
 
 # Name for waffle switch to use for enabling enterprise features on runtime.
 ENABLE_ENTERPRISE_ON_RUNTIME_SWITCH = 'enable_enterprise_on_runtime'


### PR DESCRIPTION
Caching Enterprise data for an hour significantly increases the chance
that we will end up with stale data in the cache causing Enterprise
checkout workflows to not behave as they should. Reducing the cache
timeout will decrease the likelihood of stale data while still
maintaining the performance benefits of caching.

ENT-739