### PR TITLE
ENT-1248/ENT-1267 Introduce waffle flag for using enterprise conditions

### DIFF
--- a/ecommerce/coupons/tests/mixins.py
+++ b/ecommerce/coupons/tests/mixins.py
@@ -424,9 +424,9 @@ class CouponMixin(SiteMixin):
 
         return pc
 
-    def create_coupon(self, benefit_type=Benefit.PERCENTAGE, benefit_value=100, catalog=None,
-                      catalog_query=None, client=None, code='', course_seat_types=None, email_domains=None,
-                      enterprise_customer=None, max_uses=None, note=None, partner=None, price=100, quantity=5,
+    def create_coupon(self, benefit_type=Benefit.PERCENTAGE, benefit_value=100, catalog=None, catalog_query=None,
+                      client=None, code='', course_seat_types=None, email_domains=None, enterprise_customer=None,
+                      enterprise_customer_catalog=None, max_uses=None, note=None, partner=None, price=100, quantity=5,
                       title='Test coupon', voucher_type=Voucher.SINGLE_USE, course_catalog=None, program_uuid=None):
         """Helper method for creating a coupon.
 
@@ -440,6 +440,7 @@ class CouponMixin(SiteMixin):
             course_catalog (int): Course catalog id from Discovery Service
             course_seat_types(str): A string of comma-separated list of seat types
             enterprise_customer (str): Hex-encoded UUID for an Enterprise Customer object from the Enterprise app.
+            enterprise_customer_catalog (str): UUID for an Enterprise Customer Catalog from the Enterprise app.
             email_domains(str): A comma seperated list of email domains
             max_uses (int): Number of Voucher max uses
             note (str): Coupon note.
@@ -458,7 +459,8 @@ class CouponMixin(SiteMixin):
             partner = PartnerFactory(name='Tester')
         if client is None:
             client, __ = BusinessClient.objects.get_or_create(name='Test Client')
-        if catalog is None and not ((catalog_query or course_catalog or program_uuid) and course_seat_types):
+        if (catalog is None and not enterprise_customer_catalog and not
+                ((catalog_query or course_catalog or program_uuid) and course_seat_types)):
             catalog = Catalog.objects.create(partner=partner)
         if code is not '':
             quantity = 1
@@ -479,7 +481,7 @@ class CouponMixin(SiteMixin):
                 email_domains=email_domains,
                 end_datetime=datetime.datetime(2020, 1, 1),
                 enterprise_customer=enterprise_customer,
-                enterprise_customer_catalog=None,
+                enterprise_customer_catalog=enterprise_customer_catalog,
                 max_uses=max_uses,
                 note=note,
                 partner=partner,

--- a/ecommerce/enterprise/benefits.py
+++ b/ecommerce/enterprise/benefits.py
@@ -32,3 +32,14 @@ class EnterpriseAbsoluteDiscountBenefit(BenefitWithoutRangeMixin, AbsoluteBenefi
     @property
     def name(self):
         return _('{value} fixed-price enterprise discount').format(value=self.value)
+
+
+# constants related to enterprise benefits
+BENEFIT_MAP = {
+    Benefit.FIXED: EnterpriseAbsoluteDiscountBenefit,
+    Benefit.PERCENTAGE: EnterprisePercentageDiscountBenefit,
+}
+BENEFIT_TYPE_CHOICES = (
+    (Benefit.PERCENTAGE, _('Percentage')),
+    (Benefit.FIXED, _('Absolute')),
+)

--- a/ecommerce/enterprise/constants.py
+++ b/ecommerce/enterprise/constants.py
@@ -1,18 +1,5 @@
-from django.utils.translation import ugettext_lazy as _
-from oscar.core.loading import get_model
-
-from ecommerce.enterprise.benefits import EnterpriseAbsoluteDiscountBenefit, EnterprisePercentageDiscountBenefit
-
-Benefit = get_model('offer', 'Benefit')
-
-BENEFIT_MAP = {
-    Benefit.FIXED: EnterpriseAbsoluteDiscountBenefit,
-    Benefit.PERCENTAGE: EnterprisePercentageDiscountBenefit,
-}
-BENEFIT_TYPE_CHOICES = (
-    (Benefit.PERCENTAGE, _('Percentage')),
-    (Benefit.FIXED, _('Absolute')),
-)
-
 # Waffle switch used to enable/disable Enterprise offers.
 ENTERPRISE_OFFERS_SWITCH = 'enable_enterprise_offers'
+
+# Waffle switch used to enable/disable using Enterprise Offers for Coupons.
+ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH = 'enable_enterprise_offers_for_coupons'

--- a/ecommerce/enterprise/entitlements.py
+++ b/ecommerce/enterprise/entitlements.py
@@ -208,7 +208,7 @@ def get_available_voucher_for_product(request, product, vouchers):
         if is_valid_voucher:
             voucher_offer = voucher.best_offer
             offer_range = voucher_offer.condition.range
-            if offer_range.contains_product(product):
+            if offer_range and offer_range.contains_product(product):
                 return voucher
 
     # Explicitly return None in case product has no valid voucher

--- a/ecommerce/enterprise/forms.py
+++ b/ecommerce/enterprise/forms.py
@@ -5,8 +5,8 @@ from django.forms.utils import ErrorList
 from django.utils.translation import ugettext_lazy as _
 from oscar.core.loading import get_model
 
+from ecommerce.enterprise.benefits import BENEFIT_MAP, BENEFIT_TYPE_CHOICES
 from ecommerce.enterprise.conditions import EnterpriseCustomerCondition
-from ecommerce.enterprise.constants import BENEFIT_MAP, BENEFIT_TYPE_CHOICES
 from ecommerce.enterprise.utils import get_enterprise_customer
 from ecommerce.extensions.offer.models import OFFER_PRIORITY_ENTERPRISE
 from ecommerce.programs.custom import class_path, create_condition

--- a/ecommerce/enterprise/management/commands/migrate_enterprise_conditional_offers.py
+++ b/ecommerce/enterprise/management/commands/migrate_enterprise_conditional_offers.py
@@ -9,8 +9,8 @@ from time import sleep
 from django.contrib.sites.models import Site
 from django.core.management import BaseCommand
 
+from ecommerce.enterprise.benefits import BENEFIT_MAP
 from ecommerce.enterprise.conditions import EnterpriseCustomerCondition
-from ecommerce.enterprise.constants import BENEFIT_MAP
 from ecommerce.enterprise.utils import get_enterprise_customer
 from ecommerce.extensions.voucher.models import Voucher
 from ecommerce.programs.custom import class_path, get_model

--- a/ecommerce/enterprise/migrations/0004_add_enterprise_offers_for_coupons.py
+++ b/ecommerce/enterprise/migrations/0004_add_enterprise_offers_for_coupons.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from ecommerce.enterprise.constants import ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH
+
+
+def create_switch(apps, schema_editor):
+    """Create the `enable_enterprise_on_runtime` switch if it does not already exist."""
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': False})
+
+
+def delete_switch(apps, schema_editor):
+    """Delete the `enable_enterprise_on_runtime` switch."""
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.filter(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('enterprise', '0003_add_enable_enterprise_switch'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_switch, delete_switch)
+    ]

--- a/ecommerce/enterprise/tests/test_conditions.py
+++ b/ecommerce/enterprise/tests/test_conditions.py
@@ -7,7 +7,7 @@ from oscar.core.loading import get_model
 from waffle.models import Switch
 
 from ecommerce.courses.tests.factories import CourseFactory
-from ecommerce.enterprise.constants import ENTERPRISE_OFFERS_SWITCH
+from ecommerce.enterprise.constants import ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, ENTERPRISE_OFFERS_SWITCH
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
 from ecommerce.extensions.basket.utils import basket_add_enterprise_catalog_attribute
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
@@ -129,9 +129,7 @@ class EnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, DiscoveryTest
         )
         self.assertFalse(self.condition.is_satisfied(offer, basket))
 
-    @httpretty.activate
-    def test_is_satisfied_false_for_voucher_offer(self):
-        """ Ensure the condition returns false for a coupon with an enterprise conditional offer. """
+    def setup_enterprise_coupon_data(self, mock_learner_api=True):
         offer = factories.EnterpriseOfferFactory(
             partner=self.partner,
             condition=self.condition,
@@ -139,17 +137,42 @@ class EnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, DiscoveryTest
         )
         basket = factories.BasketFactory(site=self.site, owner=self.user)
         basket.add_product(self.course_run.seat_products[0])
-        self.mock_enterprise_learner_api(
-            learner_id=self.user.id,
-            enterprise_customer_uuid=str(self.condition.enterprise_customer_uuid),
-            course_run_id=self.course_run.id,
-        )
+        if mock_learner_api:
+            self.mock_enterprise_learner_api(
+                learner_id=self.user.id,
+                enterprise_customer_uuid=str(self.condition.enterprise_customer_uuid),
+                course_run_id=self.course_run.id,
+            )
+        else:
+            self.mock_enterprise_learner_api_for_learner_with_no_enterprise()
+
         self.mock_catalog_contains_course_runs(
             [self.course_run.id],
             self.condition.enterprise_customer_uuid,
             enterprise_customer_catalog_uuid=self.condition.enterprise_customer_catalog_uuid,
         )
+        return offer, basket
+
+    @httpretty.activate
+    def test_is_satisfied_false_for_voucher_offer_coupon_switch_off(self):
+        """ Ensure the condition returns false for a coupon with an enterprise conditional offer. """
+        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': False})
+        offer, basket = self.setup_enterprise_coupon_data()
         self.assertFalse(self.condition.is_satisfied(offer, basket))
+
+    @httpretty.activate
+    def test_is_satisfied_true_for_voucher_offer_coupon_switch_on(self):
+        """ Ensure the condition returns true for a coupon with an enterprise conditional offer. """
+        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': True})
+        offer, basket = self.setup_enterprise_coupon_data()
+        self.assertTrue(self.condition.is_satisfied(offer, basket))
+
+    @httpretty.activate
+    def test_is_satisfied_true_for_voucher_offer_coupon_switch_on_new_user(self):
+        """ Ensure the condition returns true for a coupon with an enterprise conditional offer. """
+        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': True})
+        offer, basket = self.setup_enterprise_coupon_data(mock_learner_api=False)
+        self.assertTrue(self.condition.is_satisfied(offer, basket))
 
     def test_is_satisfied_empty_basket(self):
         """ Ensure the condition returns False if the basket is empty. """

--- a/ecommerce/enterprise/tests/test_forms.py
+++ b/ecommerce/enterprise/tests/test_forms.py
@@ -4,7 +4,7 @@ import uuid
 import httpretty
 from oscar.core.loading import get_model
 
-from ecommerce.enterprise.constants import BENEFIT_MAP
+from ecommerce.enterprise.benefits import BENEFIT_MAP
 from ecommerce.enterprise.forms import EnterpriseOfferForm
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
 from ecommerce.extensions.offer.models import OFFER_PRIORITY_ENTERPRISE

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -60,7 +60,12 @@ def is_enrollment_code(obj):
 
 def retrieve_benefit(obj):
     """Helper method to retrieve the benefit from voucher. """
-    return retrieve_voucher(obj).benefit
+    return retrieve_offer(obj).benefit
+
+
+def retrieve_condition(obj):
+    """Helper method to retrieve the benefit from voucher. """
+    return retrieve_offer(obj).condition
 
 
 def retrieve_end_date(obj):
@@ -686,12 +691,24 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
     def get_enterprise_customer(self, obj):
         """ Get the Enterprise Customer UUID attached to a coupon. """
         offer_range = retrieve_range(obj)
-        return offer_range.enterprise_customer if offer_range else None
+        offer_condition = retrieve_condition(obj)
+        if offer_range and offer_range.enterprise_customer:
+            return offer_range.enterprise_customer
+        elif offer_condition.enterprise_customer_uuid:
+            return offer_condition.enterprise_customer_uuid
+        else:
+            return None
 
     def get_enterprise_customer_catalog(self, obj):
         """ Get the Enterprise Customer Catalog UUID attached to a coupon. """
         offer_range = retrieve_range(obj)
-        return offer_range.enterprise_customer_catalog if offer_range else None
+        offer_condition = retrieve_condition(obj)
+        if offer_range and offer_range.enterprise_customer_catalog:
+            return offer_range.enterprise_customer_catalog
+        elif offer_condition.enterprise_customer_catalog_uuid:
+            return offer_condition.enterprise_customer_catalog_uuid
+        else:
+            return None
 
     def get_last_edited(self, obj):
         return None, obj.date_updated

--- a/ecommerce/extensions/voucher/tests/test_models.py
+++ b/ecommerce/extensions/voucher/tests/test_models.py
@@ -4,9 +4,13 @@ import ddt
 from django.core.exceptions import ValidationError
 from django.utils.timezone import now
 from oscar.core.loading import get_model
+from waffle.models import Switch
+from ecommerce.enterprise.constants import ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH
+from ecommerce.extensions.test import factories
 
 from ecommerce.tests.testcases import TestCase
 
+ConditionalOffer = get_model('offer', 'ConditionalOffer')
 Voucher = get_model('voucher', 'Voucher')
 
 
@@ -58,3 +62,26 @@ class VoucherTests(TestCase):
         self.data['start_datetime'] = self.data['end_datetime'] + datetime.timedelta(days=1)
         with self.assertRaises(ValidationError):
             Voucher.objects.create(**self.data)
+
+    def test_best_offer(self):
+        voucher = Voucher.objects.create(**self.data)
+        first_offer = factories.ConditionalOfferFactory()
+        voucher.offers.add(first_offer)
+        # Test that with the switch off, the offer gets returned.
+        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': False})
+        assert voucher.best_offer == first_offer
+        # Test that with the switch on, the same offer gets returned.
+        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': True})
+        assert voucher.best_offer == first_offer
+        # Now add a second enterprise offer, and see that with the switch on, the enterprise offer gets returned.
+        second_offer = factories.EnterpriseOfferFactory()
+        voucher.offers.add(second_offer)
+        assert voucher.best_offer == second_offer
+        # Add a third enterprise offer, and see that the original offer gets returned
+        # because of multiple enterprise offers being available, which is unexpected data.
+        third_offer = factories.EnterpriseOfferFactory()
+        voucher.offers.add(third_offer)
+        assert voucher.best_offer == first_offer
+        # Turn the switch off and see that the oldest offer gets returned.
+        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': False})
+        assert voucher.best_offer == first_offer

--- a/ecommerce/extensions/voucher/tests/test_views.py
+++ b/ecommerce/extensions/voucher/tests/test_views.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 import httpretty
 from django.test import RequestFactory
 from oscar.core.loading import get_model
@@ -38,6 +40,11 @@ class CouponReportCSVViewTest(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, 
         catalog2 = Catalog.objects.create(name="Test catalog 2", partner=partner2)
         catalog2.stock_records.add(self.stock_record)
         self.coupon2 = self.create_coupon(partner=partner2, catalog=catalog2)
+        self.coupon3 = self.create_coupon(
+            partner=partner1,
+            enterprise_customer=str(uuid4()),
+            enterprise_customer_catalog=str(uuid4())
+        )
 
     def request_specific_voucher_report(self, coupon):
         client = factories.UserFactory()
@@ -59,6 +66,7 @@ class CouponReportCSVViewTest(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, 
         self.mock_course_api_response(course=self.course)
         self.request_specific_voucher_report(self.coupon1)
         self.request_specific_voucher_report(self.coupon2)
+        self.request_specific_voucher_report(self.coupon3)
 
     def test_report_missing_stockrecord_raises_http404(self):
         """ Verify that Http404 is raised when no StockRecord for coupon """


### PR DESCRIPTION
**Description**
This PR depends on https://github.com/edx/ecommerce/pull/1925
Now that all coupons associated with an enterprise have both regular offer and enterprise offer data available, we need to introduce the ability to use the enterprise offer data when redeeming enterprise coupon vouchers.
This PR introduces a waffle switch that controls which offer to use for redemption logic when a voucher contains enterprise offer data. If the switch is off, the system will behave as it has, using the existing offer and ignoring any enterprise offers. If the switch is on, the system will use the enterprise conditional offer if it is available.
We should flip this switch when we have migrated the enterprise coupon data to be fully supported for this feature set. In particular, we will start to enforce that enterprise catalog is required for enterprise coupons.

**Test Plan**
This is currently deployed on the business sandbox, and the migration introducing the waffle switch has already been run.

With the waffle switch off:

- Test that non-enterprise coupons can be redeemed as expected. (https://ecommerce-business.sandbox.edx.org/coupons/offer/?code=10OFF)
- Test that enterprise offers (applied for enterprise customers with SSO integration) are applied as expected. (https://business.sandbox.edx.org/enterprise/d583b097-7bd9-4a7e-a98d-c15dea220354/course/course-v1:NYIF+CM2.x+3T2017/enroll/?catalog=e1a27c18-b612-4c67-a5f5-9ad0cba993d5&utm_medium=enterprise&utm_source=successfactors)
- Test that the appropriate courses are displayed on the offers page for an enterprise coupon (https://ecommerce-business.sandbox.edx.org/coupons/offer/?code=PIPNJSUK33P7PTZH)
, regardless of if an enterprise catalog is configured. If one isn't configured (https://ecommerce-business.sandbox.edx.org/coupons/offer/?code=RNBL737ZAUJXUM6E), the catalog query or catalog id option should be used to populate the list of offers.
- Test that enterprise coupons can be redeemed as expected through the coupon redemption link, and that the offer applications are being made against the regular conditional offer.
- Test that enterprise coupons can be redeemed as expected by applying a code on the basket page, and that the offer applications are being made against the regular conditional offer.

With the waffle switch on:

- Test that non-enterprise coupons can be redeemed as expected.
- Test that enterprise offers are applied as expected.
- Test that the appropriate courses are displayed on the offers page for an enterprise coupon, only if an enterprise catalog is configured. If one isn't configured, there should be no available courses for the coupon.
- Test that enterprise coupons can be redeemed as expected through the coupon redemption link, and that the offer applications are being made against the enterprise conditional offer.
- Test that enterprise coupons can be redeemed as expected by applying a code on the basket page, and that the offer applications are being made against the enterprise conditional offer.