### PR TITLE
ENT-1248/ENT-1267 Introduce waffle flag for using enterprise conditions

### DIFF
--- a/ecommerce/enterprise/benefits.py
+++ b/ecommerce/enterprise/benefits.py
@@ -32,3 +32,14 @@ class EnterpriseAbsoluteDiscountBenefit(BenefitWithoutRangeMixin, AbsoluteBenefi
     @property
     def name(self):
         return _('{value} fixed-price enterprise discount').format(value=self.value)
+
+
+# constants related to enterprise benefits
+BENEFIT_MAP = {
+    Benefit.FIXED: EnterpriseAbsoluteDiscountBenefit,
+    Benefit.PERCENTAGE: EnterprisePercentageDiscountBenefit,
+}
+BENEFIT_TYPE_CHOICES = (
+    (Benefit.PERCENTAGE, _('Percentage')),
+    (Benefit.FIXED, _('Absolute')),
+)

--- a/ecommerce/enterprise/conditions.py
+++ b/ecommerce/enterprise/conditions.py
@@ -3,12 +3,13 @@ from __future__ import unicode_literals
 import logging
 from uuid import UUID
 
+import waffle
 from oscar.core.loading import get_model
 from requests.exceptions import ConnectionError, Timeout
 from slumber.exceptions import SlumberHttpBaseException
 
 from ecommerce.enterprise.api import catalog_contains_course_runs, fetch_enterprise_learner_data
-from ecommerce.enterprise.constants import ENTERPRISE_OFFERS_SWITCH
+from ecommerce.enterprise.constants import ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, ENTERPRISE_OFFERS_SWITCH
 from ecommerce.extensions.basket.utils import ENTERPRISE_CATALOG_ATTRIBUTE_TYPE
 from ecommerce.extensions.offer.decorators import check_condition_applicability
 from ecommerce.extensions.offer.mixins import ConditionWithoutRangeMixin, SingleItemConsumptionConditionMixin
@@ -53,10 +54,12 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
             # An anonymous user is never linked to any EnterpriseCustomer.
             return False
 
-        if offer.offer_type == ConditionalOffer.VOUCHER:
+        if (offer.offer_type == ConditionalOffer.VOUCHER and
+                not waffle.switch_is_active(ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH)):
             logger.info('Skipping Voucher type enterprise conditional offer until we are ready to support it.')
             return False
 
+        learner_data = {}
         try:
             learner_data = fetch_enterprise_learner_data(basket.site, basket.owner)['results'][0]
         except (ConnectionError, KeyError, SlumberHttpBaseException, Timeout):
@@ -67,11 +70,14 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
             )
             return False
         except IndexError:
-            return False
+            if offer.offer_type == ConditionalOffer.SITE:
+                logger.info('No learner data returned for user %s', basket.owner)
+                return False
 
-        enterprise_customer = learner_data['enterprise_customer']
-        if str(self.enterprise_customer_uuid) != enterprise_customer['uuid']:
+        if (learner_data and 'enterprise_customer' in learner_data and
+                str(self.enterprise_customer_uuid) != learner_data['enterprise_customer']['uuid']):
             # Learner is not linked to the EnterpriseCustomer associated with this condition.
+            logger.info('Learner\'s enterprise does not match this conditions\'s enterprise.')
             return False
 
         course_run_ids = []
@@ -79,6 +85,7 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
             course = line.product.course
             if not course:
                 # Basket contains products not related to a course_run.
+                logger.info('Basket contains products not related to a course_run.')
                 return False
 
             course_run_ids.append(course.id)
@@ -89,12 +96,14 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
         catalog = self._get_enterprise_catalog_uuid_from_basket(basket)
         if catalog:
             if offer.condition.enterprise_customer_catalog_uuid != catalog:
+                logger.info('Enterprise catalog id on the basket does not match the catalog for this condition.')
                 return False
 
         if not catalog_contains_course_runs(basket.site, course_run_ids, self.enterprise_customer_uuid,
                                             enterprise_customer_catalog_uuid=self.enterprise_customer_catalog_uuid):
             # Basket contains course runs that do not exist in the EnterpriseCustomerCatalogs
             # associated with the EnterpriseCustomer.
+            logger.info('Enterprise catalog does not contain the course(s) in this basket.')
             return False
 
         return True

