### PR TITLE
LEARNER-5182: Refactor tiered cache.

### DIFF
--- a/ecommerce/cache_utils/middleware.py
+++ b/ecommerce/cache_utils/middleware.py
@@ -11,11 +11,11 @@ class CacheUtilsMiddleware(object):
     """
     def process_request(self, request):
         """
-        Stores whether or not 'force_django_cache_miss' was supplied in the
+        Stores whether or not FORCE_DJANGO_CACHE_MISS_KEY was supplied in the
         request. Also, clears the request cache.
         """
         RequestCache.clear()
-        TieredCache._get_and_set_force_django_cache_miss(request)  # pylint: disable=protected-access
+        TieredCache._get_and_set_force_cache_miss(request)  # pylint: disable=protected-access
 
     def process_response(self, request, response):  # pylint: disable=unused-argument
         """

--- a/ecommerce/cache_utils/tests/test_utils.py
+++ b/ecommerce/cache_utils/tests/test_utils.py
@@ -1,15 +1,20 @@
-# -*- coding: utf-8 -*-
 """
 Tests for the request cache.
 """
 import mock
 
-from ecommerce.cache_utils.utils import CACHE_MISS, CacheMissError, RequestCache, TieredCache
+from ecommerce.cache_utils.utils import (
+    SHOULD_FORCE_CACHE_MISS_KEY,
+    CacheResponse,
+    CacheResponseError,
+    RequestCache,
+    TieredCache
+)
 from ecommerce.tests.testcases import TestCase
 
 TEST_KEY = "clobert"
+TEST_KEY_2 = "clobert2"
 EXPECTED_VALUE = "bertclob"
-DEFAULT_VALUE = "default_value"
 TEST_DJANGO_TIMEOUT_CACHE = 1
 
 
@@ -17,125 +22,151 @@ class TestRequestCache(TestCase):
     def setUp(self):
         RequestCache.clear()
 
-    def test_get_value_or_cache_miss_hit(self):
+    def test_get_cache_response_hit(self):
         RequestCache.set(TEST_KEY, EXPECTED_VALUE)
-        cached_value = RequestCache.get_value_or_cache_miss(TEST_KEY)
-        self.assertEqual(cached_value, EXPECTED_VALUE)
+        cache_response = RequestCache.get_cache_response(TEST_KEY)
+        self.assertFalse(cache_response.is_miss)
+        self.assertEqual(cache_response.value, EXPECTED_VALUE)
 
-    def test_get_value_or_cache_miss_miss(self):
-        cached_value = RequestCache.get_value_or_cache_miss(TEST_KEY)
-        self.assertEqual(cached_value, CACHE_MISS)
+    def test_get_cache_response_hit_with_cached_none(self):
+        RequestCache.set(TEST_KEY, None)
+        cache_response = RequestCache.get_cache_response(TEST_KEY)
+        self.assertFalse(cache_response.is_miss)
+        self.assertEqual(cache_response.value, None)
 
-    def test_get_value_or_default_hit(self):
+    def test_get_cache_response_miss(self):
+        cache_response = RequestCache.get_cache_response(TEST_KEY)
+        self.assertTrue(cache_response.is_miss)
+
+    def test_clear(self):
         RequestCache.set(TEST_KEY, EXPECTED_VALUE)
-        cached_value = RequestCache.get_value_or_default(TEST_KEY, DEFAULT_VALUE)
-        self.assertEqual(cached_value, EXPECTED_VALUE)
+        RequestCache.clear()
+        cache_response = RequestCache.get_cache_response(TEST_KEY)
+        self.assertTrue(cache_response.is_miss)
 
-    def test_get_value_or_default_miss(self):
-        cached_value = RequestCache.get_value_or_default(TEST_KEY, DEFAULT_VALUE)
-        self.assertEqual(cached_value, DEFAULT_VALUE)
-
-    def test_set(self):
+    def test_delete(self):
         RequestCache.set(TEST_KEY, EXPECTED_VALUE)
