### PR TITLE
Fix logging for deprecated_traverse_pagination

### DIFF
--- a/ecommerce/core/utils.py
+++ b/ecommerce/core/utils.py
@@ -67,18 +67,17 @@ def deprecated_traverse_pagination(response, endpoint):
         list of dict.
 
     """
-    if waffle.switch_is_active("debug_logging_for_deprecated_traverse_pagination"):  # pragma: no cover
-        base_url = ""
-        try:
-            base_url = endpoint._store['base_url']  # pylint: disable=protected-access
-        except:  # pylint: disable=bare-except
-            pass
-        logger.info("deprecated_traverse_pagination method is called for endpoint %s", base_url)
-
     results = response.get('results', [])
 
     next_page = response.get('next')
     while next_page:
+        if waffle.switch_is_active("debug_logging_for_deprecated_traverse_pagination"):  # pragma: no cover
+            base_url = ""
+            try:
+                base_url = endpoint._store['base_url']  # pylint: disable=protected-access
+            except:  # pylint: disable=bare-except
+                pass
+            logger.info("deprecated_traverse_pagination method is called for endpoint %s", base_url)
         querystring = parse_qs(urlparse(next_page).query, keep_blank_values=True)
         response = endpoint.get(**querystring)
         results += response.get('results', [])

--- a/ecommerce/extensions/api/v2/views/baskets.py
+++ b/ecommerce/extensions/api/v2/views/baskets.py
@@ -24,7 +24,7 @@ from ecommerce.extensions.analytics.utils import audit_log
 from ecommerce.extensions.api import data as data_api
 from ecommerce.extensions.api import exceptions as api_exceptions
 from ecommerce.extensions.api.serializers import OrderSerializer
-from ecommerce.extensions.basket.constants import is_calculate_temporary_basket
+from ecommerce.extensions.basket.constants import TEMPORARY_BASKET_CACHE_KEY
 from ecommerce.extensions.basket.utils import attribute_cookie_data
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
 from ecommerce.extensions.partner.shortcuts import get_partner_for_site
@@ -446,7 +446,7 @@ class BasketCalculateView(generics.GenericAPIView):
                     'currency': basket.currency
                 }
         """
-        RequestCache.set(is_calculate_temporary_basket, True)  # TODO: LEARNER 5463
+        RequestCache.set(TEMPORARY_BASKET_CACHE_KEY, True)  # TODO: LEARNER 5463
 
         partner = get_partner_for_site(request)
         skus = request.GET.getlist('sku')

--- a/ecommerce/extensions/basket/constants.py
+++ b/ecommerce/extensions/basket/constants.py
@@ -1,1 +1,1 @@
-is_calculate_temporary_basket = "Calculate temporary basket"
+TEMPORARY_BASKET_CACHE_KEY = "ecommerce.is_calculate_temporary_basket"

--- a/ecommerce/extensions/basket/models.py
+++ b/ecommerce/extensions/basket/models.py
@@ -5,7 +5,7 @@ from oscar.core.loading import get_class
 
 from ecommerce.cache_utils.utils import RequestCache
 from ecommerce.extensions.analytics.utils import track_segment_event, translate_basket_line_for_segment
-from ecommerce.extensions.basket.constants import is_calculate_temporary_basket
+from ecommerce.extensions.basket.constants import TEMPORARY_BASKET_CACHE_KEY
 
 OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
 Selector = get_class('partner.strategy', 'Selector')
@@ -51,7 +51,7 @@ class Basket(AbstractBasket):
 
     def flush(self):
         """Remove all products in basket and fire Segment 'Product Removed' Analytic event for each"""
-        cached_response = RequestCache.get_cached_response(is_calculate_temporary_basket)
+        cached_response = RequestCache.get_cached_response(TEMPORARY_BASKET_CACHE_KEY)
         if cached_response.is_hit:
             # Do not track anything. This is a temporary basket calculation. TODO: LEARNER 5463
             return
@@ -72,7 +72,7 @@ class Basket(AbstractBasket):
         Performs AbstractBasket add_product method and fires Google Analytics 'Product Added' event.
         """
         line, created = super(Basket, self).add_product(product, quantity, options)  # pylint: disable=bad-super-call
-        cached_response = RequestCache.get_cached_response(is_calculate_temporary_basket)
+        cached_response = RequestCache.get_cached_response(TEMPORARY_BASKET_CACHE_KEY)
         if cached_response.is_hit:
             # Do not track anything. This is a temporary basket calculation. TODO: LEARNER 5463
             return line, created

--- a/ecommerce/extensions/basket/tests/test_models.py
+++ b/ecommerce/extensions/basket/tests/test_models.py
@@ -10,7 +10,7 @@ from ecommerce.cache_utils.utils import RequestCache
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.analytics.utils import parse_tracking_context, translate_basket_line_for_segment
 from ecommerce.extensions.api.v2.tests.views.mixins import CatalogMixin
-from ecommerce.extensions.basket.constants import is_calculate_temporary_basket
+from ecommerce.extensions.basket.constants import TEMPORARY_BASKET_CACHE_KEY
 from ecommerce.extensions.basket.models import Basket
 from ecommerce.extensions.basket.tests.mixins import BasketMixin
 from ecommerce.extensions.test.factories import create_basket
@@ -142,7 +142,7 @@ class BasketTests(CatalogMixin, BasketMixin, TestCase):
         TODO: LEARNER 5463
         """
         basket = self._create_basket_with_product()
-        RequestCache.set(is_calculate_temporary_basket, True)
+        RequestCache.set(TEMPORARY_BASKET_CACHE_KEY, True)
 
         with mock.patch.object(Client, 'track') as mock_track:
             basket.flush()
@@ -176,7 +176,7 @@ class BasketTests(CatalogMixin, BasketMixin, TestCase):
         course = CourseFactory()
         basket = create_basket(empty=True)
         seat = course.create_or_update_seat('verified', True, 100, self.partner)
-        RequestCache.set(is_calculate_temporary_basket, True)
+        RequestCache.set(TEMPORARY_BASKET_CACHE_KEY, True)
         with mock.patch('ecommerce.extensions.basket.models.track_segment_event') as mock_track:
             basket.add_product(seat)
             properties = translate_basket_line_for_segment(basket.lines.first())


### PR DESCRIPTION
deprecated_traverse_pagination is being called even if there are no pages to paginate to. Moved logger to log only when an external call is made.