### PR TITLE
Update Email Templates for Bulk Enrollment Purchases

### DIFF
--- a/ecommerce/conf/locale/en/LC_MESSAGES/django.po
+++ b/ecommerce/conf/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-14 09:32+0000\n"
+"POT-Creation-Date: 2018-03-15 11:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -31,6 +31,7 @@ msgstr ""
 
 #. Translators: "Waffle" is the name of a third-party library. It should not be translated
 #: ecommerce/core/admin.py:31
+#, python-brace-format
 msgid ""
 "User administration has been disabled due to the load on the database. This "
 "functionality can be restored by activating the {switch_name} Waffle switch. "
@@ -241,6 +242,7 @@ msgid "This coupon code has expired."
 msgstr ""
 
 #: ecommerce/coupons/views.py:87
+#, python-brace-format
 msgid "Product [{product}] not available for purchase."
 msgstr ""
 
@@ -291,10 +293,12 @@ msgid "Invalid data sharing consent token provided."
 msgstr ""
 
 #: ecommerce/coupons/views.py:237 ecommerce/extensions/basket/views.py:94
+#, python-brace-format
 msgid "You have already purchased {course} seat."
 msgstr ""
 
 #: ecommerce/coupons/views.py:250
+#, python-brace-format
 msgid "A discount has been applied, courtesy of {enterprise_customer_name}."
 msgstr ""
 
@@ -302,7 +306,7 @@ msgstr ""
 msgid "This coupon code is not valid for this course. Try a different course."
 msgstr ""
 
-#: ecommerce/courses/models.py:33 ecommerce/extensions/basket/models.py:14
+#: ecommerce/courses/models.py:31 ecommerce/extensions/basket/models.py:14
 #: ecommerce/extensions/offer/models.py:128
 #: ecommerce/extensions/payment/models.py:58
 #: ecommerce/templates/oscar/dashboard/offers/offer_detail.html:65
@@ -310,11 +314,12 @@ msgstr ""
 msgid "Site"
 msgstr ""
 
-#: ecommerce/courses/models.py:39
+#: ecommerce/courses/models.py:37
 msgid "Last date/time on which verification for this product can be submitted."
 msgstr ""
 
 #: ecommerce/courses/publishers.py:61
+#, python-brace-format
 msgid "Failed to publish commerce data for {course_id} to LMS."
 msgstr ""
 
@@ -345,6 +350,7 @@ msgid ""
 msgstr ""
 
 #: ecommerce/credit/views.py:63
+#, python-brace-format
 msgid ""
 "Credit is not currently available for \"{course_name}\". If you are "
 "currently enrolled in the course, please try again after all grading is "
@@ -364,6 +370,7 @@ msgid "%d%% enterprise discount"
 msgstr ""
 
 #: ecommerce/enterprise/benefits.py:33
+#, python-brace-format
 msgid "{value} fixed-price enterprise discount"
 msgstr ""
 
@@ -419,6 +426,7 @@ msgid "The start date must occur before the end date."
 msgstr ""
 
 #: ecommerce/enterprise/forms.py:98
+#, python-brace-format
 msgid "Discount provided by {enterprise_customer_name}."
 msgstr ""
 
@@ -515,26 +523,31 @@ msgid "End"
 msgstr ""
 
 #: ecommerce/enterprise/utils.py:113
+#, python-brace-format
 msgid "SKU {sku} does not exist."
 msgstr ""
 
 #: ecommerce/enterprise/utils.py:121
+#, python-brace-format
 msgid "There is no Enterprise Customer associated with SKU {sku}."
 msgstr ""
 
 #: ecommerce/enterprise/utils.py:129
+#, python-brace-format
 msgid ""
 "If you have concerns about sharing your data, please contact your "
 "administrator at {enterprise}."
 msgstr ""
 
 #: ecommerce/enterprise/utils.py:132
+#, python-brace-format
 msgid ""
 "If you have concerns about sharing your data, please contact your "
 "administrator at {enterprise} at {contact_info}."
 msgstr ""
 
 #: ecommerce/enterprise/utils.py:138
+#, python-brace-format
 msgid "Enrollment in {course_name} was not complete."
 msgstr ""
 
@@ -581,30 +594,32 @@ msgstr ""
 msgid "Products must indicate whether ID verification is required."
 msgstr ""
 
-#: ecommerce/extensions/api/serializers.py:426
+#: ecommerce/extensions/api/serializers.py:428
+#, python-brace-format
 msgid "Invalid product class [{product_class}] requested."
 msgstr ""
 
-#: ecommerce/extensions/api/serializers.py:457
+#: ecommerce/extensions/api/serializers.py:459
+#, python-brace-format
 msgid ""
 "Course [{course_id}] was not published to LMS because the switch "
 "[publish_course_modes_to_lms] is disabled. To avoid ghost SKUs, data has not "
 "been saved."
 msgstr ""
 
-#: ecommerce/extensions/api/serializers.py:649
+#: ecommerce/extensions/api/serializers.py:647
 msgid "Enrollment code"
 msgstr ""
 
-#: ecommerce/extensions/api/serializers.py:650
+#: ecommerce/extensions/api/serializers.py:648
 msgid "Discount code"
 msgstr ""
 
-#: ecommerce/extensions/api/serializers.py:664
+#: ecommerce/extensions/api/serializers.py:662
 msgid "ACTIVE"
 msgstr ""
 
-#: ecommerce/extensions/api/serializers.py:664
+#: ecommerce/extensions/api/serializers.py:662
 msgid "INACTIVE"
 msgstr ""
 
@@ -615,10 +630,12 @@ msgstr ""
 
 #: ecommerce/extensions/api/v2/views/baskets.py:373
 #: ecommerce/extensions/basket/views.py:117
+#, python-brace-format
 msgid "Products with SKU(s) [{skus}] do not exist."
 msgstr ""
 
 #: ecommerce/extensions/basket/models.py:83
+#, python-brace-format
 msgid "{id} - {status} basket (owner: {owner}, lines: {num_lines})"
 msgstr ""
 
@@ -655,10 +672,12 @@ msgid "No SKU provided."
 msgstr ""
 
 #: ecommerce/extensions/basket/views.py:66
+#, python-brace-format
 msgid "SKU [{sku}] does not exist."
 msgstr ""
 
 #: ecommerce/extensions/basket/views.py:86
+#, python-brace-format
 msgid "Product [{product}] not available to buy."
 msgstr ""
 
@@ -667,6 +686,7 @@ msgid "You have already purchased these products"
 msgstr ""
 
 #: ecommerce/extensions/basket/views.py:211
+#, python-brace-format
 msgid ""
 "{strong_start}Purchasing access just for yourself?{strong_end}"
 "{paragraph_start}If you are purchasing a single code for someone else, "
@@ -697,6 +717,7 @@ msgid ""
 msgstr ""
 
 #: ecommerce/extensions/basket/views.py:282
+#, python-brace-format
 msgid ""
 "{paragraph_start}By purchasing, you and your organization agree to the "
 "following terms:{paragraph_end} {ul_start} {li_start}Each code is valid for "
@@ -711,40 +732,48 @@ msgid ""
 "enrollment code(s). {paragraph_end}"
 msgstr ""
 
-#: ecommerce/extensions/basket/views.py:408
+#: ecommerce/extensions/basket/views.py:406
+#, python-brace-format
 msgid "Could not apply the code '{code}'; it requires data sharing consent."
 msgstr ""
 
-#: ecommerce/extensions/basket/views.py:462
+#: ecommerce/extensions/basket/views.py:460
+#, python-brace-format
 msgid "Coupon code '{code}' has expired."
 msgstr ""
 
