### PR TITLE
bugfix: allow proper currency rendering in case of discount coupons applied

### DIFF
--- a/ecommerce/extensions/checkout/utils.py
+++ b/ecommerce/extensions/checkout/utils.py
@@ -62,7 +62,6 @@ def format_currency(currency, amount, format=None, locale=None):  # pylint: disa
     return default_format_currency(
         amount,
         currency,
-        format=format,
         locale=locale
     )
 

--- a/ecommerce/extensions/offer/utils.py
+++ b/ecommerce/extensions/offer/utils.py
@@ -64,7 +64,7 @@ def format_benefit_value(benefit):
         benefit_value = _('{benefit_value}%'.format(benefit_value=benefit_value))
     else:
         converted_benefit = add_currency(Decimal(benefit.value))
-        benefit_value = _('${benefit_value}'.format(benefit_value=converted_benefit))
+        benefit_value = _('{benefit_value}'.format(benefit_value=converted_benefit))
     return benefit_value
 
 


### PR DESCRIPTION
The currency is currently hard-coded for the discount applied part on checkout page. This PR attempts to resolve it

1. My default currency is Rs. (Indian National Rupee). In case of
coupons, the discount applied was being rendered in dollars.

2. The discount currency should be the same as the default currency, and
hence the code change