### PR TITLE
ENT-938 Hide ID verification banner on Receipt page for enrollment code products

### DIFF
--- a/ecommerce/extensions/checkout/views.py
+++ b/ecommerce/extensions/checkout/views.py
@@ -182,17 +182,19 @@ class ReceiptResponseView(ThankYouView):
     def get_context_data(self, **kwargs):
         context = super(ReceiptResponseView, self).get_context_data(**kwargs)
         order = context[self.context_object_name]
+        has_enrollment_code_product = any(
+            line.product.is_enrollment_code_product for line in order.basket.all_lines()
+        )
         context.update({
             'payment_method': self.get_payment_method(order),
             'display_credit_messaging': self.order_contains_credit_seat(order),
         })
         context.update(self.get_order_dashboard_context(order))
         context.update(self.get_order_verification_context(order))
+        context.update(self.get_show_verification_banner_context(context))
         context.update({
             'explore_courses_url': get_lms_explore_courses_url(),
-            'has_enrollment_code_product': any(
-                line.product.is_enrollment_code_product for line in order.basket.all_lines()
-            )
+            'has_enrollment_code_product': has_enrollment_code_product
         })
         return context
 
@@ -253,4 +255,13 @@ class ReceiptResponseView(ThankYouView):
                     'user_verified': request.user.is_verified(site),
                 })
 
+        return context
+
+    def get_show_verification_banner_context(self, original_context):
+        context = {}
+        verification_url = original_context.get('verification_url')
+        user_verified = original_context.get('user_verified')
+        context.update({
+            'show_verification_banner': verification_url and not user_verified
+        })
         return context

--- a/ecommerce/static/sass/partials/views/_receipt.scss
+++ b/ecommerce/static/sass/partials/views/_receipt.scss
@@ -142,20 +142,17 @@
         text-align: right;
     }
 
-    #dashboard-link {
-        margin: 20px;
-        text-align: center;
-        padding-bottom: 3em;
+    #cta-nav-links {
+        margin: 40px 0;
+
+        .nav-link {
+            font-size: 16px;
+        }
 
         .dashboard-link {
-            font-size: 18px;
-            padding: 10px 15px;
+            margin-right: 40px;
         }
     }
-  #find-more-courses-link {
-    margin: 20px;
-    float: right;
-  }
 
     .dashboard-link {
         line-height: 20px;

--- a/ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
+++ b/ecommerce/templates/customer/emails/commtype_order_with_csv_body.html
@@ -29,7 +29,7 @@
                         <li>{% trans "Pro tip: Track which code is associated with which person." %}</li>
                         <li>{% trans "Learners sign-in/register with edX and enroll for the course." %}</li>
                     </ol>
-                    <p>{% blocktrans with link_start='<a href="' link_middle='">' link_end='</a>' %}To view your payment information, log in to see your Order History, under {{ link_start }}{{order_history_url}}{{ link_middle }}Account Settings{{ link_end }}{% endblocktrans %}</p>
+                    <p>{% blocktrans with link_start='<a href="' link_middle='">' link_end='</a>' %}To view your payment information, log in to see your Order History, under {{ link_start }}{{order_history_url}}{{ link_middle }}Account Settings{{ link_end }}.{% endblocktrans %}</p>
                     <p>{% blocktrans with link_start='<a href="mailto:info@edx.org">' link_end='</a>' %}For more information and assistance, contact {{ link_start }}info@edx.org.{{ link_end }}{% endblocktrans %}</p>
                     <p>{% trans "Thank You" %}</p>
                 </td>

--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -163,21 +163,22 @@
         {% endif %}
       </div>
 
-      {% if verification_url and not user_verified %}
+      {% if not has_enrollment_code_product and show_verification_banner  %}
         <div class="nav-wizard row">
             {% include 'oscar/checkout/_verification_data.html' %}
         </div>
-      {% else %}
-        <div id="dashboard-link">
-          <a class="dashboard-link nav-link" href="{{ order_dashboard_url }}">
-            {% trans "Go to Dashboard" %}
-          </a>
-        </div>
       {% endif %}
-      <div id="find-more-courses-link">
-          <a class="find-more-courses-link nav-link" href="{{ explore_courses_url }}" target="_blank">
+      <div id="cta-nav-links" class="row">
+        <div class="col-xs-12 text-right">
+          {% if not show_verification_banner %}
+          <a class="dashboard-link nav-link" href="{{ order_dashboard_url }}">
+            {% trans "Go to dashboard" %}
+          </a>
+          {% endif %}
+          <a class="find-more-courses-link nav-link" href="{{ explore_courses_url }}">
             {% trans "Find more courses" %}
           </a>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
[ENT-938](https://openedx.atlassian.net/browse/ENT-938): This PR ensures that the ID verification banner does not display on the Receipt page for enrollment code products. Additionally, it cleans up the "Go to dashboard" and "Find more courses" links.

**ID verification banner hidden & "Go to dashboard" link visible**
![no_banner](https://user-images.githubusercontent.com/2828721/38054054-cc177f82-32a3-11e8-8ad1-40d9d8fafac4.png)

**ID verification banner visible & "Go to dashboard" link hidden**
![with_banner](https://user-images.githubusercontent.com/2828721/38054056-ce688c54-32a3-11e8-94eb-11b371fd6321.png)


**Testing Instructions**
- [ ] Navigate to basket with an enrollment code SKU (example: https://ecommerce-business.sandbox.edx.org/basket/add/?sku=9CD820E)
- [ ] Purchase the product
- [ ] Verify the ID verification banner does not display on the Receipt.
- [ ] Verify the two CTA links "Go to Dashboard" and "Find more courses" are both displayed on the Receipt.