### PR TITLE
ENT-1281/ENT-1288 Refactoring Coupon create/update api backend

### DIFF
--- a/ecommerce/enterprise/conditions.py
+++ b/ecommerce/enterprise/conditions.py
@@ -80,11 +80,11 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
         if (learner_data and 'enterprise_customer' in learner_data and
                 str(self.enterprise_customer_uuid) != learner_data['enterprise_customer']['uuid']):
             # Learner is not linked to the EnterpriseCustomer associated with this condition.
-            logger.warning('Unable to apply enterprise offer %s because Learner\'s enterprise (%s)'
-                           'does not match this conditions\'s enterprise (%s).',
-                           offer.id,
-                           learner_data['enterprise_customer']['uuid'],
-                           str(self.enterprise_customer_uuid))
+            logger.debug('Unable to apply enterprise offer %s because Learner\'s enterprise (%s)'
+                         'does not match this conditions\'s enterprise (%s).',
+                         offer.id,
+                         learner_data['enterprise_customer']['uuid'],
+                         str(self.enterprise_customer_uuid))
             return False
 
         course_run_ids = []

--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -189,7 +189,7 @@ class CouponViewSetTest(CouponMixin, DiscoveryTestMixin, TestCase):
 
         view = CouponViewSet()
         view.request = request