-#: ecommerce/extensions/basket/views.py:469
+#: ecommerce/extensions/basket/views.py:467
+#, python-brace-format
 msgid "Coupon code '{code}' is not active."
 msgstr ""
 
-#: ecommerce/extensions/basket/views.py:476
+#: ecommerce/extensions/basket/views.py:474
+#, python-brace-format
 msgid "Coupon code '{code}' has already been redeemed."
 msgstr ""
 
-#: ecommerce/extensions/basket/views.py:486
-#: ecommerce/extensions/basket/views.py:500
+#: ecommerce/extensions/basket/views.py:484
+#: ecommerce/extensions/basket/views.py:498
+#, python-brace-format
 msgid "Coupon code '{code}' is not valid for this basket."
 msgstr ""
 
-#: ecommerce/extensions/basket/views.py:524
+#: ecommerce/extensions/basket/views.py:522
 msgid "Your basket does not qualify for a coupon code discount."
 msgstr ""
 
-#: ecommerce/extensions/basket/views.py:529
+#: ecommerce/extensions/basket/views.py:527
+#, python-brace-format
 msgid "Coupon code '{code}' added to basket."
 msgstr ""
 
-#: ecommerce/extensions/basket/views.py:539
+#: ecommerce/extensions/basket/views.py:537
+#, python-brace-format
 msgid "You have already added coupon code '{code}' to your basket."
 msgstr ""
 
-#: ecommerce/extensions/basket/views.py:547
+#: ecommerce/extensions/basket/views.py:545
+#, python-brace-format
 msgid "Coupon code '{code}' does not exist."
 msgstr ""
 
@@ -769,9 +798,10 @@ msgid "Email"
 msgstr ""
 
 #: ecommerce/extensions/dashboard/orders/views.py:72
+#, python-brace-format
 msgid ""
-"{link_start}Refund #{refund_id}{link_end} created! Click {link_start}here"
-"{link_end} to view it."
+"{link_start}Refund #{refund_id}{link_end} created! Click {link_start}"
+"here{link_end} to view it."
 msgstr ""
 
 #: ecommerce/extensions/dashboard/orders/views.py:76
@@ -838,15 +868,18 @@ msgid "Program UUID"
 msgstr ""
 
 #: ecommerce/extensions/offer/utils.py:64
+#, python-brace-format
 msgid "{benefit_value}%"
 msgstr ""
 
 #: ecommerce/extensions/offer/utils.py:67
+#, python-brace-format
 msgid "${benefit_value}"
 msgstr ""
 
 #. Translators: "Waffle" is the name of a third-party library. It should not be translated
 #: ecommerce/extensions/order/admin.py:29
+#, python-brace-format
 msgid ""
 "Order administration has been disabled due to the load on the database. This "
 "functionality can be restored by activating the {switch_name} Waffle switch. "
@@ -900,6 +933,7 @@ msgstr ""
 #. fields on the payment form. For example, the first name field is
 #. required, so this would read "First name (required)".
 #: ecommerce/extensions/payment/forms.py:103
+#, python-brace-format
 msgid "{label} (required)"
 msgstr ""
 
@@ -953,6 +987,7 @@ msgid "This field is required."
 msgstr ""
 
 #: ecommerce/extensions/payment/forms.py:177
+#, python-brace-format
 msgid "{state} is not a valid state/province in {country}."
 msgstr ""
 
@@ -988,6 +1023,7 @@ msgid "..."
 msgstr ""
 
 #: ecommerce/extensions/payment/views/cybersource.py:311
+#, python-brace-format
 msgid ""
 "An error occurred while processing your payment. You have not been charged. "
 "Please double-check the information you provided and try again. For help, "
@@ -1065,6 +1101,7 @@ msgstr ""
 #: ecommerce/extensions/voucher/tests/test_utils.py:347
 #: ecommerce/extensions/voucher/utils.py:90
 #: ecommerce/extensions/voucher/utils.py:136
+#, python-brace-format
 msgid "{percentage} %"
 msgstr ""
 
@@ -1184,10 +1221,12 @@ msgid "Email Domains"
 msgstr ""
 
 #: ecommerce/extensions/voucher/utils.py:534
+#, python-brace-format
 msgid "Range for coupon [{coupon_id}]"
 msgstr ""
 
 #: ecommerce/extensions/voucher/views.py:29
+#, python-brace-format
 msgid "Coupon Report for {coupon_name}"
 msgstr ""
 
@@ -1233,14 +1272,17 @@ msgid "Refund Transactions"
 msgstr ""
 
 #: ecommerce/management/views.py:51
+#, python-brace-format
 msgid "{action} is not a valid action."
 msgstr ""
 
 #: ecommerce/programs/benefits.py:25
+#, python-brace-format
 msgid "{value}% program discount"
 msgstr ""
 
 #: ecommerce/programs/benefits.py:42
+#, python-brace-format
 msgid "{value} fixed-price program discount"
 msgstr ""
 
@@ -1249,6 +1291,7 @@ msgid "An offer already exists for this program."
 msgstr ""
 
 #: ecommerce/programs/forms.py:86
+#, python-brace-format
 msgid "Discount for the {program_title} {program_type} Program"
 msgstr ""
 
@@ -1490,7 +1533,7 @@ msgstr ""
 msgid "Courses"
 msgstr ""
 
-#: ecommerce/templates/courses/course_app.html:28
+#: ecommerce/templates/courses/course_app.html:25
 #, python-format
 msgid "%(platform_name)s Course Administration Tool"
 msgstr ""
@@ -1507,7 +1550,7 @@ msgstr ""
 msgid "E-Commerce Dashboard"
 msgstr ""
 
-#: ecommerce/templates/customer/email_base.html:178
+#: ecommerce/templates/customer/email_base.html:188
 #, python-format
 msgid "Copyright © %(year)s %(platform_name)s. All rights reserved."
 msgstr ""
@@ -1591,8 +1634,8 @@ msgstr ""
 
 #: ecommerce/templates/customer/emails/commtype_credit_receipt_body.html:55
 #: ecommerce/templates/customer/emails/commtype_credit_receipt_body.txt:4
-#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:54
-#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt:4
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:24
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt:5
 #, python-format
 msgid "Dear %(full_name)s,"
 msgstr ""
@@ -1674,68 +1717,119 @@ msgid "Order Receipt"
 msgstr ""
 
 #: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:13
-msgid "Order Confirmation"
+msgid "For Business"
+msgstr ""
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:25
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt:6
+#, python-format
+msgid ""
+"Thank you for purchasing access to %(course_name)s. Let's get your group "
+"ready to learn with edX:"
 msgstr ""
 
 #: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:27
-msgid "Order confirmation for"
-msgstr ""
-
-#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:43
-msgid "View Order Information"
-msgstr ""
-
-#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:55
 #, python-format
 msgid ""
-"Thank you for purchasing access to %(course_name)s.\n"
-"                    Please click <a href=\"%(download_csv_link)s\">HERE</a> "
-"to download a CSV file with the enrollment codes for this course.\n"
-"                    Once you have the codes you can distribute them to your "
-"team. "
+"Download and save the %(link_start)s%(download_csv_link)s%(link_middle)s "
+"enrollment code file.%(link_end)s"
 msgstr ""
 
-#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:58
-#, python-format
-msgid "To view your payment information, please visit %(receipt_page_url)s."
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:28
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt:9
+msgid "Distribute one code per learner before the expiration date."
 msgstr ""
 
-#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:59
-#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt:8
-#, python-format
-msgid "To explore other courses, please visit %(lms_url)s."
-msgstr ""
-
-#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:60
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:29
 #: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt:10
-msgid "Thank you,"
+msgid "Pro tip: Track which code is associated with which person."
 msgstr ""
 
