### PR TITLE
Call get_basket_switch_data only when relevant

### DIFF
--- a/ecommerce/extensions/basket/tests/mixins.py
+++ b/ecommerce/extensions/basket/tests/mixins.py
@@ -1,10 +1,13 @@
 from oscar.core.loading import get_class, get_model
 from oscar.test import factories
 
+from ecommerce.core.constants import ENROLLMENT_CODE_PRODUCT_CLASS_NAME
+from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.tests.mixins import SiteMixin
 
 Default = get_class('partner.strategy', 'Default')
 Basket = get_model('basket', 'Basket')
+Product = get_model('catalogue', 'Product')
 
 
 class BasketMixin(SiteMixin):
@@ -18,3 +21,19 @@ class BasketMixin(SiteMixin):
             factories.create_stockrecord(product, num_in_stock=2)
             basket.add_product(product)
         return basket
+
+    def prepare_course_seat_and_enrollment_code(self, seat_type='verified', id_verification=False):
+        """
+        Helper function that creates a new course, enables enrollment codes and creates a new
+        seat and enrollment code for it.
+
+        Args:
+            seat_type (str): Seat/certification type.
+            is_verification (bool): Whether or not id verification is required for the seat.
+        Returns:
+            The newly created course, seat and enrollment code.
+        """
+        course = CourseFactory()
+        seat = course.create_or_update_seat(seat_type, id_verification, 10, self.partner, create_enrollment_code=True)
+        enrollment_code = Product.objects.get(product_class__name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME)
+        return course, seat, enrollment_code


### PR DESCRIPTION
From discovery work on performance of the Basket Summary page, we found that the util function get_basket_switch_data was being called for product types that are not relevant to the original functionality.  This is causing very slow load times for this view in cases where Entitlement products are in the users basket, because the code loops over a large and ever-growing number of StockRecords in search of a toggle product it will never find.

This change addresses the problem by ensuring this potentially expensive function gets called only when it will be efficient and when it can produce meaningful output.  I also added a doc string to the function to help developers understand its purpose.

Fixes https://openedx.atlassian.net/browse/LEARNER-5610