### PR TITLE
LEARNER-4913/LEARNER-5061: Added is_anonymous parameter to the calculate URL

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_baskets.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_baskets.py
@@ -490,7 +490,6 @@ class BasketCalculateViewTests(ProgramTestMixin, TestCase):
     @httpretty.activate
     @mock.patch('ecommerce.programs.conditions.ProgramCourseRunSeatsCondition._get_lms_resource_for_user')
     @override_flag("use_basket_calculate_none_user", active=True)
-    @override_switch("debug_logging_for_excessive_lms_calls", active=True)
     def test_basket_calculate_anonymous_skip_lms(self, mock_get_lms_resource_for_user):
         """Verify a call for an anonymous user skips calls to LMS for entitlements and enrollments"""
         products, url = self.setup_anonymous_basket_calculate()


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LEARNER-4913
https://openedx.atlassian.net/browse/LEARNER-5061

Add in check for the is_anonymous URL parameter.  If it is not present we will treat the request as if there were a username.