### PR TITLE
LEARNER-5754 disabled django debugtoolbar template panel

### DIFF
--- a/ecommerce/settings/_debug_toolbar.py
+++ b/ecommerce/settings/_debug_toolbar.py
@@ -1,5 +1,8 @@
 # DJANGO DEBUG TOOLBAR CONFIGURATION
 DEBUG_TOOLBAR_CONFIG = {
     'SHOW_TOOLBAR_CALLBACK': (lambda __: True),
+    'DISABLE_PANELS': (
+        'debug_toolbar.panels.template.TemplateDebugPanel',
+    ),
 }
 # END DJANGO DEBUG TOOLBAR CONFIGURATION


### PR DESCRIPTION
LEARNER-5754
Django debug toolbar causes a lot of delays when number of templates to render is a lot. This will just uncheck the template option from the debug toolbar panel by default to avoid the delays. If some one is debugging the templates can check the templates option and use it. 

@edx/learner-spartans  kindly review. 