### PR TITLE
Fix for bower dependency for Open Edx devstack installation

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,5 @@
 {
   "directory": "ecommerce/static/bower_components",
-  "interactive": false
+  "interactive": false,
+  "registry": "https://registry.bower.io"
 }


### PR DESCRIPTION
The Open-EDX installation was failing while trying to install bower dependencies during vagrant provisioning. The bower registry has changed. So after including the registry link in the .**bowerrc** file, installation completed successfully.