-#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:61
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:30
 #: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt:11
-#, python-format
-msgid "The %(partner_name)s team"
+msgid "Learners sign-in/register with edX and enroll for the course."
 msgstr ""
 
-#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:72
-#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt:13
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:32
 #, python-format
 msgid ""
-"You received this message because you purchased enrollment codes for "
-"%(course_name)s on %(lms_url)s. If you have any questions, please visit "
-"%(contact_url)s."
+"To view your payment information, log in to see your Order History, under "
+"%(link_start)s%(order_history_url)s%(link_middle)sAccount Settings"
+"%(link_end)s"
+msgstr ""
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:33
+#, python-format
+msgid ""
+"For more information and assistance, contact %(link_start)sinfo@edx.org."
+"%(link_end)s"
+msgstr ""
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:34
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt:16
+msgid "Thank You"
+msgstr ""
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:45
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt:18
+msgid "By purchasing, you and your organization agree to the following terms:"
+msgstr ""
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:47
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt:20
+msgid ""
+"Each code is valid for the one course covered and can be used only one time."
+msgstr ""
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:48
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt:21
+msgid "You are responsible for distributing codes to your learners."
+msgstr ""
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:49
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt:22
+msgid ""
+"Each code will expire in one year from date of purchase or, if earlier, once "
+"the course is closed."
+msgstr ""
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:50
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt:23
+msgid ""
+"If a course is not designated as self-paced, you should confirm that a "
+"course run is available before expiration."
+msgstr ""
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:51
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt:24
+msgid "You may not resell codes to third parties."
+msgstr ""
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html:52
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt:25
+msgid "All sales final. No refunds."
 msgstr ""
 
 #: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt:2
 msgid "Order confirmation for: "
 msgstr ""
 
-#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt:6
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt:8
 #, python-format
 msgid ""
-"Thank you for purchasing access to %(course_name)s. Please go to "
-"%(download_csv_link)s to download a CSV file with the enrollment codes for "
-"this course. Once you have the codes you can distribute them to your team. "
+"Please visit %(download_csv_link)s to download and save the enrollment code "
+"file."
+msgstr ""
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt:13
+#, python-format
+msgid ""
+"To view your payment information, log in to see your Order History, under "
+"Account Settings at %(order_history_url)s."
+msgstr ""
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt:14
+msgid "For more information and assistance, contact info@edx.org."
 msgstr ""
 
 #: ecommerce/templates/customer/emails/commtype_order_with_csv_subject.txt:2

--- a/ecommerce/conf/locale/en/LC_MESSAGES/djangojs.po
+++ b/ecommerce/conf/locale/en/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-14 09:32+0000\n"
+"POT-Creation-Date: 2018-03-15 11:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -42,7 +42,7 @@ msgid "A valid course ID is required"
 msgstr ""
 
 #: ecommerce/static/js/models/coupon_model.js:106
-#, c-format
+#, javascript-format
 msgid "Email domain {%s} is invalid."
 msgstr ""
 
@@ -253,28 +253,21 @@ msgstr ""
 #: ecommerce/static/js/payment_processors/cybersource.js:249
 msgid ""
 "An error occurred while processing your payment. You have NOT been charged. "
+"Please try again, or select another payment method."
 msgstr ""
 
 #: ecommerce/static/js/payment_processors/stripe.js:71
 msgid ""
 "An error occurred while attempting to process your payment. You have not "
-"been "
+"been charged. Please check your payment details, and try again."
 msgstr ""
 
 #: ecommerce/static/js/payment_processors/stripe.js:110
-msgid "An error occurred while processing your payment. "
+msgid "An error occurred while processing your payment. Please try again."
 msgstr ""
 
 #: ecommerce/static/js/utils/utils.js:184
 msgid "Trailing comma not allowed."
-msgstr ""
-
-#: ecommerce/static/js/utils/validation_patterns.js:18
-msgid "The course ID is invalid."
-msgstr ""
-
-#: ecommerce/static/js/utils/validation_patterns.js:26
-msgid "The product name cannot contain HTML."
 msgstr ""
 
 #: ecommerce/static/js/views/coupon_detail_view.js:107
@@ -380,12 +373,15 @@ msgid "Professional Education"
 msgstr ""
 
 #: ecommerce/static/js/views/course_form_view.js:66
-msgid "Paid certificate track with initial verification and Professional "
+msgid ""
+"Paid certificate track with initial verification and Professional Education "
+"Certificate"
 msgstr ""
 
 #: ecommerce/static/js/views/course_form_view.js:72
 msgid ""
 "Paid certificate track with initial verification and Verified Certificate, "
+"and option to purchase credit"
 msgstr ""
 
 #. Translators: _START_, _END_, and _TOTAL_ are placeholders. Do NOT translate them.

--- a/ecommerce/conf/locale/eo/LC_MESSAGES/django.po
+++ b/ecommerce/conf/locale/eo/LC_MESSAGES/django.po
@@ -7,14 +7,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-14 09:32+0000\n"
+"POT-Creation-Date: 2018-03-15 11:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ecommerce/core/admin.py
@@ -32,6 +32,7 @@ msgstr "Ìmpörtänt dätés Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт α#"
 #. Translators: "Waffle" is the name of a third-party library. It should not
 #. be translated
 #: ecommerce/core/admin.py
+#, python-brace-format
 msgid ""
 "User administration has been disabled due to the load on the database. This "
 "functionality can be restored by activating the {switch_name} Waffle switch."
@@ -282,6 +283,7 @@ msgid "This coupon code has expired."
 msgstr "Thïs çöüpön çödé häs éxpïréd. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢#"
 
 #: ecommerce/coupons/views.py
+#, python-brace-format
 msgid "Product [{product}] not available for purchase."
 msgstr ""
 "Prödüçt [{product}] nöt äväïläßlé för pürçhäsé. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт,"
@@ -346,12 +348,14 @@ msgstr ""
 "¢σηѕє¢тєтυя #"
 
 #: ecommerce/coupons/views.py ecommerce/extensions/basket/views.py
+#, python-brace-format
 msgid "You have already purchased {course} seat."
 msgstr ""
 "Ýöü hävé älréädý pürçhäséd {course} séät. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, "
 "¢σηѕє¢тєтυ#"
 
 #: ecommerce/coupons/views.py
+#, python-brace-format
 msgid "A discount has been applied, courtesy of {enterprise_customer_name}."
 msgstr ""
 "À dïsçöünt häs ßéén äpplïéd, çöürtésý öf {enterprise_customer_name}. Ⱡ'σяєм "
@@ -378,6 +382,7 @@ msgstr ""
 "Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя#"
 
 #: ecommerce/courses/publishers.py
+#, python-brace-format
 msgid "Failed to publish commerce data for {course_id} to LMS."
 msgstr ""
 "Fäïléd tö püßlïsh çömmérçé dätä för {course_id} tö LMS. Ⱡ'σяєм ιρѕυм ∂σłσя "
@@ -412,6 +417,7 @@ msgstr ""
 " çrédït. Trý thé tränsäçtïön ägäïn. Ⱡ'σяєм ιρѕυм ∂σłσя #"
 
 #: ecommerce/credit/views.py
+#, python-brace-format
 msgid ""
 "Credit is not currently available for \"{course_name}\". If you are "
 "currently enrolled in the course, please try again after all grading is "
@@ -441,6 +447,7 @@ msgid "%d%% enterprise discount"
 msgstr "%d%% éntérprïsé dïsçöünt Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕ#"
 
 #: ecommerce/enterprise/benefits.py
+#, python-brace-format
 msgid "{value} fixed-price enterprise discount"
 msgstr ""
 "{value} fïxéd-prïçé éntérprïsé dïsçöünt Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, "
