### PR TITLE
Check for duplicate course entitlement purchase

### DIFF
--- a/ecommerce/extensions/basket/tests/test_utils.py
+++ b/ecommerce/extensions/basket/tests/test_utils.py
@@ -28,6 +28,7 @@ Basket = get_model('basket', 'Basket')
 BasketAttribute = get_model('basket', 'BasketAttribute')
 BasketAttributeType = get_model('basket', 'BasketAttributeType')
 BUNDLE = 'bundle_identifier'
+Option = get_model('catalogue', 'Option')
 Product = get_model('catalogue', 'Product')
 
 
@@ -419,6 +420,11 @@ class BasketUtilsTransactionTests(TransactionTestCase):
         self.site_configuration.utm_cookie_name = 'test.edx.utm'
         toggle_switch(DISABLE_REPEAT_ORDER_CHECK_SWITCH_NAME, False)
         BasketAttributeType.objects.get_or_create(name=BUNDLE)
+        course_entitlement_option = Option()
+        course_entitlement_option.name = 'Course Entitlement'
+        course_entitlement_option.code = 'course_entitlement'
+        course_entitlement_option.type = Option.OPTIONAL
+        course_entitlement_option.save()
 
     def _setup_request_cookie(self):
         utm_campaign = 'test-campaign'

--- a/ecommerce/extensions/basket/tests/test_views.py
+++ b/ecommerce/extensions/basket/tests/test_views.py
@@ -187,7 +187,7 @@ class BasketSingleItemViewTests(CouponMixin, DiscoveryTestMixin, DiscoveryMockMi
         basket.add_product(product, 1)
         create_order(user=self.user, basket=basket)
         url = '{path}?sku={sku}'.format(path=self.path, sku=sku)
-        expected_content = 'You have already purchased {course} seat.'.format(course=product.course.name)
+        expected_content = 'You have already purchased {course} seat.'.format(course=product.title)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['error'], expected_content)

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -89,7 +89,8 @@ def prepare_basket(request, products, voucher=None):
     is_multi_product_basket = True if len(products) > 1 else False
     for product in products:
         if product.is_enrollment_code_product or \
-                not UserAlreadyPlacedOrder.user_already_placed_order(request.user, product):
+                not UserAlreadyPlacedOrder.user_already_placed_order(user=request.user,
+                                                                     product=product, site=request.site):
             basket.add_product(product, 1)
             # Call signal handler to notify listeners that something has been added to the basket
             basket_addition.send(sender=basket_addition, product=product, user=request.user, request=request,

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -88,7 +88,7 @@ class BasketSingleItemView(View):
         try:
             prepare_basket(request, [product], voucher)
         except AlreadyPlacedOrderException:
-            msg = _('You have already purchased {course} seat.').format(course=product.course.name)
+            msg = _('You have already purchased {course} seat.').format(course=product.title)
             return render(request, 'edx/error.html', {'error': msg})
         url = add_utm_params_to_url(reverse('basket:summary'), self.request.GET.items())
         return HttpResponseRedirect(url, status=303)

--- a/ecommerce/extensions/refund/tests/mixins.py
+++ b/ecommerce/extensions/refund/tests/mixins.py
@@ -52,8 +52,8 @@ class RefundTestMixin(DiscoveryTestMixin):
         elif free:
             basket.add_product(self.honor_product)
         elif entitlement:
-            course_entitlement = create_or_update_course_entitlement('verified', 100, self.partner, '111', 'Foo')
-            basket.add_product(course_entitlement)
+            self.course_entitlement = create_or_update_course_entitlement('verified', 100, self.partner, '111', 'Foo')
+            basket.add_product(self.course_entitlement)
         else:
             basket.add_product(self.verified_product)
 


### PR DESCRIPTION
Only allow a learner to purchase a second course entitlement they have already purchased if it has been refunded or has expired.

LEARNER-3572