### PR TITLE
ENT-1052 apply enterprise offers by provided catalog uuid

### DIFF
--- a/ecommerce/enterprise/conditions.py
+++ b/ecommerce/enterprise/conditions.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import logging
+from uuid import UUID
 
 from oscar.core.loading import get_model
 from requests.exceptions import ConnectionError, Timeout
@@ -8,9 +9,12 @@ from slumber.exceptions import SlumberHttpBaseException
 
 from ecommerce.enterprise.api import catalog_contains_course_runs, fetch_enterprise_learner_data
 from ecommerce.enterprise.constants import ENTERPRISE_OFFERS_SWITCH
+from ecommerce.extensions.basket.utils import ENTERPRISE_CATALOG_ATTRIBUTE_TYPE
 from ecommerce.extensions.offer.decorators import check_condition_applicability
 from ecommerce.extensions.offer.mixins import ConditionWithoutRangeMixin, SingleItemConsumptionConditionMixin
 
+BasketAttribute = get_model('basket', 'BasketAttribute')
+BasketAttributeType = get_model('basket', 'BasketAttributeType')
 Condition = get_model('offer', 'Condition')
 logger = logging.getLogger(__name__)
 
@@ -30,7 +34,15 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
         Determines if a user is eligible for an enterprise customer offer
         based on their association with the enterprise customer.
 
-        Args:
+        It also filter out the offer if the `enterprise_customer_catalog_uuid`
+        value set on the offer condition does not match with the basket catalog
+        value when explicitly provided by the enterprise learner.
+
+        Note: Currently there is no mechanism to prioritize or apply multiple
+        offers that may apply as opposed to disqualifying offers if the
+        catalog doesn't explicitly match.
+
+        Arguments:
             basket (Basket): Contains information about order line items, the current site,
                              and the user attempting to make the purchase.
         Returns:
@@ -66,6 +78,14 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
 
             course_run_ids.append(course.id)
 
+        # Verify that the current conditional offer is related to the provided
+        # enterprise catalog, this will also filter out offers which don't
+        # have `enterprise_customer_catalog_uuid` value set on the condition.
+        catalog = self._get_enterprise_catalog_uuid_from_basket(basket)
+        if catalog:
+            if offer.condition.enterprise_customer_catalog_uuid != catalog:
+                return False
+
         if not catalog_contains_course_runs(basket.site, course_run_ids, self.enterprise_customer_uuid,
                                             enterprise_customer_catalog_uuid=self.enterprise_customer_catalog_uuid):
             # Basket contains course runs that do not exist in the EnterpriseCustomerCatalogs
@@ -73,3 +93,37 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
             return False
 
         return True
+
+    @staticmethod
+    def _get_enterprise_catalog_uuid_from_basket(basket):
+        """
+        Helper method for fetching valid enterprise catalog UUID from basket.
+
+        Arguments:
+             basket (Basket): The provided basket can be either temporary (just
+             for calculating discounts) or an actual one to buy a product.
+        """
+        # For temporary basket try to get `catalog` from request
+        catalog = basket.strategy.request.GET.get(
+            'catalog'
+        ) if basket.strategy.request else None
+
+        if not catalog:
+            # For actual baskets get `catalog` from basket attribute
+            enterprise_catalog_attribute, __ = BasketAttributeType.objects.get_or_create(
+                name=ENTERPRISE_CATALOG_ATTRIBUTE_TYPE
+            )
+            enterprise_customer_catalog = BasketAttribute.objects.filter(
+                basket=basket,
+                attribute_type=enterprise_catalog_attribute,
+            ).first()
+            if enterprise_customer_catalog:
+                catalog = enterprise_customer_catalog.value_text
+
+        # Return only valid UUID
+        try:
+            catalog = UUID(catalog) if catalog else None
+        except ValueError:
+            catalog = None
+
+        return catalog

--- a/ecommerce/enterprise/tests/test_conditions.py
+++ b/ecommerce/enterprise/tests/test_conditions.py
@@ -1,5 +1,7 @@
 from decimal import Decimal
+from uuid import uuid4
 
+import ddt
 import httpretty
 from oscar.core.loading import get_model
 from waffle.models import Switch
@@ -7,6 +9,7 @@ from waffle.models import Switch
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.enterprise.constants import ENTERPRISE_OFFERS_SWITCH
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
+from ecommerce.extensions.basket.utils import basket_add_enterprise_catalog_attribute
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
 from ecommerce.extensions.test import factories
 from ecommerce.tests.factories import ProductFactory, SiteConfigurationFactory
@@ -16,6 +19,7 @@ Product = get_model('catalogue', 'Product')
 LOGGER_NAME = 'ecommerce.programs.conditions'
 
 