@@ -507,6 +514,7 @@ msgstr ""
 "¢σηѕє¢тєтυя α#"
 
 #: ecommerce/enterprise/forms.py
+#, python-brace-format
 msgid "Discount provided by {enterprise_customer_name}."
 msgstr ""
 "Dïsçöünt prövïdéd ßý {enterprise_customer_name}. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт "
@@ -609,16 +617,19 @@ msgid "End"
 msgstr "Énd Ⱡ'σяєм#"
 
 #: ecommerce/enterprise/utils.py
+#, python-brace-format
 msgid "SKU {sku} does not exist."
 msgstr "SKÛ {sku} döés nöt éxïst. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σ#"
 
 #: ecommerce/enterprise/utils.py
+#, python-brace-format
 msgid "There is no Enterprise Customer associated with SKU {sku}."
 msgstr ""
 "Théré ïs nö Éntérprïsé Çüstömér ässöçïätéd wïth SKÛ {sku}. Ⱡ'σяєм ιρѕυм "
 "∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
 
 #: ecommerce/enterprise/utils.py
+#, python-brace-format
 msgid ""
 "If you have concerns about sharing your data, please contact your "
 "administrator at {enterprise}."
@@ -627,6 +638,7 @@ msgstr ""
 "ädmïnïsträtör ät {enterprise}. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє#"
 
 #: ecommerce/enterprise/utils.py
+#, python-brace-format
 msgid ""
 "If you have concerns about sharing your data, please contact your "
 "administrator at {enterprise} at {contact_info}."
@@ -636,6 +648,7 @@ msgstr ""
 "αмєт, ¢#"
 
 #: ecommerce/enterprise/utils.py
+#, python-brace-format
 msgid "Enrollment in {course_name} was not complete."
 msgstr ""
 "Énröllmént ïn {course_name} wäs nöt çömplété. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, "
@@ -699,12 +712,14 @@ msgstr ""
 "∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
 
 #: ecommerce/extensions/api/serializers.py
+#, python-brace-format
 msgid "Invalid product class [{product_class}] requested."
 msgstr ""
 "Ìnvälïd prödüçt çläss [{product_class}] réqüéstéd. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт "
 "αмєт, ¢σηѕє¢тєтυя#"
 
 #: ecommerce/extensions/api/serializers.py
+#, python-brace-format
 msgid ""
 "Course [{course_id}] was not published to LMS because the switch "
 "[publish_course_modes_to_lms] is disabled. To avoid ghost SKUs, data has not"
@@ -742,12 +757,14 @@ msgstr "Nö SKÛs prövïdéd. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмє
 
 #: ecommerce/extensions/api/v2/views/baskets.py
 #: ecommerce/extensions/basket/views.py
+#, python-brace-format
 msgid "Products with SKU(s) [{skus}] do not exist."
 msgstr ""
 "Prödüçts wïth SKÛ(s) [{skus}] dö nöt éxïst. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, "
 "¢σηѕє¢тєтυя#"
 
 #: ecommerce/extensions/basket/models.py
+#, python-brace-format
 msgid "{id} - {status} basket (owner: {owner}, lines: {num_lines})"
 msgstr ""
 "{id} - {status} ßäskét (öwnér: {owner}, lïnés: {num_lines}) Ⱡ'σяєм ιρѕυм "
@@ -792,10 +809,12 @@ msgid "No SKU provided."
 msgstr "Nö SKÛ prövïdéd. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αм#"
 
 #: ecommerce/extensions/basket/views.py
+#, python-brace-format
 msgid "SKU [{sku}] does not exist."
 msgstr "SKÛ [{sku}] döés nöt éxïst. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕ#"
 
 #: ecommerce/extensions/basket/views.py
+#, python-brace-format
 msgid "Product [{product}] not available to buy."
 msgstr ""
 "Prödüçt [{product}] nöt äväïläßlé tö ßüý. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, "
@@ -808,6 +827,7 @@ msgstr ""
 "¢σηѕє¢тєтυя #"
 
 #: ecommerce/extensions/basket/views.py
+#, python-brace-format
 msgid ""
 "{strong_start}Purchasing access just for "
 "yourself?{strong_end}{paragraph_start}If you are purchasing a single code "
@@ -855,6 +875,7 @@ msgstr ""
 "çöürsé. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєт#"
 
 #: ecommerce/extensions/basket/views.py
+#, python-brace-format
 msgid ""
 "{paragraph_start}By purchasing, you and your organization agree to the "
 "following terms:{paragraph_end} {ul_start} {li_start}Each code is valid for "
@@ -881,28 +902,33 @@ msgstr ""
 "{user_email} wïth ýöür énröllmént çödé(s). {paragraph_end}#"
 
 #: ecommerce/extensions/basket/views.py
+#, python-brace-format
 msgid "Could not apply the code '{code}'; it requires data sharing consent."
 msgstr ""
 "Çöüld nöt äpplý thé çödé '{code}'; ït réqüïrés dätä shärïng çönsént. Ⱡ'σяєм "
 "ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
 
 #: ecommerce/extensions/basket/views.py
+#, python-brace-format
 msgid "Coupon code '{code}' has expired."
 msgstr ""
 "Çöüpön çödé '{code}' häs éxpïréd. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢т#"
 
 #: ecommerce/extensions/basket/views.py
+#, python-brace-format
 msgid "Coupon code '{code}' is not active."
 msgstr ""
 "Çöüpön çödé '{code}' ïs nöt äçtïvé. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тє#"
 
 #: ecommerce/extensions/basket/views.py
+#, python-brace-format
 msgid "Coupon code '{code}' has already been redeemed."
 msgstr ""
 "Çöüpön çödé '{code}' häs älréädý ßéén rédééméd. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт,"
 " ¢σηѕє¢тєтυя #"
 
 #: ecommerce/extensions/basket/views.py ecommerce/extensions/basket/views.py
+#, python-brace-format
 msgid "Coupon code '{code}' is not valid for this basket."
 msgstr ""
 "Çöüpön çödé '{code}' ïs nöt välïd för thïs ßäskét. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт "
@@ -915,18 +941,21 @@ msgstr ""
 "ѕιт αмєт, ¢σηѕє¢тєтυя α#"
 
 #: ecommerce/extensions/basket/views.py
+#, python-brace-format
 msgid "Coupon code '{code}' added to basket."
 msgstr ""
 "Çöüpön çödé '{code}' äddéd tö ßäskét. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, "
 "¢σηѕє¢тєт#"
 
 #: ecommerce/extensions/basket/views.py
+#, python-brace-format
 msgid "You have already added coupon code '{code}' to your basket."
 msgstr ""
 "Ýöü hävé älréädý äddéd çöüpön çödé '{code}' tö ýöür ßäskét. Ⱡ'σяєм ιρѕυм "
 "∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
 
 #: ecommerce/extensions/basket/views.py
+#, python-brace-format
 msgid "Coupon code '{code}' does not exist."
 msgstr ""
 "Çöüpön çödé '{code}' döés nöt éxïst. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тє#"
@@ -954,6 +983,7 @@ msgid "Email"
 msgstr "Émäïl Ⱡ'σяєм ιρѕ#"
 
 #: ecommerce/extensions/dashboard/orders/views.py
+#, python-brace-format
 msgid ""
 "{link_start}Refund #{refund_id}{link_end} created! Click "
 "{link_start}here{link_end} to view it."
@@ -1032,16 +1062,19 @@ msgid "Program UUID"
 msgstr "Prögräm ÛÛÌD Ⱡ'σяєм ιρѕυм ∂σłσя ѕ#"
 
 #: ecommerce/extensions/offer/utils.py
