### PR TITLE
LEARNER-6578 Fix

### DIFF
--- a/ecommerce/programs/conditions.py
+++ b/ecommerce/programs/conditions.py
@@ -118,7 +118,7 @@ class ProgramCourseRunSeatsCondition(SingleItemConsumptionConditionMixin, Condit
         except (HttpNotFoundError, SlumberBaseException, Timeout):
             return False
 
-        if program:
+        if program and program['status'] == 'active':
             applicable_seat_types = program['applicable_seat_types']
         else:
             return False

--- a/ecommerce/programs/tests/mixins.py
+++ b/ecommerce/programs/tests/mixins.py
@@ -13,7 +13,7 @@ from ecommerce.tests.factories import PartnerFactory
 
 class ProgramTestMixin(DiscoveryTestMixin):
     def mock_program_detail_endpoint(self, program_uuid, discovery_api_url, empty=False, title='Test Program',
-                                     include_entitlements=True):
+                                     include_entitlements=True, status='active'):
         """ Mocks the program detail endpoint on the Catalog API.
         Args:
             program_uuid (uuid): UUID of the mocked program.
@@ -59,6 +59,7 @@ class ProgramTestMixin(DiscoveryTestMixin):
             data = {
                 'uuid': program_uuid,
                 'title': title,
+                'status': status,
                 'type': 'MicroMockers',
                 'courses': courses,
                 'applicable_seat_types': [


### PR DESCRIPTION
 Program condition is_satisfied will only return true if program is Active.
If courses have multiple programs. Applicators get_offers returns offers for retired programs too. We do not update program_offers to expire. Because of which retired program offers are applied to baskets. In some cases when pcs change those offers to 0 discount. We get in a situation where after first retired program offer we have applied offer with 0 discount but actual offer was skipped. 
ie. this was happening for 
"uuid": "688dbadb-7a4c-4311-b5f3-27948bc2c41b", Expired Program
https://ecommerce.edx.org/programs/offers/19493/edit/

"uuid": "a11c408f-0986-4393-8268-8bc16500cdf3", Active Program 
https://ecommerce.edx.org/programs/offers/20270/edit/

i had to set start date and end data in expired program offer to fix the issue for active program. 