--- a/ecommerce/enterprise/constants.py
+++ b/ecommerce/enterprise/constants.py
@@ -1,18 +1,5 @@
-from django.utils.translation import ugettext_lazy as _
-from oscar.core.loading import get_model
-
-from ecommerce.enterprise.benefits import EnterpriseAbsoluteDiscountBenefit, EnterprisePercentageDiscountBenefit
-
-Benefit = get_model('offer', 'Benefit')
-
-BENEFIT_MAP = {
-    Benefit.FIXED: EnterpriseAbsoluteDiscountBenefit,
-    Benefit.PERCENTAGE: EnterprisePercentageDiscountBenefit,
-}
-BENEFIT_TYPE_CHOICES = (
-    (Benefit.PERCENTAGE, _('Percentage')),
-    (Benefit.FIXED, _('Absolute')),
-)
-
 # Waffle switch used to enable/disable Enterprise offers.
 ENTERPRISE_OFFERS_SWITCH = 'enable_enterprise_offers'
+
+# Waffle switch used to enable/disable using Enterprise Offers for Coupons.
+ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH = 'enable_enterprise_offers_for_coupons'

--- a/ecommerce/enterprise/entitlements.py
+++ b/ecommerce/enterprise/entitlements.py
@@ -208,7 +208,7 @@ def get_available_voucher_for_product(request, product, vouchers):
         if is_valid_voucher:
             voucher_offer = voucher.best_offer
             offer_range = voucher_offer.condition.range
-            if offer_range.contains_product(product):
+            if offer_range and offer_range.contains_product(product):
                 return voucher
 
     # Explicitly return None in case product has no valid voucher

--- a/ecommerce/enterprise/forms.py
+++ b/ecommerce/enterprise/forms.py
@@ -5,8 +5,8 @@ from django.forms.utils import ErrorList
 from django.utils.translation import ugettext_lazy as _
 from oscar.core.loading import get_model
 
+from ecommerce.enterprise.benefits import BENEFIT_MAP, BENEFIT_TYPE_CHOICES
 from ecommerce.enterprise.conditions import EnterpriseCustomerCondition
-from ecommerce.enterprise.constants import BENEFIT_MAP, BENEFIT_TYPE_CHOICES
 from ecommerce.enterprise.utils import get_enterprise_customer
 from ecommerce.extensions.offer.models import OFFER_PRIORITY_ENTERPRISE
 from ecommerce.programs.custom import class_path, create_condition

--- a/ecommerce/enterprise/management/commands/migrate_enterprise_conditional_offers.py
+++ b/ecommerce/enterprise/management/commands/migrate_enterprise_conditional_offers.py
@@ -9,8 +9,8 @@ from time import sleep
 from django.contrib.sites.models import Site
 from django.core.management import BaseCommand
 
+from ecommerce.enterprise.benefits import BENEFIT_MAP
 from ecommerce.enterprise.conditions import EnterpriseCustomerCondition
-from ecommerce.enterprise.constants import BENEFIT_MAP
 from ecommerce.enterprise.utils import get_enterprise_customer
 from ecommerce.extensions.voucher.models import Voucher
 from ecommerce.programs.custom import class_path, get_model

--- a/ecommerce/enterprise/migrations/0004_add_enterprise_offers_for_coupons.py
+++ b/ecommerce/enterprise/migrations/0004_add_enterprise_offers_for_coupons.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from ecommerce.enterprise.constants import ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH
+
+
+def create_switch(apps, schema_editor):
+    """Create the `enable_enterprise_on_runtime` switch if it does not already exist."""
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': False})
+
+
+def delete_switch(apps, schema_editor):
+    """Delete the `enable_enterprise_on_runtime` switch."""
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.filter(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('enterprise', '0003_add_enable_enterprise_switch'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_switch, delete_switch)
+    ]

--- a/ecommerce/enterprise/tests/test_conditions.py
+++ b/ecommerce/enterprise/tests/test_conditions.py
@@ -7,7 +7,7 @@ from oscar.core.loading import get_model
 from waffle.models import Switch
 
 from ecommerce.courses.tests.factories import CourseFactory
-from ecommerce.enterprise.constants import ENTERPRISE_OFFERS_SWITCH
+from ecommerce.enterprise.constants import ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, ENTERPRISE_OFFERS_SWITCH
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
 from ecommerce.extensions.basket.utils import basket_add_enterprise_catalog_attribute
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
@@ -129,9 +129,7 @@ class EnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, DiscoveryTest
         )
         self.assertFalse(self.condition.is_satisfied(offer, basket))
 