+#, python-brace-format
 msgid "{benefit_value}%"
 msgstr "{benefit_value}% Ⱡ'σяєм ι#"
 
 #: ecommerce/extensions/offer/utils.py
+#, python-brace-format
 msgid "${benefit_value}"
 msgstr "${benefit_value} Ⱡ'σяєм ι#"
 
 #. Translators: "Waffle" is the name of a third-party library. It should not
 #. be translated
 #: ecommerce/extensions/order/admin.py
+#, python-brace-format
 msgid ""
 "Order administration has been disabled due to the load on the database. This"
 " functionality can be restored by activating the {switch_name} Waffle "
@@ -1106,6 +1139,7 @@ msgstr "Çhöösé çöüntrý Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт#"
 #. fields on the payment form. For example, the first name field is
 #. required, so this would read "First name (required)".
 #: ecommerce/extensions/payment/forms.py
+#, python-brace-format
 msgid "{label} (required)"
 msgstr "{label} (réqüïréd) Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт#"
 
@@ -1159,6 +1193,7 @@ msgid "This field is required."
 msgstr "Thïs fïéld ïs réqüïréd. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σ#"
 
 #: ecommerce/extensions/payment/forms.py
+#, python-brace-format
 msgid "{state} is not a valid state/province in {country}."
 msgstr ""
 "{state} ïs nöt ä välïd stäté/prövïnçé ïn {country}. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт "
@@ -1200,6 +1235,7 @@ msgid "..."
 msgstr "... Ⱡ'σяєм#"
 
 #: ecommerce/extensions/payment/views/cybersource.py
+#, python-brace-format
 msgid ""
 "An error occurred while processing your payment. You have not been charged. "
 "Please double-check the information you provided and try again. For help, "
@@ -1281,6 +1317,7 @@ msgstr "Énröllmént Ⱡ'σяєм ιρѕυм ∂σłσ#"
 #: ecommerce/extensions/voucher/tests/test_utils.py
 #: ecommerce/extensions/voucher/tests/test_utils.py
 #: ecommerce/extensions/voucher/utils.py ecommerce/extensions/voucher/utils.py
+#, python-brace-format
 msgid "{percentage} %"
 msgstr "{percentage} % Ⱡ'σяєм ιρѕ#"
 
@@ -1400,10 +1437,12 @@ msgid "Email Domains"
 msgstr "Émäïl Dömäïns Ⱡ'σяєм ιρѕυм ∂σłσя ѕι#"
 
 #: ecommerce/extensions/voucher/utils.py
+#, python-brace-format
 msgid "Range for coupon [{coupon_id}]"
 msgstr "Rängé för çöüpön [{coupon_id}] Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢#"
 
 #: ecommerce/extensions/voucher/views.py
+#, python-brace-format
 msgid "Coupon Report for {coupon_name}"
 msgstr "Çöüpön Répört för {coupon_name} Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, #"
 
@@ -1451,14 +1490,17 @@ msgid "Refund Transactions"
 msgstr "Réfünd Tränsäçtïöns Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт,#"
 
 #: ecommerce/management/views.py
+#, python-brace-format
 msgid "{action} is not a valid action."
 msgstr "{action} ïs nöt ä välïd äçtïön. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕ#"
 
 #: ecommerce/programs/benefits.py
+#, python-brace-format
 msgid "{value}% program discount"
 msgstr "{value}% prögräm dïsçöünt Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, #"
 
 #: ecommerce/programs/benefits.py
+#, python-brace-format
 msgid "{value} fixed-price program discount"
 msgstr ""
 "{value} fïxéd-prïçé prögräm dïsçöünt Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тє#"
@@ -1470,6 +1512,7 @@ msgstr ""
 "¢σηѕє¢тєтυя #"
 
 #: ecommerce/programs/forms.py
+#, python-brace-format
 msgid "Discount for the {program_title} {program_type} Program"
 msgstr ""
 "Dïsçöünt för thé {program_title} {program_type} Prögräm Ⱡ'σяєм ιρѕυм ∂σłσя "
@@ -1965,65 +2008,127 @@ msgid "Order Receipt"
 msgstr "Ördér Réçéïpt Ⱡ'σяєм ιρѕυм ∂σłσя ѕι#"
 
 #: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
-msgid "Order Confirmation"
-msgstr "Ördér Çönfïrmätïön Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт#"
-
-#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
-msgid "Order confirmation for"
-msgstr "Ördér çönfïrmätïön för Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢#"
-
-#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
-msgid "View Order Information"
-msgstr "Vïéw Ördér Ìnförmätïön Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢#"
-
-#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
-#, python-format
-msgid ""
-"Thank you for purchasing access to %(course_name)s.\n"
-"                    Please click <a href=\"%(download_csv_link)s\">HERE</a> to download a CSV file with the enrollment codes for this course.\n"
-"                    Once you have the codes you can distribute them to your team. "
-msgstr ""
-"Thänk ýöü för pürçhäsïng äççéss tö %(course_name)s.\n"
-"                    Pléäsé çlïçk <a href=\"%(download_csv_link)s\">HÉRÉ</a> tö döwnlöäd ä ÇSV fïlé wïth thé énröllmént çödés för thïs çöürsé.\n"
-"                    Önçé ýöü hävé thé çödés ýöü çän dïstrïßüté thém tö ýöür téäm.  Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α∂ιριѕι¢ιηg єłιт, ѕє∂ ∂σ єιυѕмσ∂ тємρσя ιη¢ι∂ι∂υηт υт łαвσяє єт ∂σłσяє мαgηα αłιqυα. υт єηιм α∂ мιηιм νєηιαм, qυιѕ ησѕтяυ∂ єχєя¢ιтαтιση υłłαм¢σ łαвσяιѕ ηιѕι υт αłιqυιρ єχ єα ¢σммσ∂σ ¢σηѕєqυαт. ∂υιѕ αυтє ιяυяє ∂σłσя ιη яєρяєнєη∂єяιт ιη νσłυρтαтє νєłιт єѕѕє ¢ιłłυм ∂σł#"
-
-#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
-#, python-format
-msgid "To view your payment information, please visit %(receipt_page_url)s."
-msgstr ""
-"Tö vïéw ýöür päýmént ïnförmätïön, pléäsé vïsït %(receipt_page_url)s. Ⱡ'σяєм "
-"ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
-
-#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
-#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt
-#, python-format
-msgid "To explore other courses, please visit %(lms_url)s."
-msgstr ""
-"Tö éxplöré öthér çöürsés, pléäsé vïsït %(lms_url)s. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт "
-"αмєт, ¢σηѕє¢тєтυя #"
-
-#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
-#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt
-msgid "Thank you,"
-msgstr "Thänk ýöü, Ⱡ'σяєм ιρѕυм ∂σłσ#"
-
-#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
-#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt
-#, python-format
-msgid "The %(partner_name)s team"
-msgstr "Thé %(partner_name)s téäm Ⱡ'σяєм ιρѕυм ∂σłσя ѕ#"
+msgid "For Business"
+msgstr "För Büsïnéss Ⱡ'σяєм ιρѕυм ∂σłσя ѕ#"
 
 #: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
 #: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt
 #, python-format
 msgid ""
-"You received this message because you purchased enrollment codes for "
-"%(course_name)s on %(lms_url)s. If you have any questions, please visit "
-"%(contact_url)s."
+"Thank you for purchasing access to %(course_name)s. Let's get your group "
+"ready to learn with edX:"
 msgstr ""
