### PR TITLE
check for entitlement products in addition to course run products

### DIFF
--- a/ecommerce/coupons/tests/mixins.py
+++ b/ecommerce/coupons/tests/mixins.py
@@ -203,6 +203,24 @@ class DiscoveryMockMixin(object):
             ]
         )
 
+    def mock_catalog_query_contains_endpoint(self, course_run_ids, course_uuids, absent_ids, query, discovery_api_url):
+        query_contains_info = {str(identifier): True for identifier in course_run_ids + course_uuids}
+        for identifier in absent_ids:
+            query_contains_info[str(identifier)] = False
+        query_contains_info_json = json.dumps(query_contains_info)
+        url = '{base}catalog/query_contains/?course_run_ids={run_ids}&course_uuids={uuids}&query={query}'.format(
+            base=discovery_api_url,
+            run_ids=",".join(course_run_id for course_run_id in course_run_ids),
+            uuids=",".join(str(course_uuid) for course_uuid in course_uuids),
+            query=query
+        )
+        httpretty.register_uri(
+            httpretty.GET, url,
+            body=query_contains_info_json,
+            content_type='application/json'
+        )
+        return url
+
     def mock_catalog_contains_endpoint(
             self, discovery_api_url, catalog_id=1, course_run_ids=None
     ):
@@ -219,7 +237,6 @@ class DiscoveryMockMixin(object):
         catalog_contains_uri = '{}contains/?course_run_id={}'.format(
             self.build_discovery_catalogs_url(discovery_api_url, catalog_id), ','.join(course_run_ids)
         )
-
         httpretty.register_uri(
             method=httpretty.GET,
             uri=catalog_contains_uri,

--- a/ecommerce/extensions/catalogue/tests/mixins.py
+++ b/ecommerce/extensions/catalogue/tests/mixins.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import logging
+from uuid import uuid4
 
 from oscar.core.loading import get_model
 from oscar.core.utils import slugify
@@ -73,6 +74,16 @@ class DiscoveryTestMixin(object):
 
         seat = course.create_or_update_seat(seat_type, id_verification, price, partner)
         return course, seat
+
+    def create_entitlement_product(self, course_uuid=None, certificate_type='verified'):
+        entitlement = factories.ProductFactory(
+            product_class=self.entitlement_product_class, stockrecords__partner=PartnerFactory(),
+            stockrecords__price_currency='USD'
+        )
+        entitlement.attr.UUID = course_uuid if course_uuid else uuid4()
+        entitlement.attr.certificate_type = certificate_type
+        entitlement.save()
+        return entitlement
 
     def _create_product_class(self, class_name, slug, attributes):
         """ Helper method for creating product classes.


### PR DESCRIPTION
Allow courses in addition to course runs to be included in Coupon Ranges' catalog queries

[LEARNER-4166](https://openedx.atlassian.net/browse/LEARNER-4166), [Ecommerce subtask](https://openedx.atlassian.net/browse/LEARNER-4359)