### PR TITLE
ARCH-177: Add RequestCache namespacing.

### DIFF
--- a/ecommerce/cache_utils/README.rst
+++ b/ecommerce/cache_utils/README.rst
@@ -6,13 +6,16 @@ RequestCache
 
 A thread-local for storing request scoped cache values.
 
+An optional namespace can be used with the RequestCache, or you can use
+the `DEFAULT_REQUEST_CACHE`.
+
 
 TieredCache
 -----------
 
-The first tier is a request cache that is tied to the life of a
-given request. The second tier is the Django cache -- e.g. the
-"default" entry in settings.CACHES, typically backed by memcached.
+The first tier is the default request cache that is tied to the life of a
+given request. The second tier is the Django cache -- e.g. the "default"
+entry in settings.CACHES, typically backed by memcached.
 
 Some baseline rules:
 
@@ -42,11 +45,16 @@ Sample Usage using is_miss::
     return x_cached_response.value
 
 
+You must include 'ecommerce.cache_utils.middleware.CacheUtilsMiddleware'
+for the TieredCache to work properly.
+
 Force Django Cache Miss
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 To force recompute a value stored in the django cache, add the query
 parameter 'force_django_cache_miss'. This will force a CACHE_MISS.
+
+This requires staff permissions.
 
 Example::
 

--- a/ecommerce/cache_utils/middleware.py
+++ b/ecommerce/cache_utils/middleware.py
@@ -14,19 +14,19 @@ class CacheUtilsMiddleware(object):
         Stores whether or not FORCE_DJANGO_CACHE_MISS_KEY was supplied in the
         request. Also, clears the request cache.
         """
-        RequestCache.clear()
+        RequestCache.clear_all_namespaces()
         TieredCache._get_and_set_force_cache_miss(request)  # pylint: disable=protected-access
 
     def process_response(self, request, response):  # pylint: disable=unused-argument
         """
          Clear the request cache after processing a response.
          """
-        RequestCache.clear()
+        RequestCache.clear_all_namespaces()
         return response
 
     def process_exception(self, request, exception):  # pylint: disable=unused-argument
         """
         Clear the request cache after a failed request.
         """
-        RequestCache.clear()
+        RequestCache.clear_all_namespaces()
         return None

--- a/ecommerce/cache_utils/tests/test_middleware.py
+++ b/ecommerce/cache_utils/tests/test_middleware.py
@@ -3,6 +3,7 @@
 Tests for the CacheUtilsMiddleware.
 """
 from django.test import RequestFactory
+from mock import MagicMock
 
 from ecommerce.cache_utils import middleware
 from ecommerce.cache_utils.utils import FORCE_CACHE_MISS_PARAM, SHOULD_FORCE_CACHE_MISS_KEY, RequestCache
@@ -10,6 +11,7 @@ from ecommerce.tests.testcases import TestCase
 
 TEST_KEY = "clobert"
 EXPECTED_VALUE = "bertclob"
+TEST_NAMESPACE = "test_namespace"
 
 
 class TestCacheUtilsMiddleware(TestCase):
@@ -18,35 +20,60 @@ class TestCacheUtilsMiddleware(TestCase):
         super(TestCacheUtilsMiddleware, self).setUp()
         self.middleware = middleware.CacheUtilsMiddleware()
         self.request = RequestFactory().get('/')
+        self.request.user = self._mock_user(is_staff=True)
+
+        self.request_cache = RequestCache()
+        self.other_request_cache = RequestCache(TEST_NAMESPACE)
         self._dirty_request_cache()
 
     def test_process_request(self):
         self.middleware.process_request(self.request)
 
-        self.assertTrue(RequestCache.get_cached_response(TEST_KEY).is_miss)
-        self.assertFalse(RequestCache.get_cached_response(SHOULD_FORCE_CACHE_MISS_KEY).value)
+        self._check_request_caches_cleared()
+        self.assertFalse(self.request_cache.get_cached_response(SHOULD_FORCE_CACHE_MISS_KEY).value)
 
     def test_process_request_force_django_cache_miss(self):
         request = RequestFactory().get('/?{}=tRuE'.format(FORCE_CACHE_MISS_PARAM))
+        request.user = self._mock_user(is_staff=True)
 
         self.middleware.process_request(request)
 
