### PR TITLE
Proposal: Skip displaying prices in the receipt page for free orders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ docs/_build
 # Certificates
 *.cer
 *.pem
+


### PR DESCRIPTION
This is a follow-up to the https://github.com/edx/ecommerce/pull/1676 PR which was merged and then reverted a while later. The goal of that PR was to skip displaying the receipt page when it is a free order. The implementation that was merged initially, skipped the receipt page by default. It was reverted later because the receipt page added sufficient delay for the enrolled course to show up in the dashboard and without that, the users were redirected to the dashboard which didn't show the enrolled course till they refresh the page. Also, there were some e2e tests which were failing and had to be rewritten.

**Proposed approach**
Instead of skipping the receipt page for free orders, the receipt page will be shown without the price. This could behind a flag, or could be the new default behaviour.

In case there is a need to display the price for free orders, that could be made configurable at a per-course level or at a per-coupon level if it makes sense.

CC @mduboseedx @kaizoku