### PR TITLE
[REV-23] add course id to receipt page

### DIFF
--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -89,7 +89,9 @@
                 <dd class="course-description">
                   <span>{{ line.title }}</span>
                   {% if line.product.course %}
-                    <p>{{ line.product.course.id|course_organization }}</p>
+                    <p class="course-description-subtitle" data-course-id="{{ line.product.course.id }}">
+                      {{ line.product.course.id|course_organization }}
+                    </p>
                   {% endif %}
                 </dd>
                 <dt class="line-price sr">{% trans "Item Price:" %}</dt>


### PR DESCRIPTION
I have the other necessary information set up to post the relevant data to the key-value store once the user hits the receipt page 
(key - course id, value - doesn't matter yet, but we may find a use for it later)  

The plan was that when a user tries to unenroll, we check if they are in the experiment for the course, and if they are, we allow audit mode refunds.

P.S. how do we want code reviews to work? Lately on the growth team we had the PR submitter pick one code reviewer to assign to review the PR and this was meant to be high priority for that specific person (this worked pretty fast). At one point in the past we tagged the whole team with an alias in the PR description. I'll include everyone until we've decided this.