### PR TITLE
Revert "Revert "ENT-1052 add discount by enterprise catalog""

### DIFF
--- a/ecommerce/enterprise/conditions.py
+++ b/ecommerce/enterprise/conditions.py
@@ -8,9 +8,12 @@ from slumber.exceptions import SlumberHttpBaseException
 
 from ecommerce.enterprise.api import catalog_contains_course_runs, fetch_enterprise_learner_data
 from ecommerce.enterprise.constants import ENTERPRISE_OFFERS_SWITCH
+from ecommerce.extensions.basket.utils import ENTERPRISE_CATALOG_ATTRIBUTE_TYPE
 from ecommerce.extensions.offer.decorators import check_condition_applicability
 from ecommerce.extensions.offer.mixins import ConditionWithoutRangeMixin, SingleItemConsumptionConditionMixin
 
+BasketAttribute = get_model('basket', 'BasketAttribute')
+BasketAttributeType = get_model('basket', 'BasketAttributeType')
 Condition = get_model('offer', 'Condition')
 logger = logging.getLogger(__name__)
 
@@ -29,6 +32,9 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
         """
         Determines if a user is eligible for an enterprise customer offer
         based on their association with the enterprise customer.
+
+        It also verifies the catalog `enterprise_customer_catalog_uuid` on the
+        offer with the catalog on the basket when provided.
 
         Args:
             basket (Basket): Contains information about order line items, the current site,
@@ -66,6 +72,13 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
 
             course_run_ids.append(course.id)
 
+        # Verify that the current conditional offer is related to the provided
+        # enterprise catalog
+        enterprise_customer_catalog_uuid = self._get_enterprise_catalog_uuid_from_basket(basket)
+        if enterprise_customer_catalog_uuid:
+            if str(offer.condition.enterprise_customer_catalog_uuid) != enterprise_customer_catalog_uuid:
+                return False
+
         if not catalog_contains_course_runs(basket.site, course_run_ids, self.enterprise_customer_uuid,
                                             enterprise_customer_catalog_uuid=self.enterprise_customer_catalog_uuid):
             # Basket contains course runs that do not exist in the EnterpriseCustomerCatalogs
@@ -73,3 +86,33 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
             return False
 
         return True
+
+    @staticmethod
+    def _get_enterprise_catalog_uuid_from_basket(basket):
+        """
+        Helper method for fetching enterprise catalog UUID from basket.
+
+        Arguments:
+             basket (Basket): The provided basket can be either temporary (just
+             for calculating discounts) or an actual one to buy a product.
+        """
+        # For temporary basket try to get `enterprise_customer_catalog_uuid`
+        # from request
+        enterprise_customer_catalog_uuid = basket.strategy.request.GET.get(
+            'enterprise_customer_catalog_uuid'
+        ) if basket.strategy.request else None
+
+        if not enterprise_customer_catalog_uuid:
+            # For actual baskets get `enterprise_customer_catalog_uuid` from
+            # basket attribute
+            enterprise_catalog_attribute, __ = BasketAttributeType.objects.get_or_create(
+                name=ENTERPRISE_CATALOG_ATTRIBUTE_TYPE
+            )
+            enterprise_customer_catalog = BasketAttribute.objects.filter(
+                basket=basket,
+                attribute_type=enterprise_catalog_attribute,
+            ).first()
+            if enterprise_customer_catalog:
+                enterprise_customer_catalog_uuid = enterprise_customer_catalog.value_text
+
+        return enterprise_customer_catalog_uuid

--- a/ecommerce/enterprise/tests/test_conditions.py
+++ b/ecommerce/enterprise/tests/test_conditions.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from uuid import uuid4
 
 import httpretty
 from oscar.core.loading import get_model
@@ -7,6 +8,7 @@ from waffle.models import Switch
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.enterprise.constants import ENTERPRISE_OFFERS_SWITCH
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
+from ecommerce.extensions.basket.utils import basket_add_enterprise_catalog_attribute
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
 from ecommerce.extensions.test import factories
 from ecommerce.tests.factories import ProductFactory, SiteConfigurationFactory
@@ -49,6 +51,61 @@ class EnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, DiscoveryTest
             enterprise_customer_catalog_uuid=self.condition.enterprise_customer_catalog_uuid,
         )
         self.assertTrue(self.condition.is_satisfied(offer, basket))
+
+    def _check_condition_is_satisfied(self, offer, basket, is_satisfied):
+        """
+        Helper method to verify that conditional offer is valid for provided basket.
+        """
+        basket.add_product(self.course_run.seat_products[0])
+        self.mock_enterprise_learner_api(
+            learner_id=self.user.id,
+            enterprise_customer_uuid=str(self.condition.enterprise_customer_uuid),
+            course_run_id=self.course_run.id,
+        )
+        self.mock_catalog_contains_course_runs(
+            [self.course_run.id],
+            self.condition.enterprise_customer_uuid,
+            enterprise_customer_catalog_uuid=self.condition.enterprise_customer_catalog_uuid,
+        )
+        assert is_satisfied == self.condition.is_satisfied(offer, basket)
+
+    @httpretty.activate
+    def test_is_satisfied_true_for_enterprise_catalog_in_get_request(self):
+        """
+        Ensure that condition returns true for valid enterprise catalog uuid in GET request.
+        """
+        offer = factories.EnterpriseOfferFactory(site=self.site, condition=self.condition)
+        enterprise_catalog_uuid = str(self.condition.enterprise_customer_catalog_uuid)
+        basket = factories.BasketFactory(site=self.site, owner=self.user)
+        basket.strategy.request = self.request
+        basket.strategy.request.GET = {'enterprise_customer_catalog_uuid': enterprise_catalog_uuid}
+        self._check_condition_is_satisfied(offer, basket, is_satisfied=True)
+
+    @httpretty.activate
+    def test_is_satisfied_true_for_enterprise_catalog_in_basket_attribute(self):
+        """
+        Ensure that condition returns true for valid enterprise catalog uuid in basket attribute.
+        """
+        offer = factories.EnterpriseOfferFactory(site=self.site, condition=self.condition)
+        enterprise_catalog_uuid = str(self.condition.enterprise_customer_catalog_uuid)
+        basket = factories.BasketFactory(site=self.site, owner=self.user)
+        request_data = {'enterprise_customer_catalog_uuid': enterprise_catalog_uuid}
+        basket_add_enterprise_catalog_attribute(basket, request_data)
+        self._check_condition_is_satisfied(offer, basket, is_satisfied=True)
+
+    @httpretty.activate
+    def test_is_satisfied_false_for_invalid_enterprise_catalog(self):
+        """
+        Ensure the condition returns false if provide enterprise catalog UUID.
+        """
+        offer = factories.EnterpriseOfferFactory(site=self.site, condition=self.condition)
+
+        invalid_enterprise_catalog_uuid = str(uuid4())
+        basket = factories.BasketFactory(site=self.site, owner=self.user)
+        basket.strategy.request = self.request
+        basket.strategy.request.GET = {'enterprise_customer_catalog_uuid': invalid_enterprise_catalog_uuid}
+        self._check_condition_is_satisfied(offer, basket, is_satisfied=False)
+        assert invalid_enterprise_catalog_uuid != offer.condition.enterprise_customer_catalog_uuid
 
     @httpretty.activate
     def test_is_satisfied_for_anonymous_user(self):

--- a/ecommerce/extensions/api/v2/views/baskets.py
+++ b/ecommerce/extensions/api/v2/views/baskets.py
@@ -350,7 +350,7 @@ class BasketCalculateView(generics.GenericAPIView):
             # This is to avoid merging this temporary basket with a real user basket.
             with transaction.atomic():
                 basket = Basket(owner=user, site=request.site)
-                basket.strategy = Selector().strategy(user=user)
+                basket.strategy = Selector().strategy(user=user, request=request)
 
                 for product in products:
                     basket.add_product(product, 1)

--- a/ecommerce/extensions/basket/tests/test_utils.py
+++ b/ecommerce/extensions/basket/tests/test_utils.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+from uuid import uuid4
 
 import ddt
 import httpretty
@@ -16,6 +17,7 @@ from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.entitlements.utils import create_or_update_course_entitlement
 from ecommerce.extensions.basket.tests.mixins import BasketMixin
 from ecommerce.extensions.basket.utils import (
+    ENTERPRISE_CATALOG_ATTRIBUTE_TYPE,
     add_utm_params_to_url,
     attribute_cookie_data,
     get_basket_switch_data,
@@ -416,6 +418,24 @@ class BasketUtilsTests(DiscoveryTestMixin, BasketMixin, TestCase):
 
         # Verify that no exception is raised when no basket attribute exists fitting the delete statement parameters
         prepare_basket(request, [product])
+
+    def test_prepare_basket_with_enterprise_catalog(self):
+        """
+        Test `prepare_basket` with enterprise catalog.
+        """
+        product = ProductFactory()
+        request = self.request
+        expected_enterprise_catalog_uuid = str(uuid4())
+        request.GET = {'enterprise_customer_catalog_uuid': expected_enterprise_catalog_uuid}
+        basket = prepare_basket(request, [product])
+
+        # Verify that the enterprise catalog attribute exists for the basket
+        # when basket is prepared with the value of provide catalog UUID
+        enterprise_catalog_uuid = BasketAttribute.objects.get(
+            basket=basket,
+            attribute_type__name=ENTERPRISE_CATALOG_ATTRIBUTE_TYPE
+        ).value_text
+        assert expected_enterprise_catalog_uuid == enterprise_catalog_uuid
 
     def test_basket_switch_data(self):
         """Verify the correct basket switch data (single vs. multi quantity) is retrieved."""

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -24,6 +24,7 @@ BasketAttribute = get_model('basket', 'BasketAttribute')
 BasketAttributeType = get_model('basket', 'BasketAttributeType')
 BUNDLE = 'bundle_identifier'
 ORGANIZATION_ATTRIBUTE_TYPE = 'organization'
+ENTERPRISE_CATALOG_ATTRIBUTE_TYPE = 'enterprise_catalog_uuid'
 StockRecord = get_model('partner', 'StockRecord')
 OrderLine = get_model('order', 'Line')
 Refund = get_model('refund', 'Refund')
@@ -63,6 +64,7 @@ def prepare_basket(request, products, voucher=None):
         basket (Basket): Contains the product to be redeemed and the Voucher applied.
     """
     basket = Basket.get_basket(request.user, request.site)
