### PR TITLE
[ENT-1031] Fix case where we get integrity error due to conflicting names.

### DIFF
--- a/ecommerce/enterprise/forms.py
+++ b/ecommerce/enterprise/forms.py
@@ -12,7 +12,6 @@ from ecommerce.extensions.offer.models import OFFER_PRIORITY_ENTERPRISE
 from ecommerce.programs.custom import class_path, create_condition
 
 Benefit = get_model('offer', 'Benefit')
-Condition = get_model('offer', 'Condition')
 ConditionalOffer = get_model('offer', 'ConditionalOffer')
 Range = get_model('offer', 'Range')
 
@@ -95,8 +94,12 @@ class EnterpriseOfferForm(forms.ModelForm):
         enterprise_customer = get_enterprise_customer(site, enterprise_customer_uuid)
         enterprise_customer_name = enterprise_customer['name']
 
-        self.instance.name = _(u'Discount provided by {enterprise_customer_name}.'.format(
-            enterprise_customer_name=enterprise_customer_name
+        # Note: the actual name is not displayed like this in the template, so it's safe to use the UUID here.
+        # And in fact we have to, because otherwise we face integrity errors since Oscar forces this name to be unique.
+        self.instance.name = _(u'Discount of type {} provided by {} for {}.'.format(
+            ConditionalOffer.SITE,
+            enterprise_customer_name,
+            enterprise_customer_catalog_uuid,
         ))
         self.instance.status = ConditionalOffer.OPEN
         self.instance.offer_type = ConditionalOffer.SITE

--- a/ecommerce/enterprise/tests/test_forms.py
+++ b/ecommerce/enterprise/tests/test_forms.py
@@ -118,7 +118,11 @@ class EnterpriseOfferFormTests(EnterpriseServiceMockMixin, TestCase):
             data['enterprise_customer_catalog_uuid'],
             data['benefit_value'],
             data['benefit_type'],
-            'Discount provided by {}.'.format(data['enterprise_customer_name']),
+            'Discount of type {} provided by {} for {}.'.format(
+                ConditionalOffer.SITE,
+                data['enterprise_customer_name'],
+                data['enterprise_customer_catalog_uuid']
+            ),
         )
 
     @httpretty.activate
@@ -140,7 +144,9 @@ class EnterpriseOfferFormTests(EnterpriseServiceMockMixin, TestCase):
             data['enterprise_customer_catalog_uuid'],
             data['benefit_value'],
             data['benefit_type'],
-            'Discount provided by Spánish Enterprise.'
+            'Discount of type Site provided by Spánish Enterprise for {}.'.format(
+                data['enterprise_customer_catalog_uuid']
+            ),
         )
 
     @httpretty.activate
@@ -164,7 +170,11 @@ class EnterpriseOfferFormTests(EnterpriseServiceMockMixin, TestCase):
             data['enterprise_customer_catalog_uuid'],
             data['benefit_value'],
             data['benefit_type'],
-            'Discount provided by {}.'.format(data['enterprise_customer_name']),
+            'Discount of type {} provided by {} for {}.'.format(
+                ConditionalOffer.SITE,
+                data['enterprise_customer_name'],
+                data['enterprise_customer_catalog_uuid']
+            ),
         )
 
     @httpretty.activate
@@ -194,7 +204,11 @@ class EnterpriseOfferFormTests(EnterpriseServiceMockMixin, TestCase):
             data['enterprise_customer_catalog_uuid'],
             data['benefit_value'],
             data['benefit_type'],
-            'Discount provided by {}.'.format(data['enterprise_customer_name']),
+            'Discount of type {} provided by {} for {}.'.format(
+                ConditionalOffer.SITE,
+                data['enterprise_customer_name'],
+                data['enterprise_customer_catalog_uuid']
+            ),
         )
 
     def test_create_when_conditional_offer_with_uuid_exists(self):


### PR DESCRIPTION
It seems that Oscar requires the name of a conditional offer to be unique. We set the conditional offer's name to only rely on the Enterprise Customer's name, so if we ever create more than 1 offer for any Enterprise Customer, we will have an integrity error.

To solve this we just add more values to define the name. The perfect set of values to pick are those very values used to determine whether a conflicting conditional offer exists in the first place when cleaning up inputs from the form. Those values are the condition offer type, the enterprise customer name, and the enterprise customer catalog UUID.

Note that it seems the template used to render text in the basket when a discount exists is not reliant on this actual name, so changing this name only affects internal representations. [(Reference)](https://github.com/edx/ecommerce/blob/master/ecommerce/templates/oscar/basket/partials/client_side_checkout_basket.html#L80).

**Test Instructions**:

1. Login at https://business.sandbox.edx.org/admin/
2. Login at https://ecommerce-business.sandbox.edx.org/login
3. Go to https://ecommerce-business.sandbox.edx.org/enterprise/offers/
4. Copy down **1** Enterprise Customer UUID, and **1** Enterprise Customer Catalog UUID that does not already correspond to the previously chosen Enterprise Customer on this list.
5. Try to make a new Enterprise Offer using this customer and catalog, and ensure that it works.
6. Register for a course that exists in the chosen catalog through this Enterprise Customer, and ensure that the 'Discount provided by X' text in the basket is displayed appropriately.