-        self.assertEqual(RequestCache.get_value_or_cache_miss(TEST_KEY), EXPECTED_VALUE)
+        RequestCache.set(TEST_KEY_2, EXPECTED_VALUE)
+        RequestCache.delete(TEST_KEY)
+
+        cache_response = RequestCache.get_cache_response(TEST_KEY)
+        self.assertTrue(cache_response.is_miss)
+
+        cache_response = RequestCache.get_cache_response(TEST_KEY_2)
+        self.assertTrue(cache_response.is_hit)
+        self.assertEqual(cache_response.value, EXPECTED_VALUE)
+
+    def test_delete_missing_key(self):
+        try:
+            RequestCache.delete(TEST_KEY)
+        except KeyError:
+            self.fail('Deleting a missing key from the request cache should not cause an error.')
 
 
 class TestTieredCache(TestCase):
     def setUp(self):
-        RequestCache.clear()
+        TieredCache.clear_all_tiers()
 
-    def test_get_value_or_cache_miss_all_tier_miss(self):
-        cached_value = TieredCache.get_value_or_cache_miss(TEST_KEY)
-        self.assertEqual(cached_value, CACHE_MISS)
+    def test_get_cache_response_all_tier_miss(self):
+        cache_response = TieredCache.get_cache_response(TEST_KEY)
+        self.assertTrue(cache_response.is_miss)
 
-    def test_get_value_or_cache_miss_request_cache_hit(self):
+    def test_get_cache_response_request_cache_hit(self):
         RequestCache.set(TEST_KEY, EXPECTED_VALUE)
-        cached_value = TieredCache.get_value_or_cache_miss(TEST_KEY)
-        self.assertEqual(cached_value, EXPECTED_VALUE)
+        cache_response = TieredCache.get_cache_response(TEST_KEY)
+        self.assertTrue(cache_response.is_hit)
+        self.assertEqual(cache_response.value, EXPECTED_VALUE)
 
     @mock.patch('django.core.cache.cache.get')
-    def test_get_value_or_cache_miss_django_cache_hit(self, mock_cache_get):
+    def test_get_cache_response_django_cache_hit(self, mock_cache_get):
         mock_cache_get.return_value = EXPECTED_VALUE
-        cached_value = TieredCache.get_value_or_cache_miss(TEST_KEY)
-        self.assertEqual(cached_value, EXPECTED_VALUE)
-        self.assertEqual(RequestCache.get_value_or_cache_miss(TEST_KEY), EXPECTED_VALUE)
+        cache_response = TieredCache.get_cache_response(TEST_KEY)
+        self.assertTrue(cache_response.is_hit)
+        self.assertEqual(cache_response.value, EXPECTED_VALUE)
+
+        cache_response = RequestCache.get_cache_response(TEST_KEY)
+        self.assertTrue(cache_response.is_hit, 'Django cache hit should cache value in request cache.')
 
     @mock.patch('django.core.cache.cache.get')
-    def test_get_value_or_cache_miss_force_django_cache_miss(self, mock_cache_get):
-        RequestCache.set('force_django_cache_miss', True)
+    def test_get_cache_response_force_django_cache_miss(self, mock_cache_get):
+        RequestCache.set(SHOULD_FORCE_CACHE_MISS_KEY, True)
         mock_cache_get.return_value = EXPECTED_VALUE
-        cached_value = TieredCache.get_value_or_cache_miss(TEST_KEY)
-        self.assertEqual(cached_value, CACHE_MISS)
-        self.assertEqual(RequestCache.get_value_or_cache_miss(TEST_KEY), CACHE_MISS)
+        cache_response = TieredCache.get_cache_response(TEST_KEY)
+        self.assertTrue(cache_response.is_miss)
 