-"Ýöü réçéïvéd thïs méssägé ßéçäüsé ýöü pürçhäséd énröllmént çödés för "
-"%(course_name)s ön %(lms_url)s. Ìf ýöü hävé äný qüéstïöns, pléäsé vïsït "
-"%(contact_url)s. Ⱡ'σяєм #"
+"Thänk ýöü för pürçhäsïng äççéss tö %(course_name)s. Lét's gét ýöür gröüp "
+"réädý tö léärn wïth édX: Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢#"
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
+#, python-format
+msgid ""
+"Download and save the %(link_start)s%(download_csv_link)s%(link_middle)s "
+"enrollment code file.%(link_end)s"
+msgstr ""
+"Döwnlöäd änd sävé thé %(link_start)s%(download_csv_link)s%(link_middle)s "
+"énröllmént çödé fïlé.%(link_end)s Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя "
+"α#"
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt
+msgid "Distribute one code per learner before the expiration date."
+msgstr ""
+"Dïstrïßüté öné çödé pér léärnér ßéföré thé éxpïrätïön däté. Ⱡ'σяєм ιρѕυм "
+"∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt
+msgid "Pro tip: Track which code is associated with which person."
+msgstr ""
+"Prö tïp: Träçk whïçh çödé ïs ässöçïätéd wïth whïçh pérsön. Ⱡ'σяєм ιρѕυм "
+"∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt
+msgid "Learners sign-in/register with edX and enroll for the course."
+msgstr ""
+"Léärnérs sïgn-ïn/régïstér wïth édX änd énröll för thé çöürsé. Ⱡ'σяєм ιρѕυм "
+"∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
+#, python-format
+msgid ""
+"To view your payment information, log in to see your Order History, under "
+"%(link_start)s%(order_history_url)s%(link_middle)sAccount "
+"Settings%(link_end)s"
+msgstr ""
+"Tö vïéw ýöür päýmént ïnförmätïön, lög ïn tö séé ýöür Ördér Hïstörý, ündér "
+"%(link_start)s%(order_history_url)s%(link_middle)sÀççöünt "
+"Séttïngs%(link_end)s Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αм#"
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
+#, python-format
+msgid ""
+"For more information and assistance, contact "
+"%(link_start)sinfo@edx.org.%(link_end)s"
+msgstr ""
+"För möré ïnförmätïön änd ässïstänçé, çöntäçt "
+"%(link_start)sïnfö@édx.örg.%(link_end)s Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, "
+"¢σηѕє¢тєтυя α#"
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt
+msgid "Thank You"
+msgstr "Thänk Ýöü Ⱡ'σяєм ιρѕυм ∂σł#"
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt
+msgid "By purchasing, you and your organization agree to the following terms:"
+msgstr ""
+"Bý pürçhäsïng, ýöü änd ýöür örgänïzätïön ägréé tö thé föllöwïng térms: "
+"Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя #"
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt
+msgid ""
+"Each code is valid for the one course covered and can be used only one time."
+msgstr ""
+"Éäçh çödé ïs välïd för thé öné çöürsé çövéréd änd çän ßé üséd önlý öné tïmé."
+" Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυ#"
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt
+msgid "You are responsible for distributing codes to your learners."
+msgstr ""
+"Ýöü äré réspönsïßlé för dïstrïßütïng çödés tö ýöür léärnérs. Ⱡ'σяєм ιρѕυм "
+"∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt
+msgid ""
+"Each code will expire in one year from date of purchase or, if earlier, once"
+" the course is closed."
+msgstr ""
+"Éäçh çödé wïll éxpïré ïn öné ýéär fröm däté öf pürçhäsé ör, ïf éärlïér, önçé"
+" thé çöürsé ïs çlöséd. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт,#"
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt
+msgid ""
+"If a course is not designated as self-paced, you should confirm that a "
+"course run is available before expiration."
+msgstr ""
+"Ìf ä çöürsé ïs nöt désïgnätéd äs sélf-päçéd, ýöü shöüld çönfïrm thät ä "
+"çöürsé rün ïs äväïläßlé ßéföré éxpïrätïön. Ⱡ'σяєм ιρѕυм ∂σłσ#"
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt
+msgid "You may not resell codes to third parties."
+msgstr ""
+"Ýöü mäý nöt réséll çödés tö thïrd pärtïés. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, "
+"¢σηѕє¢тєтυя #"
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt
+msgid "All sales final. No refunds."
+msgstr "Àll sälés fïnäl. Nö réfünds. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢#"
 
 #: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt
 msgid "Order confirmation for: "
@@ -2032,19 +2137,26 @@ msgstr "Ördér çönfïrmätïön för:  Ⱡ'σяєм ιρѕυм ∂σłσя ѕ
 #: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt
 #, python-format
 msgid ""
-"Thank you for purchasing access to %(course_name)s. Please go to "
-"%(download_csv_link)s to download a CSV file with the enrollment codes for "
-"this course. Once you have the codes you can distribute them to your team. "
+"Please visit %(download_csv_link)s to download and save the enrollment code "
+"file."
 msgstr ""
-"Thänk ýöü för pürçhäsïng äççéss tö %(course_name)s. Pléäsé gö tö "
-"%(download_csv_link)s tö döwnlöäd ä ÇSV fïlé wïth thé énröllmént çödés för "
-"thïs çöürsé. Önçé ýöü hävé thé çödés ýöü çän dïstrïßüté thém tö ýöür téäm.  "
-"Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α∂ιριѕι¢ιηg єłιт, ѕє∂ ∂σ єιυѕмσ∂ "
-"тємρσя ιη¢ι∂ι∂υηт υт łαвσяє єт ∂σłσяє мαgηα αłιqυα. υт єηιм α∂ мιηιм νєηιαм,"
-" qυιѕ ησѕтяυ∂ єχєя¢ιтαтιση υłłαм¢σ łαвσяιѕ ηιѕι υт αłιqυιρ єχ єα ¢σммσ∂σ "
-"¢σηѕєqυαт. ∂υιѕ αυтє ιяυяє ∂σłσя ιη яєρяєнєη∂єяιт ιη νσłυρтαтє νєłιт єѕѕє "
-"¢ιłłυм ∂σłσяє єυ ƒυgιαт ηυłłα ραяιαтυя. єχ¢єρтєυя ѕιηт σ¢¢αє¢αт ¢υρι∂αтαт "
-"ηση ρяσι∂єηт#"
+"Pléäsé vïsït %(download_csv_link)s tö döwnlöäd änd sävé thé énröllmént çödé "
+"fïlé. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt
+#, python-format
+msgid ""
+"To view your payment information, log in to see your Order History, under "
+"Account Settings at %(order_history_url)s."
+msgstr ""
+"Tö vïéw ýöür päýmént ïnförmätïön, lög ïn tö séé ýöür Ördér Hïstörý, ündér "
+"Àççöünt Séttïngs ät %(order_history_url)s. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт,#"
+
+#: ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt
+msgid "For more information and assistance, contact info@edx.org."
+msgstr ""
+"För möré ïnförmätïön änd ässïstänçé, çöntäçt ïnfö@édx.örg. Ⱡ'σяєм ιρѕυм "
+"∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
 
 #: ecommerce/templates/customer/emails/commtype_order_with_csv_subject.txt
 #, python-format

--- a/ecommerce/conf/locale/eo/LC_MESSAGES/djangojs.po
+++ b/ecommerce/conf/locale/eo/LC_MESSAGES/djangojs.po
@@ -7,14 +7,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-14 09:32+0000\n"
+"POT-Creation-Date: 2018-03-15 11:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ecommerce/static/js/models/coupon_model.js
@@ -46,7 +46,7 @@ msgid "A valid course ID is required"
 msgstr "À välïd çöürsé ÌD ïs réqüïréd Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢#"
 
 #: ecommerce/static/js/models/coupon_model.js
-#, c-format
+#, javascript-format
 msgid "Email domain {%s} is invalid."
 msgstr "Émäïl dömäïn {%s} ïs ïnvälïd. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢#"
 
