### PR TITLE
Add pyinotify to improve dev server code reloading

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -10,3 +10,6 @@ edx-i18n-tools==0.4.4
 
 # Visual Studio Code Debugger
 ptvsd==3.0
+
+# For devserver code reloading
+pyinotify==0.9.6


### PR DESCRIPTION
On devstack, each IDA consumes ~2% CPU while idle, because of Django's dev server code reloading. Adding the pyinotify library decreases CPU usage to <0.1%