-    @httpretty.activate
-    def test_is_satisfied_false_for_voucher_offer(self):
-        """ Ensure the condition returns false for a coupon with an enterprise conditional offer. """
+    def setup_enterprise_coupon_data(self):
         offer = factories.EnterpriseOfferFactory(
             partner=self.partner,
             condition=self.condition,
@@ -149,7 +147,21 @@ class EnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, DiscoveryTest
             self.condition.enterprise_customer_uuid,
             enterprise_customer_catalog_uuid=self.condition.enterprise_customer_catalog_uuid,
         )
+        return offer, basket
+
+    @httpretty.activate
+    def test_is_satisfied_false_for_voucher_offer_coupon_switch_off(self):
+        """ Ensure the condition returns false for a coupon with an enterprise conditional offer. """
+        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': False})
+        offer, basket = self.setup_enterprise_coupon_data()
         self.assertFalse(self.condition.is_satisfied(offer, basket))
+
+    @httpretty.activate
+    def test_is_satisfied_true_for_voucher_offer_coupon_switch_on(self):
+        """ Ensure the condition returns true for a coupon with an enterprise conditional offer. """
+        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': True})
+        offer, basket = self.setup_enterprise_coupon_data()
+        self.assertTrue(self.condition.is_satisfied(offer, basket))
 
     def test_is_satisfied_empty_basket(self):
         """ Ensure the condition returns False if the basket is empty. """

--- a/ecommerce/enterprise/tests/test_forms.py
+++ b/ecommerce/enterprise/tests/test_forms.py
@@ -4,7 +4,7 @@ import uuid
 import httpretty
 from oscar.core.loading import get_model
 
-from ecommerce.enterprise.constants import BENEFIT_MAP
+from ecommerce.enterprise.benefits import BENEFIT_MAP
 from ecommerce.enterprise.forms import EnterpriseOfferForm
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
 from ecommerce.extensions.offer.models import OFFER_PRIORITY_ENTERPRISE

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -60,7 +60,12 @@ def is_enrollment_code(obj):
 
 def retrieve_benefit(obj):
     """Helper method to retrieve the benefit from voucher. """
-    return retrieve_voucher(obj).benefit
+    return retrieve_offer(obj).benefit
+
+
+def retrieve_condition(obj):
+    """Helper method to retrieve the benefit from voucher. """
+    return retrieve_offer(obj).condition
 
 
 def retrieve_end_date(obj):
@@ -686,12 +691,24 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
     def get_enterprise_customer(self, obj):
         """ Get the Enterprise Customer UUID attached to a coupon. """
         offer_range = retrieve_range(obj)
-        return offer_range.enterprise_customer if offer_range else None
+        offer_condition = retrieve_condition(obj)
+        if offer_range and offer_range.enterprise_customer:
+            return offer_range.enterprise_customer
+        elif offer_condition.enterprise_customer_uuid:
+            return offer_condition.enterprise_customer_uuid
+        else:
+            return None
 
     def get_enterprise_customer_catalog(self, obj):
         """ Get the Enterprise Customer Catalog UUID attached to a coupon. """
         offer_range = retrieve_range(obj)
-        return offer_range.enterprise_customer_catalog if offer_range else None
+        offer_condition = retrieve_condition(obj)
+        if offer_range and offer_range.enterprise_customer_catalog:
+            return offer_range.enterprise_customer_catalog
+        elif offer_condition.enterprise_customer_catalog_uuid:
+            return offer_condition.enterprise_customer_catalog_uuid
+        else:
+            return None
 
     def get_last_edited(self, obj):
         return None, obj.date_updated

--- a/ecommerce/extensions/api/v2/tests/views/test_vouchers.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_vouchers.py
@@ -17,14 +17,21 @@ from requests.exceptions import ConnectionError, Timeout
 from rest_framework import status
 from rest_framework.test import APIRequestFactory
 from slumber.exceptions import SlumberBaseException
+from waffle.models import Switch
 
 from ecommerce.coupons.tests.mixins import CouponMixin, DiscoveryMockMixin
 from ecommerce.courses.tests.factories import CourseFactory