+    basket_add_enterprise_catalog_attribute(basket, request.GET)
     basket.flush()
     basket.save()
     basket_addition = get_class('basket.signals', 'basket_addition')
@@ -306,6 +308,32 @@ def basket_add_organization_attribute(basket, request_data):
             basket=basket,
             attribute_type=organization_attribute,
             value_text=business_client.strip()
+        )
+
+
+@newrelic.agent.function_trace()
+def basket_add_enterprise_catalog_attribute(basket, request_data):
+    """
+    Add enterprise catalog UUID attribute on basket, if the catalog UUID value
+    is provided in the request.
+
+    Arguments:
+        basket(Basket): order basket
+        request_data (dict): HttpRequest data
+
+    """
+    # Value of enterprise catalog UUID is being passed as
+    # `enterprise_customer_catalog_uuid` from basket page
+    enterprise_catalog_uuid = request_data.get('enterprise_customer_catalog_uuid') if request_data else None
+
+    if enterprise_catalog_uuid:
+        enterprise_catalog_attribute, __ = BasketAttributeType.objects.get_or_create(
+            name=ENTERPRISE_CATALOG_ATTRIBUTE_TYPE
+        )
+        BasketAttribute.objects.update_or_create(
+            basket=basket,
+            attribute_type=enterprise_catalog_attribute,
+            defaults={'value_text': enterprise_catalog_uuid.strip()}
         )
 
 


