### PR TITLE
compare enrollment run key to program data course run list

### DIFF
--- a/ecommerce/programs/conditions.py
+++ b/ecommerce/programs/conditions.py
@@ -131,10 +131,10 @@ class ProgramCourseRunSeatsCondition(SingleItemConsumptionConditionMixin, Condit
 
         for course in program['courses']:
             # If the user is already enrolled in a course, we do not need to check their basket for it
-            if any(course['key'] in enrollment['course_details']['course_id'] and
+            if any(enrollment['course_details']['course_id'] in [run['key'] for run in course['course_runs']] and
                    enrollment['mode'] in applicable_seat_types for enrollment in enrollments):
                 continue
-            if any(course['uuid'] in entitlement['course_uuid'] and
+            if any(course['uuid'] == entitlement['course_uuid'] and
                    entitlement['mode'] in applicable_seat_types for entitlement in entitlements):
                 continue
 

--- a/ecommerce/programs/tests/test_conditions.py
+++ b/ecommerce/programs/tests/test_conditions.py
@@ -92,8 +92,6 @@ class ProgramCourseRunSeatsConditionTests(ProgramTestMixin, TestCase):
         program = self.mock_program_detail_endpoint(
             self.condition.program_uuid, self.site_configuration.discovery_api_url
         )
-        enrollments = [{'mode': 'verified', 'course_details': {'course_id': 'course-v1:test-org+course+1'}},
-                       {'mode': 'verified', 'course_details': {'course_id': 'course-v1:test-org+course+2'}}]
 
         # Extract one verified seat for each course
         verified_seats = []
@@ -103,8 +101,14 @@ class ProgramCourseRunSeatsConditionTests(ProgramTestMixin, TestCase):
                 if seat.attr.id_verification_required:
                     verified_seats.append(seat)
 
+        # Add verified enrollments for the first two program courses to the mock user data
+        enrollments = [
+            {'mode': 'verified', 'course_details': {'course_id': program['courses'][0]['course_runs'][0]['key']}},
+            {'mode': 'verified', 'course_details': {'course_id': program['courses'][1]['course_runs'][0]['key']}}
+        ]
         self.mock_user_data(basket.owner.username, owned_products=enrollments)
-        # If the user has not added all of the remaining courses in program to their basket,
+
+        # If the user has not added all of the remaining courses in the program to their basket,
         # the condition should not be satisfied
         basket.flush()
         for seat in verified_seats[2:len(verified_seats) - 1]:


### PR DESCRIPTION
Like on the marketing site, we were comparing course run key strings to course key strings in the offer satisfaction logic in the ecommerce service instead of comparing them to the list of course run keys for a given course in the program data retrieved from discovery. This caused issues with the Supply Chain Micromasters due to the state of course keys and course run keys for the program.

[LEARNER-5030](https://openedx.atlassian.net/browse/LEARNER-5030)