### PR TITLE
Point to program dashboard in receipt

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -324,6 +324,10 @@ class SiteConfiguration(models.Model):
         """
         return urljoin(settings.ENTERPRISE_SERVICE_URL, path)
 
+    def build_program_dashboard_url(self, uuid):
+        """ Returns a URL to a specific student program dashboard (hosted by LMS). """
+        return self.build_lms_url('/dashboard/programs/{}'.format(uuid))
+
     @property
     def student_dashboard_url(self):
         """ Returns a URL to the student dashboard (hosted by LMS). """

--- a/ecommerce/core/url_utils.py
+++ b/ecommerce/core/url_utils.py
@@ -39,6 +39,11 @@ def get_lms_dashboard_url():
     return site_configuration.student_dashboard_url
 
 
+def get_lms_program_dashboard_url(uuid):
+    site_configuration = _get_site_configuration()
+    return site_configuration.build_program_dashboard_url(uuid)
+
+
 def get_lms_enrollment_api_url():
     # TODO Update consumers of this method to use `get_lms_enrollment_base_api_url` (which should be renamed
     # get_lms_enrollment_api_url).

--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -160,7 +160,7 @@
         </div>
       {% else %}
         <div id="dashboard-link">
-          <a class="dashboard-link nav-link" href="{{ lms_dashboard_url }}">
+          <a class="dashboard-link nav-link" href="{{ order_dashboard_url }}">
             {% trans "Go to Dashboard" %}
           </a>
         </div>

--- a/ecommerce/templates/oscar/checkout/_verification_data.html
+++ b/ecommerce/templates/oscar/checkout/_verification_data.html
@@ -26,7 +26,7 @@
     data-track-category="verification"
     data-track-event="edx.bi.user.verification.immediate"
     data-track-type="click"
-    href="{{ lms_dashboard_url }}">
+    href="{{ order_dashboard_url }}">
     {% trans "Go to my dashboard and verify later" %}
   </a>
 </div>


### PR DESCRIPTION
*Clone of https://github.com/edx/ecommerce/pull/1599 to work around codecov issues*

When a user purchases a program (rather than a single course run),
we want the receipt to point them at the dashboard of the program,
not the learner's normal course dashboard.

LEARNER-3525