-    def test_get_value_or_default_all_tier_miss(self):
-        cached_value = TieredCache.get_value_or_default(TEST_KEY, DEFAULT_VALUE)
-        self.assertEqual(cached_value, DEFAULT_VALUE)
-
-    def test_get_value_or_default_request_cache_hit(self):
-        RequestCache.set(TEST_KEY, EXPECTED_VALUE)
-        cached_value = TieredCache.get_value_or_default(TEST_KEY, DEFAULT_VALUE)
-        self.assertEqual(cached_value, EXPECTED_VALUE)
-
-    @mock.patch('django.core.cache.cache.get')
-    def test_get_value_or_default_django_cache_hit(self, mock_cache_get):
-        mock_cache_get.return_value = EXPECTED_VALUE
-        cached_value = TieredCache.get_value_or_default(TEST_KEY, DEFAULT_VALUE)
-        self.assertEqual(cached_value, EXPECTED_VALUE)
-        self.assertEqual(RequestCache.get_value_or_cache_miss(TEST_KEY), EXPECTED_VALUE)
-
-    @mock.patch('django.core.cache.cache.get')
-    def test_get_value_or_default_force_django_cache_miss(self, mock_cache_get):
-        RequestCache.set('force_django_cache_miss', True)
-        mock_cache_get.return_value = EXPECTED_VALUE
-        cached_value = TieredCache.get_value_or_default(TEST_KEY, DEFAULT_VALUE)
-        self.assertEqual(cached_value, DEFAULT_VALUE)
-        self.assertEqual(RequestCache.get_value_or_cache_miss(TEST_KEY), CACHE_MISS)
+        cache_response = RequestCache.get_cache_response(TEST_KEY)
+        self.assertTrue(cache_response.is_miss, 'Forced Django cache miss should not cache value in request cache.')
 
     @mock.patch('django.core.cache.cache.set')
     def test_set_all_tiers(self, mock_cache_set):
         mock_cache_set.return_value = EXPECTED_VALUE
         TieredCache.set_all_tiers(TEST_KEY, EXPECTED_VALUE, TEST_DJANGO_TIMEOUT_CACHE)
         mock_cache_set.assert_called_with(TEST_KEY, EXPECTED_VALUE, TEST_DJANGO_TIMEOUT_CACHE)
-        self.assertEqual(RequestCache.get_value_or_cache_miss(TEST_KEY), EXPECTED_VALUE)
+        self.assertEqual(RequestCache.get_cache_response(TEST_KEY).value, EXPECTED_VALUE)
+
+    @mock.patch('django.core.cache.cache.clear')
+    def test_clear_all_tiers(self, mock_cache_clear):
+        TieredCache.set_all_tiers(TEST_KEY, EXPECTED_VALUE)
+        TieredCache.clear_all_tiers()
+        self.assertTrue(RequestCache.get_cache_response(TEST_KEY).is_miss)
+        mock_cache_clear.assert_called_once_with()
+
+    @mock.patch('django.core.cache.cache.delete')
+    def test_delete(self, mock_cache_delete):
+        TieredCache.set_all_tiers(TEST_KEY, EXPECTED_VALUE)
+        TieredCache.set_all_tiers(TEST_KEY_2, EXPECTED_VALUE)
+        TieredCache.delete_all_tiers(TEST_KEY)
+        self.assertTrue(RequestCache.get_cache_response(TEST_KEY).is_miss)
+        self.assertEqual(RequestCache.get_cache_response(TEST_KEY_2).value, EXPECTED_VALUE)
+        mock_cache_delete.assert_called_with(TEST_KEY)
 
 
-class CacheUtilityTests(TestCase):
-    def test_miss_cache_valid_use(self):
-        """ Test the valid uses of CACHE_MISS. """
-        self.assertTrue(CACHE_MISS is CACHE_MISS)
+class CacheResponseTests(TestCase):
+    def test_is_miss(self):
+        is_miss = True
+        cache_response = CacheResponse(is_miss, EXPECTED_VALUE)
+        self.assertTrue(cache_response.is_miss)
+        self.assertFalse(cache_response.is_hit)
+        with self.assertRaises(CacheResponseError):
+            cache_response.value  # pylint: disable=pointless-statement
+        self.assertEqual(cache_response.__repr__(), 'CacheResponse (is_hit=False)')
 
