### PR TITLE
ENT-1052 Rename enterprise customer catalog uuid in queryparam to catalog

### DIFF
--- a/ecommerce/enterprise/conditions.py
+++ b/ecommerce/enterprise/conditions.py
@@ -33,7 +33,7 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
         Determines if a user is eligible for an enterprise customer offer
         based on their association with the enterprise customer.
 
-        It also verifies the catalog `enterprise_customer_catalog_uuid` on the
+        It also verifies the catalog `catalog` on the
         offer with the catalog on the basket when provided.
 
         Args:
@@ -74,9 +74,9 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
 
         # Verify that the current conditional offer is related to the provided
         # enterprise catalog
-        enterprise_customer_catalog_uuid = self._get_enterprise_catalog_uuid_from_basket(basket)
-        if enterprise_customer_catalog_uuid:
-            if str(offer.condition.enterprise_customer_catalog_uuid) != enterprise_customer_catalog_uuid:
+        catalog = self._get_enterprise_catalog_uuid_from_basket(basket)
+        if catalog:
+            if str(offer.condition.enterprise_customer_catalog_uuid) != catalog:
                 return False
 
         if not catalog_contains_course_runs(basket.site, course_run_ids, self.enterprise_customer_uuid,
@@ -96,15 +96,13 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
              basket (Basket): The provided basket can be either temporary (just
              for calculating discounts) or an actual one to buy a product.
         """
-        # For temporary basket try to get `enterprise_customer_catalog_uuid`
-        # from request
-        enterprise_customer_catalog_uuid = basket.strategy.request.GET.get(
-            'enterprise_customer_catalog_uuid'
+        # For temporary basket try to get `catalog` from request
+        catalog = basket.strategy.request.GET.get(
+            'catalog'
         ) if basket.strategy.request else None
 
-        if not enterprise_customer_catalog_uuid:
-            # For actual baskets get `enterprise_customer_catalog_uuid` from
-            # basket attribute
+        if not catalog:
+            # For actual baskets get `catalog` from basket attribute
             enterprise_catalog_attribute, __ = BasketAttributeType.objects.get_or_create(
                 name=ENTERPRISE_CATALOG_ATTRIBUTE_TYPE
             )
@@ -113,6 +111,6 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
                 attribute_type=enterprise_catalog_attribute,
             ).first()
             if enterprise_customer_catalog:
-                enterprise_customer_catalog_uuid = enterprise_customer_catalog.value_text
+                catalog = enterprise_customer_catalog.value_text
 
-        return enterprise_customer_catalog_uuid
+        return catalog

--- a/ecommerce/enterprise/tests/test_conditions.py
+++ b/ecommerce/enterprise/tests/test_conditions.py
@@ -78,7 +78,7 @@ class EnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, DiscoveryTest
         enterprise_catalog_uuid = str(self.condition.enterprise_customer_catalog_uuid)
         basket = factories.BasketFactory(site=self.site, owner=self.user)
         basket.strategy.request = self.request
-        basket.strategy.request.GET = {'enterprise_customer_catalog_uuid': enterprise_catalog_uuid}
+        basket.strategy.request.GET = {'catalog': enterprise_catalog_uuid}
         self._check_condition_is_satisfied(offer, basket, is_satisfied=True)
 
     @httpretty.activate
@@ -89,7 +89,7 @@ class EnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, DiscoveryTest
         offer = factories.EnterpriseOfferFactory(site=self.site, condition=self.condition)
         enterprise_catalog_uuid = str(self.condition.enterprise_customer_catalog_uuid)
         basket = factories.BasketFactory(site=self.site, owner=self.user)
-        request_data = {'enterprise_customer_catalog_uuid': enterprise_catalog_uuid}
+        request_data = {'catalog': enterprise_catalog_uuid}
         basket_add_enterprise_catalog_attribute(basket, request_data)
         self._check_condition_is_satisfied(offer, basket, is_satisfied=True)
 
@@ -103,7 +103,7 @@ class EnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, DiscoveryTest
         invalid_enterprise_catalog_uuid = str(uuid4())
         basket = factories.BasketFactory(site=self.site, owner=self.user)
         basket.strategy.request = self.request
-        basket.strategy.request.GET = {'enterprise_customer_catalog_uuid': invalid_enterprise_catalog_uuid}
+        basket.strategy.request.GET = {'catalog': invalid_enterprise_catalog_uuid}
         self._check_condition_is_satisfied(offer, basket, is_satisfied=False)
         assert invalid_enterprise_catalog_uuid != offer.condition.enterprise_customer_catalog_uuid
 

--- a/ecommerce/extensions/basket/tests/test_utils.py
+++ b/ecommerce/extensions/basket/tests/test_utils.py
@@ -426,7 +426,7 @@ class BasketUtilsTests(DiscoveryTestMixin, BasketMixin, TestCase):
         product = ProductFactory()
         request = self.request
         expected_enterprise_catalog_uuid = str(uuid4())
-        request.GET = {'enterprise_customer_catalog_uuid': expected_enterprise_catalog_uuid}
+        request.GET = {'catalog': expected_enterprise_catalog_uuid}
         basket = prepare_basket(request, [product])
 
         # Verify that the enterprise catalog attribute exists for the basket

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -281,9 +281,9 @@ def basket_add_enterprise_catalog_attribute(basket, request_data):
         request_data (dict): HttpRequest data
 
     """
-    # Value of enterprise catalog UUID is being passed as
-    # `enterprise_customer_catalog_uuid` from basket page
-    enterprise_catalog_uuid = request_data.get('enterprise_customer_catalog_uuid') if request_data else None
+    # Value of enterprise catalog UUID is being passed as `catalog` from
+    # basket page
+    enterprise_catalog_uuid = request_data.get('catalog') if request_data else None
 
     if enterprise_catalog_uuid:
         enterprise_catalog_attribute, __ = BasketAttributeType.objects.get_or_create(


### PR DESCRIPTION
**Description:** Add/Show discount for enterprise learners by provided valid enterprise catalog `UUID`. This enterprise catalog `UUID` can be provided by passing the queryparam `catalog={enterprise_catalog_uuid}` to enterprise course enrollment urls.

**JIRA:** [ENT-1052](https://openedx.atlassian.net/browse/ENT-1052)

**Dependencies:**

1. edx-platform: https://github.com/edx/edx-platform/pull/18508
2. edx-enterprise: https://github.com/edx/edx-enterprise/pull/336

**Installation instructions:**  
1. Checkout edx-platform to branch `zub/ENT-1052-rename-enterprise-customer-catalog-uuid-queryparam`.
2. Install `edx-enterprise` from branch `zub/ENT-1052-rename-enterprise-customer-catalog-uuid-queryparam` in `edx-platform`.
3. Checkout ecommerce to branch `zub/ENT-1052-rename-enterprise-customer-catalog-uuid-queryparam`.
4. In ecommerce django admin (admin/waffle/switch/) verify following waffle flags:
```
force_anonymous_user_response_for_basket_calculate = False
enable_enterprise_offers = True
enable_enterprise_on_runtime = True
```
**Testing instructions:**

1. Create an enterprise with 2 catalogs with a verified course (both catalogs should have this verified course)
2. For catalog A, create enterprise offer with 100% discount.
3. For catalog B, create enterprise offer with 15% discount.
4. Now access the enterprise course enrollment URL with the `UUID` of catalog A, i.e. `http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+TEST_01+2016_R1/enroll/?catalog=a113c7e2-13ac-46ae-9e24-b75bf7c0058d`
5. Verify that learner sees 100 discount on verified seat for verified course
6. Clicking on 'Continue' button (after consenting) user is redirect to courseware page after automatic enrollment (100% discount).
7. Now access the enterprise course enrollment URL with the `UUID` of catalog B, i.e. `http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+TEST_01+2016_R1/enroll/?catalog=6eca3efb-f3a0-4c08-806f-c6e6b65d61cb`
8. Verify that learner sees 15 discount on verified seat for verified course
9. Clicking on 'Continue' button (after consenting) user is redirect to basket page with 15% discount applied by the learner's enterprise.