### PR TITLE
ENT-964 Fix encoding on enrollment code product titles for fulfillment

### DIFF
--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -511,7 +511,7 @@ class EnrollmentCodeFulfillmentModule(BaseFulfillmentModule):
             _range.save()
 
             vouchers = create_vouchers(
-                name='Enrollment code voucher [{}]'.format(line.product.title),
+                name=unicode('Enrollment code voucher [{}]').format(line.product.title),
                 benefit_type=Benefit.PERCENTAGE,
                 benefit_value=100,
                 catalog=coupon_catalog,


### PR DESCRIPTION
[ENT-964](https://openedx.atlassian.net/browse/ENT-964)

This PR addresses an issue where orders of enrollment code products that had special character such as an `ñ` would cause a Fulfillment Error.

**Testing Instructions**
1. Perform an enrollment code purchase of this course ([Basket URL](https://ecommerce-business.sandbox.edx.org/basket/add/?sku=4E50690)).
2. Verify that you see the receipt page after the purchase.
3. Verify that the order is marked as complete (not "Fulfillment Error") in [Ecommerce dashboard](https://ecommerce-business.sandbox.edx.org/dashboard/orders/).