### PR TITLE
override codecov precision

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+# Override team (default) settings
+coverage:
+  precision: 1


### PR DESCRIPTION
This change adds a CodeCov configuration file to the repo to enable us to override the default settings.  The setting being overridden is coverage precision changing from 2 decimal places to 1.  This should avoid many instances where a PR with 100% coverage on the patch being blocked from merging due to a resulting slightly lower overall coverage percentage for the repo.  The tolerance for that will now be up to 0.09% instead of 0.01%.