### PR TITLE
LEARNER-4913: Remove call to enrollments and entitlements when it is an anonymous

### DIFF
--- a/ecommerce/enterprise/conditions.py
+++ b/ecommerce/enterprise/conditions.py
@@ -36,6 +36,10 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
         Returns:
             bool
         """
+        if not basket.owner:
+            # An anonymous user is never linked to any EnterpriseCustomer.
+            return False
+
         try:
             learner_data = fetch_enterprise_learner_data(basket.site, basket.owner)['results'][0]
         except (ConnectionError, KeyError, SlumberHttpBaseException, Timeout):
@@ -46,7 +50,6 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
             )
             return False
         except IndexError:
-            # Learner is not linked to any EnterpriseCustomer.
             return False
 
         enterprise_customer = learner_data['enterprise_customer']

--- a/ecommerce/extensions/analytics/utils.py
+++ b/ecommerce/extensions/analytics/utils.py
@@ -134,6 +134,9 @@ def track_segment_event(site, user, event, properties):
         (success, msg): Tuple indicating the success of enqueuing the event on the message queue.
             This can be safely ignored unless needed for debugging purposes.
     """
+    if not user:
+        return False, 'Event is not fired for anonymous user.'
+
     site_configuration = site.siteconfiguration
     if not site_configuration.segment_key:
         msg = 'Event [{event}] was NOT fired because no Segment key is set for site configuration [{site_id}]'

--- a/ecommerce/extensions/api/v2/views/baskets.py
+++ b/ecommerce/extensions/api/v2/views/baskets.py
@@ -342,7 +342,7 @@ class BasketCalculateView(generics.GenericAPIView):
     permission_classes = (IsAuthenticated,)
     MARKETING_USER = 'marketing_site_worker'
 
-    def _calculate_basket(self, user, request, products, voucher, skus, code):
+    def _calculate_temporary_basket(self, user, request, products, voucher, skus, code):
         response = None
         try:
             # We wrap this in an atomic operation so we never commit this to the db.
@@ -424,11 +424,7 @@ class BasketCalculateView(generics.GenericAPIView):
         username = request.GET.get('username', default='')
         user = request.user
 
-        # True if this request was made by the marketing user, and does not include a username
-        # query param, and thus is calculating the non-logged in (anonymous) price.
-        # Note: We need to verify separately that all calls without a username query param
-        # can be treated in this same way.
-        is_marketing_anonymous_request = False
+        is_anonymous = False
 
         # If a username is passed in, validate that the user has staff access or is the same user.
         if username:
@@ -440,12 +436,18 @@ class BasketCalculateView(generics.GenericAPIView):
             else:
                 return HttpResponseForbidden('Unauthorized user credentials')
         elif user.username == self.MARKETING_USER:
-            is_marketing_anonymous_request = True
+            # A request made by the marketing user without a username query param,
+            # means this is calculating the non-logged in (anonymous) price.
+            # TODO: LEARNER-4993: Switch to a query param rather than hardcoding to
+            # the marketing user.
+            if waffle.flag_is_active(request, "use_basket_calculate_none_user"):
+                user = None
+            is_anonymous = True
 
         cache_key = None
-        # Since we know we can't have any enrollments or entitlements, we can directly get
-        # the cached price.
-        if is_marketing_anonymous_request:
+        if is_anonymous:
+            # For an anonymous user we can directly get the cached price, because
+            # there can't be any enrollments or entitlements.
             cache_key = get_cache_key(
                 site_comain=request.site,
                 resource_name='calculate',
@@ -456,9 +458,9 @@ class BasketCalculateView(generics.GenericAPIView):
                 if basket_calculate_results:
                     return Response(basket_calculate_results)
 
-        response = self._calculate_basket(user, request, products, voucher, skus, code)
+        response = self._calculate_temporary_basket(user, request, products, voucher, skus, code)
 
-        if response and is_marketing_anonymous_request:
+        if response and is_anonymous:
             cache.set(cache_key, response, settings.ANONYMOUS_BASKET_CALCULATE_CACHE_TIMEOUT)
 
         return Response(response)

--- a/ecommerce/extensions/offer/models.py
+++ b/ecommerce/extensions/offer/models.py
@@ -235,8 +235,9 @@ class ConditionalOffer(AbstractConditionalOffer):
         In addition to Oscar's check to see if the condition is satisfied,
         a check for if basket owners email domain is within the allowed email domains.
         """
-        if not self.is_email_valid(basket.owner.email):
+        if basket.owner and not self.is_email_valid(basket.owner.email):
             return False
+
         if self.benefit.range and self.benefit.range.catalog_query:
             # The condition is only satisfied if all basket lines are in the offer range
             num_lines = basket.all_lines().count()

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -253,8 +253,8 @@ CREDIT_PROVIDER_CACHE_TIMEOUT = 600
 # Anonymous User Calculate Cache timeout
 ANONYMOUS_BASKET_CALCULATE_CACHE_TIMEOUT = 3600  # Value is in seconds.
 
-# Enrollment API settings used for fetching information from LMS
-ENROLLMENT_API_CACHE_TIMEOUT = 30  # Value is in seconds.
+# LMS API settings used for fetching information from LMS
+LMS_API_CACHE_TIMEOUT = 30  # Value is in seconds.
 # END URL CONFIGURATION
 
 VOUCHER_CACHE_TIMEOUT = 10  # Value is in seconds.


### PR DESCRIPTION
LEARNER-4913

Skips calls to get enrollments and entitlements for an anonymous basket calculate.

NOTE: The implementation for this is to create a basket with the user=None.  Several other changes were needed to make this work.

This change is protected by a waffle flag.