### PR TITLE
log duplicate order attempts accurately

### DIFF
--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -55,6 +55,7 @@ class CyberSourceProcessorMixin(object):
 
 class OrderCreationMixin(EdxOrderPlacementMixin):
     def create_order(self, request, basket, billing_address):
+        order_number = OrderNumberGenerator().order_number(basket)
         try:
             # Note (CCB): In the future, if we do end up shipping physical products, we will need to
             # properly implement shipping methods. For more, see
@@ -66,7 +67,6 @@ class OrderCreationMixin(EdxOrderPlacementMixin):
             # thus we use the amounts stored in the database rather than those received from the payment processor.
             order_total = OrderTotalCalculator().calculate(basket, shipping_charge)
             user = basket.owner
-            order_number = OrderNumberGenerator().order_number(basket)
 
             return self.handle_order_placement(
                 order_number,
@@ -79,8 +79,8 @@ class OrderCreationMixin(EdxOrderPlacementMixin):
                 order_total,
                 request=request
             )
-        except Exception as e:  # pylint: disable=broad-except
-            logger.exception(self.order_placement_failure_msg, basket.id, e)
+        except Exception:  # pylint: disable=broad-except
+            self.log_order_placement_exception(order_number, basket.id)
             raise
 
 

--- a/ecommerce/extensions/payment/views/paypal.py
+++ b/ecommerce/extensions/payment/views/paypal.py
@@ -104,6 +104,11 @@ class PaypalPaymentExecutionView(EdxOrderPlacementMixin, View):
             logger.exception('Attempts to handle payment for basket [%d] failed.', basket.id)
             return redirect(receipt_url)
 
+        self.call_handle_order_placement(basket, request)
+
+        return redirect(receipt_url)
+
+    def call_handle_order_placement(self, basket, request):
         try:
             shipping_method = NoShippingRequired()
             shipping_charge = shipping_method.calculate(basket)
@@ -128,10 +133,8 @@ class PaypalPaymentExecutionView(EdxOrderPlacementMixin, View):
             )
             self.handle_post_order(order)
 
-            return redirect(receipt_url)
-        except Exception as e:  # pylint: disable=broad-except
-            logger.exception(self.order_placement_failure_msg, basket.id, e)
-            return redirect(receipt_url)
+        except Exception:  # pylint: disable=broad-except
+            self.log_order_placement_exception(basket.order_number, basket.id)
 
 
 class PaypalProfileAdminView(View):


### PR DESCRIPTION
There are some problems with the way we log order placement failures after payment has been successfully processed:

1. in some cases an order for the basket id / order number in question already exists
2. in other cases an inactive voucher was somehow in place on the basket up through this post-payment pre-order point
3. there may be other cases where some other problem caused this condition

Other work is in progress to handle item 2 (PR #1862).  This change addresses item 1 by logging duplicate order cases separately from any other (item 3) cases that may occur.  This will enable us to make the alerting for the duplicate order case more precise and establish a straightforward runbook for Support to manually address those cases.

https://openedx.atlassian.net/browse/LEARNER-5466