### PR DESCRIPTION
This reverts commit a2ce57411c99849766efe135af77774e95e28311.
e2e tests started failing due to these changes so we had to revert the merged change. I have created this new PR to re-revert the changes as they seems to pass now each time.

**Original PR:** https://github.com/edx/ecommerce/pull/1830
**Revert PR:** https://github.com/edx/ecommerce/pull/1838

@asadiqbal08 @saleem-latif @muhammad-ammar @irfanuddinahmad @georgebabey 
**Description:** Add/Show discount for enterprise learners by provided valid enterprise catalog UUID.

**JIRA:** [ENT-1052](https://openedx.atlassian.net/browse/ENT-1052)

**Installation instructions:**  
1. Checkout edx-platform to branch `zub/ENT-1052-discount-by-enterprise-catalog`.
2. Install `edx-enterprise` from this branch `zub/ENT-1052-discount-by-enterprise-catalog` in `edx-platform`.
3. Checkout ecommerce to this branch `zub/ENT-1052-discount-by-enterprise-catalog`.
4. In ecommerce django admin (admin/waffle/switch/) verify following waffle flags:
```
force_anonymous_user_response_for_basket_calculate = False
enable_enterprise_offers = True
enable_enterprise_on_runtime = True
```
**Testing instructions:**

1. Create an enterprise with 2 catalogs with a verified course (both catalogs should have this verified course)
2. For catalog A, create enterprise offer with 100% discount.
3. For catalog B, create enterprise offer with 15% discount.
4. Now access the enterprise course enrollment URL with the `UUID` of catalog A, i.e. `http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+TEST_01+2016_R1/enroll/?enterprise_customer_catalog_uuid=a113c7e2-13ac-46ae-9e24-b75bf7c0058d`
5. Verify that learner sees 100 discount on verified seat for verified course
6. Clicking on 'Continue' button (after consenting) user is redirect to courseware page after automatic enrollment (100% discount).
7. Now access the enterprise course enrollment URL with the `UUID` of catalog B, i.e. `http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+TEST_01+2016_R1/enroll/?enterprise_customer_catalog_uuid=6eca3efb-f3a0-4c08-806f-c6e6b65d61cb`
8. Verify that learner sees 15 discount on verified seat for verified course
9. Clicking on 'Continue' button (after consenting) user is redirect to basket page with 15% discount applied by the learner's enterprise.