### PR TITLE
ENT-1085 Revert changes related to ENT-1052

### DIFF
--- a/ecommerce/enterprise/conditions.py
+++ b/ecommerce/enterprise/conditions.py
@@ -8,12 +8,9 @@ from slumber.exceptions import SlumberHttpBaseException
 
 from ecommerce.enterprise.api import catalog_contains_course_runs, fetch_enterprise_learner_data
 from ecommerce.enterprise.constants import ENTERPRISE_OFFERS_SWITCH
-from ecommerce.extensions.basket.utils import ENTERPRISE_CATALOG_ATTRIBUTE_TYPE
 from ecommerce.extensions.offer.decorators import check_condition_applicability
 from ecommerce.extensions.offer.mixins import ConditionWithoutRangeMixin, SingleItemConsumptionConditionMixin
 
-BasketAttribute = get_model('basket', 'BasketAttribute')
-BasketAttributeType = get_model('basket', 'BasketAttributeType')
 Condition = get_model('offer', 'Condition')
 logger = logging.getLogger(__name__)
 
@@ -32,9 +29,6 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
         """
         Determines if a user is eligible for an enterprise customer offer
         based on their association with the enterprise customer.
-
-        It also verifies the catalog `catalog` on the
-        offer with the catalog on the basket when provided.
 
         Args:
             basket (Basket): Contains information about order line items, the current site,
@@ -72,13 +66,6 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
 
             course_run_ids.append(course.id)
 
-        # Verify that the current conditional offer is related to the provided
-        # enterprise catalog
-        catalog = self._get_enterprise_catalog_uuid_from_basket(basket)
-        if catalog:
-            if str(offer.condition.enterprise_customer_catalog_uuid) != catalog:
-                return False
-
         if not catalog_contains_course_runs(basket.site, course_run_ids, self.enterprise_customer_uuid,
                                             enterprise_customer_catalog_uuid=self.enterprise_customer_catalog_uuid):
             # Basket contains course runs that do not exist in the EnterpriseCustomerCatalogs
@@ -86,31 +73,3 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
             return False
 
         return True
-
-    @staticmethod
-    def _get_enterprise_catalog_uuid_from_basket(basket):
-        """
-        Helper method for fetching enterprise catalog UUID from basket.
-
-        Arguments:
-             basket (Basket): The provided basket can be either temporary (just
-             for calculating discounts) or an actual one to buy a product.
-        """
-        # For temporary basket try to get `catalog` from request
-        catalog = basket.strategy.request.GET.get(
-            'catalog'
-        ) if basket.strategy.request else None
-
-        if not catalog:
-            # For actual baskets get `catalog` from basket attribute
-            enterprise_catalog_attribute, __ = BasketAttributeType.objects.get_or_create(
-                name=ENTERPRISE_CATALOG_ATTRIBUTE_TYPE
-            )
-            enterprise_customer_catalog = BasketAttribute.objects.filter(
-                basket=basket,
-                attribute_type=enterprise_catalog_attribute,
-            ).first()
-            if enterprise_customer_catalog:
-                catalog = enterprise_customer_catalog.value_text
-
-        return catalog

--- a/ecommerce/enterprise/tests/test_conditions.py
+++ b/ecommerce/enterprise/tests/test_conditions.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-from uuid import uuid4
 
 import httpretty
 from oscar.core.loading import get_model
@@ -8,7 +7,6 @@ from waffle.models import Switch
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.enterprise.constants import ENTERPRISE_OFFERS_SWITCH
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
-from ecommerce.extensions.basket.utils import basket_add_enterprise_catalog_attribute
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
 from ecommerce.extensions.test import factories
 from ecommerce.tests.factories import ProductFactory, SiteConfigurationFactory
@@ -51,61 +49,6 @@ class EnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, DiscoveryTest
             enterprise_customer_catalog_uuid=self.condition.enterprise_customer_catalog_uuid,
         )
         self.assertTrue(self.condition.is_satisfied(offer, basket))
-
-    def _check_condition_is_satisfied(self, offer, basket, is_satisfied):
-        """
-        Helper method to verify that conditional offer is valid for provided basket.
-        """
-        basket.add_product(self.course_run.seat_products[0])
-        self.mock_enterprise_learner_api(
-            learner_id=self.user.id,
-            enterprise_customer_uuid=str(self.condition.enterprise_customer_uuid),
-            course_run_id=self.course_run.id,
-        )
-        self.mock_catalog_contains_course_runs(
-            [self.course_run.id],
-            self.condition.enterprise_customer_uuid,
-            enterprise_customer_catalog_uuid=self.condition.enterprise_customer_catalog_uuid,
-        )
-        assert is_satisfied == self.condition.is_satisfied(offer, basket)
-
-    @httpretty.activate
-    def test_is_satisfied_true_for_enterprise_catalog_in_get_request(self):
-        """
-        Ensure that condition returns true for valid enterprise catalog uuid in GET request.
-        """
-        offer = factories.EnterpriseOfferFactory(site=self.site, condition=self.condition)
-        enterprise_catalog_uuid = str(self.condition.enterprise_customer_catalog_uuid)
-        basket = factories.BasketFactory(site=self.site, owner=self.user)
-        basket.strategy.request = self.request
-        basket.strategy.request.GET = {'catalog': enterprise_catalog_uuid}
-        self._check_condition_is_satisfied(offer, basket, is_satisfied=True)
-
-    @httpretty.activate
-    def test_is_satisfied_true_for_enterprise_catalog_in_basket_attribute(self):
-        """
-        Ensure that condition returns true for valid enterprise catalog uuid in basket attribute.
-        """
-        offer = factories.EnterpriseOfferFactory(site=self.site, condition=self.condition)
-        enterprise_catalog_uuid = str(self.condition.enterprise_customer_catalog_uuid)
-        basket = factories.BasketFactory(site=self.site, owner=self.user)
-        request_data = {'catalog': enterprise_catalog_uuid}
-        basket_add_enterprise_catalog_attribute(basket, request_data)
-        self._check_condition_is_satisfied(offer, basket, is_satisfied=True)
-
-    @httpretty.activate
-    def test_is_satisfied_false_for_invalid_enterprise_catalog(self):
-        """
-        Ensure the condition returns false if provide enterprise catalog UUID.
-        """
-        offer = factories.EnterpriseOfferFactory(site=self.site, condition=self.condition)
-
-        invalid_enterprise_catalog_uuid = str(uuid4())
-        basket = factories.BasketFactory(site=self.site, owner=self.user)
-        basket.strategy.request = self.request
-        basket.strategy.request.GET = {'catalog': invalid_enterprise_catalog_uuid}
-        self._check_condition_is_satisfied(offer, basket, is_satisfied=False)
-        assert invalid_enterprise_catalog_uuid != offer.condition.enterprise_customer_catalog_uuid
 
     @httpretty.activate
     def test_is_satisfied_for_anonymous_user(self):

--- a/ecommerce/extensions/api/v2/views/baskets.py
+++ b/ecommerce/extensions/api/v2/views/baskets.py
@@ -350,7 +350,7 @@ class BasketCalculateView(generics.GenericAPIView):
             # This is to avoid merging this temporary basket with a real user basket.
             with transaction.atomic():
                 basket = Basket(owner=user, site=request.site)
-                basket.strategy = Selector().strategy(user=user, request=request)
+                basket.strategy = Selector().strategy(user=user)
 
                 for product in products:
                     basket.add_product(product, 1)

--- a/ecommerce/extensions/basket/tests/test_utils.py
+++ b/ecommerce/extensions/basket/tests/test_utils.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-from uuid import uuid4
 
 import ddt
 import httpretty
@@ -17,7 +16,6 @@ from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.entitlements.utils import create_or_update_course_entitlement
 from ecommerce.extensions.basket.tests.mixins import BasketMixin
 from ecommerce.extensions.basket.utils import (
-    ENTERPRISE_CATALOG_ATTRIBUTE_TYPE,
     add_utm_params_to_url,
     attribute_cookie_data,
     get_basket_switch_data,
@@ -418,24 +416,6 @@ class BasketUtilsTests(DiscoveryTestMixin, BasketMixin, TestCase):
 
         # Verify that no exception is raised when no basket attribute exists fitting the delete statement parameters
         prepare_basket(request, [product])
-
-    def test_prepare_basket_with_enterprise_catalog(self):
-        """
-        Test `prepare_basket` with enterprise catalog.
-        """
-        product = ProductFactory()
-        request = self.request
-        expected_enterprise_catalog_uuid = str(uuid4())
-        request.GET = {'catalog': expected_enterprise_catalog_uuid}
-        basket = prepare_basket(request, [product])
-
-        # Verify that the enterprise catalog attribute exists for the basket
-        # when basket is prepared with the value of provide catalog UUID
-        enterprise_catalog_uuid = BasketAttribute.objects.get(
-            basket=basket,
-            attribute_type__name=ENTERPRISE_CATALOG_ATTRIBUTE_TYPE
-        ).value_text
-        assert expected_enterprise_catalog_uuid == enterprise_catalog_uuid
 
     def test_basket_switch_data(self):
         """Verify the correct basket switch data (single vs. multi quantity) is retrieved."""

--- a/ecommerce/static/js/payment_processors/cybersource.js
+++ b/ecommerce/static/js/payment_processors/cybersource.js
@@ -145,13 +145,13 @@ define([
                         var applePayBtn = document.getElementById('applePayBtn');
 
                         if (canMakePayments) {
-                            console.log('Learner is eligible for Apple Pay');
+                            console.log('Learner is eligible for Apple Pay');   // eslint-disable-line no-console
 
                             // Display the button
                             applePayBtn.style.display = 'inline-flex';
                             applePayBtn.addEventListener('click', self.onApplePayButtonClicked.bind(self));
                         } else {
-                            console.log('Apple Pay not setup.');
+                            console.log('Apple Pay not setup.');   // eslint-disable-line no-console
                         }
                     }
                 );
@@ -198,7 +198,7 @@ define([
 
         onApplePayValidateMerchant: function(event) {
             var self = this;
-            console.log('Validating merchant...');
+            console.log('Validating merchant...');   // eslint-disable-line no-console
 
             $.ajax({
                 method: 'POST',
@@ -209,17 +209,17 @@ define([
                 data: JSON.stringify({url: event.validationURL}),
                 contentType: 'application/json',
                 success: function(data) {
-                    console.log('Merchant validation succeeded.');
-                    console.log(data);
+                    console.log('Merchant validation succeeded.');   // eslint-disable-line no-console
+                    console.log(data);   // eslint-disable-line no-console
                     self.applePaySession.completeMerchantValidation(data);
                 },
                 error: function(jqXHR, textStatus, errorThrown) {
                     // Translators: Do not translate "Apple Pay".
                     var msg = gettext('Apple Pay is not available at this time. Please try another payment method.');
 
-                    console.log('Merchant validation failed!');
-                    console.log(textStatus);
-                    console.log(errorThrown);
+                    console.log('Merchant validation failed!');   // eslint-disable-line no-console
+                    console.log(textStatus);   // eslint-disable-line no-console
+                    console.log(errorThrown);   // eslint-disable-line no-console
 
                     self.applePaySession.abort();
                     self.displayErrorMessage(msg);
@@ -229,7 +229,7 @@ define([
 
         onApplePayPaymentAuthorized: function(event) {
             var self = this;
-            console.log('Submitting Apple Pay payment to CyberSource...');
+            console.log('Submitting Apple Pay payment to CyberSource...');   // eslint-disable-line no-console
 
             $.ajax({
                 method: 'POST',
@@ -240,8 +240,7 @@ define([
                 data: JSON.stringify(event.payment),
                 contentType: 'application/json',
                 success: function(data) {
-                    console.log('Successfully submitted Apple Pay payment to CyberSource.');
-                    console.log(data);
+                    console.log(data);   // eslint-disable-line no-console
                     self.applePaySession.completePayment(ApplePaySession.STATUS_SUCCESS);
                     self.redirectToReceipt(data.number);
                 },
@@ -249,9 +248,8 @@ define([
                     var msg = gettext('An error occurred while processing your payment. You have NOT been charged. ' +
                         'Please try again, or select another payment method.');
 
-                    console.log('Failed to submit Apple Pay payment to CyberSource!');
-                    console.log(textStatus);
-                    console.log(errorThrown);
+                    console.log(textStatus);   // eslint-disable-line no-console
+                    console.log(errorThrown);   // eslint-disable-line no-console
                     self.applePaySession.completePayment(ApplePaySession.STATUS_FAILURE);
                     self.displayErrorMessage(msg);
                 }


### PR DESCRIPTION
We are currently seeing no enterprise offers being applied in the basket page in production. To be sure that we will use the previous offers logic, I am reverting the feature changes in ecommerce. The lms will still send the catalog param but the intent of this revert is that ecommerce will do nothing with the param.