### PR TITLE
Streamline checkout process for Enterprise orders.

### DIFF
--- a/ecommerce/core/url_utils.py
+++ b/ecommerce/core/url_utils.py
@@ -34,6 +34,19 @@ def get_ecommerce_url(path=''):
     return site_configuration.build_ecommerce_url(path)
 
 
+def get_lms_courseware_url(course_run_id):
+    """
+    Return the courseware URL for the given course run.
+
+    Arguments:
+        course_run_id (string): The serialized course run ID.
+
+    Returns:
+        string: The courseware URL.
+    """
+    return get_lms_url('courses/{}/info'.format(course_run_id))
+
+
 def get_lms_dashboard_url():
     site_configuration = _get_site_configuration()
     return site_configuration.student_dashboard_url

--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -18,6 +18,7 @@ from slumber.exceptions import SlumberHttpBaseException
 
 from ecommerce.core.utils import traverse_pagination
 from ecommerce.enterprise.exceptions import EnterpriseDoesNotExist
+from ecommerce.extensions.offer.models import OFFER_PRIORITY_ENTERPRISE
 
 ConditionalOffer = get_model('offer', 'ConditionalOffer')
 StockRecord = get_model('partner', 'StockRecord')
@@ -355,3 +356,19 @@ def set_enterprise_customer_cookie(site, response, enterprise_customer_uuid, max
         )
 
     return response
+
+
+def has_enterprise_offer(basket):
+    """
+    Return True if the basket has an Enterprise-related offer applied.
+
+    Arguments:
+        basket (Basket): The basket object.
+
+    Returns:
+        boolean: True if the basket has an Enterprise-related offer applied, false otherwise.
+    """
+    for offer in basket.offer_discounts:
+        if offer['offer'].priority == OFFER_PRIORITY_ENTERPRISE:
+            return True
+    return False

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -2,12 +2,13 @@ from __future__ import unicode_literals
 
 import logging
 from datetime import datetime
+from decimal import Decimal
 from urllib import urlencode
 
 import dateutil.parser
 import waffle
 from django.http import HttpResponseBadRequest, HttpResponseRedirect
-from django.shortcuts import render
+from django.shortcuts import redirect, render
 from django.utils.translation import ugettext as _
 from opaque_keys.edx.keys import CourseKey
 from oscar.apps.basket.views import VoucherAddView as BaseVoucherAddView
@@ -21,7 +22,7 @@ from ecommerce.core.exceptions import SiteConfigurationError
 from ecommerce.core.url_utils import get_lms_url
 from ecommerce.courses.utils import get_certificate_type_display_value, get_course_info_from_catalog
 from ecommerce.enterprise.entitlements import get_enterprise_code_redemption_redirect
-from ecommerce.enterprise.utils import CONSENT_FAILED_PARAM, get_enterprise_customer_from_voucher
+from ecommerce.enterprise.utils import CONSENT_FAILED_PARAM, get_enterprise_customer_from_voucher, has_enterprise_offer
 from ecommerce.extensions.analytics.utils import (
     prepare_analytics_data,
     track_segment_event,
@@ -347,7 +348,10 @@ class BasketSummaryView(BasketView):
         except Exception:  # pylint: disable=broad-except
             logger.exception('Failed to fire Cart Viewed event for basket [%d]', basket.id)
 
-        return super(BasketSummaryView, self).get(request, *args, **kwargs)
+        if has_enterprise_offer(basket) and basket.total_incl_tax == Decimal(0):
+            return redirect('checkout:free-checkout')
+        else:
+            return super(BasketSummaryView, self).get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         context = super(BasketSummaryView, self).get_context_data(**kwargs)

--- a/ecommerce/extensions/checkout/views.py
+++ b/ecommerce/extensions/checkout/views.py
@@ -12,7 +12,8 @@ from django.views.generic import RedirectView, TemplateView
 from oscar.apps.checkout.views import *  # pylint: disable=wildcard-import, unused-wildcard-import
 from oscar.core.loading import get_class, get_model
 
-from ecommerce.core.url_utils import get_lms_dashboard_url, get_lms_program_dashboard_url
+from ecommerce.core.url_utils import get_lms_courseware_url, get_lms_dashboard_url, get_lms_program_dashboard_url
+from ecommerce.enterprise.utils import has_enterprise_offer
 from ecommerce.extensions.checkout.exceptions import BasketNotFreeError
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
 from ecommerce.extensions.checkout.utils import get_receipt_page_url
@@ -22,6 +23,24 @@ Basket = get_model('basket', 'Basket')
 BasketAttribute = get_model('basket', 'BasketAttribute')
 BasketAttributeType = get_model('basket', 'BasketAttributeType')
 Order = get_model('order', 'Order')
+
+
+def get_program_uuid(order):
+    """
+    Return the program UUID associated with the given order, if one exists.
+
+    Arguments:
+        order (Order): The order object.
+
+    Returns:
+        string: The program UUID if the order is associated with a bundled purchase, otherwise None.
+    """
+    bundle_attributes = BasketAttribute.objects.filter(
+        basket=order.basket,
+        attribute_type=BasketAttributeType.objects.get(name='bundle_identifier')
+    )
+    bundle_attribute = bundle_attributes.first()
+    return bundle_attribute.value_text if bundle_attribute else None
 
 
 class FreeCheckoutView(EdxOrderPlacementMixin, RedirectView):
@@ -55,12 +74,22 @@ class FreeCheckoutView(EdxOrderPlacementMixin, RedirectView):
                 )
 
             order = self.place_free_order(basket)
