### PR TITLE
WL-1575: Fixed management command to handle a scenario when dns is changed

### DIFF
--- a/ecommerce/theming/management/commands/tests/test_create_sites_and_partners.py
+++ b/ecommerce/theming/management/commands/tests/test_create_sites_and_partners.py
@@ -160,3 +160,12 @@ class TestCreateSitesAndPartners(TestCase):
         )
         # if we run command with same dns then it will not duplicates the sites and partners.
         self._assert_sites_data_is_valid()
+
+        self.dns_name = "new-dns"
+        call_command(
+            "create_sites_and_partners",
+            "--dns-name", self.dns_name,
+            "--theme-path", self.theme_path
+        )
+        # if we run command with same partner but different dns then it should update sites.
+        self._assert_sites_data_is_valid()


### PR DESCRIPTION
This PR has changes to handle a scenario when site domain of and existing partner is changed. These changes would allow us to update site instead of creating new one and then causing `IntegrityError` when we created site configuration.
@hasnain-naveed could you please review.