### PR TITLE
ARCH-274: Enhance jwt_decode_handler to handle transition.

### DIFF
--- a/ecommerce/extensions/api/handlers.py
+++ b/ecommerce/extensions/api/handlers.py
@@ -2,25 +2,66 @@
 import logging
 
 import jwt
+import waffle
 from django.conf import settings
+from edx_django_utils import monitoring as monitoring_utils
+from edx_rest_framework_extensions.auth.jwt.decoder import jwt_decode_handler as edx_drf_extensions_jwt_decode_handler
 from rest_framework_jwt.settings import api_settings
 
 logger = logging.getLogger(__name__)
 
+JWT_DECODE_HANDLER_METRIC_KEY = 'ecom_jwt_decode_handler'
 
-def jwt_decode_handler(token):
-    """Attempt to decode the given token with each of the configured JWT issuers.
 
-    Args:
-        token (str): The JWT to decode.
+def _ecommerce_jwt_decode_handler_updated_configs(token):
+    """
+    Same as original with minor modifications to expect
+    configuration format matching the expectations of
+    edx-drf-extensions decoder.
 
-    Returns:
-        dict: The JWT's payload.
+      JWT_AUTH:
+        JWT_ISSUERS:
+          - AUDIENCE: '{{ COMMON_JWT_AUDIENCE }}'
+            ISSUER: '{{ COMMON_JWT_ISSUER }}'
+            SECRET_KEY: '{{ COMMON_JWT_SECRET_KEY }}'
 
