### PR TITLE
Skip receipt page if placing free order

### DIFF
--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -12,7 +12,7 @@ from factory.fuzzy import FuzzyText
 from oscar.core.loading import get_class, get_model
 from oscar.test.factories import OrderFactory, OrderLineFactory, RangeFactory, VoucherFactory
 
-from ecommerce.core.url_utils import get_lms_url
+from ecommerce.core.url_utils import get_lms_dashboard_url, get_lms_url
 from ecommerce.coupons.tests.mixins import CouponMixin, DiscoveryMockMixin
 from ecommerce.coupons.views import voucher_is_valid
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
@@ -430,12 +430,15 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
 
     @httpretty.activate
     def test_basket_redirect_enrollment_code(self):
-        """ Verify the view redirects to the receipt page when an enrollment code is provided. """
+        """ Verify the view redirects to the LMS dashboard when an enrollment code is provided. """
         code = self.create_coupon_and_get_code(benefit_value=100, code='', catalog=self.catalog)
         self.mock_account_api(self.request, self.user.username, data={'is_active': True})
         self.mock_access_token_response()
 
-        self.assert_redirects_to_receipt_page(code=code)
+        self.assert_redemption_page_redirects(
+            get_lms_dashboard_url(),
+            code=code,
+        )
 
     @httpretty.activate
     @mock.patch.object(EdxOrderPlacementMixin, 'place_free_order')
@@ -444,7 +447,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         code = self.create_coupon_and_get_code(benefit_value=100, code='', catalog=self.catalog)
         self.mock_account_api(self.request, self.user.username, data={'is_active': True})
         self.mock_access_token_response()
-        place_free_order.return_value = Exception
+        place_free_order.side_effect = Exception
 
         with mock.patch('ecommerce.coupons.views.logger.exception') as mock_logger:
             self.assert_redemption_page_redirects(
@@ -528,7 +531,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
 
     @httpretty.activate
     def test_enterprise_customer_successful_redemption(self):
-        """ Verify the view redirects to LMS when valid consent is provided. """
+        """ Verify the view redirects to the LMS dashboard when valid consent is provided. """
         code = self.prepare_enterprise_data(catalog=self.catalog)
         self.mock_enterprise_learner_api_for_learner_with_no_enterprise()
         self.mock_enterprise_learner_post_api()
@@ -539,9 +542,10 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
             ENTERPRISE_CUSTOMER
         )
 
