### PR TITLE
Support creating entitlements

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_products.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_products.py
@@ -8,7 +8,7 @@ from django.test import RequestFactory
 from django.urls import reverse
 from oscar.core.loading import get_model
 
-from ecommerce.core.constants import COUPON_PRODUCT_CLASS_NAME, COURSE_ENTITLEMENT_PRODUCT_CLASS_NAME
+from ecommerce.core.constants import COUPON_PRODUCT_CLASS_NAME
 from ecommerce.coupons.tests.mixins import CouponMixin
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.api.serializers import ProductSerializer
@@ -133,49 +133,6 @@ class ProductViewSetTests(ProductViewSetBase):
             'results': []
         }
         self.assertDictEqual(json.loads(response.content), expected)
-
-
-class ProductViewSetCourseEntitlementTests(ProductViewSetBase):
-    def setUp(self):
-        self.entitlement_data = {
-            "product_class": COURSE_ENTITLEMENT_PRODUCT_CLASS_NAME,
-            "title": "Test Course",
-            "price": 50,
-            "expires": "2018-10-10T00:00:00Z",
-            "attribute_values": [
-                {
-                    "name": "certificate_type",
-                    "code": "certificate_type",
-                    "value": "verified"
-                },
-                {
-                    "name": "UUID",
-                    "code": "UUID",
-                    "value": "f9044e15-133f-4a4f-b587-99530e8a8e88"
-                }
-            ],
-            "is_available_to_buy": "false"
-        }
-        super(ProductViewSetCourseEntitlementTests, self).setUp()
-
-    def test_entitlement_post(self):
-        """ Verify the view allows individual Course Entitlement products to be made via post"""
-        response = self.client.post('/api/v2/products/', json.dumps(self.entitlement_data), JSON_CONTENT_TYPE)
-        self.assertEqual(response.status_code, 201)
-
-    def test_entitlement_post_bad_request(self):
-        """ Verify the view allows individual Course Entitlement products to be made via post"""
-        bad_entitlement_data = self.entitlement_data
-        bad_entitlement_data['attribute_values'] = []
-        response = self.client.post('/api/v2/products/', json.dumps(bad_entitlement_data), JSON_CONTENT_TYPE)
-        self.assertEqual(response.status_code, 400)
-
-    def test_non_entitlement_post(self):
-        """ Verify the view allows individual Course Entitlement products to be made via post"""
-        bad_entitlement_data = self.entitlement_data
-        bad_entitlement_data['product_class'] = 'Seat'
-        response = self.client.post('/api/v2/products/', json.dumps(bad_entitlement_data), JSON_CONTENT_TYPE)
-        self.assertEqual(response.status_code, 400)
 
 
 class ProductViewSetCouponTests(CouponMixin, ProductViewSetBase):

--- a/ecommerce/extensions/api/v2/views/products.py
+++ b/ecommerce/extensions/api/v2/views/products.py
@@ -1,14 +1,10 @@
 """HTTP endpoints for interacting with products."""
 from django.db.models import Q
-from django.http import HttpResponseBadRequest
 from oscar.core.loading import get_model
-from rest_framework import filters, status
+from rest_framework import filters
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
-from rest_framework.response import Response
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
-from ecommerce.core.constants import COURSE_ENTITLEMENT_PRODUCT_CLASS_NAME
-from ecommerce.entitlements.utils import create_or_update_course_entitlement
 from ecommerce.extensions.api import serializers
 from ecommerce.extensions.api.filters import ProductFilter
 from ecommerce.extensions.api.v2.views import NonDestroyableModelViewSet
@@ -33,39 +29,3 @@ class ProductViewSet(NestedViewSetMixin, NonDestroyableModelViewSet):
             Q(stockrecords__partner=self.request.site.siteconfiguration.partner) |
             Q(course__site=self.request.site)
         )