-    Raises:
-        InvalidIssuerError: If the issuer claim in the provided token does not match
-            any configured JWT issuers.
-        """
+    """
+    options = {
+        'verify_exp': api_settings.JWT_VERIFY_EXPIRATION,
+        'verify_aud': settings.JWT_AUTH['JWT_VERIFY_AUDIENCE'],
+    }
+
+    # JWT_ISSUERS is not one of DRF-JWT's default settings, and cannot be accessed
+    # using the `api_settings` object without overriding DRF-JWT's defaults.
+    issuers = settings.JWT_AUTH['JWT_ISSUERS']
+
+    # Unlike the original two secret-key/issuer loops, here we have a single
+    # loop because the secret key is now part of the issuer config.
+    for issuer in issuers:
+        try:
+            return jwt.decode(
+                token,
+                issuer['SECRET_KEY'],
+                api_settings.JWT_VERIFY,
+                options=options,
+                leeway=api_settings.JWT_LEEWAY,
+                audience=issuer['AUDIENCE'],
+                issuer=issuer['ISSUER'],
+                algorithms=[api_settings.JWT_ALGORITHM]
+            )
+        except jwt.InvalidIssuerError:
+            # Ignore these errors since we have multiple issuers
+            pass
+        except jwt.DecodeError:
+            # Ignore these errors since we have multiple issuers
+            pass
+        except jwt.InvalidTokenError:
+            logger.exception('Custom config JWT decode failed!')
+
+    raise jwt.InvalidTokenError('All combinations of JWT issuers with updated config failed to validate the token.')
+
+
+def _ecommerce_jwt_decode_handler_original(token):
     options = {
         'verify_exp': api_settings.JWT_VERIFY_EXPIRATION,
         'verify_aud': settings.JWT_AUTH['JWT_VERIFY_AUDIENCE'],
@@ -53,6 +94,57 @@ def jwt_decode_handler(token):
                 # Ignore these errors since we have multiple signing keys
                 pass
             except jwt.InvalidTokenError:
-                logger.exception('JWT decode failed!')
+                logger.exception('Original JWT decode failed!')
 
     raise jwt.InvalidTokenError('All combinations of JWT issuers and secret keys failed to validate the token.')
+
+
+def jwt_decode_handler(token):
+    """Attempt to decode the given token with each of the configured JWT issuers.
+
+    Args:
+        token (str): The JWT to decode.
+
+    Returns:
+        dict: The JWT's payload.
+
+    Raises:
+        InvalidTokenError: If the token is invalid, or if none of the
+            configured issuer/secret-key combos can properly decode the token.
+
+    """
+
+    # The following versions of decoding are part of a larger rollout plan that
+    # will ultimately end in retiring this ecommerce jwt_decode_handler
+    # altogether.  See ARCH-261 for detailed plan.
+
+    # first, try jwt_decode_handler from edx_drf_extensions
+    try:
+        jwt_payload = edx_drf_extensions_jwt_decode_handler(token)
+        monitoring_utils.set_custom_metric(JWT_DECODE_HANDLER_METRIC_KEY, 'edx-drf-extensions')
+        return jwt_payload
+    except Exception:  # pylint: disable=broad-except
+        # continue and try again
+        if waffle.switch_is_active('jwt_decode_handler.log_exception.edx-drf-extensions'):
+            logger.info('Failed to use edx-drf-extensions jwt_decode_handler.', exc_info=True)
+
+    # next, try temporary ecommerce decoder which matches expected config
+    # format of edx-drf-extensions
+    try:
+        jwt_payload = _ecommerce_jwt_decode_handler_updated_configs(token)
+        monitoring_utils.set_custom_metric(JWT_DECODE_HANDLER_METRIC_KEY, 'ecommerce-updated-config')
+        return jwt_payload
+    except Exception:  # pylint: disable=broad-except
+        # continue and try again
+        if waffle.switch_is_active('jwt_decode_handler.log_exception.ecommerce-updated-config'):
+            logger.info('Failed to use custom jwt_decode_handler with updated configs.', exc_info=True)
+
+    # if all else fails, fallback to the original version
+    try:
+        jwt_payload = _ecommerce_jwt_decode_handler_original(token)
+        monitoring_utils.set_custom_metric(JWT_DECODE_HANDLER_METRIC_KEY, 'ecommerce-original')
+        return jwt_payload
+    except Exception:  # pylint: disable=broad-except
+        if waffle.switch_is_active('jwt_decode_handler.log_exception.ecommerce-original'):
+            logger.info('Failed to use original jwt_decode_handler.', exc_info=True)
+        raise

--- a/ecommerce/extensions/api/tests/test_handlers.py
+++ b/ecommerce/extensions/api/tests/test_handlers.py
@@ -4,8 +4,9 @@ from time import time
 import jwt
 import mock
 from django.conf import settings
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from oscar.test.factories import UserFactory
+from waffle.testutils import override_switch
 
 from ecommerce.extensions.api.handlers import jwt_decode_handler
 
@@ -19,12 +20,13 @@ def generate_jwt_token(payload, signing_key=None):
     return jwt.encode(payload, signing_key).decode('utf-8')
 
 
-def generate_jwt_payload(user):
+def generate_jwt_payload(user, issuer=None):
     """Generate a valid JWT payload given a user."""
     now = int(time())
     ttl = 5
+    issuer = issuer or settings.JWT_AUTH['JWT_ISSUERS'][0]
     return {
-        'iss': settings.JWT_AUTH['JWT_ISSUERS'][0],
+        'iss': issuer,
         'username': user.username,
         'email': user.email,
         'iat': now,
@@ -41,8 +43,12 @@ class JWTDecodeHandlerTests(TestCase):
         self.payload = generate_jwt_payload(self.user)
         self.jwt = generate_jwt_token(self.payload)
 
-    def test_decode_success(self):
+    @mock.patch('edx_django_utils.monitoring.set_custom_metric')
+    @mock.patch('ecommerce.extensions.api.handlers.logger')
+    def test_decode_success(self, mock_logger, mock_set_custom_metric):
         self.assertEqual(jwt_decode_handler(self.jwt), self.payload)
+        mock_set_custom_metric.assert_called_with('ecom_jwt_decode_handler', 'ecommerce-original')
+        mock_logger.exception.assert_not_called()
 
     def test_decode_success_with_multiple_issuers(self):
         settings.JWT_AUTH['JWT_ISSUERS'] = ISSUERS
@@ -59,13 +65,125 @@ class JWTDecodeHandlerTests(TestCase):
             token = generate_jwt_token(self.payload, signing_key)
             self.assertEqual(jwt_decode_handler(token), self.payload)
 
+    @override_switch('jwt_decode_handler.log_exception.ecommerce-original', active=True)
     def test_decode_error(self):
         # Update the payload to ensure a validation error
         self.payload['exp'] = 0
         token = generate_jwt_token(self.payload)
 
-        with mock.patch('ecommerce.extensions.api.handlers.logger') as patched_log:
+        with mock.patch('ecommerce.extensions.api.handlers.logger') as mock_logger:
             with self.assertRaises(jwt.InvalidTokenError):
                 jwt_decode_handler(token)
 
-            patched_log.exception.assert_called_once_with('JWT decode failed!')
+            mock_logger.exception.assert_called_with('Original JWT decode failed!')
+            mock_logger.info.assert_called_with('Failed to use original jwt_decode_handler.', exc_info=True)
+
+    @override_settings(
+        JWT_AUTH={
+            'JWT_ISSUERS': [{
+                'AUDIENCE': 'test-audience',
+                'ISSUER': 'test-issuer',
+                'SECRET_KEY': 'test-secret-key',
+            }],
+            'JWT_VERIFY_AUDIENCE': False,
+        }
+    )
+    @mock.patch('edx_django_utils.monitoring.set_custom_metric')
+    def test_decode_success_edx_drf_extensions(self, mock_set_custom_metric):
+        """
+        Should pass using the edx-drf-extensions jwt_decode_handler.
+
+        This would happen with the combination of the JWT_ISSUERS configured in
+        the way that edx-drf-extensions is expected, and using the secret-key
+        of the first configured issuer.
+        """
+        payload = generate_jwt_payload(self.user, issuer='test-issuer')
+        token = generate_jwt_token(payload, 'test-secret-key')
+        self.assertDictContainsSubset(payload, jwt_decode_handler(token))
+        mock_set_custom_metric.assert_called_with('ecom_jwt_decode_handler', 'edx-drf-extensions')
+
+    @override_settings(
+        JWT_AUTH={
+            'JWT_ISSUERS': [
+                {
+                    'AUDIENCE': 'test-audience',
+                    'ISSUER': 'test-issuer',
+                    'SECRET_KEY': 'test-secret-key',
+                },
+                {
+                    'AUDIENCE': 'test-audience',
+                    'ISSUER': 'test-invalid-issuer',
+                    'SECRET_KEY': 'test-secret-key-2',
+                },
+                {
+                    'AUDIENCE': 'test-audience',
+                    'ISSUER': 'test-issuer-2',
+                    'SECRET_KEY': 'test-secret-key-2',
+                },
+            ],
+            'JWT_VERIFY_AUDIENCE': False,
+        }
+    )
+    @mock.patch('edx_django_utils.monitoring.set_custom_metric')
+    @mock.patch('ecommerce.extensions.api.handlers.logger')
+    def test_decode_success_updated_config(self, mock_logger, mock_set_custom_metric):
+        """
+        Should pass using ``_ecommerce_jwt_decode_handler_updated_configs``.
+
+        This would happen with the combination of the JWT_ISSUERS configured in
+        the way that edx-drf-extensions is expected, but when the token was
+        generated from the second issuer.
+        """
+        payload = generate_jwt_payload(self.user, issuer='test-issuer-2')
+        token = generate_jwt_token(payload, 'test-secret-key-2')
+        self.assertDictContainsSubset(payload, jwt_decode_handler(token))
+        mock_set_custom_metric.assert_called_with('ecom_jwt_decode_handler', 'ecommerce-updated-config')
+        mock_logger.exception.assert_not_called()
+
+    @override_settings(
+        JWT_AUTH={
+            'JWT_ISSUERS': [
+                {
+                    'AUDIENCE': 'test-audience',
+                    'ISSUER': 'test-issuer',
+                    'SECRET_KEY': 'test-secret-key',
+                },
+                {
+                    'AUDIENCE': 'test-audience',
+                    'ISSUER': 'test-issuer-2',
+                    'SECRET_KEY': 'test-secret-key-2',
+                },
+            ],
+            'JWT_VERIFY_AUDIENCE': False,
+            'JWT_SECRET_KEYS': SIGNING_KEYS
+        }
+    )
+    @mock.patch('ecommerce.extensions.api.handlers.logger')
+    @override_switch('jwt_decode_handler.log_exception.ecommerce-updated-config', active=True)
+    def test_decode_error_invalid_token(self, mock_logger):
+        """
+        Should fail ``_ecommerce_jwt_decode_handler_updated_configs`` due to
+        invalid token, not because it is not configured properly.
+
+        IMPORTANT: The original decode_handler still requires JWT_SECRET_KEYS.
+        JWT_SECRET_KEYS cannot be removed from config until the original decode_handler
+        code is first removed from the codebase.
+        """
+        # Update the payload to ensure a validation error
+        payload = generate_jwt_payload(self.user, issuer='test-issuer-2')
+        payload['exp'] = 0
+        token = generate_jwt_token(payload, 'test-secret-key-2')
+        with self.assertRaises(jwt.InvalidTokenError):
+            jwt_decode_handler(token)
+
+            mock_logger.exception.assert_called_with('Custom config JWT decode failed!')
+            mock_logger.info.assert_called_with(
+                'Failed to use custom jwt_decode_handler with updated configs.',
+                exc_info=True,
+            )
+
+    @mock.patch('ecommerce.extensions.api.handlers.logger')
+    @override_switch('jwt_decode_handler.log_exception.edx-drf-extensions', active=True)
+    def test_decode_with_edx_drf_extensions_log(self, mock_logger):
+        self.assertEqual(jwt_decode_handler(self.jwt), self.payload)
+        mock_logger.info.assert_called_with('Failed to use edx-drf-extensions jwt_decode_handler.', exc_info=True)


### PR DESCRIPTION
As part of ARCH-261, the ecommerce service and ecom-workers will be
transitioning to use the LMS as the sole issuer of JWT tokens. This
update temporarily make the jwt_decode_handler work with several
steps of the final rollout. Ultimately, once the jwt_decode_handler
is only being used to delegate the the edx-drf-extensions version of
the jwt_decode_handler, this custom one will be retired.  See ARCH-261
for the detailed plan.

ARCH-274