### PR TITLE
Do not render bad SKUs when SKUs are not found

### DIFF
--- a/ecommerce/extensions/api/v2/views/baskets.py
+++ b/ecommerce/extensions/api/v2/views/baskets.py
@@ -418,7 +418,8 @@ class BasketCalculateView(generics.GenericAPIView):
 
         products = Product.objects.filter(stockrecords__partner=partner, stockrecords__partner_sku__in=skus)
         if not products:
-            return HttpResponseBadRequest(_('Products with SKU(s) [{skus}] do not exist.').format(skus=', '.join(skus)))
+            logger.warning('Products with SKU(s) [%s] do not exist.', ', '.join(skus))
+            return HttpResponseBadRequest(_('Provided SKUs do not exist.'))
 
         # If there is only one product apply an Enterprise entitlement voucher
         if not voucher and len(products) == 1:


### PR DESCRIPTION
Rather than escaping the sku, I think we should not return this information at all. It seems like this is meant more for debugging which shouldn't be on production. We should add a log statement in the case of missed SKUs and create an alert in splunk to catch these (possibly with a thresholds to avoid one off alerts).
https://github.com/edx/ecommerce/blob/275f0dff43ea710a638cc51afd5c1ebfc365e625/ecommerce/extensions/basket/views.py#L68


Pros:
* We don't have to worry about escaping anything
* We will have a log history of SKU's that are not working
* We do not expose any product information in our database to users

Cons:
* We will have another alert to potentially calibrate