-        self.assertTrue(RequestCache.get_cached_response(TEST_KEY).is_miss)
-        self.assertTrue(RequestCache.get_cached_response(SHOULD_FORCE_CACHE_MISS_KEY).value)
+        self._check_request_caches_cleared()
+        self.assertTrue(self.request_cache.get_cached_response(SHOULD_FORCE_CACHE_MISS_KEY).value)
+
+    def test_process_request_force_django_cache_miss_non_staff(self):
+        request = RequestFactory().get('/?{}=tRuE'.format(FORCE_CACHE_MISS_PARAM))
+        request.user = self._mock_user(is_staff=False)
+
+        self.middleware.process_request(request)
+
+        self._check_request_caches_cleared()
+        self.assertFalse(self.request_cache.get_cached_response(SHOULD_FORCE_CACHE_MISS_KEY).value)
 
     def test_process_response(self):
         response = self.middleware.process_response(self.request, EXPECTED_VALUE)
 
         self.assertEqual(response, EXPECTED_VALUE)
-        self.assertTrue(RequestCache.get_cached_response(TEST_KEY).is_miss)
+        self._check_request_caches_cleared()
 
     def test_process_exception(self):
         response = self.middleware.process_exception(self.request, EXPECTED_VALUE)
 
         self.assertEqual(response, None)
-        self.assertTrue(RequestCache.get_cached_response(TEST_KEY).is_miss)
+        self._check_request_caches_cleared()
 
-    @staticmethod
-    def _dirty_request_cache():
-        """ Dirties the request cache to ensure it is cleared later. """
-        RequestCache.set(TEST_KEY, EXPECTED_VALUE)
+    def _check_request_caches_cleared(self):
+        """ Checks that all request caches were cleared. """
+        self.assertTrue(self.request_cache.get_cached_response(TEST_KEY).is_miss)
+        self.assertTrue(self.other_request_cache.get_cached_response(TEST_KEY).is_miss)
+
+    def _dirty_request_cache(self):
+        """ Dirties the request caches to ensure the middleware is clearing it. """
+        self.request_cache.set(TEST_KEY, EXPECTED_VALUE)
+        self.other_request_cache.set(TEST_KEY, EXPECTED_VALUE)
+
+    def _mock_user(self, is_staff=True):
+        mock_user = MagicMock()
+        mock_user.is_active = True
+        mock_user.is_staff = is_staff
+        return mock_user

