### PR TITLE
LEARNER-6478 fixed bug

### DIFF
--- a/ecommerce/management/tests/test_utils.py
+++ b/ecommerce/management/tests/test_utils.py
@@ -1,5 +1,3 @@
-import json
-
 import mock
 from django.db import transaction
 from django.test import override_settings
@@ -65,7 +63,7 @@ class FulfillFrozenBasketsTests(TestCase):
         basket.status = 'Frozen'
         basket.save()
         PaymentProcessorResponse.objects.create(basket=basket, transaction_id='PAY-123', processor_name='paypal',
-                                                response=json.dumps({'state': 'approved'}))
+                                                response={'state': 'approved'})
         return basket
 
     @staticmethod
@@ -95,7 +93,7 @@ class FulfillFrozenBasketsTests(TestCase):
             u'decision': u'ACCEPT',
         }
         PaymentProcessorResponse.objects.create(basket=basket, transaction_id='abc', processor_name='cybersource',
-                                                response=json.dumps(response))
+                                                response=response)
         assert FulfillFrozenBaskets().fulfill_basket(basket.id, self.site)
 
         order = Order.objects.get(number=basket.order_number)
@@ -128,7 +126,7 @@ class FulfillFrozenBasketsTests(TestCase):
         """ Test utility against multiple payment processor responses."""
         basket = self._dummy_basket_data()
         PaymentProcessorResponse.objects.create(basket=basket, transaction_id='abc', processor_name='cybersource',
-                                                response=json.dumps({u'decision': u'ACCEPT'}))
+                                                response={u'decision': u'ACCEPT'})
         assert FulfillFrozenBaskets().fulfill_basket(basket.id, self.site)
 
     def test_no_successful_transaction(self):
@@ -219,6 +217,6 @@ class FulfillFrozenBasketsTests(TestCase):
         basket.save()
 
         PaymentProcessorResponse.objects.create(basket=basket, transaction_id='PAY-123', processor_name='paypal',
-                                                response=json.dumps({'state': 'approved'}))
+                                                response={'state': 'approved'})
         with mock.patch('oscar.apps.offer.applicator.Applicator.apply', side_effect=ValueError):
             assert FulfillFrozenBaskets().fulfill_basket(basket.id, self.site)


### PR DESCRIPTION
Fix the following bug.
`Traceback (most recent call last):
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
    response = self._get_response(request)
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/django/utils/decorators.py", line 185, in inner
    return func(*args, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/newrelic/hooks/framework_django.py", line 544, in wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/django/views/generic/base.py", line 68, in view
    return self.dispatch(request, *args, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/django/contrib/auth/mixins.py", line 56, in dispatch
    return super(LoginRequiredMixin, self).dispatch(request, *args, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/django/contrib/auth/mixins.py", line 116, in dispatch
    return super(UserPassesTestMixin, self).dispatch(request, *args, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/newrelic/hooks/framework_django.py", line 940, in wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/django/views/generic/base.py", line 88, in dispatch
    return handler(request, *args, **kwargs)
  File "/edx/app/ecommerce/ecommerce/ecommerce/management/views.py", line 44, in post
    fulfilled = FulfillFrozenBaskets().fulfill_basket(basket_id=basket_id, site=request.site)
  File "/edx/app/ecommerce/ecommerce/ecommerce/management/utils.py", line 136, in fulfill_basket
    card_number=json.loads(successful_payment_notification.response).get(
  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
TypeError: expected string or buffer`