### PR TITLE
Improve Performance of Journal Bundle Offer Page

### DIFF
--- a/ecommerce/journals/tests/test_views.py
+++ b/ecommerce/journals/tests/test_views.py
@@ -29,7 +29,7 @@ class JournalBundleOfferListViewTests(ViewTestMixin, TestCase):
         """ Test the "GET" endpoint with offers and assert the rendered template """
         mock_journal_endpoint.return_value = _get_mocked_endpoint()
 
-        journal_bundle_offers = factories.JournalBundleOfferFactory.create_batch(3)
+        journal_bundle_offers = factories.JournalBundleOfferFactory.create_batch(3, site=self.site)
 
         response = self.assert_get_response_status(200)
         self.assertContains(response, "mocked_title")
@@ -45,8 +45,8 @@ class JournalBundleOfferListViewTests(ViewTestMixin, TestCase):
         mock_journal_endpoint.return_value = _get_mocked_endpoint()
 
         # These should be ignored since their associated Condition objects do NOT have journal bundle UUIDs
-        factories.ConditionalOfferFactory.create_batch(3)
-        journal_bundle_offers = factories.JournalBundleOfferFactory.create_batch(3)
+        factories.ConditionalOfferFactory.create_batch(3, site=self.site)
+        journal_bundle_offers = factories.JournalBundleOfferFactory.create_batch(3, site=self.site)
 
         response = self.assert_get_response_status(200)
         self.assertEqual(list(response.context['offers']), journal_bundle_offers)

--- a/ecommerce/journals/views.py
+++ b/ecommerce/journals/views.py
@@ -23,6 +23,13 @@ class JournalBundleOfferViewMixin(StaffOnlyMixin):
         context['admin'] = 'journals'
         return context
 
+    def get_queryset(self):
+        return super(JournalBundleOfferViewMixin, self).get_queryset().filter(
+            site=self.request.site.id,
+            condition__journal_bundle_uuid__isnull=False,
+            offer_type=ConditionalOffer.SITE
+        )
+
 
 class JournalBundleProcessFormViewMixin(JournalBundleOfferViewMixin):
     form_class = JournalBundleOfferForm
@@ -75,16 +82,12 @@ class JournalBundleOfferListView(JournalBundleOfferViewMixin, ListView):
         context = super(JournalBundleOfferListView, self).get_context_data(**kwargs)
 
         offers = []
-        # context['object_list'] returns all conditional offers (including enterprise and program)
-        # we only want to pass journal bundle offers to the context, so ignore all offers that do not
-        # have a journal bundle uuid
         for offer in context['object_list']:
-            if offer.condition.journal_bundle_uuid:
-                offer.journal_bundle = fetch_journal_bundle(
-                    site=self.request.site,
-                    journal_bundle_uuid=offer.condition.journal_bundle_uuid
-                )
-                offers.append(offer)
+            offer.journal_bundle = fetch_journal_bundle(
+                site=self.request.site,
+                journal_bundle_uuid=offer.condition.journal_bundle_uuid
+            )
+            offers.append(offer)
 
         context['offers'] = offers
         return context


### PR DESCRIPTION
- The Problem: The Journal Bundle Offer page had a very high response
  time and was often timing out.  This was because it was looping over
  every row in the conditional_offer table.  This was unecessary because
  the Journal Bundle Offer page does not need knowledge of Program
  Offers or Enterprise Offers.  It was also a huge performance hit
  because there are a lot of conditional offers.
- The Solution: Implemented 'get_queryset' for
  'JournalBundleOfferViewMixin' so it only has to loop through the
  relevant offers.  Previously, we were looping through every offer and
  checking that it was a Journal Bundle Offer, I removed that check as
  it is no longer needed.