--- a/ecommerce/cache_utils/tests/test_utils.py
+++ b/ecommerce/cache_utils/tests/test_utils.py
@@ -4,6 +4,7 @@ Tests for the request cache.
 import mock
 
 from ecommerce.cache_utils.utils import (
+    DEFAULT_NAMESPACE,
     SHOULD_FORCE_CACHE_MISS_KEY,
     CachedResponse,
     CachedResponseError,
@@ -15,64 +16,96 @@ from ecommerce.tests.testcases import TestCase
 TEST_KEY = "clobert"
 TEST_KEY_2 = "clobert2"
 EXPECTED_VALUE = "bertclob"
+TEST_NAMESPACE = "test_namespace"
 TEST_DJANGO_TIMEOUT_CACHE = 1
 
 
 class TestRequestCache(TestCase):
     def setUp(self):
-        RequestCache.clear()
+        RequestCache.clear_all_namespaces()
+        self.request_cache = RequestCache()
+        self.other_request_cache = RequestCache(TEST_NAMESPACE)
 
     def test_get_cached_response_hit(self):
-        RequestCache.set(TEST_KEY, EXPECTED_VALUE)
-        cached_response = RequestCache.get_cached_response(TEST_KEY)
-        self.assertFalse(cached_response.is_miss)
+        self.request_cache.set(TEST_KEY, EXPECTED_VALUE)
+        cached_response = self.request_cache.get_cached_response(TEST_KEY)
+        self.assertTrue(cached_response.is_hit)
+        self.assertEqual(cached_response.value, EXPECTED_VALUE)
+        cached_response = self.other_request_cache.get_cached_response(TEST_KEY)
+        self.assertTrue(cached_response.is_miss)
+
+        self.other_request_cache.set(TEST_KEY_2, EXPECTED_VALUE)
+        cached_response = self.request_cache.get_cached_response(TEST_KEY_2)
+        self.assertTrue(cached_response.is_miss)
+        cached_response = self.other_request_cache.get_cached_response(TEST_KEY_2)
+        self.assertTrue(cached_response.is_hit)
         self.assertEqual(cached_response.value, EXPECTED_VALUE)
 
     def test_get_cached_response_hit_with_cached_none(self):
-        RequestCache.set(TEST_KEY, None)
-        cached_response = RequestCache.get_cached_response(TEST_KEY)
+        self.request_cache.set(TEST_KEY, None)
+        cached_response = self.request_cache.get_cached_response(TEST_KEY)
         self.assertFalse(cached_response.is_miss)
         self.assertEqual(cached_response.value, None)
 
     def test_get_cached_response_miss(self):
-        cached_response = RequestCache.get_cached_response(TEST_KEY)
+        cached_response = self.request_cache.get_cached_response(TEST_KEY)
         self.assertTrue(cached_response.is_miss)
 
     def test_clear(self):
-        RequestCache.set(TEST_KEY, EXPECTED_VALUE)
-        RequestCache.clear()
-        cached_response = RequestCache.get_cached_response(TEST_KEY)
+        self.request_cache.set(TEST_KEY, EXPECTED_VALUE)
+        self.other_request_cache.set(TEST_KEY, EXPECTED_VALUE)
+        self.request_cache.clear()
+        cached_response = self.request_cache.get_cached_response(TEST_KEY)
+        self.assertTrue(cached_response.is_miss)
+        cached_response = self.other_request_cache.get_cached_response(TEST_KEY)
+        self.assertTrue(cached_response.is_hit)
+
+    def test_clear_all_namespaces(self):
+        self.request_cache.set(TEST_KEY, EXPECTED_VALUE)
+        self.other_request_cache.set(TEST_KEY, EXPECTED_VALUE)
+        RequestCache.clear_all_namespaces()
+        cached_response = self.request_cache.get_cached_response(TEST_KEY)
+        self.assertTrue(cached_response.is_miss)
+
+        cached_response = self.other_request_cache.get_cached_response(TEST_KEY)
         self.assertTrue(cached_response.is_miss)
 
     def test_delete(self):
-        RequestCache.set(TEST_KEY, EXPECTED_VALUE)
-        RequestCache.set(TEST_KEY_2, EXPECTED_VALUE)
-        RequestCache.delete(TEST_KEY)
+        self.request_cache.set(TEST_KEY, EXPECTED_VALUE)
+        self.request_cache.set(TEST_KEY_2, EXPECTED_VALUE)
+        self.other_request_cache.set(TEST_KEY, EXPECTED_VALUE)
+        self.request_cache.delete(TEST_KEY)
 
-        cached_response = RequestCache.get_cached_response(TEST_KEY)
+        cached_response = self.request_cache.get_cached_response(TEST_KEY)
         self.assertTrue(cached_response.is_miss)
-
-        cached_response = RequestCache.get_cached_response(TEST_KEY_2)
+        cached_response = self.request_cache.get_cached_response(TEST_KEY_2)
         self.assertTrue(cached_response.is_hit)
         self.assertEqual(cached_response.value, EXPECTED_VALUE)
+        cached_response = self.other_request_cache.get_cached_response(TEST_KEY)
+        self.assertTrue(cached_response.is_hit)
 
     def test_delete_missing_key(self):
         try:
-            RequestCache.delete(TEST_KEY)
+            self.request_cache.delete(TEST_KEY)
         except KeyError:
             self.fail('Deleting a missing key from the request cache should not cause an error.')
+
+    def test_create_request_cache_with_default_namespace(self):
+        with self.assertRaises(AssertionError):
+            RequestCache(DEFAULT_NAMESPACE)
 
 
 class TestTieredCache(TestCase):
     def setUp(self):
-        TieredCache.clear_all_tiers()
+        self.request_cache = RequestCache()
+        TieredCache.dangerous_clear_all_tiers()
 
     def test_get_cached_response_all_tier_miss(self):
         cached_response = TieredCache.get_cached_response(TEST_KEY)
         self.assertTrue(cached_response.is_miss)
 
     def test_get_cached_response_request_cache_hit(self):
-        RequestCache.set(TEST_KEY, EXPECTED_VALUE)
+        self.request_cache.set(TEST_KEY, EXPECTED_VALUE)
         cached_response = TieredCache.get_cached_response(TEST_KEY)
         self.assertTrue(cached_response.is_hit)
         self.assertEqual(cached_response.value, EXPECTED_VALUE)
@@ -84,17 +117,17 @@ class TestTieredCache(TestCase):
         self.assertTrue(cached_response.is_hit)
         self.assertEqual(cached_response.value, EXPECTED_VALUE)
 
-        cached_response = RequestCache.get_cached_response(TEST_KEY)
+        cached_response = self.request_cache.get_cached_response(TEST_KEY)
         self.assertTrue(cached_response.is_hit, 'Django cache hit should cache value in request cache.')
 
     @mock.patch('django.core.cache.cache.get')
     def test_get_cached_response_force_django_cache_miss(self, mock_cache_get):
-        RequestCache.set(SHOULD_FORCE_CACHE_MISS_KEY, True)
+        self.request_cache.set(SHOULD_FORCE_CACHE_MISS_KEY, True)
         mock_cache_get.return_value = EXPECTED_VALUE
         cached_response = TieredCache.get_cached_response(TEST_KEY)
         self.assertTrue(cached_response.is_miss)
 
-        cached_response = RequestCache.get_cached_response(TEST_KEY)
+        cached_response = self.request_cache.get_cached_response(TEST_KEY)
         self.assertTrue(cached_response.is_miss, 'Forced Django cache miss should not cache value in request cache.')
 
     @mock.patch('django.core.cache.cache.set')
@@ -102,13 +135,13 @@ class TestTieredCache(TestCase):
         mock_cache_set.return_value = EXPECTED_VALUE
         TieredCache.set_all_tiers(TEST_KEY, EXPECTED_VALUE, TEST_DJANGO_TIMEOUT_CACHE)
         mock_cache_set.assert_called_with(TEST_KEY, EXPECTED_VALUE, TEST_DJANGO_TIMEOUT_CACHE)
-        self.assertEqual(RequestCache.get_cached_response(TEST_KEY).value, EXPECTED_VALUE)
+        self.assertEqual(self.request_cache.get_cached_response(TEST_KEY).value, EXPECTED_VALUE)
 
     @mock.patch('django.core.cache.cache.clear')
-    def test_clear_all_tiers(self, mock_cache_clear):
+    def test_dangerous_clear_all_tiers_and_namespaces(self, mock_cache_clear):
         TieredCache.set_all_tiers(TEST_KEY, EXPECTED_VALUE)
-        TieredCache.clear_all_tiers()
-        self.assertTrue(RequestCache.get_cached_response(TEST_KEY).is_miss)
+        TieredCache.dangerous_clear_all_tiers()
+        self.assertTrue(self.request_cache.get_cached_response(TEST_KEY).is_miss)
         mock_cache_clear.assert_called_once_with()
 
     @mock.patch('django.core.cache.cache.delete')
@@ -116,8 +149,8 @@ class TestTieredCache(TestCase):
         TieredCache.set_all_tiers(TEST_KEY, EXPECTED_VALUE)
         TieredCache.set_all_tiers(TEST_KEY_2, EXPECTED_VALUE)
         TieredCache.delete_all_tiers(TEST_KEY)
-        self.assertTrue(RequestCache.get_cached_response(TEST_KEY).is_miss)
-        self.assertEqual(RequestCache.get_cached_response(TEST_KEY_2).value, EXPECTED_VALUE)
+        self.assertTrue(self.request_cache.get_cached_response(TEST_KEY).is_miss)
+        self.assertEqual(self.request_cache.get_cached_response(TEST_KEY_2).value, EXPECTED_VALUE)
         mock_cache_delete.assert_called_with(TEST_KEY)
 
 

--- a/ecommerce/coupons/tests/mixins.py
+++ b/ecommerce/coupons/tests/mixins.py
@@ -20,7 +20,7 @@ class DiscoveryMockMixin(object):
     """ Mocks for the Discovery service response. """
     def setUp(self):
         super(DiscoveryMockMixin, self).setUp()
-        TieredCache.clear_all_tiers()
+        TieredCache.dangerous_clear_all_tiers()
 
     @staticmethod
     def build_discovery_catalogs_url(discovery_api_url, catalog_id=''):

--- a/ecommerce/extensions/api/v2/tests/views/test_payments.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_payments.py
@@ -34,7 +34,7 @@ class PaymentProcessorListViewTests(TestCase):
         self.addCleanup(reset_site_config)
 
         # Clear the view cache
-        TieredCache.clear_all_tiers()
+        TieredCache.dangerous_clear_all_tiers()
 
     def toggle_payment_processor(self, processor, active):
         """Set the given payment processor's Waffle switch."""

--- a/ecommerce/extensions/api/v2/views/baskets.py
+++ b/ecommerce/extensions/api/v2/views/baskets.py
@@ -16,7 +16,7 @@ from rest_framework import generics, status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from ecommerce.cache_utils.utils import RequestCache, TieredCache
+from ecommerce.cache_utils.utils import DEFAULT_REQUEST_CACHE, TieredCache
 from ecommerce.core.utils import get_cache_key
 from ecommerce.enterprise.entitlements import get_entitlement_voucher
 from ecommerce.extensions.analytics.utils import audit_log
@@ -402,7 +402,7 @@ class BasketCalculateView(generics.GenericAPIView):
                     'currency': basket.currency
                 }
         """
-        RequestCache.set(TEMPORARY_BASKET_CACHE_KEY, True)
+        DEFAULT_REQUEST_CACHE.set(TEMPORARY_BASKET_CACHE_KEY, True)
 
         partner = get_partner_for_site(request)
         skus = request.GET.getlist('sku')

--- a/ecommerce/extensions/basket/models.py
+++ b/ecommerce/extensions/basket/models.py
@@ -3,7 +3,7 @@ from django.utils.translation import ugettext_lazy as _
 from oscar.apps.basket.abstract_models import AbstractBasket
 from oscar.core.loading import get_class
 
-from ecommerce.cache_utils.utils import RequestCache
+from ecommerce.cache_utils.utils import DEFAULT_REQUEST_CACHE
 from ecommerce.extensions.analytics.utils import track_segment_event, translate_basket_line_for_segment
 from ecommerce.extensions.basket.constants import TEMPORARY_BASKET_CACHE_KEY
 
@@ -51,7 +51,7 @@ class Basket(AbstractBasket):
 
     def flush(self):
         """Remove all products in basket and fire Segment 'Product Removed' Analytic event for each"""
-        cached_response = RequestCache.get_cached_response(TEMPORARY_BASKET_CACHE_KEY)
+        cached_response = DEFAULT_REQUEST_CACHE.get_cached_response(TEMPORARY_BASKET_CACHE_KEY)
         if cached_response.is_hit:
             # Do not track anything. This is a temporary basket calculation.
             return
@@ -72,7 +72,7 @@ class Basket(AbstractBasket):
         Performs AbstractBasket add_product method and fires Google Analytics 'Product Added' event.
         """
         line, created = super(Basket, self).add_product(product, quantity, options)  # pylint: disable=bad-super-call