+from ecommerce.enterprise.constants import ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH
 from ecommerce.extensions.api import serializers
 from ecommerce.extensions.api.v2.views.vouchers import VoucherViewSet
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
 from ecommerce.extensions.partner.strategy import DefaultStrategy
-from ecommerce.extensions.test.factories import ConditionalOfferFactory, VoucherFactory, prepare_voucher
+from ecommerce.extensions.test.factories import (
+    ConditionalOfferFactory,
+    VoucherFactory,
+    prepare_enterprise_voucher,
+    prepare_voucher
+)
 from ecommerce.extensions.voucher.models import CouponVouchers
 from ecommerce.tests.factories import PartnerFactory
 from ecommerce.tests.mixins import Catalog, LmsApiMockMixin
@@ -459,6 +466,7 @@ class VoucherViewOffersEndpointTests(DiscoveryMockMixin, CouponMixin, DiscoveryT
 
     def test_get_offers_for_enterprise_catalog_voucher(self):
         """ Verify that the course offers data is returned for an enterprise catalog voucher. """
+        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': False})
         self.mock_access_token_response()
         course, seat = self.create_course_and_seat()
         enterprise_catalog_id = str(uuid4())
@@ -495,6 +503,57 @@ class VoucherViewOffersEndpointTests(DiscoveryMockMixin, CouponMixin, DiscoveryT
             'title': course.name,
             'voucher_end_date': voucher.end_datetime,
         })
+
+    def test_get_offers_for_enterprise_offer_switch_on(self):
+        """ Verify that the course offers data is returned for an enterprise catalog voucher. """
+        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': True})
+        self.mock_access_token_response()
+        course, seat = self.create_course_and_seat()
+        enterprise_customer_id = str(uuid4())
+        enterprise_catalog_id = str(uuid4())
+        self.mock_enterprise_catalog_course_endpoint(
+            self.site_configuration.enterprise_api_url, enterprise_catalog_id, course_run=course
+        )
+        voucher = prepare_enterprise_voucher(
+            benefit_value=10,
+            enterprise_customer=enterprise_customer_id,
+            enterprise_customer_catalog=enterprise_catalog_id
+        )
+        benefit = voucher.offers.first().benefit
+        request = self.prepare_offers_listing_request(voucher.code)
+        offers = VoucherViewSet().get_offers(request=request, voucher=voucher)['results']
+        first_offer = offers[0]
+        self.assertEqual(len(offers), 1)
+        self.assertDictEqual(first_offer, {
+            'benefit': {
+                'type': benefit.type,
+                'value': benefit.value
+            },
+            'contains_verified': True,
+            'course_start_date': '2016-05-01T00:00:00Z',
+            'id': course.id,
+            'image_url': 'path/to/the/course/image',
+            'multiple_credit_providers': False,
+            'organization': CourseKey.from_string(course.id).org,
+            'credit_provider_price': None,
+            'seat_type': course.type,
+            'stockrecords': serializers.StockRecordSerializer(seat.stockrecords.first()).data,
+            'title': course.name,
+            'voucher_end_date': voucher.end_datetime,
+        })
+
+    def test_get_offers_for_enterprise_offer_switch_on_no_catalog(self):
+        """ Verify that the course offers data is returned for an enterprise catalog voucher. """
+        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': True})
+        self.mock_access_token_response()
+        enterprise_customer_id = str(uuid4())
+        voucher = prepare_enterprise_voucher(
+            benefit_value=10,
+            enterprise_customer=enterprise_customer_id,
+        )
+        request = self.prepare_offers_listing_request(voucher.code)
+        response = self.endpointView(request)
+        self.assertEqual(response.status_code, 404)
 
     def test_get_offers_for_course_catalog_voucher(self):
         """ Verify that the course offers data is returned for a course catalog voucher. """

--- a/ecommerce/extensions/api/v2/views/vouchers.py
+++ b/ecommerce/extensions/api/v2/views/vouchers.py
@@ -151,45 +151,20 @@ class VoucherViewSet(NonDestroyableModelViewSet):
         stock_records = StockRecord.objects.filter(product__in=products)
         return products, stock_records, course_run_metadata
 
