### PR TITLE
ENT-1163 Extend COURSES_API_CACHE_TIMEOUT from 1 hr to 24 hrs

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -246,7 +246,7 @@ ROOT_URLCONF = '{}.urls'.format(SITE_NAME)
 COMMERCE_API_TIMEOUT = 7
 
 # Cache course info from course API.
-COURSES_API_CACHE_TIMEOUT = 3600  # Value is in seconds
+COURSES_API_CACHE_TIMEOUT = 86400  # Value is in seconds
 PROGRAM_CACHE_TIMEOUT = 3600  # Value is in seconds.
 
 # PROVIDER DATA PROCESSING


### PR DESCRIPTION
Relating to https://github.com/edx/ecommerce/pull/1898, @robrap requested that we raise the value of COURSE_API_CACHE_TIMEOUT. From what I can tell, this is where the value gets set. I am making this change separately since various calls throughout ecommerce to discovery use this value, so we can monitor it separately from my changeset.