### PR TITLE
Remove unecessary logic in coupon utils

### DIFF
--- a/ecommerce/coupons/utils.py
+++ b/ecommerce/coupons/utils.py
@@ -7,7 +7,7 @@ from django.core.cache import cache
 from oscar.core.loading import get_model
 from slumber.exceptions import HttpNotFoundError
 
-from ecommerce.core.utils import get_cache_key, traverse_pagination
+from ecommerce.core.utils import get_cache_key
 
 Product = get_model('catalogue', 'Product')
 
@@ -70,27 +70,12 @@ def get_catalog_course_runs(site, query, limit=None, offset=None):
     if not response:
         api = site.siteconfiguration.discovery_api_client
         endpoint = getattr(api, api_resource_name)
-
-        if limit:
-            response = endpoint().get(
-                partner=partner_code,
-                q=query,
-                limit=limit,
-                offset=offset
-            )
-        else:
-            response = endpoint().get(
-                partner=partner_code,
-                q=query
-            )
-            all_response_results = traverse_pagination(response, endpoint)
-            response = {
-                'count': len(all_response_results),
-                'next': 'None',
-                'previous': 'None',
-                'results': all_response_results,
-            }
-
+        response = endpoint().get(
+            partner=partner_code,
+            q=query,
+            limit=limit,
+            offset=offset
+        )
         cache.set(cache_key, response, settings.COURSES_API_CACHE_TIMEOUT)
 
     return response


### PR DESCRIPTION
This PR unblocks codecov requirements in https://github.com/edx/ecommerce/pull/1764

Remove unnecessary handling of the case where limit == False. DRF already handles all different inputs for limit. 

For each example below, DRF will just use the default limit. 
`www.thing.com?limit=` 
`www.thing.com?limit=gwesgw`
`www.thing.com?limit=None`
`www.thing.com?limit=False`
`www.thing.com?limit=0`

The other possible use case is that someone would want a response that has all of the data in one giant call. For example, instead of 
```
{
    'count': 100,
    'next': 'www.page2of5.com',
    'previous': 'None',
    'results': [
        1,
        2,
        ...
        20
    ]
}
```
A caller may want
```
{
    'count': 100,
    'next': 'None',
    'previous': 'None',
    'results': [
        1,
        2,
        ...
        100
    ]
}
```

This seems like an odd and dangerous use case since the latter response traverses the entire course_runs catalog. There are only two places that this method is called and both callers set the limit with...
`limit = request.GET.get('limit', DEFAULT_CATALOG_PAGE_SIZE)` where `DEFAULT_CATALOG_PAGE_SIZE` is set to 100. 