-    def test_miss_cache_invalid_use(self):
-        """ Test invalid uses of CACHE_MISS. """
-        with self.assertRaises(CacheMissError):
-            bool(CACHE_MISS)
+    def test_is_hit(self):
+        is_miss = False
+        cache_response = CacheResponse(is_miss, EXPECTED_VALUE)
+        self.assertFalse(cache_response.is_miss)
+        self.assertTrue(cache_response.is_hit)
+        self.assertEqual(cache_response.value, EXPECTED_VALUE)
+        self.assertEqual(cache_response.__repr__(), 'CacheResponse (is_hit=True)')
 
-        with self.assertRaises(CacheMissError):
+    def test_cache_response_misuse(self):
+        cache_response = CacheResponse(False, EXPECTED_VALUE)
+
+        with self.assertRaises(CacheResponseError):
+            bool(cache_response)
+
+        with self.assertRaises(CacheResponseError):
             # For Python 3
-            CACHE_MISS.__bool__()
+            cache_response.__bool__()
 
-        with self.assertRaises(CacheMissError):
-            CACHE_MISS.get('x')
+        with self.assertRaises(CacheResponseError):
+            cache_response.get('x')
 
-        with self.assertRaises(CacheMissError):
-            CACHE_MISS.x = None
+        with self.assertRaises(CacheResponseError):
+            cache_response.x = None
 
-        with self.assertRaises(CacheMissError):
-            CACHE_MISS['key']  # pylint: disable=pointless-statement
+        with self.assertRaises(CacheResponseError):
+            cache_response['key']  # pylint: disable=pointless-statement
 
-        with self.assertRaises(CacheMissError):
-            CACHE_MISS['key'] = None
+        with self.assertRaises(CacheResponseError):
+            cache_response['key'] = None
 
-        with self.assertRaises(CacheMissError):
-            [0, 1][CACHE_MISS]  # pylint: disable=expression-not-assigned, pointless-statement
+        with self.assertRaises(CacheResponseError):
+            ['a list'][cache_response]  # pylint: disable=expression-not-assigned, pointless-statement
 
-        with self.assertRaises(CacheMissError):
-            'x' in CACHE_MISS  # pylint: disable=pointless-statement
+        with self.assertRaises(CacheResponseError):
+            'x' in cache_response  # pylint: disable=pointless-statement
 
-        with self.assertRaises(CacheMissError):
-            for x in CACHE_MISS:  # pylint: disable=unused-variable
+        with self.assertRaises(CacheResponseError):
+            for x in cache_response:  # pylint: disable=unused-variable
                 pass
-
-    def test_miss_cache_repr(self):
-        """ Test the valid uses of CACHE_MISS. """
-        self.assertEqual(CACHE_MISS.__repr__(), 'CACHE_MISS')


### PR DESCRIPTION
[LEARNER-5182](https://openedx.atlassian.net/browse/LEARNER-5182)

Refactor of tiered cache based on learnings from applying to the rest of ecommerce (see upcoming PR).

Also, includes removal of waffle switch `use_request_cache_for_getting_lms_resource`.

NOTE: @nasthagiri came upon https://github.com/dimagi/quickcache which is a possible replacement for most of this, with the following caveats:
1. We still need to implement a RequestCache, but it would need to be a complete Django Cache.
2. Quick cache documents being automatically versioned by the source it wraps.  Could be good in many cases.  May not be great if you want to do something like add logging to a call that is expensive.  Something to keep an eye on.
3. Are we ok with the key generation code in quick cache?  The current implementation punts on this issue by just accepting keys.
4. Would we want to enforce that the Django caches are never called directly?  This implementation fixes a common bug that appears when caching Falsey values like `None`.  The quick cache gets around this by avoiding calls to get/set, by instead using decorators only.