@@ -281,37 +281,34 @@ msgstr ""
 #: ecommerce/static/js/payment_processors/cybersource.js
 msgid ""
 "An error occurred while processing your payment. You have NOT been charged. "
+"Please try again, or select another payment method."
 msgstr ""
-"Àn érrör öççürréd whïlé pröçéssïng ýöür päýmént. Ýöü hävé NÖT ßéén çhärgéd."
-"  Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυ#"
+"Àn érrör öççürréd whïlé pröçéssïng ýöür päýmént. Ýöü hävé NÖT ßéén çhärgéd. "
+"Pléäsé trý ägäïn, ör séléçt änöthér päýmént méthöd. Ⱡ'σяє#"
 
 #: ecommerce/static/js/payment_processors/stripe.js
 msgid ""
 "An error occurred while attempting to process your payment. You have not "
-"been "
+"been charged. Please check your payment details, and try again."
 msgstr ""
 "Àn érrör öççürréd whïlé ättémptïng tö pröçéss ýöür päýmént. Ýöü hävé nöt "
-"ßéén  Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєт#"
+"ßéén çhärgéd. Pléäsé çhéçk ýöür päýmént détäïls, änd trý ägäïn. Ⱡ'σяєм ιρѕυм"
+" ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α∂ιριѕι¢ιηg єłιт, ѕє∂ ∂σ єιυѕмσ∂ тємρσя "
+"ιη¢ι∂ι∂υηт υт łαвσяє єт ∂σłσяє мαgηα αłιqυα. υт єηιм α∂ мιηιм νєηιαм, qυιѕ "
+"ησѕтяυ∂ єχєя¢ιтαтιση υłłαм¢σ łαвσяιѕ ηιѕι υт αłιqυιρ єχ єα ¢σммσ∂σ "
+"¢σηѕєqυαт. ∂υιѕ αυтє ιяυяє ∂σłσя ιη яєρяєнєη∂єяιт ιη νσłυρтαтє νєłιт єѕѕє "
+"¢ιłłυм ∂σłσяє єυ ƒυgιαт ηυłłα ραяιαтυя. єχ¢єρтєυя ѕιηт σ¢¢αє¢αт ¢υρι∂αтαт "
+"ηση ρяσι∂єηт, ѕυηт ιη ¢υłρα qυι σƒƒι¢ια ∂єѕєяυηт мσłłιт αηιм ι∂ єѕт łαвσя#"
 
 #: ecommerce/static/js/payment_processors/stripe.js
-msgid "An error occurred while processing your payment. "
+msgid "An error occurred while processing your payment. Please try again."
 msgstr ""
-"Àn érrör öççürréd whïlé pröçéssïng ýöür päýmént.  Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт "
-"αмєт, ¢σηѕє¢тєтυя α#"
+"Àn érrör öççürréd whïlé pröçéssïng ýöür päýmént. Pléäsé trý ägäïn. Ⱡ'σяєм "
+"ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя #"
 
 #: ecommerce/static/js/utils/utils.js
 msgid "Trailing comma not allowed."
 msgstr "Träïlïng çömmä nöt ällöwéd. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє#"
-
-#: ecommerce/static/js/utils/validation_patterns.js
-msgid "The course ID is invalid."
-msgstr "Thé çöürsé ÌD ïs ïnvälïd. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕ#"
-
-#: ecommerce/static/js/utils/validation_patterns.js
-msgid "The product name cannot contain HTML."
-msgstr ""
-"Thé prödüçt nämé çännöt çöntäïn HTML. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, "
-"¢σηѕє¢тєтυ#"
 
 #: ecommerce/static/js/views/coupon_detail_view.js
 #: ecommerce/static/js/views/coupon_form_view.js
@@ -428,17 +425,20 @@ msgid "Professional Education"
 msgstr "Pröféssïönäl Édüçätïön Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢#"
 
 #: ecommerce/static/js/views/course_form_view.js
-msgid "Paid certificate track with initial verification and Professional "
+msgid ""
+"Paid certificate track with initial verification and Professional Education "
+"Certificate"
 msgstr ""
-"Päïd çértïfïçäté träçk wïth ïnïtïäl vérïfïçätïön änd Pröféssïönäl  Ⱡ'σяєм "
-"ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя #"
+"Päïd çértïfïçäté träçk wïth ïnïtïäl vérïfïçätïön änd Pröféssïönäl Édüçätïön "
+"Çértïfïçäté Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє#"
 
 #: ecommerce/static/js/views/course_form_view.js
 msgid ""
 "Paid certificate track with initial verification and Verified Certificate, "
+"and option to purchase credit"
 msgstr ""
-"Päïd çértïfïçäté träçk wïth ïnïtïäl vérïfïçätïön änd Vérïfïéd Çértïfïçäté,  "
-"Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυ#"
+"Päïd çértïfïçäté träçk wïth ïnïtïäl vérïfïçätïön änd Vérïfïéd Çértïfïçäté, "
+"änd öptïön tö pürçhäsé çrédït Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт α#"
 
 #. Translators: _START_, _END_, and _TOTAL_ are placeholders. Do NOT translate
 #. them.

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -310,7 +310,7 @@ class EnrollmentCodeCsvView(View):
         response['Content-Disposition'] = 'attachment; filename={filename}'.format(filename=file_name)
 
         redeem_url = get_ecommerce_url(reverse('coupons:offer'))
-        voucher_field_names = ('Code', 'Redemption URL')
+        voucher_field_names = ('Code', 'Redemption URL', 'Name Of Employee', 'Date Of Distribution', 'Employee Email')
         voucher_writer = csv.DictWriter(response, fieldnames=voucher_field_names)
 
         writer = csv.writer(response)

--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -568,6 +568,7 @@ class EnrollmentCodeFulfillmentModule(BaseFulfillmentModule):
                 'order_number': order.number,
                 'partner_name': order.site.siteconfiguration.partner.name,
                 'receipt_page_url': receipt_page_url,
+                'order_history_url': order.site.siteconfiguration.build_lms_url('account/settings'),
             },
             site=order.site
         )

