### PR TITLE
ENT-921: Remove create_or_activate_enrollment_code field from serializer as its usage is also removed from discovery.

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -408,8 +408,6 @@ class AtomicPublicationSerializer(serializers.Serializer):  # pylint: disable=ab
     uuid = serializers.UUIDField(required=False)
     name = serializers.CharField(max_length=255)
 
-    # ENT-803: by default enable enrollment code creation
-    create_or_activate_enrollment_code = serializers.BooleanField(default=True)
     # Verification deadline should only be required if the course actually requires verification.
     verification_deadline = serializers.DateTimeField(required=False, allow_null=True)
     products = serializers.ListField()
@@ -453,7 +451,8 @@ class AtomicPublicationSerializer(serializers.Serializer):  # pylint: disable=ab
         course_uuid = self.validated_data.get('uuid')
         course_name = self.validated_data['name']
         course_verification_deadline = self.validated_data.get('verification_deadline')
-        create_or_activate_enrollment_code = self.validated_data.get('create_or_activate_enrollment_code')
+        # ENT-803: by default enable enrollment code creation
+        create_or_activate_enrollment_code = True
         products = self.validated_data['products']
         partner = self.get_partner()
 

--- a/ecommerce/extensions/api/v2/tests/views/test_publication.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_publication.py
@@ -318,21 +318,6 @@ class AtomicPublicationTests(DiscoveryTestMixin, TestCase):
             self.assert_course_saved(self.course_id, expected=self.data, enrollment_code_count=1)
             self.assertTrue(Product.objects.filter(product_class__name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME).exists())
 
-    def test_create_with_enrollment_code_creation_disabled(self):
-        """
-        Verify that an enrollment code is not created when payload data specifically disables its creations.
-        """
-        with mock.patch.object(LMSPublisher, 'publish') as mock_publish:
-            # disable enrollment code creation
-            self.data.update(create_or_activate_enrollment_code=False)
-
-            # If publication succeeds, the view should return a 201 and data should be saved.
-            mock_publish.return_value = None
-            response = self.client.post(self.create_path, json.dumps(self.data), JSON_CONTENT_TYPE)
-            self.assertEqual(response.status_code, 201)
-            self.assert_course_saved(self.course_id, expected=self.data, enrollment_code_count=0)
-            self.assertFalse(Product.objects.filter(product_class__name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME).exists())
-
     def test_update(self):
         """Verify that a Course and associated products can be updated and published."""
         self.create_course_and_seats()


### PR DESCRIPTION
__Description:__
 In https://github.com/edx/course-discovery/pull/1370 we have removed the usage of `create_or_activate_enrollment_code` which was the only place where it was being used, so we can safely remove the serializer field from ecommerce too.