-        self.assert_redirects_to_receipt_page(
+        self.assert_redemption_page_redirects(
+            get_lms_dashboard_url(),
             code=code,
-            consent_token=consent_token
+            consent_token=consent_token,
         )
         last_request = httpretty.last_request()
         self.assertEqual(last_request.path, '/api/enrollment/v1/enrollment')
@@ -595,7 +599,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
 
     @httpretty.activate
     def test_multiple_vouchers(self):
-        """ Verify a redirect to LMS happens when a basket with already existing vouchers is used. """
+        """ Verify a redirect to LMS dashboard happens when a basket with already existing vouchers is used. """
         code = self.create_coupon_and_get_code(benefit_value=100, code='', catalog=self.catalog)
         basket = Basket.get_basket(self.user, self.site)
         basket.vouchers.add(Voucher.objects.get(code=code))
@@ -603,7 +607,10 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         self.mock_account_api(self.request, self.user.username, data={'is_active': True})
         self.mock_access_token_response()
 
-        self.assert_redirects_to_receipt_page(code=code)
+        self.assert_redemption_page_redirects(
+            get_lms_dashboard_url(),
+            code=code,
+        )
 
     @httpretty.activate
     def test_already_enrolled_rejection(self):

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -16,7 +16,7 @@ from django.utils.translation import ugettext as _
 from django.views.generic import TemplateView, View
 from oscar.core.loading import get_class, get_model
 
-from ecommerce.core.url_utils import get_ecommerce_url
+from ecommerce.core.url_utils import get_ecommerce_url, get_lms_dashboard_url
 from ecommerce.core.views import StaffOnlyMixin
 from ecommerce.coupons.decorators import login_required_for_credit
 from ecommerce.coupons.utils import is_voucher_applied
@@ -32,7 +32,6 @@ from ecommerce.enterprise.utils import (
 from ecommerce.extensions.api import exceptions
 from ecommerce.extensions.basket.utils import prepare_basket
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
-from ecommerce.extensions.checkout.utils import get_receipt_page_url
 from ecommerce.extensions.offer.utils import render_email_confirmation_if_required
 from ecommerce.extensions.order.exceptions import AlreadyPlacedOrderException
 from ecommerce.extensions.voucher.utils import get_voucher_and_products_from_code
@@ -154,7 +153,6 @@ class CouponRedeemView(EdxOrderPlacementMixin, View):
         code = request.GET.get('code')
         sku = request.GET.get('sku')
         failure_url = request.GET.get('failure_url')
-        site_configuration = request.site.siteconfiguration
 
         if not code:
             return render(request, template_name, {'error': _('Code not provided.')})
@@ -238,12 +236,7 @@ class CouponRedeemView(EdxOrderPlacementMixin, View):
             return render(request, template_name, {'error': msg})
 
         if basket.total_excl_tax == 0:
-            try:
-                order = self.place_free_order(basket)
-                return HttpResponseRedirect(get_receipt_page_url(site_configuration, order.number))
-            except:  # pylint: disable=bare-except
-                logger.exception('Failed to create a free order for basket [%d]', basket.id)
-                return HttpResponseRedirect(reverse('checkout:error'))
+            return self._handle_free_order(basket)
 
         if enterprise_customer:
             if is_voucher_applied(basket, voucher):
@@ -259,6 +252,14 @@ class CouponRedeemView(EdxOrderPlacementMixin, View):
                 self.request.basket.vouchers.remove(voucher)
 
         return HttpResponseRedirect(reverse('basket:summary'))
+
+    def _handle_free_order(self, basket):
+        try:
+            self.place_free_order(basket)
+            return HttpResponseRedirect(get_lms_dashboard_url())
+        except:  # pylint: disable=bare-except
+            logger.exception('Failed to create a free order for basket [%d]', basket.id)
+            return HttpResponseRedirect(reverse('checkout:error'))
 
 
 class EnrollmentCodeCsvView(View):

--- a/ecommerce/extensions/checkout/tests/test_views.py
+++ b/ecommerce/extensions/checkout/tests/test_views.py
@@ -8,11 +8,10 @@ from django.urls import reverse
 from oscar.core.loading import get_model
 from oscar.test import factories
 
-from ecommerce.core.url_utils import get_lms_courseware_url, get_lms_program_dashboard_url
+from ecommerce.core.url_utils import get_lms_courseware_url, get_lms_dashboard_url, get_lms_program_dashboard_url
 from ecommerce.coupons.tests.mixins import DiscoveryMockMixin
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
 from ecommerce.extensions.checkout.exceptions import BasketNotFreeError
-from ecommerce.extensions.checkout.utils import get_receipt_page_url
 from ecommerce.extensions.checkout.views import ReceiptResponseView
 from ecommerce.extensions.refund.tests.mixins import RefundTestMixin
 from ecommerce.tests.mixins import LmsApiMockMixin
@@ -87,19 +86,14 @@ class FreeCheckoutViewTests(EnterpriseServiceMockMixin, TestCase):
         self.assertRedirects(response, expected_url, fetch_redirect_response=False)
 
     @httpretty.activate
-    def test_successful_redirect(self):
-        """ Verify redirect to the receipt page. """
+    def test_successful_redirect_dashboard(self):
+        """ Verify redirect to the dashboard page. """
         self.prepare_basket(0)
         self.assertEqual(Order.objects.count(), 0)
         response = self.client.get(self.path)
         self.assertEqual(Order.objects.count(), 1)
 
-        order = Order.objects.first()
-        expected_url = get_receipt_page_url(
-            order_number=order.number,
-            site_configuration=order.site.siteconfiguration
-        )
-        self.assertRedirects(response, expected_url, fetch_redirect_response=False)
+        self.assertRedirects(response, get_lms_dashboard_url(), fetch_redirect_response=False)
 
 
 class CancelCheckoutViewTests(TestCase):

--- a/ecommerce/extensions/checkout/views.py
+++ b/ecommerce/extensions/checkout/views.py
@@ -21,7 +21,6 @@ from ecommerce.core.url_utils import (
 from ecommerce.enterprise.utils import has_enterprise_offer
 from ecommerce.extensions.checkout.exceptions import BasketNotFreeError
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
-from ecommerce.extensions.checkout.utils import get_receipt_page_url
 
 Applicator = get_class('offer.applicator', 'Applicator')
 Basket = get_model('basket', 'Basket')
@@ -52,7 +51,7 @@ class FreeCheckoutView(EdxOrderPlacementMixin, RedirectView):
     """ View to handle free checkouts.
 
     Retrieves the user's basket and checks to see if the basket is free in which case
-    the user is redirected to the receipt page. Otherwise the user is redirected back
+    the user is redirected to the LMS dashboard. Otherwise the user is redirected back
     to the basket summary page.
     """
 
@@ -90,11 +89,7 @@ class FreeCheckoutView(EdxOrderPlacementMixin, RedirectView):
                     course_run_id = order.lines.all()[:1].get().product.course.id
                     url = get_lms_courseware_url(course_run_id)
             else:
-                receipt_path = get_receipt_page_url(
-                    order_number=order.number,
-                    site_configuration=order.site.siteconfiguration
-                )
-                url = site.siteconfiguration.build_lms_url(receipt_path)
+                url = get_lms_dashboard_url()
         else:
             # If a user's basket is empty redirect the user to the basket summary
             # page which displays the appropriate message for empty baskets.


### PR DESCRIPTION
This PR changes the behaviour of ecommerce to skip the receipt page when a coupon redemption doesn't require any payment. When placing a free order the receipt page will be skipped and users will be directed to the LMS dashboard page on redemption instead. 

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:
The regular test suite can be used for testing this change by running the tests for  ``ecommerce.extensions.checkout``

**Reviewers**
- [ ] @kaizoku
- [ ] edX reviewer[s] TBD