-
-    def create(self, request, *args, **kwargs):
-        product_class = request.data.get('product_class')
-        if product_class == COURSE_ENTITLEMENT_PRODUCT_CLASS_NAME:
-
-            product_creation_fields = {
-                'partner': request.site.siteconfiguration.partner,
-                'name': request.data.get('title'),
-                'price': request.data.get('price'),
-                'certificate_type': self._fetch_value_from_attribute_values('certificate_type'),
-                'UUID': self._fetch_value_from_attribute_values('UUID')
-            }
-
-            for attribute_name, attribute_value in product_creation_fields.items():
-                if attribute_value is None:
-                    bad_rqst = 'Missing or bad value for: {}, required for Entitlement creation.'.format(attribute_name)
-                    return HttpResponseBadRequest(bad_rqst)
-
-            entitlement = create_or_update_course_entitlement(
-                product_creation_fields['certificate_type'],
-                product_creation_fields['price'],
-                product_creation_fields['partner'],
-                product_creation_fields['UUID'],
-                product_creation_fields['name']
-            )
-
-            data = self.serializer_class(entitlement, context={'request': request}).data
-            return Response(data, status=status.HTTP_201_CREATED)
-        else:
-            bad_rqst = "Product API only supports POST for {} products".format(COURSE_ENTITLEMENT_PRODUCT_CLASS_NAME)
-            return HttpResponseBadRequest(bad_rqst)
-
-    def _fetch_value_from_attribute_values(self, attribute_name):
-        attributes = {attribute.get('name'): attribute.get('value') for attribute in self.request.data.get('attribute_values')}  # pylint: disable=line-too-long
-        val = attributes.get(attribute_name)
-        return val

--- a/ecommerce/extensions/catalogue/tests/mixins.py
+++ b/ecommerce/extensions/catalogue/tests/mixins.py
@@ -7,6 +7,7 @@ from oscar.core.utils import slugify
 from oscar.test import factories
 
 from ecommerce.core.constants import (
+    COURSE_ENTITLEMENT_PRODUCT_CLASS_NAME,
     ENROLLMENT_CODE_PRODUCT_CLASS_NAME,
     ENROLLMENT_CODE_SWITCH,
     SEAT_PRODUCT_CLASS_NAME
@@ -35,14 +36,16 @@ class DiscoveryTestMixin(object):
         super(DiscoveryTestMixin, self).setUp()
 
         # Force the creation of a seat ProductClass
+        self.entitlement_product_class  # pylint: disable=pointless-statement
         self.seat_product_class  # pylint: disable=pointless-statement
         self.enrollment_code_product_class  # pylint: disable=pointless-statement
 
-        category_name = 'Seats'
-        try:
-            self.category = Category.objects.get(name=category_name)
-        except Category.DoesNotExist:
-            self.category = factories.CategoryFactory(name=category_name)
+        for category_name in ['Course Entitlements', 'Seats']:
+            try:
+                Category.objects.get(name=category_name)
+            except Category.DoesNotExist:
+                factories.CategoryFactory(name=category_name)
+        self.category = Category.objects.get(name='Seats')
 
     def create_course_and_seat(
             self, course_id=None, seat_type='verified', id_verification=False, price=10, partner=None
@@ -91,6 +94,17 @@ class DiscoveryTestMixin(object):
                 factories.ProductAttributeFactory(code=code, name=code, product_class=pc, type=attr_type)
 
         return pc
+
+    @property
+    def entitlement_product_class(self):
+        attributes = (
+            ('certificate_type', 'text'),
+            ('UUID', 'text'),
+        )
+        product_class = self._create_product_class(
+            COURSE_ENTITLEMENT_PRODUCT_CLASS_NAME, slugify(COURSE_ENTITLEMENT_PRODUCT_CLASS_NAME), attributes
+        )
+        return product_class
 
     @property
     def seat_product_class(self):


### PR DESCRIPTION
Allow creating entitlement products via the AtomicPublication API.
Just pass them in like normal seat products, with an entitlement
product class instead of a seat class.

And remove the unused /products create endpoint (that had been
intended to support this workflow, but it's not atomic, so we'll
keep using the generic publication endpoint with new support for
entitlements and drop the unused create-one-entitlement endpoint).

This reverts commit fc824bf7a6a5cfffa7486a40804778b5e0f41792 which was
itself a reversion to back out these changes while we fixed our staging
services.

LEARNER-3891