-    def get_offers_from_catalog(self, request, voucher, catalog_query, enterprise_catalog):
-        """ Helper method for collecting offers from catalog query or enterprise catalog.
-
-        Args:
-            request (WSGIRequest): Request data.
-            voucher (Voucher): Oscar Voucher for which the offers are returned.
-            catalog_query (str): The query for the Course Discovery.
-
-        Returns:
-            A list of dictionaries with retrieved offers and a link to the next
-            page of the Course Discovery results.
-            """
+    def convert_catalog_response_to_offers(self, request, voucher, response):
         offers = []
         benefit = voucher.best_offer.benefit
-        course_seat_types = benefit.range.course_seat_types
+        # default course_seat_types value to all paid seat types.
+        course_seat_types = 'verified,professional,credit'
+        if benefit.range and benefit.range.course_seat_types:
+            course_seat_types = benefit.range.course_seat_types
         multiple_credit_providers = False
         credit_provider_price = None
-        response = {}
 
-        if enterprise_catalog:
-            response = get_enterprise_catalog(
-                site=request.site,
-                enterprise_catalog=enterprise_catalog,
-                limit=request.GET.get('limit', DEFAULT_CATALOG_PAGE_SIZE),
-                page=request.GET.get('page'),
-            )
-        elif catalog_query:
-            response = get_catalog_course_runs(
-                site=request.site,
-                query=catalog_query,
-                limit=request.GET.get('limit', DEFAULT_CATALOG_PAGE_SIZE),
-                offset=request.GET.get('offset'),
-            )
-
-        next_page = response['next']
         products, stock_records, course_run_metadata = self.retrieve_course_objects(
             response['results'], course_seat_types
         )
-        contains_verified_course = (course_seat_types == 'verified')
+        contains_verified_course = ('verified' in course_seat_types)
         for product in products:
             # Omit unavailable seats from the offer results so that one seat does not cause an
             # error message for every seat in the query result.
@@ -240,6 +215,60 @@ class VoucherViewSet(NonDestroyableModelViewSet):
                     voucher=voucher
                 ))
 
+        return offers
+
+    def get_offers_from_catalog(self, request, voucher):
+        """ Helper method for collecting offers from catalog query or enterprise catalog.
+
+        Args:
+            request (WSGIRequest): Request data.
+            voucher (Voucher): Oscar Voucher for which the offers are returned.
+
+        Returns:
+            A list of dictionaries with retrieved offers and a link to the next
+            page of the Course Discovery results.
+            """
+        benefit = voucher.best_offer.benefit
+        condition = voucher.best_offer.condition
+
+        # Pull all catalog related data from the offer.
+        catalog_query = benefit.range.catalog_query if benefit.range else None
+        catalog_id = benefit.range.course_catalog if benefit.range else None
+        enterprise_catalog = (condition.enterprise_customer_catalog_uuid or
+                              (benefit.range and benefit.range.enterprise_customer_catalog))
+
+        if catalog_id:
+            catalog = fetch_course_catalog(request.site, catalog_id)
+            catalog_query = catalog.get("query") if catalog else catalog_query
+
+        # There is no catalog related data specified for this condition, so return None.
+        if not catalog_query and not enterprise_catalog:
+            return None, None
+
+        if enterprise_catalog:
+            response = get_enterprise_catalog(
+                site=request.site,
+                enterprise_catalog=enterprise_catalog,
+                limit=request.GET.get('limit', DEFAULT_CATALOG_PAGE_SIZE),
+                page=request.GET.get('page'),
+            )
+        elif catalog_query:
+            response = get_catalog_course_runs(
+                site=request.site,
+                query=catalog_query,
+                limit=request.GET.get('limit', DEFAULT_CATALOG_PAGE_SIZE),
+                offset=request.GET.get('offset'),
+            )
+        else:
+            logger.warning(
+                'User is trying to redeem Voucher %s, but no catalog information is configured!',
+                voucher.code
+            )
+            return [], None
+
+        next_page = response['next']
+        offers = self.convert_catalog_response_to_offers(request, voucher, response)
+
         return offers, next_page
 
     def get_offers(self, request, voucher):