-        cached_response = RequestCache.get_cached_response(TEMPORARY_BASKET_CACHE_KEY)
+        cached_response = DEFAULT_REQUEST_CACHE.get_cached_response(TEMPORARY_BASKET_CACHE_KEY)
         if cached_response.is_hit:
             # Do not track anything. This is a temporary basket calculation.
             return line, created

--- a/ecommerce/extensions/basket/tests/test_models.py
+++ b/ecommerce/extensions/basket/tests/test_models.py
@@ -5,7 +5,7 @@ from oscar.core.loading import get_class, get_model
 from oscar.test import factories
 
 from analytics import Client
-from ecommerce.cache_utils.utils import RequestCache
+from ecommerce.cache_utils.utils import DEFAULT_REQUEST_CACHE
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.analytics.utils import parse_tracking_context, translate_basket_line_for_segment
 from ecommerce.extensions.api.v2.tests.views.mixins import CatalogMixin
@@ -139,7 +139,7 @@ class BasketTests(CatalogMixin, BasketMixin, TestCase):
         Verify the method does NOT fire 'Product Removed' Segment for temporary basket calculation
         """
         basket = self._create_basket_with_product()
-        RequestCache.set(TEMPORARY_BASKET_CACHE_KEY, True)
+        DEFAULT_REQUEST_CACHE.set(TEMPORARY_BASKET_CACHE_KEY, True)
 
         with mock.patch.object(Client, 'track') as mock_track:
             basket.flush()
@@ -171,7 +171,7 @@ class BasketTests(CatalogMixin, BasketMixin, TestCase):
         course = CourseFactory()
         basket = create_basket(empty=True)
         seat = course.create_or_update_seat('verified', True, 100, self.partner)
-        RequestCache.set(TEMPORARY_BASKET_CACHE_KEY, True)
+        DEFAULT_REQUEST_CACHE.set(TEMPORARY_BASKET_CACHE_KEY, True)
         with mock.patch('ecommerce.extensions.basket.models.track_segment_event') as mock_track:
             basket.add_product(seat)
             properties = translate_basket_line_for_segment(basket.lines.first())

--- a/ecommerce/journals/api/tests/test_views.py
+++ b/ecommerce/journals/api/tests/test_views.py
@@ -4,7 +4,7 @@ import simplejson as json
 from django.urls import reverse
 from oscar.core.loading import get_model
 
-from ecommerce.journals.tests.mixins import JournalMixin     # pylint: disable=no-name-in-module
+from ecommerce.journals.tests.mixins import JournalMixin  # pylint: disable=no-name-in-module
 from ecommerce.tests.testcases import TestCase
 
 Product = get_model('catalogue', 'Product')

--- a/ecommerce/journals/fulfillment/tests/test_modules.py
+++ b/ecommerce/journals/fulfillment/tests/test_modules.py
@@ -8,7 +8,7 @@ from ecommerce.extensions.fulfillment.status import LINE
 from ecommerce.extensions.test.factories import create_order
 from ecommerce.journals.constants import JOURNAL_PRODUCT_CLASS_NAME
 from ecommerce.journals.fulfillment.modules import JournalFulfillmentModule
-from ecommerce.journals.tests.mixins import JournalMixin     # pylint: disable=no-name-in-module
+from ecommerce.journals.tests.mixins import JournalMixin  # pylint: disable=no-name-in-module
 from ecommerce.tests.testcases import TestCase
 
 Product = get_model('catalogue', 'Product')

--- a/ecommerce/journals/migrations/0001_initial.py
+++ b/ecommerce/journals/migrations/0001_initial.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations
+
 import ecommerce.extensions.offer.mixins
 
 

--- a/ecommerce/journals/tests/test_condition.py
+++ b/ecommerce/journals/tests/test_condition.py
@@ -4,7 +4,7 @@ from requests.exceptions import Timeout
 from slumber.exceptions import HttpNotFoundError, SlumberBaseException
 
 from ecommerce.extensions.test import factories
-from ecommerce.journals.tests.mixins import JournalMixin     # pylint: disable=no-name-in-module
+from ecommerce.journals.tests.mixins import JournalMixin  # pylint: disable=no-name-in-module
 from ecommerce.tests.testcases import TestCase
 
 Product = get_model('catalogue', 'Product')

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -81,7 +81,7 @@ class ThrottlingMixin(object):
         super(ThrottlingMixin, self).setUp()
 
         # Throttling for tests relies on the cache. To get around throttling, simply clear the cache.
-        self.addCleanup(TieredCache.clear_all_tiers)
+        self.addCleanup(TieredCache.dangerous_clear_all_tiers)
 
 
 class JwtMixin(object):

--- a/ecommerce/tests/testcases.py
+++ b/ecommerce/tests/testcases.py
@@ -9,11 +9,11 @@ from ecommerce.tests.mixins import SiteMixin, TestServerUrlMixin, UserMixin
 
 class TieredCacheMixin(object):
     def setUp(self):
-        TieredCache.clear_all_tiers()
+        TieredCache.dangerous_clear_all_tiers()
         super(TieredCacheMixin, self).setUp()
 
     def tearDown(self):
-        TieredCache.clear_all_tiers()
+        TieredCache.dangerous_clear_all_tiers()
         super(TieredCacheMixin, self).tearDown()
 
 


### PR DESCRIPTION
The following changes were added in preparation of pulling cache_utils
out to another repo:
1. Added namespacing to the RequestCache.
2. Query param 'force_django_cache_miss' now requires staff permissions.

[ARCH-177](https://openedx.atlassian.net/browse/ARCH-177)