### PR TITLE
Add option to use cybersource email for notifications

### DIFF
--- a/ecommerce/extensions/checkout/signals.py
+++ b/ecommerce/extensions/checkout/signals.py
@@ -94,7 +94,7 @@ def track_completed_order(sender, order=None, **kwargs):  # pylint: disable=unus
 
 @receiver(post_checkout, dispatch_uid='send_completed_order_email')
 @silence_exceptions("Failed to send order completion email.")
-def send_course_purchase_email(sender, order=None, **kwargs):  # pylint: disable=unused-argument
+def send_course_purchase_email(sender, order=None, request=None, **kwargs):  # pylint: disable=unused-argument
     """Send course purchase notification email when a course is purchased."""
     if waffle.switch_is_active('ENABLE_NOTIFICATIONS'):
         # We do not currently support email sending for orders with more than one item.
@@ -116,6 +116,8 @@ def send_course_purchase_email(sender, order=None, **kwargs):  # pylint: disable
                     order_number=order.number,
                     site_configuration=order.site.siteconfiguration
                 )
+
+                recipient = request.POST.get('req_bill_to_email', order.user.email)
 
                 if provider_data:
                     send_notification(

--- a/ecommerce/extensions/checkout/signals.py
+++ b/ecommerce/extensions/checkout/signals.py
@@ -129,7 +129,8 @@ def send_course_purchase_email(sender, order=None, request=None, **kwargs):  # p
                             'credit_hours': product.attr.credit_hours,
                             'credit_provider': provider_data['display_name'],
                         },
-                        order.site
+                        order.site,
+                        recipient
                     )
 
         else:

--- a/ecommerce/extensions/checkout/signals.py
+++ b/ecommerce/extensions/checkout/signals.py
@@ -117,7 +117,7 @@ def send_course_purchase_email(sender, order=None, request=None, **kwargs):  # p
                     site_configuration=order.site.siteconfiguration
                 )
 
-                recipient = request.POST.get('req_bill_to_email', order.user.email)
+                recipient = request.POST.get('req_bill_to_email', order.user.email) if request else order.user.email
 
                 if provider_data:
                     send_notification(

--- a/ecommerce/extensions/customer/utils.py
+++ b/ecommerce/extensions/customer/utils.py
@@ -25,26 +25,27 @@ class Dispatcher(Dispatcher):
             # pylint: disable=protected-access
             CommunicationEvent._default_manager.create(order=order, event_type=event_type)
 
-    def dispatch_user_messages(self, user, messages, site=None):  # pylint: disable=arguments-differ
+    def dispatch_user_messages(self, user, messages, site=None, recipient=None):  # pylint: disable=arguments-differ
         """
         Send messages to a site user
         """
         if messages['subject'] and (messages['body'] or messages['html']):
-            self.send_user_email_messages(user, messages, site)
+            self.send_user_email_messages(user, messages, site, recipient)
         if messages['sms']:
             self.send_text_message(user, messages['sms'])
 
-    def send_user_email_messages(self, user, messages, site=None):  # pylint: disable=arguments-differ
+    def send_user_email_messages(self, user, messages, site=None, recipient=None):  # pylint: disable=arguments-differ
         """
         Sends message to the registered user / customer and collects data in
         database
         """
-        if not user.email:
+        if not (recipient or user.email):
             msg = "Unable to send email messages: No email address for '{username}'.".format(username=user.username)
             self.logger.warning(msg)
             return
 
-        email = self.send_email_messages(user.email, messages, site)
+        recipient = recipient if recipient else user.email
+        email = self.send_email_messages(recipient, messages, site)
 
         # Is user is signed in, record the event for audit
         if email and user.is_authenticated():

--- a/ecommerce/notifications/notifications.py
+++ b/ecommerce/notifications/notifications.py
@@ -10,7 +10,7 @@ CommunicationEventType = get_model('customer', 'CommunicationEventType')
 Dispatcher = get_class('customer.utils', 'Dispatcher')
 
 
-def send_notification(user, commtype_code, context, site):
+def send_notification(user, commtype_code, context, site, recipient):
     """Send different notification mail to the user based on the triggering event.
 
     Args:
@@ -46,4 +46,4 @@ def send_notification(user, commtype_code, context, site):
 
     if messages and (messages['body'] or messages['html']):
         messages['html'] = transform(messages['html'])
-        Dispatcher().dispatch_user_messages(user, messages, site)
+        Dispatcher().dispatch_user_messages(user, messages, site, recipient)

--- a/ecommerce/notifications/notifications.py
+++ b/ecommerce/notifications/notifications.py
@@ -10,13 +10,14 @@ CommunicationEventType = get_model('customer', 'CommunicationEventType')
 Dispatcher = get_class('customer.utils', 'Dispatcher')
 
 
-def send_notification(user, commtype_code, context, site, recipient):
+def send_notification(user, commtype_code, context, site, recipient=None):
     """Send different notification mail to the user based on the triggering event.
 
     Args:
     user(obj): 'User' object to whom email is to send
     commtype_code(str): Communication type code
     context(dict): context to be used in the mail
+    recipient(str): Email which overrides user.email when set
 
     """
 


### PR DESCRIPTION
This PR will use the email address returned from the CyberSource checkout process to send ecommerce notifications, rather than the user's email address from edx-platform.

**Sandbox URL**: TBD - sandbox is being provisioned.

**Testing instructions**:

1. Complete the purchase of a seat in the sandbox providing a different email address from the one configured in edX during the CyberSource checkout sequence.
2. Check to see that the seat fulfillment notification is sent to the address used on CyberSource.

**Author notes and concerns**:

1. Should this be behind a waffle flag?

**Reviewers**
- [ ] (@xirdneh)
- [ ] edX reviewer[s] TBD