--- a/ecommerce/templates/customer/email_base.html
+++ b/ecommerce/templates/customer/email_base.html
@@ -136,13 +136,23 @@
         }
         .cn-content-clear {
             padding: 0px 18px 18px;
-            border-top: 3px solid #1d9fd9;
+            border-top: 3px solid #B92167;
         }
         .cn-content-clear .cn-footer {
             border-top-width: 6px;
         }
         .cn-content p {
             padding: 5px 0;
+        }
+        .cn-content-msg {
+            color: #636C72;
+            line-height: 1.5rem;
+        }
+        .cn-content-msg a {
+            color: #005686 ;
+        }
+        .cn-footer-content {
+            color: #636C72;
         }
         .cn-footer-content p {
             padding: 5px 0;

--- a/ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
+++ b/ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
@@ -6,11 +6,11 @@
         <table class="cn-body">
             <!-- Message header -->
             <tr align="left" class="cn-img-wrapper">
-                <td colspan="2" align="left" class="cn-img-wrapper cn-full-width" style="font-size: 20px; vertical-align: middle; padding-left: 20px; color: #127eb1;">
+                <td colspan="2" align="left" class="cn-img-wrapper cn-full-width" style="font-size: 20px; vertical-align: middle; padding-left: 2px; color: #127eb1;">
                     <img src="http://gallery.mailchimp.com/1822a33c054dc20e223ca40e2/images/logo_web_edx_studio01aad778f34f.png"
                         height="30" alt="{{partner_name}} Logo" border="0" hspace="0" vspace="0"
                         class="platform-img">
-                    {% trans "Order Confirmation" %}
+                    {% trans "For Business" %}
                 </td>
             </tr>
 
@@ -18,47 +18,20 @@
                 <td class="cn-content-clear" colspan="2"></td>
             </tr>
 
-            <!-- Message sub-header -->
-            <tr class="force-col" valign="middle" style="background-color: #f3f3f3;">
-                <td style="padding: 20px;">
-                    <table border="0" cellspacing="0" cellpadding="0" width="280" align="left" class="col-2">
-                        <tr>
-                            <td align="left" valign="top" style="font-size:13px; line-height: 20px; color: #aaaaaa;">
-                                {% trans "Order confirmation for" %}:
-                            </td>
-                        </tr>
-                        <tr>
-                            <td align="left" valign="top" style="line-height: 26px; font-size:24px; color: #002D40;">
-                                {{ order_number }}
-                            </td>
-                        </tr>
-                    </table>
-                </td>
-                <td style="padding: 20px;">
-                    <table border="0" cellspacing="0" cellpadding="10" width="100" align="right" class="col-2">
-                        <tr>
-                            <td align="center" valign="middle"
-                                style="font-size:13px; background-color: #127eb1; border-radius: 5px; box-shadow: 0 2px #002D40;">
-                                <a href="{{ receipt_page_url }}" style="color: #ffffff; text-decoration: none;">
-                                    {% trans "View Order Information" %}
-                                </a>
-                            </td>
-                        </tr>
-                    </table>
-                </td>
-            <tr>
-
             <!-- Message Body -->
             <tr class="cn-content cn-full-width">
-                <td colspan="2">
+                <td colspan="2" class="cn-content-msg">
                     <p>{% blocktrans %}Dear {{full_name}},{% endblocktrans %}</p>
-                    <p>{% blocktrans %}Thank you for purchasing access to {{course_name}}.
-                    Please click <a href="{{download_csv_link}}">HERE</a> to download a CSV file with the enrollment codes for this course.
-                    Once you have the codes you can distribute them to your team. {% endblocktrans %}</p>
-                    <p>{% blocktrans %}To view your payment information, please visit {{receipt_page_url}}.{% endblocktrans %}</p>
-                    <p>{% blocktrans %}To explore other courses, please visit {{lms_url}}.{% endblocktrans %}</p>
-                    <p>{% trans "Thank you," %}</p>
-                    <p>{% blocktrans %}The {{partner_name}} team{% endblocktrans %}</p>
+                    <p>{% blocktrans %}Thank you for purchasing access to {{course_name}}. Let's get your group ready to learn with edX:{% endblocktrans %}</p>
+                    <ol>
+                        <li>{% blocktrans with link_start='<a href="' link_middle='">' link_end='</a>'%}Download and save the {{ link_start }}{{ download_csv_link }}{{ link_middle }} enrollment code file.{{ link_end }}{% endblocktrans %}</li>
+                        <li>{% trans "Distribute one code per learner before the expiration date." %}</li>
+                        <li>{% trans "Pro tip: Track which code is associated with which person." %}</li>
+                        <li>{% trans "Learners sign-in/register with edX and enroll for the course." %}</li>
+                    </ol>
+                    <p>{% blocktrans with link_start='<a href="' link_middle='">' link_end='</a>' %}To view your payment information, log in to see your Order History, under {{ link_start }}{{order_history_url}}{{ link_middle }}Account Settings{{ link_end }}{% endblocktrans %}</p>
+                    <p>{% blocktrans with link_start='<a href="mailto:info@edx.org">' link_end='</a>' %}For more information and assistance, contact {{ link_start }}info@edx.org.{{ link_end }}{% endblocktrans %}</p>
+                    <p>{% trans "Thank You" %}</p>
                 </td>
             </tr>
 
@@ -69,7 +42,15 @@
             <!-- Footer content -->
             <tr class="cn-full-width">
                 <td class="cn-footer-content" colspan="2">
-                    <p>{% blocktrans %}You received this message because you purchased enrollment codes for {{course_name}} on {{lms_url}}. If you have any questions, please visit {{contact_url}}.{% endblocktrans %}</p>
+                    <p>{% trans "By purchasing, you and your organization agree to the following terms:" %}</p>
+                    <ul>
+                        <li>{% trans "Each code is valid for the one course covered and can be used only one time." %}</li>
+                        <li>{% trans "You are responsible for distributing codes to your learners."%}</li>
+                        <li>{% trans "Each code will expire in one year from date of purchase or, if earlier, once the course is closed."%}</li>
+                        <li>{% trans "If a course is not designated as self-paced, you should confirm that a course run is available before expiration."%}</li>
+                        <li>{% trans "You may not resell codes to third parties."%}</li>
+                        <li>{% trans "All sales final. No refunds."%}</li>
+                    </ul>
                 </td>
             </tr>
 

--- a/ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt
+++ b/ecommerce/templates/customer/emails/commtype_order_with_csv_body.txt
@@ -1,13 +1,26 @@
 {% load i18n %}
 {% trans "Order confirmation for: " %}{{order_number}}
 
+
 {% blocktrans %}Dear {{full_name}},{% endblocktrans %}
+{% blocktrans %}Thank you for purchasing access to {{course_name}}. Let's get your group ready to learn with edX:{% endblocktrans %}
 
-{% blocktrans %}Thank you for purchasing access to {{course_name}}. Please go to {{download_csv_link}} to download a CSV file with the enrollment codes for this course. Once you have the codes you can distribute them to your team. {% endblocktrans %}
+{% blocktrans %}Please visit {{download_csv_link}} to download and save the enrollment code file.{% endblocktrans %}
+{% trans "Distribute one code per learner before the expiration date." %}
+{% trans "Pro tip: Track which code is associated with which person." %}
+{% trans "Learners sign-in/register with edX and enroll for the course." %}
 
-{% blocktrans %}To explore other courses, please visit {{lms_url}}.{% endblocktrans %}
+{% blocktrans %}To view your payment information, log in to see your Order History, under Account Settings at {{order_history_url}}.{% endblocktrans %}
+{% blocktrans %}For more information and assistance, contact info@edx.org.{% endblocktrans %}
 
-{% trans "Thank you," %}
-{% blocktrans %}The {{partner_name}} team{% endblocktrans %}
+{% trans "Thank You" %}
 
-{% blocktrans %}You received this message because you purchased enrollment codes for {{course_name}} on {{lms_url}}. If you have any questions, please visit {{contact_url}}.{% endblocktrans %}
+{% trans "By purchasing, you and your organization agree to the following terms:" %}
+
+{% trans "Each code is valid for the one course covered and can be used only one time." %}
+{% trans "You are responsible for distributing codes to your learners."%}
+{% trans "Each code will expire in one year from date of purchase or, if earlier, once the course is closed."%}
+{% trans "If a course is not designated as self-paced, you should confirm that a course run is available before expiration."%}
+{% trans "You may not resell codes to third parties."%}
+{% trans "All sales final. No refunds."%}
+


### PR DESCRIPTION
#### Testing Instructions:

1. Enable bulk enrollment for a course on e-commerce business sandbox. 
2. Follow the checkout flow for bulk enrollment courses. 
3. Enter the credit card information on basket during checkout.
4. After successful payment, User will redirected to receipt page and will get the email as modified in current PR.

**Text-Only Version:**

<img width="713" alt="current text 14 march" src="https://user-images.githubusercontent.com/7334669/37509537-849bf126-2919-11e8-92e2-65dda08abef9.png">

**HTML Version:**

<img width="575" alt="current html 14 march" src="https://user-images.githubusercontent.com/7334669/37509539-84dfa3ee-2919-11e8-8313-025f5d99a0f4.png">




@rrakhshan @georgebabey @zubair-arbi  FYI