### PR TITLE
fix return type of get_applicable_lines

### DIFF
--- a/ecommerce/extensions/offer/models.py
+++ b/ecommerce/extensions/offer/models.py
@@ -116,7 +116,7 @@ class Benefit(AbstractBenefit):
                     cache.set(metadata['cache_key'], in_range, settings.COURSES_API_CACHE_TIMEOUT)
                     if not in_range:
                         applicable_lines.remove(metadata['line'])
-            return applicable_lines
+            return [(line.product.stockrecords.first().price_excl_tax, line) for line in applicable_lines]
         else:
             return super(Benefit, self).get_applicable_lines(offer, basket, range=range)  # pylint: disable=bad-super-call
 

--- a/ecommerce/extensions/offer/tests/test_models.py
+++ b/ecommerce/extensions/offer/tests/test_models.py
@@ -464,7 +464,7 @@ class BenefitTests(DiscoveryTestMixin, DiscoveryMockMixin, TestCase):
 
         basket.add_product(entitlement_product)
         basket.add_product(seat)
-        applicable_lines = list(basket.all_lines())
+        applicable_lines = [(line.product.stockrecords.first().price_excl_tax, line) for line in basket.all_lines()]
         basket.add_product(no_certificate_product)
 
         self.mock_access_token_response()


### PR DESCRIPTION
Get applicable lines is expected to return a list of (price, line) tuples, not just a list of lines.

[LEARNER-4166](https://openedx.atlassian.net/browse/LEARNER-4166), [Ecommerce subtask](https://openedx.atlassian.net/browse/LEARNER-4166)