### PR TITLE
Change geckodriver version to be able to install it behind proxy

### DIFF
--- a/docs/install_ecommerce.rst
+++ b/docs/install_ecommerce.rst
@@ -28,6 +28,14 @@ Set Up a Virtual Environment
 
    For more information, see `Virtual Environments`_.
 
+#. (Optional) If your server is behind a proxy, set the `GECKODRIVER_CDNURL`
+   in your environment. You need to download `geckodriver` first and
+   place it in a server inside your network:
+
+   [Download according to your server specifications](https://github.com/vladikoff/node-geckodriver/blob/v1.7.1/index.js#L19-L23)
+
+   Add the `GECKODRIVER_CDNURL` setting to the `/etc/environment` file.
+
 #. Run the following command to install dependencies.
 
    .. code-block:: bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1585,8 +1585,8 @@
       }
     },
     "geckodriver": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-1.6.1.tgz",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-1.7.1.tgz",
       "integrity": "sha1-Bqxo1X+qxyNFxZDB3ScwWd+QqfE=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "apple-pay-js-stubs": "1.0.4",
     "eslint": "3.19.0",
     "eslint-config-edx-es5": "3.0.0",
-    "geckodriver": "1.6.1",
+    "geckodriver": "1.7.1",
     "gulp": "3.9.1",
     "gulp-eslint": "3.0.1",
     "jasmine-core": "2.6.1",


### PR DESCRIPTION
Following PR #1954

@natabene 

Ecommerce has a dependency with `geckodriver`. This library uses `got` dependency to download its `.tar.gz` file. The `got` dependency does not work behind a proxy. So the installation of ecommerce fails with:

```
RequestError: connect ECONNREFUSED 192.30.253.113:443
    at ClientRequest.<anonymous> (/edx/app/ecommerce/ecommerce/node_modules/got/index.js:69:21)
```

The `got` developers does not have in their roadmap to make it work behind proxy: https://github.com/sindresorhus/got/issues/560

> Proxy support is really hard to get right and not something I'm interested in spending time on and I don't want to bloat Got with dependencies to support it.

The `geckodriver` version used in `open-release/hawthorn.master` is `1.6.1`, where the download is made by one of these URLs:
https://github.com/vladikoff/node-geckodriver/blob/v1.6.1/index.js#L14-L18

In the version `1.7.1` of `geckodriver`, the URL is configurable:
https://github.com/vladikoff/node-geckodriver/blob/v1.7.1/index.js#L14-L23

The workaround to fix ecommerce installation behind proxy is to upgrade `geckodriver` to `1.7.1`. The process of installation should be downloading the `geckodriver` first to the same network as the proxy, place the file in a URL the server can access and define `GECKODRIVER_CDNURL` in the environment before installing it.

I've made this PR to `master`, but I would like this to be cherry-picked to `open-release/hawthorn.master`  if possible, because our installation is made behind proxy. Without this fix, we can not install Open edX at all. Is it possible to contribute it to Hawthorn?