### PR TITLE
WIP: Add default paypal locale

### DIFF
--- a/ecommerce/extensions/payment/constants.py
+++ b/ecommerce/extensions/payment/constants.py
@@ -47,6 +47,9 @@ PAYPAL_LOCALES = {
     'es': 'MX',
 }
 
+# Set to one of the country codes in in PAYPAL_LOCALES
+PAYPAL_DEFAULT_LOCALE = 'US'
+
 APPLE_PAY_CYBERSOURCE_CARD_TYPE_MAP = {
     value['apple_pay_network']: value['cybersource_code'] for value in six.itervalues(CARD_TYPES) if
     'cybersource_code' in value

--- a/ecommerce/extensions/payment/processors/paypal.py
+++ b/ecommerce/extensions/payment/processors/paypal.py
@@ -12,11 +12,10 @@ import waffle
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.utils.functional import cached_property
-from django.utils.translation import get_language
 from oscar.apps.payment.exceptions import GatewayError
 
 from ecommerce.core.url_utils import get_ecommerce_url
-from ecommerce.extensions.payment.constants import PAYPAL_LOCALES
+from ecommerce.extensions.payment.constants import PAYPAL_DEFAULT_LOCALE, PAYPAL_LOCALES
 from ecommerce.extensions.payment.models import PaypalProcessorConfiguration, PaypalWebProfile
 from ecommerce.extensions.payment.processors import BasePaymentProcessor, HandledProcessorResponse
 from ecommerce.extensions.payment.utils import middle_truncate
@@ -67,11 +66,10 @@ class Paypal(BasePaymentProcessor):
         return get_ecommerce_url(self.configuration['error_path'])
 
     def resolve_paypal_locale(self, language_code):
-        default_paypal_locale = PAYPAL_LOCALES.get(re.split(r'[_-]', get_language())[0].lower())
-        if not language_code:
-            return default_paypal_locale
+        if language_code:
+            return PAYPAL_LOCALES.get(re.split(r'[_-]', language_code)[0].lower(), PAYPAL_DEFAULT_LOCALE)
         else:
-            return PAYPAL_LOCALES.get(re.split(r'[_-]', language_code)[0].lower(), default_paypal_locale)
+            return PAYPAL_DEFAULT_LOCALE
 
     def create_temporary_web_profile(self, locale_code):
         """


### PR DESCRIPTION
The default paypal locale was being set to the current language set
in Django. This change allows us to set the default language.