-            receipt_path = get_receipt_page_url(
-                order_number=order.number,
-                site_configuration=order.site.siteconfiguration
-            )
 
-            url = site.siteconfiguration.build_lms_url(receipt_path)
+            if has_enterprise_offer(basket):
+                # Skip the receipt page and redirect to the LMS
+                # if the order is free due to an Enterprise-related offer.
+                program_uuid = get_program_uuid(order)
+                if program_uuid:
+                    url = get_lms_program_dashboard_url(program_uuid)
+                else:
+                    course_run_id = order.lines.all()[:1].get().product.course.id
+                    url = get_lms_courseware_url(course_run_id)
+            else:
+                receipt_path = get_receipt_page_url(
+                    order_number=order.number,
+                    site_configuration=order.site.siteconfiguration
+                )
+                url = site.siteconfiguration.build_lms_url(receipt_path)
         else:
             # If a user's basket is empty redirect the user to the basket summary
             # page which displays the appropriate message for empty baskets.
@@ -185,16 +214,8 @@ class ReceiptResponseView(ThankYouView):
                 return True
         return False
 
-    def get_program_uuid(self, order):
-        bundle_attributes = BasketAttribute.objects.filter(
-            basket=order.basket,
-            attribute_type=BasketAttributeType.objects.get(name='bundle_identifier')
-        )
-        bundle_attribute = bundle_attributes.first()
-        return bundle_attribute.value_text if bundle_attribute else None
-
     def get_order_dashboard_context(self, order):
-        program_uuid = self.get_program_uuid(order)
+        program_uuid = get_program_uuid(order)
         if program_uuid:
             order_dashboard_url = get_lms_program_dashboard_url(program_uuid)
         else:

--- a/ecommerce/extensions/test/factories.py
+++ b/ecommerce/extensions/test/factories.py
@@ -9,7 +9,7 @@ from oscar.test.factories import *  # pylint:disable=wildcard-import,unused-wild
 
 from ecommerce.enterprise.benefits import EnterpriseAbsoluteDiscountBenefit, EnterprisePercentageDiscountBenefit
 from ecommerce.enterprise.conditions import EnterpriseCustomerCondition
-from ecommerce.extensions.offer.models import OFFER_PRIORITY_VOUCHER
+from ecommerce.extensions.offer.models import OFFER_PRIORITY_ENTERPRISE, OFFER_PRIORITY_VOUCHER
 from ecommerce.programs.benefits import AbsoluteDiscountBenefitWithoutRange, PercentageDiscountBenefitWithoutRange
 from ecommerce.programs.conditions import ProgramCourseRunSeatsCondition
 from ecommerce.programs.custom import class_path
@@ -200,5 +200,5 @@ class EnterpriseOfferFactory(ConditionalOfferFactory):
     condition = factory.SubFactory(EnterpriseCustomerConditionFactory)
     max_basket_applications = 1
     offer_type = ConditionalOffer.SITE
-    priority = 10
+    priority = OFFER_PRIORITY_ENTERPRISE
     status = ConditionalOffer.OPEN


### PR DESCRIPTION
This will skip any ecommerce-related pages for users who are attempting
to enroll in a course/program which has a 100% discount due to an
Enterprise offer and redirect the user to the appropriate LMS page while still
recording a completed order in the ecommerce system for reporting purposes.
 
# Testing Instructions
## Course Enrollment
1. Visit https://business.sandbox.edx.org/enterprise/2b5a2956-7746-4fc9-9587-bc887ba45973/course/course-v1:edX+DemoX+Demo_Course/enroll/?catalog=cff09318-1358-4703-a277-bc2596480ed5.
2. Login using TestShib.
3. Create new account.
4. Click continue on enrollment landing page.
5. Verify you are redirected to the course info page.

## Program Enrollment
1. Visit https://business.sandbox.edx.org/enterprise/2b5a2956-7746-4fc9-9587-bc887ba45973/program/52ad909b-c57d-4ff1-bab3-999813a2479b/enroll/?catalog=18a9d491-68e0-47c2-98b1-38226ebe2fe5.
2. Login using TestShib.
3. Create new account.
4. Click continue on enrollment landing page.
5. Verify you are redirected to the program dashboard page.