### PR TITLE
Temporary disable of Django Debug toolbar for performance issues

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -578,16 +578,21 @@ ENABLE_ENTERPRISE_ON_RUNTIME_SWITCH = 'enable_enterprise_on_runtime'
 ENTERPRISE_CUSTOMER_COOKIE_NAME = 'enterprise_customer_uuid'
 # END ENTERPRISE APP CONFIGURATION
 
+# NOTE: The DJANGO DEBUG toolbar is being removed temporarily for performance issues in Devstack 3/30/2018
+# This will be revisited once we are able to resolve the underlying cause.
+# BUG ticket: https://openedx.atlassian.net/browse/LEARNER-4824
+
+
 # DJANGO DEBUG TOOLBAR CONFIGURATION
 # http://django-debug-toolbar.readthedocs.org/en/latest/installation.html
-if os.environ.get('ENABLE_DJANGO_TOOLBAR', False):
-    INSTALLED_APPS += [
-        'debug_toolbar',
-    ]
-
-    MIDDLEWARE_CLASSES += (
-        'debug_toolbar.middleware.DebugToolbarMiddleware',
-    )
+# if os.environ.get('ENABLE_DJANGO_TOOLBAR', False):
+#     INSTALLED_APPS += [
+#         'debug_toolbar',
+#     ]
+#
+#     MIDDLEWARE_CLASSES += (
+#         'debug_toolbar.middleware.DebugToolbarMiddleware',
+#     )
 # END DJANGO DEBUG TOOLBAR CONFIGURATION
 
 # Determines if events are actually sent to Segment. This should only be set to False for testing purposes.


### PR DESCRIPTION
By disabling this Debug toolbar we are able to remove the performance pressure on the ecommerce service in the development environment, this is only meant to be a temporary change until we can resolve other ecommerce performance issues.