### PR TITLE
Revert "Switch to segment analytics-python from edx fork"

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -3,7 +3,6 @@ import hashlib
 import logging
 from urlparse import urljoin
 
-from analytics import Client as SegmentClient
 from dateutil.parser import parse
 from django.conf import settings
 from django.contrib.auth.models import AbstractUser
@@ -19,6 +18,7 @@ from jsonfield.fields import JSONField
 from requests.exceptions import ConnectionError, Timeout
 from slumber.exceptions import HttpNotFoundError, SlumberBaseException
 
+from analytics import Client as SegmentClient
 from ecommerce.core.url_utils import get_lms_url
 from ecommerce.core.utils import log_message_and_raise_validation_error
 from ecommerce.extensions.payment.exceptions import ProcessorNotFoundError

--- a/ecommerce/extensions/analytics/tests/test_utils.py
+++ b/ecommerce/extensions/analytics/tests/test_utils.py
@@ -2,11 +2,11 @@ import json
 
 import ddt
 import mock
-from analytics import Client
 from django.contrib.auth.models import AnonymousUser
 from django.test.client import RequestFactory
 from oscar.test import factories
 
+from analytics import Client
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.analytics.utils import (
     get_google_analytics_client_id,

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -14,12 +14,8 @@ from oscar.core.loading import get_class, get_model
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 
-from ecommerce.core.constants import (
-    COURSE_ENTITLEMENT_PRODUCT_CLASS_NAME,
-    COURSE_ID_REGEX,
-    ISO_8601_FORMAT,
-    SEAT_PRODUCT_CLASS_NAME
-)
+from ecommerce.core.constants import (COURSE_ENTITLEMENT_PRODUCT_CLASS_NAME, COURSE_ID_REGEX,
+                                      ISO_8601_FORMAT, SEAT_PRODUCT_CLASS_NAME)
 from ecommerce.core.url_utils import get_ecommerce_url
 from ecommerce.courses.models import Course
 from ecommerce.entitlements.utils import create_or_update_course_entitlement

--- a/ecommerce/extensions/basket/tests/test_models.py
+++ b/ecommerce/extensions/basket/tests/test_models.py
@@ -1,10 +1,10 @@
 import itertools
 
 import mock
-from analytics import Client
 from oscar.core.loading import get_class, get_model
 from oscar.test import factories
 
+from analytics import Client
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.analytics.utils import parse_tracking_context, translate_basket_line_for_segment
 from ecommerce.extensions.api.v2.tests.views.mixins import CatalogMixin

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,8 +3,8 @@
 #  edX Fork of Segment's python-analytics 1.2.8 using gevent for queueing
 #
 #############################
+-e git+https://github.com/edx/analytics-python.git@1.2.11#egg=analytics-python==1.2.11
 
-analytics-python==1.2.9
 coreapi==2.3.1
 django==1.11.9
 django-compressor==2.2


### PR DESCRIPTION
LEARNER-4675: This reverts commit 75909f6

Things have gotten worse in Production.  It isn't clear what combo of moving away from the fork and dropping use of gevent is the cause.  I'm not sure the sum total of changes in the fork that we lost.

This is just a straight up revert to get back to earlier bad steady-state.

The following is a graph of both healthy and unhealthy hosts from the ELB for ecommerce:
![screen shot 2018-03-27 at 12 04 43 pm](https://user-images.githubusercontent.com/14576445/37979660-2153acb6-31b7-11e8-891a-74a6d30255a9.png)