@@ -252,20 +281,9 @@ class VoucherViewSet(NonDestroyableModelViewSet):
             dict: Dictionary containing a link to the next page of Course Discovery results and
                   a List of course offers where each offer is represented as a dictionary.
         """
-        benefit = voucher.best_offer.benefit
-        catalog_query = benefit.range.catalog_query
-        catalog_id = benefit.range.course_catalog
-        enterprise_catalog = benefit.range.enterprise_customer_catalog
-        next_page = None
-        offers = []
-
-        if catalog_id:
-            catalog = fetch_course_catalog(request.site, catalog_id)
-            catalog_query = catalog.get("query") if catalog else catalog_query
-
-        if catalog_query or enterprise_catalog:
-            offers, next_page = self.get_offers_from_catalog(request, voucher, catalog_query, enterprise_catalog)
-        else:
+        offers, next_page = self.get_offers_from_catalog(request, voucher)
+        if offers is None:
+            offers = []
             product_range = voucher.best_offer.benefit.range
             products = product_range.all_products()
             if products:
@@ -279,7 +297,7 @@ class VoucherViewSet(NonDestroyableModelViewSet):
 
             if course_info:
                 offers.append(self.get_course_offer_data(
-                    benefit=benefit,
+                    benefit=voucher.best_offer.benefit,
                     course=course,
                     course_info=course_info,
                     credit_provider_price=None,

--- a/ecommerce/extensions/test/factories.py
+++ b/ecommerce/extensions/test/factories.py
@@ -7,6 +7,7 @@ from oscar.test.factories import ConditionalOfferFactory as BaseConditionalOffer
 from oscar.test.factories import VoucherFactory as BaseVoucherFactory
 from oscar.test.factories import *  # pylint:disable=wildcard-import,unused-wildcard-import
 
+from ecommerce.enterprise.benefits import BENEFIT_MAP as ENTERPRISE_BENEFIT_MAP
 from ecommerce.enterprise.benefits import EnterpriseAbsoluteDiscountBenefit, EnterprisePercentageDiscountBenefit
 from ecommerce.enterprise.conditions import EnterpriseCustomerCondition
 from ecommerce.extensions.offer.models import OFFER_PRIORITY_ENTERPRISE, OFFER_PRIORITY_VOUCHER
@@ -106,7 +107,7 @@ def prepare_voucher(code='COUPONTEST', _range=None, start_datetime=None, end_dat
         usage=usage
     )
     benefit = BenefitFactory(type=benefit_type, range=_range, value=benefit_value)
-    condition = ConditionFactory(value=1, range=_range)
+    condition = ConditionFactory(value=1, range=_range, enterprise_customer_uuid=enterprise_customer)
     if max_usage:
         offer = ConditionalOfferFactory(
             offer_type=ConditionalOffer.VOUCHER,
@@ -127,6 +128,39 @@ def prepare_voucher(code='COUPONTEST', _range=None, start_datetime=None, end_dat
         )
     voucher.offers.add(offer)
     return voucher, product
+
+
+def prepare_enterprise_voucher(code='COUPONTEST', start_datetime=None, end_datetime=None, benefit_value=100,
+                               benefit_type=Benefit.PERCENTAGE, usage=Voucher.SINGLE_USE,
+                               enterprise_customer=None, enterprise_customer_catalog=None):
+    """ Helper function to create a voucher and add an enterprise conditional offer to it. """
+    if start_datetime is None:
+        start_datetime = now() - datetime.timedelta(days=1)
+
+    if end_datetime is None:
+        end_datetime = now() + datetime.timedelta(days=10)
+
+    voucher = VoucherFactory(
+        code=code,
+        start_datetime=start_datetime,
+        end_datetime=end_datetime,
+        usage=usage
+    )
+    benefit = BenefitFactory(proxy_class=class_path(ENTERPRISE_BENEFIT_MAP[benefit_type]), value=benefit_value)
+    condition = ConditionFactory(
+        proxy_class=class_path(EnterpriseCustomerCondition),
+        enterprise_customer_uuid=enterprise_customer,
+        enterprise_customer_catalog_uuid=enterprise_customer_catalog,
+    )
+    offer = ConditionalOfferFactory(
+        offer_type=ConditionalOffer.VOUCHER,
+        benefit=benefit,
+        condition=condition,
+        priority=OFFER_PRIORITY_VOUCHER
+    )
+
+    voucher.offers.add(offer)
+    return voucher
 
 
 class VoucherFactory(BaseVoucherFactory):  # pylint: disable=function-redefined

--- a/ecommerce/extensions/voucher/tests/test_models.py
+++ b/ecommerce/extensions/voucher/tests/test_models.py
@@ -4,9 +4,13 @@ import ddt
 from django.core.exceptions import ValidationError
 from django.utils.timezone import now
 from oscar.core.loading import get_model
+from waffle.models import Switch
+from ecommerce.enterprise.constants import ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH
+from ecommerce.extensions.test import factories
 
 from ecommerce.tests.testcases import TestCase
 
+ConditionalOffer = get_model('offer', 'ConditionalOffer')
 Voucher = get_model('voucher', 'Voucher')
 
 
@@ -58,3 +62,26 @@ class VoucherTests(TestCase):
         self.data['start_datetime'] = self.data['end_datetime'] + datetime.timedelta(days=1)
         with self.assertRaises(ValidationError):
             Voucher.objects.create(**self.data)
+
+    def test_best_offer(self):
+        voucher = Voucher.objects.create(**self.data)
+        first_offer = factories.ConditionalOfferFactory()
+        voucher.offers.add(first_offer)
+        # Test that with the switch off, the offer gets returned.
+        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': False})
+        assert voucher.best_offer == first_offer
+        # Test that with the switch on, the same offer gets returned.
+        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': True})
+        assert voucher.best_offer == first_offer
+        # Now add a second enterprise offer, and see that with the switch on, the enterprise offer gets returned.
+        second_offer = factories.EnterpriseOfferFactory()
+        voucher.offers.add(second_offer)
+        assert voucher.best_offer == second_offer
+        # Add a third enterprise offer, and see that the original offer gets returned
+        # because of multiple enterprise offers being available, which is unexpected data.
+        third_offer = factories.EnterpriseOfferFactory()
+        voucher.offers.add(third_offer)
+        assert voucher.best_offer == first_offer
+        # Turn the switch off and see that the oldest offer gets returned.
+        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': False})
+        assert voucher.best_offer == first_offer


### PR DESCRIPTION
**Description**
This PR depends on https://github.com/edx/ecommerce/pull/1925
Now that all coupons associated with an enterprise have both regular offer and enterprise offer data available, we need to introduce the ability to use the enterprise offer data when redeeming enterprise coupon vouchers.
This PR introduces a waffle switch that controls which offer to use for redemption logic when a voucher contains enterprise offer data. If the switch is off, the system will behave as it has, using the existing offer and ignoring any enterprise offers. If the switch is on, the system will use the enterprise conditional offer if it is available.
We should flip this switch when we have migrated the enterprise coupon data to be fully supported for this feature set. In particular, we will start to enforce that enterprise catalog is required for enterprise coupons.

**Test Plan**
This is currently deployed on the business sandbox, and the migration introducing the waffle switch has already been run.

With the waffle switch off:

- Test that non-enterprise coupons can be redeemed as expected. (https://ecommerce-business.sandbox.edx.org/coupons/offer/?code=10OFF)
- Test that enterprise offers (applied for enterprise customers with SSO integration) are applied as expected. (https://business.sandbox.edx.org/enterprise/d583b097-7bd9-4a7e-a98d-c15dea220354/course/course-v1:NYIF+CM2.x+3T2017/enroll/?catalog=e1a27c18-b612-4c67-a5f5-9ad0cba993d5&utm_medium=enterprise&utm_source=successfactors)
- Test that the appropriate courses are displayed on the offers page for an enterprise coupon (https://ecommerce-business.sandbox.edx.org/coupons/offer/?code=PIPNJSUK33P7PTZH)
, regardless of if an enterprise catalog is configured. If one isn't configured (https://ecommerce-business.sandbox.edx.org/coupons/offer/?code=RNBL737ZAUJXUM6E), the catalog query or catalog id option should be used to populate the list of offers.
- Test that enterprise coupons can be redeemed as expected through the coupon redemption link, and that the offer applications are being made against the regular conditional offer.
- Test that enterprise coupons can be redeemed as expected by applying a code on the basket page, and that the offer applications are being made against the regular conditional offer.

With the waffle switch on:

- Test that non-enterprise coupons can be redeemed as expected.
- Test that enterprise offers are applied as expected.
- Test that the appropriate courses are displayed on the offers page for an enterprise coupon, only if an enterprise catalog is configured. If one isn't configured, there should be no available courses for the coupon.
- Test that enterprise coupons can be redeemed as expected through the coupon redemption link, and that the offer applications are being made against the enterprise conditional offer.
- Test that enterprise coupons can be redeemed as expected by applying a code on the basket page, and that the offer applications are being made against the enterprise conditional offer.