### PR TITLE
LEARNER-5603 Hot Fix

### DIFF
--- a/ecommerce/extensions/payment/constants.py
+++ b/ecommerce/extensions/payment/constants.py
@@ -55,3 +55,5 @@ APPLE_PAY_CYBERSOURCE_CARD_TYPE_MAP = {
 STRIPE_CARD_TYPE_MAP = {
     value['stripe_brand']: key for key, value in six.iteritems(CARD_TYPES) if 'stripe_brand' in value
 }
+
+VOUCHER_VALIDATION_BEFORE_PAYMENT = 'voucher_validation_before_payment'

--- a/ecommerce/extensions/payment/tests/views/test_paypal.py
+++ b/ecommerce/extensions/payment/tests/views/test_paypal.py
@@ -32,9 +32,11 @@ Order = get_model('order', 'Order')
 PaymentEvent = get_model('order', 'PaymentEvent')
 PaymentEventType = get_model('order', 'PaymentEventType')
 PaymentProcessorResponse = get_model('payment', 'PaymentProcessorResponse')
+Product = get_model('catalogue', 'Product')
 Selector = get_class('partner.strategy', 'Selector')
 SourceType = get_model('payment', 'SourceType')
-Product = get_model('catalogue', 'Product')
+Voucher = get_model('voucher', 'Voucher')
+
 
 post_checkout = get_class('checkout.signals', 'post_checkout')
 


### PR DESCRIPTION
[LEARNER-5603](https://openedx.atlassian.net/browse/LEARNER-5603)
Students are skipping the basket views which have all the voucher checks if its valid or not. Students are able to submit payments but after payments oscar checks if voucher is valid or not and breaks the system as vouchers used for those baskets is not valid. On average we are receiving around 20 such cases every day which is causing a lot of problem for support. Also we have to fix all the previous paid baskets which have expired vouchers. 
This will prevent students from paying using a expired coupon. I do know this is not a good solution. We will be reverting this after we figure out how students are able to bypass basket views and direct submit payment using submit payment view.  