### PR TITLE
Add id endpoint to allow for Segment retirement

### DIFF
--- a/ecommerce/extensions/analytics/tests/test_utils.py
+++ b/ecommerce/extensions/analytics/tests/test_utils.py
@@ -9,6 +9,7 @@ from oscar.test import factories
 from analytics import Client
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.analytics.utils import (
+    ECOM_TRACKING_ID_FMT,
     get_google_analytics_client_id,
     parse_tracking_context,
     prepare_analytics_data,
@@ -62,7 +63,7 @@ class UtilsTest(DiscoveryTestMixin, BasketMixin, TransactionTestCase):
         # If no LMS user ID is provided, we should create one based on the E-Commerce ID
         del tracking_context['lms_user_id']
         user = self.create_user(tracking_context=tracking_context)
-        expected = ('ecommerce-{}'.format(user.id), tracking_context['ga_client_id'], tracking_context['lms_ip'])
+        expected = (ECOM_TRACKING_ID_FMT.format(user.id), tracking_context['ga_client_id'], tracking_context['lms_ip'])
         self.assertEqual(parse_tracking_context(user), expected)
 
     def test_track_segment_event_without_segment_key(self):

--- a/ecommerce/extensions/analytics/utils.py
+++ b/ecommerce/extensions/analytics/utils.py
@@ -6,6 +6,8 @@ from ecommerce.courses.utils import mode_for_product
 
 logger = logging.getLogger(__name__)
 
+ECOM_TRACKING_ID_FMT = 'ecommerce-{}'
+
 
 def parse_tracking_context(user):
     """Extract user ID, client ID, and IP address from a user's tracking context.
@@ -24,7 +26,7 @@ def parse_tracking_context(user):
         # event with an arbitrary local user ID. However, we need to disambiguate the ID we choose
         # since there's no guarantee it won't collide with a platform user ID that may be tracked
         # at some point.
-        user_tracking_id = 'ecommerce-{}'.format(user.id)
+        user_tracking_id = ECOM_TRACKING_ID_FMT.format(user.id)
 
     lms_ip = tracking_context.get('lms_ip')
     ga_client_id = tracking_context.get('ga_client_id')

--- a/ecommerce/extensions/api/v2/tests/views/test_retirement.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_retirement.py
@@ -1,0 +1,26 @@
+import ddt
+from rest_framework import status
+
+from ecommerce.extensions.analytics.utils import ECOM_TRACKING_ID_FMT
+from ecommerce.extensions.api.v2.views.retirement import EcommerceIdView
+from ecommerce.tests.testcases import TestCase
+
+
+@ddt.ddt
+class EcommerceIdViewTest(TestCase):
+    def test_successful_get(self):
+        user = self.create_user()
+        response = EcommerceIdView().get(None, username=user.username)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertDictEqual(
+            response.data,
+            {
+                'id': user.pk,
+                'ecommerce_tracking_id': ECOM_TRACKING_ID_FMT.format(user.pk)
+            }
+        )
+
+    @ddt.data('does_not_exist', None)
+    def test_unknown_user(self, username):
+        response = EcommerceIdView().get(None, username=username)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/ecommerce/extensions/api/v2/urls.py
+++ b/ecommerce/extensions/api/v2/urls.py
@@ -15,6 +15,7 @@ from ecommerce.extensions.api.v2.views import products as product_views
 from ecommerce.extensions.api.v2.views import providers as provider_views
 from ecommerce.extensions.api.v2.views import publication as publication_views
 from ecommerce.extensions.api.v2.views import refunds as refund_views
+from ecommerce.extensions.api.v2.views import retirement as retirement_views
 from ecommerce.extensions.api.v2.views import sdn as sdn_views
 from ecommerce.extensions.api.v2.views import stockrecords as stockrecords_views
 from ecommerce.extensions.api.v2.views import vouchers as voucher_views
@@ -22,6 +23,10 @@ from ecommerce.extensions.voucher.views import CouponReportCSVView
 
 ORDER_NUMBER_PATTERN = r'(?P<number>[-\w]+)'
 BASKET_ID_PATTERN = r'(?P<basket_id>[\d]+)'
+
+# From edx-platform's lms/envs/common.py as of 2018-10-09
+USERNAME_REGEX_PARTIAL = r'[\w .@_+-]+'
+USERNAME_PATTERN = r'(?P<username>{regex})'.format(regex=USERNAME_REGEX_PARTIAL)
 
 BASKET_URLS = [
     url(r'^$', basket_views.BasketCreateView.as_view(), name='create'),
@@ -45,6 +50,10 @@ PAYMENT_URLS = [
 REFUND_URLS = [
     url(r'^$', refund_views.RefundCreateView.as_view(), name='create'),
     url(r'^(?P<pk>[\d]+)/process/$', refund_views.RefundProcessView.as_view(), name='process'),
+]
+
+RETIREMENT_URLS = [
+    url(r'^tracking_id/{}/$'.format(USERNAME_PATTERN), retirement_views.EcommerceIdView.as_view(), name='tracking_id')
 ]
 
 COUPON_URLS = [
@@ -86,6 +95,7 @@ urlpatterns = [
     url(r'^providers/', include(PROVIDER_URLS, namespace='providers')),
     url(r'^publication/', include(ATOMIC_PUBLICATION_URLS, namespace='publication')),
     url(r'^refunds/', include(REFUND_URLS, namespace='refunds')),
+    url(r'^retirement/', include(RETIREMENT_URLS, namespace='retirement')),
     url(r'^sdn/', include(SDN_URLS, namespace='sdn')),
 ]
 

--- a/ecommerce/extensions/api/v2/views/retirement.py
+++ b/ecommerce/extensions/api/v2/views/retirement.py
@@ -1,0 +1,43 @@
+"""
+Endpoints to facilitate retirement actions
+"""
+
+from edx_rest_framework_extensions.authentication import JwtAuthentication
+from rest_framework import permissions, status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from ecommerce.core.models import User
+from ecommerce.extensions.analytics.utils import ECOM_TRACKING_ID_FMT
+
+
+class EcommerceIdView(APIView):
+    """
+    Allows synchronization of the ecommerce user id and tracking id with
+    other systems. Specifically this is used to retire users identified
+    by "ecommerce-{id}" from Segment.
+    """
+    authentication_classes = (JwtAuthentication, )
+    permission_classes = (permissions.IsAuthenticated, permissions.IsAdminUser)
+
+    def get(self, _, username):
+        """
+        Returns the ecommerce tracking id of the given LMS user, identified
+        by username.
+        """
+        try:
+            if not username:
+                raise User.DoesNotExist()
+
+            user = User.objects.get(username=username)
+            return Response(
+                {
+                    'id': user.pk,
+                    'ecommerce_tracking_id': ECOM_TRACKING_ID_FMT.format(user.pk)
+                }
+            )
+        except User.DoesNotExist:
+            return Response(
+                status=status.HTTP_404_NOT_FOUND,
+                data={'message': 'Invalid user.'}
+            )

--- a/ecommerce/extensions/checkout/tests/test_mixins.py
+++ b/ecommerce/extensions/checkout/tests/test_mixins.py
@@ -13,7 +13,11 @@ from ecommerce.core.constants import ENROLLMENT_CODE_PRODUCT_CLASS_NAME, ENROLLM
 from ecommerce.core.models import BusinessClient, SegmentClient
 from ecommerce.core.tests import toggle_switch
 from ecommerce.courses.tests.factories import CourseFactory
-from ecommerce.extensions.analytics.utils import parse_tracking_context, translate_basket_line_for_segment
+from ecommerce.extensions.analytics.utils import (
+    ECOM_TRACKING_ID_FMT,
+    parse_tracking_context,
+    translate_basket_line_for_segment
+)
 from ecommerce.extensions.basket.utils import basket_add_organization_attribute
 from ecommerce.extensions.checkout.exceptions import BasketNotFreeError
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
@@ -215,7 +219,7 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin,
         self.assert_correct_event(
             mock_track,
             self.order,
-            'ecommerce-{}'.format(self.user.id),
+            ECOM_TRACKING_ID_FMT.format(self.user.id),
             None,
             None,
             self.order.number,

--- a/ecommerce/extensions/refund/tests/test_signals.py
+++ b/ecommerce/extensions/refund/tests/test_signals.py
@@ -2,6 +2,7 @@ from mock import patch
 from oscar.test.factories import UserFactory
 
 from ecommerce.core.models import SegmentClient
+from ecommerce.extensions.analytics.utils import ECOM_TRACKING_ID_FMT
 from ecommerce.extensions.refund.api import create_refunds
 from ecommerce.extensions.refund.tests.mixins import RefundTestMixin
 from ecommerce.tests.testcases import TestCase
@@ -21,7 +22,10 @@ class RefundTrackingTests(RefundTestMixin, TestCase):
         (event_user_id, event_name, event_payload), kwargs = mock_track.call_args
 
         self.assertTrue(mock_track.called)
-        self.assertEqual(event_user_id, tracking_context.get('lms_user_id', 'ecommerce-{}'.format(refund.user.id)))
+        self.assertEqual(
+            event_user_id,
+            tracking_context.get('lms_user_id', ECOM_TRACKING_ID_FMT.format(refund.user.id))
+        )
         self.assertEqual(event_name, 'Order Refunded')
 
         expected_context = {


### PR DESCRIPTION
When ecommerce cannot find an LMS ID to use as a user identifier for Segment, it uses one in the format of `ecommerce-{ecommerce user id}`. When we retire a user from Segment we need to retire this ID as well, but it is unavailable to other systems currently. This PR creates an endpoint to expose both the ecommerce user ID and the formatted tracking id.