+@ddt.ddt
 class EnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, DiscoveryTestMixin, TestCase):
     def setUp(self):
         super(EnterpriseCustomerConditionTests, self).setUp()
@@ -49,6 +53,62 @@ class EnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, DiscoveryTest
             enterprise_customer_catalog_uuid=self.condition.enterprise_customer_catalog_uuid,
         )
         self.assertTrue(self.condition.is_satisfied(offer, basket))
+
+    def _check_condition_is_satisfied(self, offer, basket, is_satisfied):
+        """
+        Helper method to verify that conditional offer is valid for provided basket.
+        """
+        basket.add_product(self.course_run.seat_products[0])
+        self.mock_enterprise_learner_api(
+            learner_id=self.user.id,
+            enterprise_customer_uuid=str(self.condition.enterprise_customer_uuid),
+            course_run_id=self.course_run.id,
+        )
+        self.mock_catalog_contains_course_runs(
+            [self.course_run.id],
+            self.condition.enterprise_customer_uuid,
+            enterprise_customer_catalog_uuid=self.condition.enterprise_customer_catalog_uuid,
+            contains_content=is_satisfied,
+        )
+        assert is_satisfied == self.condition.is_satisfied(offer, basket)
+
+    @httpretty.activate
+    def test_is_satisfied_true_for_enterprise_catalog_in_get_request(self):
+        """
+        Ensure that condition returns true for valid enterprise catalog uuid in GET request.
+        """
+        offer = factories.EnterpriseOfferFactory(site=self.site, condition=self.condition)
+        enterprise_catalog_uuid = str(self.condition.enterprise_customer_catalog_uuid)
+        basket = factories.BasketFactory(site=self.site, owner=self.user)
+        basket.strategy.request = self.request
+        basket.strategy.request.GET = {'catalog': enterprise_catalog_uuid}
+        self._check_condition_is_satisfied(offer, basket, is_satisfied=True)
+
+    @httpretty.activate
+    def test_is_satisfied_true_for_enterprise_catalog_in_basket_attribute(self):
+        """
+        Ensure that condition returns true for valid enterprise catalog uuid in basket attribute.
+        """
+        offer = factories.EnterpriseOfferFactory(site=self.site, condition=self.condition)
+        enterprise_catalog_uuid = str(self.condition.enterprise_customer_catalog_uuid)
+        basket = factories.BasketFactory(site=self.site, owner=self.user)
+        request_data = {'catalog': enterprise_catalog_uuid}
+        basket_add_enterprise_catalog_attribute(basket, request_data)
+        self._check_condition_is_satisfied(offer, basket, is_satisfied=True)
+
+    @httpretty.activate
+    @ddt.data(str(uuid4()), 'INVALID_UUID_STRING')
+    def test_is_satisfied_false_for_invalid_enterprise_catalog(self, invalid_enterprise_catalog_uuid):
+        """
+        Ensure the condition returns false if provided enterprise catalog UUID is invalid.
+        """
+        offer = factories.EnterpriseOfferFactory(site=self.site, condition=self.condition)
+
+        basket = factories.BasketFactory(site=self.site, owner=self.user)
+        basket.strategy.request = self.request
+        basket.strategy.request.GET = {'catalog': invalid_enterprise_catalog_uuid}
+        self._check_condition_is_satisfied(offer, basket, is_satisfied=False)
+        assert invalid_enterprise_catalog_uuid != offer.condition.enterprise_customer_catalog_uuid
 
     @httpretty.activate
     def test_is_satisfied_for_anonymous_user(self):

--- a/ecommerce/extensions/api/v2/views/baskets.py
+++ b/ecommerce/extensions/api/v2/views/baskets.py
@@ -349,7 +349,7 @@ class BasketCalculateView(generics.GenericAPIView):
             # This is to avoid merging this temporary basket with a real user basket.
             with transaction.atomic():
                 basket = Basket(owner=user, site=request.site)
-                basket.strategy = Selector().strategy(user=user)
+                basket.strategy = Selector().strategy(user=user, request=request)
 
                 for product in products:
                     basket.add_product(product, 1)

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -3,6 +3,7 @@ import json
 import logging
 from urllib import unquote, urlencode
 
+import newrelic.agent
 import pytz
 from django.conf import settings
 from django.contrib import messages
@@ -22,6 +23,7 @@ BasketAttribute = get_model('basket', 'BasketAttribute')
 BasketAttributeType = get_model('basket', 'BasketAttributeType')
 BUNDLE = 'bundle_identifier'
 ORGANIZATION_ATTRIBUTE_TYPE = 'organization'
