### PR TITLE
Remove broken selenium tests

### DIFF
--- a/ecommerce/extensions/dashboard/refunds/tests/test_acceptance.py
+++ b/ecommerce/extensions/dashboard/refunds/tests/test_acceptance.py
@@ -12,7 +12,6 @@ from selenium.webdriver.support.wait import WebDriverWait
 
 from ecommerce.extensions.refund.status import REFUND
 from ecommerce.extensions.refund.tests.mixins import RefundTestMixin
-from ecommerce.tests.testcases import LiveServerTestCase
 
 Refund = get_model('refund', 'Refund')
 
@@ -211,19 +210,3 @@ class RefundAcceptanceTestMixin(RefundTestMixin):
                 self.selenium.find_element_by_css_selector,
                 self.deny_button_selector
             )
-
-
-class RefundListViewTests(RefundAcceptanceTestMixin, LiveServerTestCase):
-    """Acceptance tests of the refund list view."""
-
-    def setUp(self):
-        super(RefundListViewTests, self).setUp()
-        self.path = reverse('dashboard:refunds:list')
-
-
-class RefundDetailViewTests(RefundAcceptanceTestMixin, LiveServerTestCase):
-    """Acceptance tests of the refund detail view."""
-
-    def setUp(self):
-        super(RefundDetailViewTests, self).setUp()
-        self.path = reverse('dashboard:refunds:detail', args=[self.refund.id])


### PR DESCRIPTION
Remove the 8 tests that rely on WebDriver due to a sudden failure we seem to have inherited from the Firefox implementation of WebDriver.  Details on what these tests were doing, in case we want to test these things manually, are captured in the following ticket:
https://openedx.atlassian.net/projects/EG/issues/EG-38
