### PR TITLE
WL-1583: Ecommerce Support for Journal Refunds

### DIFF
--- a/ecommerce/journal/client.py
+++ b/ecommerce/journal/client.py
@@ -44,6 +44,25 @@ def post_journal_access(site_configuration, order_number, username, journal_uuid
     return client.journalaccess.post(data)
 
 
+def revoke_journal_access(site_configuration, order_number):
+    """
+    POST revoke access request to journal access api
+
+    Args:
+        site_configuration (SiteConfiguration): site configuration
+        order_number (str): number of order to be revoked
+
+    Returns:
+        response
+    """
+    client = get_journals_service_client(site_configuration)
+    data = {
+        'order_number': order_number,
+        'revoke_access': "true"
+    }
+    return client.journalaccess.post(data)
+
+
 def fetch_journal_bundle(site, journal_bundle_uuid):
     """
     Retrieve journal bundle for given uuid.


### PR DESCRIPTION
- Implemented "revoke_line" in journal fulfillment module.
- When a journal order is revoked in the oscar dashboard, "revoke_line"
  is called.
- Created method called "revoke_journal_access" which allows for easier
  integration with the journal access revoke api