-        cleaned_voucher_data = view.clean_voucher_request_data(request)
+        cleaned_voucher_data = view.clean_voucher_request_data(request.data, request.site.siteconfiguration.partner)
 
         expected_cleaned_voucher_data_keys = [
             'benefit_type',
@@ -584,6 +584,18 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': True})
         self._test_update_enterprise_coupon()
 
+    def test_update_coupon_to_add_enterprise_fields(self):
+        """
+        Test that a coupon without enterprise data will get enterprise conditional offers when updated
+        to have enterprise data.
+        """
+        self.data.update({
+            'enterprise_customer': None,
+            'enterprise_customer_catalog': None,
+        })
+        self.get_response('POST', COUPONS_LINK, self.data)
+        self._test_update_enterprise_coupon()
+
     def test_update_name(self):
         """Test updating voucher name."""
         data = {
@@ -769,10 +781,9 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             "ecommerce.extensions.voucher.utils.get_enterprise_customer",
             mock.Mock(return_value={'name': 'Fake enterprise'})
         ):
-            CouponViewSet().update_coupon_offer(
-                benefit_value=benefit_value,
+            CouponViewSet().update_offer_data(
+                request_data={'benefit_value': benefit_value},
                 vouchers=vouchers,
-                coupon=self.coupon,
                 site=self.site,
             )
         for voucher in vouchers:
@@ -783,9 +794,9 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         baskets = Basket.objects.filter(lines__product_id=self.coupon.id)
         basket = baskets.first()
         client_username = 'Tešt Člient Ušername'
-        CouponViewSet().update_coupon_client(
-            baskets=baskets,
-            client_username=client_username
+        CouponViewSet().update_coupon_product_data(
+            request_data={'client': client_username},
+            coupon=self.coupon
         )
 
         invoice = Invoice.objects.get(order__basket=basket)
@@ -796,7 +807,7 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         self.assertEqual(invoice.discount_type, Invoice.PERCENTAGE)
         CouponViewSet().update_invoice_data(
             coupon=self.coupon,
-            data={
+            request_data={
                 'invoice_discount_type': Invoice.FIXED
             }
         )

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -24,7 +24,9 @@ from ecommerce.extensions.catalogue.utils import create_coupon_product, get_or_c
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
 from ecommerce.extensions.payment.processors.invoice import InvoicePayment
 from ecommerce.extensions.voucher.models import CouponVouchers
-from ecommerce.extensions.voucher.utils import update_voucher_offer, update_voucher_with_enterprise_offer
+from ecommerce.extensions.voucher.utils import (
+    get_or_create_enterprise_offer, update_voucher_offer, update_voucher_with_enterprise_offer
+)
 from ecommerce.invoice.models import Invoice
 
 Basket = get_model('basket', 'Basket')
@@ -86,37 +88,16 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
         try:
             with transaction.atomic():
                 try:
-                    cleaned_voucher_data = self.clean_voucher_request_data(request)
+                    cleaned_voucher_data = self.clean_voucher_request_data(
+                        request.data, request.site.siteconfiguration.partner
+                    )
                 except ValidationError as error:
                     logger.exception('Failed to create coupon. %s', error.message)
                     # FIXME This should ALWAYS return 400.
                     return Response(error.message, status=error.code or 400)
 
                 try:
-                    coupon_product = create_coupon_product(
-                        benefit_type=cleaned_voucher_data['benefit_type'],
-                        benefit_value=cleaned_voucher_data['benefit_value'],
-                        catalog=cleaned_voucher_data['coupon_catalog'],
-                        catalog_query=cleaned_voucher_data['catalog_query'],
-                        category=cleaned_voucher_data['category'],
-                        code=cleaned_voucher_data['code'],
-                        course_catalog=cleaned_voucher_data['course_catalog'],
-                        course_seat_types=cleaned_voucher_data['course_seat_types'],
-                        email_domains=cleaned_voucher_data['email_domains'],
-                        end_datetime=cleaned_voucher_data['end_datetime'],
-                        enterprise_customer=cleaned_voucher_data['enterprise_customer'],
-                        enterprise_customer_catalog=cleaned_voucher_data['enterprise_customer_catalog'],
-                        max_uses=cleaned_voucher_data['max_uses'],
-                        note=cleaned_voucher_data['note'],
-                        partner=cleaned_voucher_data['partner'],
-                        price=cleaned_voucher_data['price'],
-                        quantity=cleaned_voucher_data['quantity'],
-                        start_datetime=cleaned_voucher_data['start_datetime'],
-                        title=cleaned_voucher_data['title'],
-                        voucher_type=cleaned_voucher_data['voucher_type'],
-                        program_uuid=cleaned_voucher_data['program_uuid'],
-                        site=self.request.site
-                    )
+                    coupon_product = self.create_coupon_and_vouchers(cleaned_voucher_data)
                 except (KeyError, IntegrityError) as error:
                     logger.exception('Coupon creation failed!')
                     return Response(str(error), status=status.HTTP_400_BAD_REQUEST)
@@ -134,27 +115,53 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
         except ValidationError as e:
             raise serializers.ValidationError(e.message)
 
+    def create_coupon_and_vouchers(self, cleaned_voucher_data):
+        return create_coupon_product(
+            benefit_type=cleaned_voucher_data['benefit_type'],
+            benefit_value=cleaned_voucher_data['benefit_value'],
+            catalog=cleaned_voucher_data['coupon_catalog'],
+            catalog_query=cleaned_voucher_data['catalog_query'],
+            category=cleaned_voucher_data['category'],
+            code=cleaned_voucher_data['code'],
+            course_catalog=cleaned_voucher_data['course_catalog'],
+            course_seat_types=cleaned_voucher_data['course_seat_types'],
+            email_domains=cleaned_voucher_data['email_domains'],
+            end_datetime=cleaned_voucher_data['end_datetime'],
+            enterprise_customer=cleaned_voucher_data['enterprise_customer'],
+            enterprise_customer_catalog=cleaned_voucher_data['enterprise_customer_catalog'],
+            max_uses=cleaned_voucher_data['max_uses'],
+            note=cleaned_voucher_data['note'],
+            partner=cleaned_voucher_data['partner'],
+            price=cleaned_voucher_data['price'],
+            quantity=cleaned_voucher_data['quantity'],
+            start_datetime=cleaned_voucher_data['start_datetime'],
+            title=cleaned_voucher_data['title'],
+            voucher_type=cleaned_voucher_data['voucher_type'],
+            program_uuid=cleaned_voucher_data['program_uuid'],
+            site=self.request.site
+        )
+
     @classmethod
-    def clean_voucher_request_data(cls, request):
+    def clean_voucher_request_data(cls, request_data, partner):
         """
         Helper method to return cleaned request data for voucher creation or
         raise validation error with error code.
 
         Arguments:
-            request (HttpRequest): request with voucher data
+            request (dict): request's data with voucher data
+            partner (str): the request's site's partner
 
         """
-        benefit_type = request.data.get('benefit_type')
-        category_data = request.data.get('category')
-        code = request.data.get('code')
-        course_catalog_data = request.data.get('course_catalog')
-        enterprise_customer_data = request.data.get('enterprise_customer')
-        course_seat_types = request.data.get('course_seat_types')
-        max_uses = request.data.get('max_uses')
-        partner = request.site.siteconfiguration.partner
-        stock_record_ids = request.data.get('stock_record_ids')
-        voucher_type = request.data.get('voucher_type')
-        program_uuid = request.data.get('program_uuid')
+        benefit_type = request_data.get('benefit_type')
+        category_data = request_data.get('category')
+        code = request_data.get('code')
+        course_catalog_data = request_data.get('course_catalog')
+        enterprise_customer_data = request_data.get('enterprise_customer')
+        course_seat_types = request_data.get('course_seat_types')
+        max_uses = request_data.get('max_uses')
+        stock_record_ids = request_data.get('stock_record_ids')
+        voucher_type = request_data.get('voucher_type')
+        program_uuid = request_data.get('program_uuid')
 
         if benefit_type not in (Benefit.PERCENTAGE, Benefit.FIXED,):
             raise ValidationError('Benefit type [{type}] is not allowed'.format(type=benefit_type))
@@ -196,24 +203,24 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
 
         return {
             'benefit_type': benefit_type,
-            'benefit_value': request.data.get('benefit_value'),
+            'benefit_value': request_data.get('benefit_value'),
             'coupon_catalog': coupon_catalog,
-            'catalog_query': request.data.get('catalog_query'),
+            'catalog_query': request_data.get('catalog_query'),
             'category': category,
             'code': code,
             'course_catalog': course_catalog,
             'course_seat_types': course_seat_types,
-            'email_domains': request.data.get('email_domains'),
-            'end_datetime': request.data.get('end_datetime'),
+            'email_domains': request_data.get('email_domains'),
+            'end_datetime': request_data.get('end_datetime'),
             'enterprise_customer': enterprise_customer,
-            'enterprise_customer_catalog': request.data.get('enterprise_customer_catalog'),
+            'enterprise_customer_catalog': request_data.get('enterprise_customer_catalog'),
             'max_uses': max_uses,
-            'note': request.data.get('note'),
+            'note': request_data.get('note'),
             'partner': partner,
-            'price': request.data.get('price'),
-            'quantity': request.data.get('quantity'),
-            'start_datetime': request.data.get('start_datetime'),
-            'title': request.data.get('title'),
+            'price': request_data.get('price'),
+            'quantity': request_data.get('quantity'),
+            'start_datetime': request_data.get('start_datetime'),
+            'title': request_data.get('title'),
             'voucher_type': voucher_type,
             'program_uuid': program_uuid,
         }
@@ -290,104 +297,17 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
 
         return response_data
 
-    def update_range_data(self, request, vouchers):
-        """
-        Update the range data for a particular request.
-        """
-        range_data = self.create_update_data_dict(data=request.data, fields=Range.UPDATABLE_RANGE_FIELDS)
-
-        if not range_data:
-            return None
-
-        voucher_range = vouchers.first().original_offer.benefit.range
-
-        enterprise_customer_data = request.data.get('enterprise_customer')
-
-        # Remove catalog if switching from single course to dynamic query
-        # In case of enterprise, range_data has enterprise data in it as enterprise is defined in UPDATABLE_RANGE_FIELDS
-        # so Catalog should not be None if there is an enterprise is associated with it.
-        if voucher_range.catalog:
-            if not enterprise_customer_data:
-                range_data['catalog'] = None
-
-            if enterprise_customer_data and range_data.get('catalog_query'):
-                range_data['catalog'] = None
-
-        course_catalog_data = request.data.get('course_catalog')
-        if course_catalog_data:
-            course_catalog = course_catalog_data.get('id')
-            range_data['course_catalog'] = course_catalog
-
-            # Remove catalog_query, switching from the dynamic query coupon to
-            # course catalog coupon
-            range_data['catalog_query'] = None
-        else:
-            range_data['course_catalog'] = None
-
-        if enterprise_customer_data:
-            range_data['enterprise_customer'] = enterprise_customer_data.get('id')
-        else:
-            range_data['enterprise_customer'] = None
-
-        if 'enterprise_customer_catalog' in request.data:
-            range_data['enterprise_customer_catalog'] = request.data.get('enterprise_customer_catalog') or None
-
-        for attr, value in range_data.iteritems():
-            setattr(voucher_range, attr, value)
-
-        voucher_range.save()
-
     def update(self, request, *args, **kwargs):
         """Update coupon depending on request data sent."""
         try:
             super(CouponViewSet, self).update(request, *args, **kwargs)
-
             coupon = self.get_object()
             vouchers = coupon.attr.coupon_vouchers.vouchers
-            baskets = Basket.objects.filter(lines__product_id=coupon.id, status=Basket.SUBMITTED)
-            data = self.create_update_data_dict(data=request.data, fields=CouponVouchers.UPDATEABLE_VOUCHER_FIELDS)
-
-            if data:
-                vouchers.all().update(**data)
-
-            self.update_range_data(request, vouchers)
-
-            program_uuid = request.data.get('program_uuid')
-            benefit_value = request.data.get('benefit_value')
-            enterprise_customer = request.data.get('enterprise_customer', {}).get('id', None)
-            enterprise_catalog = request.data.get('enterprise_customer_catalog') or None
-            if benefit_value or program_uuid or enterprise_customer or enterprise_catalog:
-                self.update_coupon_offer(
-                    benefit_value=benefit_value,
-                    vouchers=vouchers,
-                    site=self.request.site,
-                    coupon=coupon,
-                    program_uuid=program_uuid,
-                    enterprise_customer=enterprise_customer,
-                    enterprise_catalog=enterprise_catalog
-                )
-
-            category_data = request.data.get('category')
-            if category_data:
-                category = Category.objects.get(name=category_data['name'])
-                ProductCategory.objects.filter(product=coupon).update(category=category)
-
-            client_username = request.data.get('client')
-            if client_username:
-                self.update_coupon_client(baskets=baskets, client_username=client_username)
-
-            coupon_price = request.data.get('price')
-            if coupon_price:
-                StockRecord.objects.filter(product=coupon).update(price_excl_tax=coupon_price)
-
-            note = request.data.get('note')
-            if note is not None:
-                coupon.attr.note = note
-                coupon.save()
-
-            self.update_offer_data(request.data, vouchers, coupon.id)
-            self.update_invoice_data(coupon, request.data)
-
+            self.update_voucher_data(request.data, vouchers)
+            self.update_range_data(request.data, vouchers)
+            self.update_offer_data(request.data, vouchers, self.request.site)
+            self.update_coupon_product_data(request.data, coupon)
+            self.update_invoice_data(request.data, coupon)
             serializer = self.get_serializer(coupon)
             return Response(serializer.data)
         except ValidationError as error:
@@ -397,6 +317,11 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
             )
             logger.exception(error_message)
             raise serializers.ValidationError(error_message)
+
+    def update_voucher_data(self, request_data, vouchers):
+        data = self.create_update_data_dict(data=request_data, fields=CouponVouchers.UPDATEABLE_VOUCHER_FIELDS)
+        if data:
+            vouchers.all().update(**data)
 
     def create_update_data_dict(self, data, fields):
         """
@@ -424,8 +349,76 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
                     update_dict[field.replace('invoice_', '')] = value
         return update_dict
 
-    def update_coupon_offer(self, coupon, vouchers, site, benefit_value=None, program_uuid=None,
-                            enterprise_customer=None, enterprise_catalog=None):
+    def update_range_data(self, request_data, vouchers):
+        """
+        Update the range data for a particular request.
+        """
+        range_data = self.create_update_data_dict(data=request_data, fields=Range.UPDATABLE_RANGE_FIELDS)
+
+        if not range_data:
+            return None
+
+        voucher_range = vouchers.first().original_offer.benefit.range
+
+        enterprise_customer_data = request_data.get('enterprise_customer')
+
+        # Remove catalog if switching from single course to dynamic query
+        # In case of enterprise, range_data has enterprise data in it as enterprise is defined in UPDATABLE_RANGE_FIELDS
+        # so Catalog should not be None if there is an enterprise is associated with it.
+        if voucher_range.catalog:
+            if not enterprise_customer_data:
+                range_data['catalog'] = None
+
+            if enterprise_customer_data and range_data.get('catalog_query'):
+                range_data['catalog'] = None
+
+        course_catalog_data = request_data.get('course_catalog')
+        if course_catalog_data:
+            course_catalog = course_catalog_data.get('id')
+            range_data['course_catalog'] = course_catalog
+
+            # Remove catalog_query, switching from the dynamic query coupon to
+            # course catalog coupon
+            range_data['catalog_query'] = None
+        else:
+            range_data['course_catalog'] = None
+
+        if enterprise_customer_data:
+            range_data['enterprise_customer'] = enterprise_customer_data.get('id')
+        else:
+            range_data['enterprise_customer'] = None
+
+        if 'enterprise_customer_catalog' in request_data:
+            range_data['enterprise_customer_catalog'] = request_data.get('enterprise_customer_catalog') or None
+
+        for attr, value in range_data.iteritems():
+            setattr(voucher_range, attr, value)
+
+        voucher_range.save()
+
+    def update_coupon_product_data(self, request_data, coupon):
+        baskets = Basket.objects.filter(lines__product_id=coupon.id, status=Basket.SUBMITTED)
+
+        category_data = request_data.get('category')
+        if category_data:
+            category = Category.objects.get(name=category_data['name'])
+            ProductCategory.objects.filter(product=coupon).update(category=category)
+
+        client_username = request_data.get('client')
+        if client_username:
+            client, __ = BusinessClient.objects.get_or_create(name=client_username)
+            Invoice.objects.filter(order__basket=baskets.first()).update(business_client=client)
+
+        coupon_price = request_data.get('price')
+        if coupon_price:
+            StockRecord.objects.filter(product=coupon).update(price_excl_tax=coupon_price)
+
+        note = request_data.get('note')
+        if note is not None:
+            coupon.attr.note = note
+            coupon.save()
+
+    def update_offer_data(self, request_data, vouchers, site):
         """
         Remove all offers from the vouchers and add a new offer
         Arguments:
@@ -437,94 +430,79 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
             enterprise_customer (str): Enterprise Customer UUID
             enterprise_catalog (str): Enterprise Catalog UUID
         """
-        new_offers = []
+        program_uuid = request_data.get('program_uuid')
+        benefit_value = request_data.get('benefit_value')
+        enterprise_customer = request_data.get('enterprise_customer', {}).get('id', None)
+        enterprise_catalog = request_data.get('enterprise_customer_catalog') or None
+        max_uses = request_data.get('max_uses')
+        email_domains = request_data.get('email_domains')
 
-        # Only process the original conditional offer, and update/create the enterprise offer if needed.
-        voucher_offer = vouchers.first().best_offer
-        oldest_offer = vouchers.first().original_offer
-        if program_uuid:
-            Condition.objects.filter(
-                program_uuid=voucher_offer.condition.program_uuid
-            ).update(program_uuid=program_uuid)
-
-        # The program uuid (if program coupon) is required for the benefit and condition update logic
-        program_uuid = program_uuid or voucher_offer.condition.program_uuid
-
-        new_offers.append(update_voucher_offer(
-            offer=oldest_offer,
-            benefit_value=benefit_value or oldest_offer.benefit.value,
-            benefit_type=oldest_offer.benefit.type or getattr(
-                oldest_offer.benefit.proxy(), 'benefit_class_type', None
-            ),
-            coupon=coupon,
-            max_uses=oldest_offer.max_global_applications,
-            program_uuid=program_uuid,
-            site=site,
-        ))
-
-        if enterprise_customer:
-            new_offers.append(update_voucher_with_enterprise_offer(
-                offer=voucher_offer,
-                benefit_value=benefit_value or voucher_offer.benefit.value,
-                benefit_type=voucher_offer.benefit.type or getattr(
-                    voucher_offer.benefit.proxy(), 'benefit_class_type', None
-                ),
-                coupon=coupon,
-                max_uses=voucher_offer.max_global_applications,
-                enterprise_customer=enterprise_customer,
-                enterprise_catalog=enterprise_catalog,
-                site=site,
-            ))
+        # Validate max_uses
+        if max_uses is not None:
+            if vouchers.first().usage == Voucher.SINGLE_USE:
+                log_message_and_raise_validation_error(
+                    'Failed to update Coupon. '
+                    'max_global_applications field cannot be set for voucher type [{voucher_type}].'.format(
+                        voucher_type=Voucher.SINGLE_USE
+                    ))
+            try:
+                max_uses = int(max_uses)
+                if max_uses < 1:
+                    raise ValueError
+            except ValueError:
+                raise ValidationError('max_global_applications field must be a positive number.')
 
         for voucher in vouchers.all():
+            updated_original_offer = update_voucher_offer(
+                offer=voucher.original_offer,
+                benefit_value=benefit_value,
+                max_uses=max_uses,
+                program_uuid=program_uuid,
+                email_domains=email_domains,
+                site=site,
+            )
+            updated_enterprise_offer = None
+            if voucher.enterprise_offer:
+                updated_enterprise_offer = update_voucher_with_enterprise_offer(
+                    offer=voucher.enterprise_offer,
+                    benefit_value=benefit_value,
+                    max_uses=max_uses,
+                    enterprise_customer=enterprise_customer,
+                    enterprise_catalog=enterprise_catalog,
+                    email_domains=email_domains,
+                    site=site,
+                )
+            elif enterprise_customer:
+                # If we are performing an update on an existing enterprise coupon,
+                # we need to ensure the enterprise offer is created if it didn't already exist.
+                updated_enterprise_offer = get_or_create_enterprise_offer(
+                    benefit_value=benefit_value or voucher.original_offer.benefit.value,
+                    benefit_type=voucher.original_offer.benefit.type,
+                    enterprise_customer=enterprise_customer,
+                    enterprise_customer_catalog=enterprise_catalog,
+                    offer_name=voucher.original_offer.name + " ENT Offer",
+                    max_uses=max_uses or voucher.original_offer.max_global_applications,
+                    email_domains=email_domains or voucher.original_offer.email_domains,
+                    site=site or voucher.original_offer.site,
+                )
             voucher.offers.clear()
-            for new_offer in new_offers:
-                voucher.offers.add(new_offer)
+            voucher.offers.add(updated_original_offer)
+            if updated_enterprise_offer:
+                voucher.offers.add(updated_enterprise_offer)
 
-    def update_coupon_client(self, baskets, client_username):
-        """
-        Update Invoice client for new coupons.
-        Arguments:
-            baskets (QuerySet): Baskets associated with the coupons
-            client_username (str): Client username
-        """
-        client, __ = BusinessClient.objects.get_or_create(name=client_username)
-        Invoice.objects.filter(order__basket=baskets.first()).update(business_client=client)
-
-    def update_invoice_data(self, coupon, data):
+    def update_invoice_data(self, request_data, coupon):
         """
         Update the invoice data.
 
         Arguments:
-            coupon (Product): The coupon product with which the invoice is retrieved.
-            data (dict): The request's data from which the invoice data is retrieved
+            request_data (dict): The request's data from which the invoice data is retrieved
                          and used for the updated.
+            coupon (Product): The coupon product with which the invoice is retrieved.
         """
-        invoice_data = self.create_update_data_dict(data=data, fields=Invoice.UPDATEABLE_INVOICE_FIELDS)
+        invoice_data = self.create_update_data_dict(data=request_data, fields=Invoice.UPDATEABLE_INVOICE_FIELDS)
 
         if invoice_data:
             Invoice.objects.filter(order__lines__product=coupon).update(**invoice_data)
-
-    def update_offer_data(self, data, vouchers, coupon_id):
-        offer_data = self.create_update_data_dict(data=data, fields=ConditionalOffer.UPDATABLE_OFFER_FIELDS)
-
-        if offer_data:
-            if offer_data.get('max_global_applications') is not None:
-                if vouchers.first().usage == Voucher.SINGLE_USE:
-                    log_message_and_raise_validation_error(
-                        'Failed to update Coupon [{coupon_id}]. '
-                        'max_global_applications field cannot be set for voucher type [{voucher_type}].'.format(
-                            coupon_id=coupon_id,
-                            voucher_type=Voucher.SINGLE_USE
-                        )
-                    )
-                try:
-                    offer_data['max_global_applications'] = int(offer_data['max_global_applications'])
-                    if offer_data['max_global_applications'] < 1:
-                        raise ValueError
-                except ValueError:
-                    raise ValidationError('max_global_applications field must be a positive number.')
-            ConditionalOffer.objects.filter(vouchers__in=vouchers.all()).update(**offer_data)
 
     def destroy(self, request, pk):  # pylint: disable=unused-argument
         try:

--- a/ecommerce/extensions/voucher/models.py
+++ b/ecommerce/extensions/voucher/models.py
@@ -73,19 +73,21 @@ class Voucher(AbstractVoucher):
             return self.offers.order_by('date_created')[0]
 
     @property
+    def enterprise_offer(self):
+        try:
+            return self.offers.get(condition__enterprise_customer_uuid__isnull=False)
+        except ObjectDoesNotExist:
+            return None
+        except MultipleObjectsReturned:
+            logger.exception('There is more than one enterprise offer associated with voucher %s!', self.id)
+            return self.offers.filter(condition__enterprise_customer_uuid__isnull=False)[0]
+
+    @property
     def best_offer(self):
         # If the ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH is inactive, return offer containing a range
         if not waffle.switch_is_active(ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH):
             return self.original_offer
         # If the switch is enabled, return the enterprise offer if it exists.
-        try:
-            return self.offers.get(condition__enterprise_customer_uuid__isnull=False)
-        except ObjectDoesNotExist:
-            # If no enterprise offer is found, return the first available offer.
-            return self.original_offer
-        except MultipleObjectsReturned:
-            logger.exception('There is more than one enterprise offer associated with voucher %s!', self.id)
-            return self.original_offer
-
+        return self.enterprise_offer or self.original_offer
 
 from oscar.apps.voucher.models import *  # noqa isort:skip pylint: disable=wildcard-import,unused-wildcard-import,wrong-import-position,wrong-import-order,ungrouped-imports

--- a/ecommerce/extensions/voucher/tests/test_models.py
+++ b/ecommerce/extensions/voucher/tests/test_models.py
@@ -77,11 +77,11 @@ class VoucherTests(TestCase):
         second_offer = factories.EnterpriseOfferFactory()
         voucher.offers.add(second_offer)
         assert voucher.best_offer == second_offer
-        # Add a third enterprise offer, and see that the original offer gets returned
-        # because of multiple enterprise offers being available, which is unexpected data.
+        # Add a third enterprise offer, and see that the first enterprise offer gets returned
+        # because of multiple enterprise offers being available.
         third_offer = factories.EnterpriseOfferFactory()
         voucher.offers.add(third_offer)
-        assert voucher.best_offer == first_offer
+        assert voucher.best_offer == second_offer
         # Turn the switch off and see that the oldest offer gets returned.
         Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': False})
         assert voucher.best_offer == first_offer

--- a/ecommerce/extensions/voucher/tests/test_utils.py
+++ b/ecommerce/extensions/voucher/tests/test_utils.py
@@ -637,7 +637,7 @@ class UtilTests(CouponMixin, DiscoveryMockMixin, DiscoveryTestMixin, LmsApiMockM
         new_email_domains = 'example.org'
         new_offer = update_voucher_offer(
             voucher_offer, 50.00, Benefit.PERCENTAGE,
-            self.coupon, email_domains=new_email_domains
+            email_domains=new_email_domains
         )
         self.assertEqual(new_offer.benefit.type, Benefit.PERCENTAGE)
         self.assertEqual(new_offer.benefit.value, 50.00)

--- a/ecommerce/extensions/voucher/utils.py
+++ b/ecommerce/extensions/voucher/utils.py
@@ -307,9 +307,24 @@ def generate_coupon_report(coupon_vouchers):
     return field_names, rows
 
 
+def generate_offer_name(coupon_id, benefit_type, benefit_value, offer_number=None, is_enterprise=False):
+    offer_name = "Coupon [{}]-{}-{}".format(coupon_id, benefit_type, benefit_value)
+    if offer_number:
+        offer_name = "{} [{}]".format(offer_name, offer_number)
+    if is_enterprise:
+        offer_name = offer_name + " ENT Offer"
+    return offer_name
+
+
 def _get_or_create_offer(
-        product_range, benefit_type, benefit_value, coupon_id=None,
-        max_uses=None, offer_number=None, email_domains=None, program_uuid=None, site=None
+        product_range,
+        benefit_type,
+        benefit_value,
+        offer_name,
+        max_uses,
+        site,
+        email_domains=None,
+        program_uuid=None
 ):
     """
     Return an offer for a catalog with condition and benefit.
@@ -358,7 +373,7 @@ def _get_or_create_offer(
                 offer_benefit.value = benefit_value
                 offer_benefit.save()
 
-            offer_name = "Coupon [{}]-{}".format(coupon_id, offer_benefit.name)
+            offer_name = "{}-{}".format(offer_name, offer_benefit.name)
         else:
             offer_benefit, __ = Benefit.objects.get_or_create(
                 range=product_range,
@@ -366,21 +381,17 @@ def _get_or_create_offer(
                 value=Decimal(benefit_value),
                 max_affected_items=1,
             )
-            offer_name = "Coupon [{}]-{}-{}".format(coupon_id, offer_benefit.type, offer_benefit.value)
 
     except (TypeError, DecimalException):  # If the benefit_value parameter is not sent TypeError will be raised
         log_message_and_raise_validation_error(
             'Failed to create Benefit. Benefit value must be a positive number or 0.'
         )
 
-    if offer_number:
-        offer_name = "{} [{}]".format(offer_name, offer_number)
-
     offer_kwargs = {
         'offer_type': ConditionalOffer.VOUCHER,
         'condition': offer_condition,
         'benefit': offer_benefit,
-        'max_global_applications': max_uses,
+        'max_global_applications': int(max_uses) if max_uses is not None else None,
         'email_domains': email_domains,
         'site': site,
         'partner': site.siteconfiguration.partner if site else None,
@@ -391,9 +402,15 @@ def _get_or_create_offer(
     return offer
 
 
-def _get_or_create_enterprise_offer(benefit_type, benefit_value, enterprise_customer,
-                                    enterprise_customer_catalog, coupon_id=None, max_uses=None, offer_number=None,
-                                    email_domains=None, site=None):
+def get_or_create_enterprise_offer(
+        benefit_type,
+        benefit_value,
+        enterprise_customer,
+        enterprise_customer_catalog,
+        offer_name,
+        site,
+        max_uses=None,
+        email_domains=None):
 
     enterprise_customer_object = get_enterprise_customer(site, enterprise_customer) if site else {}
     enterprise_customer_name = enterprise_customer_object.get('name', '')
@@ -413,15 +430,11 @@ def _get_or_create_enterprise_offer(benefit_type, benefit_value, enterprise_cust
         max_affected_items=1,
     )
 
-    offer_name = "Coupon [{}]-{}-{} ENT Offer".format(coupon_id, benefit_type, benefit_value)
-    if offer_number:
-        offer_name = "{} [{}] ENT Offer".format(offer_name, offer_number)
-
     offer_kwargs = {
         'offer_type': ConditionalOffer.VOUCHER,
         'condition': condition,
         'benefit': benefit,
-        'max_global_applications': max_uses,
+        'max_global_applications': int(max_uses) if max_uses is not None else None,
         'email_domains': email_domains,
         'site': site,
         'partner': site.siteconfiguration.partner if site else None,
@@ -459,7 +472,7 @@ def _generate_code_string(length):
     return voucher_code
 
 
-def _create_new_voucher(code, end_datetime, name, offer, start_datetime, voucher_type):
+def create_new_voucher(code, end_datetime, name, start_datetime, voucher_type):
     """
     Creates a voucher.
 
@@ -476,15 +489,56 @@ def _create_new_voucher(code, end_datetime, name, offer, start_datetime, voucher
     Returns:
         Voucher
     """
-    if offer.benefit.type == Benefit.PERCENTAGE and offer.benefit.value == 100 and code:
-        log_message_and_raise_validation_error('Failed to create Voucher. Code may not be set for enrollment coupon.')
     voucher_code = code or _generate_code_string(settings.VOUCHER_CODE_LENGTH)
+    if not isinstance(start_datetime, datetime.datetime):
+        start_datetime = dateutil.parser.parse(start_datetime)
+
+    if not isinstance(end_datetime, datetime.datetime):
+        end_datetime = dateutil.parser.parse(end_datetime)
+
+    voucher = Voucher.objects.create(
+        name=name[:128],
+        code=voucher_code,
+        usage=voucher_type,
+        start_datetime=start_datetime,
+        end_datetime=end_datetime,
+    )
+
+    return voucher
+
+
+def validate_voucher_fields(
+        max_uses,
+        voucher_type,
+        benefit_type,
+        benefit_value,
+        code,
+        end_datetime,
+        start_datetime):
+    # Maximum number of uses can be set for each voucher type and disturb
+    # the predefined behaviours of the different voucher types. Therefor
+    # here we enforce that the max_uses variable can't be used for SINGLE_USE
+    # voucher types.
+    if max_uses is not None:
+        if voucher_type == Voucher.SINGLE_USE:
+            log_message_and_raise_validation_error(
+                'Failed to create Voucher. max_uses field cannot be set for voucher type [{voucher_type}].'.format(
+                    voucher_type=Voucher.SINGLE_USE
+                )
+            )
+        try:
+            int(max_uses)
+        except ValueError:
+            raise log_message_and_raise_validation_error('Failed to create Voucher. max_uses field must be a number.')
+
+    if benefit_type == Benefit.PERCENTAGE and benefit_value == 100 and code:
+        log_message_and_raise_validation_error('Failed to create Voucher. Code may not be set for enrollment coupon.')
 
     if not end_datetime:
         log_message_and_raise_validation_error('Failed to create Voucher. Voucher end datetime field must be set.')
     elif not isinstance(end_datetime, datetime.datetime):
         try:
-            end_datetime = dateutil.parser.parse(end_datetime)
+            dateutil.parser.parse(end_datetime)
         except (AttributeError, ValueError, TypeError):
             log_message_and_raise_validation_error(
                 'Failed to create Voucher. Voucher end datetime value [{date}] is invalid.'.format(date=end_datetime)
@@ -494,22 +548,11 @@ def _create_new_voucher(code, end_datetime, name, offer, start_datetime, voucher
         log_message_and_raise_validation_error('Failed to create Voucher. Voucher start datetime field must be set.')
     elif not isinstance(start_datetime, datetime.datetime):
         try:
-            start_datetime = dateutil.parser.parse(start_datetime)
+            dateutil.parser.parse(start_datetime)
         except (AttributeError, ValueError, TypeError):
             log_message_and_raise_validation_error(
                 'Failed to create Voucher. Voucher start datetime [{date}] is invalid.'.format(date=start_datetime)
             )
-
-    voucher = Voucher.objects.create(
-        name=name[:128],
-        code=voucher_code,
-        usage=voucher_type,
-        start_datetime=start_datetime,
-        end_datetime=end_datetime
-    )
-    voucher.offers.add(offer)
-
-    return voucher
 
 
 def create_vouchers(
@@ -568,21 +611,15 @@ def create_vouchers(
     offers = []
     enterprise_offers = []
 
-    # Maximum number of uses can be set for each voucher type and disturb
-    # the predefined behaviours of the different voucher types. Therefor
-    # here we enforce that the max_uses variable can't be used for SINGLE_USE
-    # voucher types.
-    if max_uses is not None:
-        if voucher_type == Voucher.SINGLE_USE:
-            log_message_and_raise_validation_error(
-                'Failed to create Voucher. max_uses field cannot be set for voucher type [{voucher_type}].'.format(
-                    voucher_type=Voucher.SINGLE_USE
-                )
-            )
-        try:
-            max_uses = int(max_uses)
-        except ValueError:
-            raise log_message_and_raise_validation_error('Failed to create Voucher. max_uses field must be a number.')
+    # Validation
+    validate_voucher_fields(
+        max_uses,
+        voucher_type,
+        benefit_type,
+        benefit_value,
+        code,
+        end_datetime,
+        start_datetime)
 
     if _range:
         # Enrollment codes use a custom range.
@@ -614,18 +651,15 @@ def create_vouchers(
     # offer because the usage is tied to the offer so that a usage on one voucher would
     # mean all vouchers will have their usage decreased by one, hence each voucher needs
     # its own offer to keep track of its own usages without interfering with others.
-    multi_offer = True if (
-        voucher_type == Voucher.MULTI_USE or voucher_type == Voucher.ONCE_PER_CUSTOMER
-    ) else False
-    num_of_offers = quantity if multi_offer else 1
+    num_of_offers = quantity if voucher_type in (Voucher.MULTI_USE, Voucher.ONCE_PER_CUSTOMER) else 1
     for num in range(num_of_offers):
+        offer_name = generate_offer_name(coupon.id, benefit_type, benefit_value, num)
         offer = _get_or_create_offer(
             product_range=product_range,
             benefit_type=benefit_type,
             benefit_value=benefit_value,
             max_uses=max_uses,
-            coupon_id=coupon.id,
-            offer_number=num,
+            offer_name=offer_name,
             email_domains=email_domains,
             program_uuid=program_uuid,
             site=site
@@ -636,30 +670,30 @@ def create_vouchers(
         # and redemption logic to use enterprise conditional offers when appropriate.
         # This and the surrounding code will be refactored at that point.
         if enterprise_customer:
-            enterprise_offer = _get_or_create_enterprise_offer(
+            offer_name = generate_offer_name(coupon.id, benefit_type, benefit_value, num, is_enterprise=True)
+            enterprise_offer = get_or_create_enterprise_offer(
                 benefit_type=benefit_type,
                 benefit_value=benefit_value,
                 enterprise_customer=enterprise_customer,
                 enterprise_customer_catalog=enterprise_customer_catalog,
                 max_uses=max_uses,
-                coupon_id=coupon.id,
-                offer_number=num,
+                offer_name=offer_name,
                 email_domains=email_domains,
                 site=site
             )
             enterprise_offers.append(enterprise_offer)
 
     for i in range(quantity):
-        voucher = _create_new_voucher(
+        voucher = create_new_voucher(
             end_datetime=end_datetime,
-            offer=offers[i] if multi_offer else offers[0],
             start_datetime=start_datetime,
             voucher_type=voucher_type,
             code=code,
             name=name
         )
+        voucher.offers.add(offers[i] if len(offers) > 1 else offers[0])
         if enterprise_customer:
-            voucher.offers.add(enterprise_offers[i] if multi_offer else enterprise_offers[0])
+            voucher.offers.add(enterprise_offers[i] if len(enterprise_offers) > 1 else enterprise_offers[0])
         vouchers.append(voucher)
 
     return vouchers
@@ -707,7 +741,7 @@ def get_voucher_discount_info(benefit, price):
         }
 
 
-def update_voucher_with_enterprise_offer(offer, benefit_value, benefit_type, coupon, enterprise_customer,
+def update_voucher_with_enterprise_offer(offer, benefit_value, enterprise_customer, benefit_type=None,
                                          max_uses=None, email_domains=None, enterprise_catalog=None, site=None):
     """
     Update voucher with enteprise offer.
@@ -729,19 +763,21 @@ def update_voucher_with_enterprise_offer(offer, benefit_value, benefit_type, cou
     Returns:
         Offer
     """
-    return _get_or_create_enterprise_offer(
-        benefit_value=benefit_value,
-        benefit_type=benefit_type,
-        enterprise_customer=enterprise_customer,
-        enterprise_customer_catalog=enterprise_catalog,
-        coupon_id=coupon.id,
-        max_uses=max_uses,
-        email_domains=email_domains,
-        site=offer.site or site,
+    return get_or_create_enterprise_offer(
+        benefit_value=benefit_value or offer.benefit.value,
+        benefit_type=benefit_type or offer.benefit.type or getattr(
+            offer.benefit.proxy(), 'benefit_class_type', None
+        ),
+        enterprise_customer=enterprise_customer or offer.condition.enterprise_customer_uuid,
+        enterprise_customer_catalog=enterprise_catalog or offer.condition.enterprise_customer_catalog_uuid,
+        offer_name=offer.name,
+        max_uses=max_uses or offer.max_global_applications,
+        email_domains=email_domains or offer.email_domains,
+        site=site or offer.site,
     )
 
 
-def update_voucher_offer(offer, benefit_value, benefit_type, coupon, max_uses=None, email_domains=None,
+def update_voucher_offer(offer, benefit_value, benefit_type=None, max_uses=None, email_domains=None,
                          program_uuid=None, site=None):
     """
     Update voucher offer with new benefit value.
@@ -750,7 +786,6 @@ def update_voucher_offer(offer, benefit_value, benefit_type, coupon, max_uses=No
         offer (Offer): Offer associated with a voucher.
         benefit_value (Decimal): Value of benefit associated with vouchers.
         benefit_type (str): Type of benefit associated with vouchers.
-        coupon (Product): The coupon whos offer(s) is updated.
 
     Kwargs:
         max_uses (int): number of maximum global application number an offer can have.
@@ -765,13 +800,15 @@ def update_voucher_offer(offer, benefit_value, benefit_type, coupon, max_uses=No
 
     return _get_or_create_offer(
         product_range=offer.benefit.range,
-        benefit_value=benefit_value,
-        benefit_type=benefit_type,
-        coupon_id=coupon.id,
-        max_uses=max_uses,
-        email_domains=email_domains,
-        program_uuid=program_uuid,
-        site=offer.site or site,
+        benefit_value=benefit_value or offer.benefit.value,
+        benefit_type=benefit_type or offer.benefit.type or getattr(
+            offer.benefit.proxy(), 'benefit_class_type', None
+        ),
+        offer_name=offer.name,
+        max_uses=max_uses or offer.max_global_applications,
+        email_domains=email_domains or offer.email_domains,
+        program_uuid=program_uuid or offer.condition.program_uuid,
+        site=site or offer.site,
     )
 
 


### PR DESCRIPTION
**Description**
In this PR, the backend api for creating and updating Coupons is refactored to better support the new coupon screen. There are no functional changes in how the code works, all changes are related to how the code is structured and organized.

**Test Instructions**
Most of what we need to test for is finding regressions.
- Create a coupon without enterprise data.
- Create a coupon with enterprise data. Each voucher should be linked to two conditional offers in the database.
- Update a non-enterprise related field on a previously existing coupon that does not have enterprise data.
- Update a coupon without an enterprise to have an enterprise. This should create an additional enterprise conditional offer for each voucher.
- Update a coupon set to have multiple codes that can be used once by multiple customers. Download the csv and proceed with redeeming a code. It should be successful. [Specifically, we are testing that https://openedx.atlassian.net/browse/ENT-1288 is fixed]

**Special Notes**
This PR stops short of being able to have a new enterprise conditional offer created when updating previously existing coupons with an enterprise set but no enterprise catalog. It has no adverse effects, and it should be possible with the next PR.