### PR TITLE
Fix fulfillment error for donations

### DIFF
--- a/ecommerce/core/constants.py
+++ b/ecommerce/core/constants.py
@@ -16,6 +16,10 @@ USER_LIST_VIEW_SWITCH = 'enable_user_list_view'
 # Coupon constant
 COUPON_PRODUCT_CLASS_NAME = 'Coupon'
 
+# Donations from checkout tests constant
+# Don't use this code for your own purposes, thanks.
+DONATIONS_FROM_CHECKOUT_TESTS_PRODUCT_TYPE_NAME = 'Donation'
+
 # Enrollment Code constants
 ENROLLMENT_CODE_PRODUCT_CLASS_NAME = 'Enrollment Code'
 ENROLLMENT_CODE_SWITCH = 'create_enrollment_codes'

--- a/ecommerce/extensions/catalogue/migrations/0028_donations_from_checkout_tests_product_type.py
+++ b/ecommerce/extensions/catalogue/migrations/0028_donations_from_checkout_tests_product_type.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from oscar.core.loading import get_model
+from oscar.core.utils import slugify
+
+from ecommerce.core.constants import DONATIONS_FROM_CHECKOUT_TESTS_PRODUCT_TYPE_NAME
+
+Category = get_model("catalogue", "Category")
+Product = get_model('catalogue', 'Product')
+ProductAttribute = get_model("catalogue", "ProductAttribute")
+ProductClass = get_model("catalogue", "ProductClass")
+
+
+def create_product_class(apps, schema_editor):  # pylint: disable=unused-argument
+    """ Create a donation product class for donations from checkout tests """
+
+    # Create a new product class for donations for the donations from checkout tests
+    donation, __ = ProductClass.objects.get_or_create(
+        track_stock=False,
+        requires_shipping=False,
+        name=DONATIONS_FROM_CHECKOUT_TESTS_PRODUCT_TYPE_NAME,
+        slug=slugify(DONATIONS_FROM_CHECKOUT_TESTS_PRODUCT_TYPE_NAME)
+    )
+
+    Category.add_root(
+        description="All donations",
+        slug="donations",
+        image="",
+        name="Donations"
+    )
+
+
+def remove_product_class(apps, schema_editor):  # pylint: disable=unused-argument
+    """ Reverse function. """
+    donation_class = ProductClass.objects.get(name=DONATIONS_FROM_CHECKOUT_TESTS_PRODUCT_TYPE_NAME)
+    Product.objects.filter(product_class=donation_class).delete()
+    Category.objects.filter(slug='donations').delete()
+    donation_class.delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('catalogue', '0001_initial'),
+        ('catalogue', '0027_catalogue_entitlement_option')
+    ]
+
+    operations = [
+        migrations.RunPython(create_product_class, remove_product_class),
+    ]

--- a/ecommerce/extensions/fulfillment/tests/mixins.py
+++ b/ecommerce/extensions/fulfillment/tests/mixins.py
@@ -8,10 +8,10 @@ class FulfillmentTestMixin(object):
 
     Inheriting classes should have a `create_user` method.
     """
-    def generate_open_order(self):
+    def generate_open_order(self, product_class=None):
         """ Returns an open order, ready to be fulfilled. """
         user = self.create_user()
-        return create_order(user=user, status=ORDER.OPEN)
+        return create_order(user=user, status=ORDER.OPEN, product_class=product_class)
 
     def assert_order_fulfilled(self, order):
         """

--- a/ecommerce/extensions/fulfillment/tests/test_api.py
+++ b/ecommerce/extensions/fulfillment/tests/test_api.py
@@ -33,6 +33,12 @@ class FulfillmentApiTests(FulfillmentTestMixin, TestCase):
         api.fulfill_order(self.order, self.order.lines)
         self.assert_order_fulfilled(self.order)
 
+    def test_donation_fulfill_order_successful_fulfillment(self):
+        """ Test a successful fulfillment of a donation order. """
+        order_with_donation = self.generate_open_order(product_class="Donation")
+        api.fulfill_order(order_with_donation, order_with_donation.lines)
+        self.assert_order_fulfilled(order_with_donation)
+
     @override_settings(FULFILLMENT_MODULES=['ecommerce.extensions.fulfillment.tests.modules.FakeFulfillmentModule', ])
     @raises(exceptions.IncorrectOrderStatusError)
     def test_fulfill_order_bad_fulfillment_state(self):

--- a/ecommerce/settings/_oscar.py
+++ b/ecommerce/settings/_oscar.py
@@ -79,6 +79,7 @@ FULFILLMENT_MODULES = [
     'ecommerce.extensions.fulfillment.modules.CouponFulfillmentModule',
     'ecommerce.extensions.fulfillment.modules.EnrollmentCodeFulfillmentModule',
     'ecommerce.extensions.fulfillment.modules.CourseEntitlementFulfillmentModule',
+    'ecommerce.extensions.fulfillment.modules.DonationsFromCheckoutTestFulfillmentModule'
 ]
 
 HAYSTACK_CONNECTIONS = {


### PR DESCRIPTION
Fulfillment of donation failed which contributed to it not being reported properly in the data warehouse.
https://ecommerce.edx.org/dashboard/orders/EDX-31196785/

For the purposes of the test at least, we do not need to do anything for the fulfillment step.
In theory there could be a fullfillment module with empty methods that contain "pass" but that seems overly complex for a noop.
If we wanted something more "extensible" for the test we could have a constant with a list of SKIP_FULFILLMENT_LINE_TYPES?