### PR TITLE
ENT-898: Fixed Bulk enrollment code creation.

### DIFF
--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -25,6 +25,7 @@ from ecommerce.courses.models import Course
 from ecommerce.courses.utils import mode_for_product
 from ecommerce.enterprise.utils import get_or_create_enterprise_customer_user
 from ecommerce.extensions.analytics.utils import audit_log, parse_tracking_context
+from ecommerce.extensions.api.v2.views.coupons import CouponViewSet
 from ecommerce.extensions.checkout.utils import get_receipt_page_url
 from ecommerce.extensions.fulfillment.status import LINE
 from ecommerce.extensions.voucher.models import OrderLineVouchers
@@ -36,6 +37,7 @@ Option = get_model('catalogue', 'Option')
 Product = get_model('catalogue', 'Product')
 Range = get_model('offer', 'Range')
 Voucher = get_model('voucher', 'Voucher')
+StockRecord = get_model('partner', 'StockRecord')
 logger = logging.getLogger(__name__)
 
 
@@ -503,11 +505,16 @@ class EnrollmentCodeFulfillmentModule(BaseFulfillmentModule):
             if created:
                 _range.add_product(seat)
 
+            stock_record = StockRecord.objects.get(product=seat, partner=seat.course.partner)
+            coupon_catalog = CouponViewSet.get_coupon_catalog([stock_record.id], seat.course.partner)
+            _range.catalog = coupon_catalog
+            _range.save()
+
             vouchers = create_vouchers(
                 name='Enrollment code voucher [{}]'.format(line.product.title),
                 benefit_type=Benefit.PERCENTAGE,
                 benefit_value=100,
-                catalog=None,
+                catalog=coupon_catalog,
                 coupon=seat,
                 end_datetime=settings.ENROLLMENT_CODE_EXIPRATION_DATE,
                 enterprise_customer=None,

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -523,7 +523,7 @@ class EnrollmentCodeFulfillmentModuleTests(DiscoveryTestMixin, TestCase):
 
     def setUp(self):
         super(EnrollmentCodeFulfillmentModuleTests, self).setUp()
-        course = CourseFactory()
+        course = CourseFactory(site=self.site)
         course.create_or_update_seat('verified', True, 50, self.partner, create_enrollment_code=True)
         enrollment_code = Product.objects.get(product_class__name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME)
         user = factories.UserFactory()
@@ -556,6 +556,7 @@ class EnrollmentCodeFulfillmentModuleTests(DiscoveryTestMixin, TestCase):
         self.assertEqual(completed_lines[0].status, LINE.COMPLETE)
         self.assertEqual(OrderLineVouchers.objects.count(), 1)
         self.assertEqual(OrderLineVouchers.objects.first().vouchers.count(), self.QUANTITY)
+        self.assertIsNotNone(OrderLineVouchers.objects.first().vouchers.first().benefit.range.catalog)
 
     def test_revoke_line(self):
         line = self.order.lines.first()


### PR DESCRIPTION
**JIRA Ticket:** [ENT-898](https://openedx.atlassian.net/browse/ENT-898)
__Description:__
This PR fixes the issue where bulk enrollment codes were being created without correct parameters.
There were two problems present with enrollment codes

1. Coupon code had 10,000 redemptions created for enrollment codes
2. Single course/multi-course and cert type fields were both blank for enrollment codes

We could not reproduce `10,000 redemptions` part as all new coupons had only one redemption. and with the merge of https://github.com/edx/ecommerce/pull/1655 I think this problems mostly likely already resolved.
Whenever, a enrollment is created via CAT tool or some other way it will have an associated range, benefit, coupon code product etc. This range contains fields like catalog, catalog query, seat types etc. that define the course and seat types for the coupon application. Previously, the Range created for enrollment codes did not have any of these fields populated which was causing problems. This PR fixes that issue by assigning a catalog for the course whose enrollment codes are being created.

**Testing Instructions:**

1. Create a could with bulk enrollment codes enabled, https://mitxpro-sb.sandbox.edx.org/courses/course-v1:MITxPRO+MPTC101+2018_T1/about can be used for testing.
2. Click on "Purchase for a Group", you will be redirected to ecommerce basket page where you will need to add enrollment codes quantity and payment information.
3. After submitting the form, make sure there is a new Range product with catalog field populated. Look for the newest Range product.