### PR TITLE
Ignore Health endpoint in NewRelic

### DIFF
--- a/ecommerce/core/tests/test_views.py
+++ b/ecommerce/core/tests/test_views.py
@@ -27,6 +27,12 @@ class HealthTests(TestCase):
         """Test that the endpoint reports when all services are healthy."""
         self._assert_health(status.HTTP_200_OK, Status.OK, Status.OK)
 
+    @mock.patch('newrelic.agent')
+    def test_health_check_is_ignored_by_new_relic(self, mock_newrelic_agent):
+        """Test that the health endpoint is ignored by NewRelic"""
+        self._assert_health(status.HTTP_200_OK, Status.OK, Status.OK)
+        self.assertTrue(mock_newrelic_agent.ignore_transaction.called)
+
     @mock.patch('django.contrib.sites.middleware.get_current_site', mock.Mock(return_value=None))
     @mock.patch('django.db.backends.base.base.BaseDatabaseWrapper.cursor', mock.Mock(side_effect=DatabaseError))
     def test_database_outage(self):

--- a/ecommerce/core/views.py
+++ b/ecommerce/core/views.py
@@ -14,6 +14,11 @@ from django.views.generic import View
 
 from ecommerce.core.constants import Status
 
+try:
+    import newrelic.agent
+except ImportError:  # pragma: no cover
+    newrelic = None  # pylint: disable=invalid-name
+
 logger = logging.getLogger(__name__)
 User = get_user_model()
 
@@ -37,6 +42,9 @@ def health(_):
         >>> response.content
         '{"overall_status": "OK", "detailed_status": {"database_status": "OK"}}'
     """
+    if newrelic:  # pragma: no cover
+        newrelic.agent.ignore_transaction()
+
     overall_status = database_status = Status.UNAVAILABLE
 
     try:


### PR DESCRIPTION
@robrap This is ready for review. 

We would like to ignore the Health check endpoint on ecommerce because it accounts for 90% of the throughput and skewing the monitoring data.