+ENTERPRISE_CATALOG_ATTRIBUTE_TYPE = 'enterprise_catalog_uuid'
 StockRecord = get_model('partner', 'StockRecord')
 OrderLine = get_model('order', 'Line')
 Refund = get_model('refund', 'Refund')
@@ -59,6 +61,7 @@ def prepare_basket(request, products, voucher=None):
         basket (Basket): Contains the product to be redeemed and the Voucher applied.
     """
     basket = Basket.get_basket(request.user, request.site)
+    basket_add_enterprise_catalog_attribute(basket, request.GET)
     basket.flush()
     basket.save()
     basket_addition = get_class('basket.signals', 'basket_addition')
@@ -265,6 +268,36 @@ def basket_add_organization_attribute(basket, request_data):
             attribute_type=organization_attribute,
             value_text=business_client.strip()
         )
+
+
+@newrelic.agent.function_trace()
+def basket_add_enterprise_catalog_attribute(basket, request_data):
+    """
+    Add enterprise catalog UUID attribute on basket, if the catalog UUID value
+    is provided in the request.
+
+    Arguments:
+        basket(Basket): order basket
+        request_data (dict): HttpRequest data
+
+    """
+    # Value of enterprise catalog UUID is being passed as `catalog` from
+    # basket page
+    enterprise_catalog_uuid = request_data.get('catalog') if request_data else None
+    enterprise_catalog_attribute, __ = BasketAttributeType.objects.get_or_create(
+        name=ENTERPRISE_CATALOG_ATTRIBUTE_TYPE
+    )
+    if enterprise_catalog_uuid:
+        BasketAttribute.objects.update_or_create(
+            basket=basket,
+            attribute_type=enterprise_catalog_attribute,
+            defaults={
+                'value_text': enterprise_catalog_uuid.strip()
+            }
+        )
+    else:
+        # Remove the enterprise catalog attribute for future update in basket
+        BasketAttribute.objects.filter(basket=basket, attribute_type=enterprise_catalog_attribute).delete()
 
 
 def _set_basket_bundle_status(bundle, basket):


### PR DESCRIPTION
**Description:** Add/Show discount for enterprise learners by provided valid enterprise catalog `UUID`. This enterprise catalog `UUID` can be provided by passing the queryparam `catalog={enterprise_catalog_uuid}` to enterprise course enrollment urls. If catalog `UUID` is provided in course enrollment url then the default enterprise coupon (first enterprise offer) will be applied.

**JIRA:** [ENT-1052](https://openedx.atlassian.net/browse/ENT-1052)

**Revert PR:** https://github.com/edx/ecommerce/pull/1848/files

**Dependencies:**

1. edx-enterprise: https://github.com/edx/edx-enterprise/pull/343

**Installation instructions:**  
1. Checkout edx-platform to branch `master`.
2. Install `edx-enterprise` from branch `zub/ENT-1052-pass-catalog-input-only-when-provided` in `edx-platform`.
3. Checkout ecommerce to branch `zub/ENT-1052-apply-enterprise-offer-by-catalog-id`.
4. In ecommerce django admin (admin/waffle/switch/) verify following waffle flags:
```
force_anonymous_user_response_for_basket_calculate = False
enable_enterprise_offers = True
enable_enterprise_on_runtime = True
```
**Testing instructions:**

1. Create an enterprise with 2 catalogs with a verified course (both catalogs should have this verified course)
2. For catalog A, create enterprise offer with 100% discount.
3. For catalog B, create enterprise offer with 15% discount.
4. Now access the enterprise course enrollment URL with the `UUID` of catalog A, i.e. `http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+TEST_01+2016_R1/enroll/?catalog=a113c7e2-13ac-46ae-9e24-b75bf7c0058d`
5. Verify that learner sees 100 discount on verified seat for verified course
6. Clicking on 'Continue' button (after consenting) user is redirect to courseware page after automatic enrollment (100% discount).
7. Now access the enterprise course enrollment URL with the `UUID` of catalog B, i.e. `http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+TEST_01+2016_R1/enroll/?catalog=6eca3efb-f3a0-4c08-806f-c6e6b65d61cb`
8. Verify that learner sees 15 discount on verified seat for verified course
9. Clicking on 'Continue' button (after consenting) user is redirect to basket page with 15% discount applied by the learner's enterprise.
10. Now access the enterprise course enrollment URL without the catalog `UUID`, i.e. `http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+TEST_01+2016_R1/enroll/`
11. Now verify that course enrollment page shows the 100% discount offered by the first enterprise offer.
12. Also verify the clicking on  button (after consenting) user is redirect to courseware page after automatic enrollment (100% discount).