### PR TITLE
Update JWT_ISSUERS to the edx-drf-extensions format.

### DIFF
--- a/docs/test_ecommerce.rst
+++ b/docs/test_ecommerce.rst
@@ -101,6 +101,12 @@ these models, which are used for multi-tenancy.
       ecommerce.courses.tests.test_utils --settings=ecommerce.settings.test
       --with-ignore-docstrings --logging-level=DEBUG
 
+To debug when running tests using ``manage.py``, you may need to use the
+following instead of ``pdb`` directly, or nosetests may hang while creating
+the database::
+
+    import nose.tools as nosepdb; nosepdb.set_trace()
+
 * To run tests without creating a database (i.e. really fast), use pytest.
   If a test has a database dependency, the test will not pass.
 

--- a/ecommerce/extensions/api/handlers.py
+++ b/ecommerce/extensions/api/handlers.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from edx_django_utils import monitoring as monitoring_utils
 from edx_rest_framework_extensions.auth.jwt.decoder import jwt_decode_handler as edx_drf_extensions_jwt_decode_handler
 from rest_framework_jwt.settings import api_settings
+from six import string_types
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +31,7 @@ def _ecommerce_jwt_decode_handler_updated_configs(token):
         'verify_exp': api_settings.JWT_VERIFY_EXPIRATION,
         'verify_aud': settings.JWT_AUTH['JWT_VERIFY_AUDIENCE'],
     }
+    error_msg = ''
 
     # JWT_ISSUERS is not one of DRF-JWT's default settings, and cannot be accessed
     # using the `api_settings` object without overriding DRF-JWT's defaults.
@@ -51,14 +53,17 @@ def _ecommerce_jwt_decode_handler_updated_configs(token):
             )
         except jwt.InvalidIssuerError:
             # Ignore these errors since we have multiple issuers
-            pass
+            error_msg += "Issuer {} does not match token. ".format(issuer['ISSUER'])
         except jwt.DecodeError:
             # Ignore these errors since we have multiple issuers
-            pass
+            error_msg += "Wrong secret_key for issuer {}. ".format(issuer['ISSUER'])
         except jwt.InvalidTokenError:
+            error_msg += "Invalid token found using issuer {}. ".format(issuer['ISSUER'])
             logger.exception('Custom config JWT decode failed!')
 
-    raise jwt.InvalidTokenError('All combinations of JWT issuers with updated config failed to validate the token.')
+    raise jwt.InvalidTokenError(
+        'All combinations of JWT issuers with updated config failed to validate the token. ' + error_msg
+    )
 
 
 def _ecommerce_jwt_decode_handler_original(token):
@@ -118,33 +123,37 @@ def jwt_decode_handler(token):
     # will ultimately end in retiring this ecommerce jwt_decode_handler
     # altogether.  See ARCH-261 for detailed plan.
 
-    # first, try jwt_decode_handler from edx_drf_extensions
-    try:
-        jwt_payload = edx_drf_extensions_jwt_decode_handler(token)
-        monitoring_utils.set_custom_metric(JWT_DECODE_HANDLER_METRIC_KEY, 'edx-drf-extensions')
-        return jwt_payload
-    except Exception:  # pylint: disable=broad-except
-        # continue and try again
-        if waffle.switch_is_active('jwt_decode_handler.log_exception.edx-drf-extensions'):
-            logger.info('Failed to use edx-drf-extensions jwt_decode_handler.', exc_info=True)
+    use_original_jwt_decode_handler = isinstance(settings.JWT_AUTH['JWT_ISSUERS'][0], string_types)
+    if use_original_jwt_decode_handler:
 
-    # next, try temporary ecommerce decoder which matches expected config
-    # format of edx-drf-extensions
-    try:
-        jwt_payload = _ecommerce_jwt_decode_handler_updated_configs(token)
-        monitoring_utils.set_custom_metric(JWT_DECODE_HANDLER_METRIC_KEY, 'ecommerce-updated-config')
-        return jwt_payload
-    except Exception:  # pylint: disable=broad-except
-        # continue and try again
-        if waffle.switch_is_active('jwt_decode_handler.log_exception.ecommerce-updated-config'):
-            logger.info('Failed to use custom jwt_decode_handler with updated configs.', exc_info=True)
+        try:
+            jwt_payload = _ecommerce_jwt_decode_handler_original(token)
+            monitoring_utils.set_custom_metric(JWT_DECODE_HANDLER_METRIC_KEY, 'ecommerce-original')
+            return jwt_payload
+        except Exception:  # pylint: disable=broad-except
+            if waffle.switch_is_active('jwt_decode_handler.log_exception.ecommerce-original'):  # pragma: no cover
+                logger.info('Failed to use original jwt_decode_handler.', exc_info=True)
+            raise
 
-    # if all else fails, fallback to the original version
-    try:
-        jwt_payload = _ecommerce_jwt_decode_handler_original(token)
-        monitoring_utils.set_custom_metric(JWT_DECODE_HANDLER_METRIC_KEY, 'ecommerce-original')
-        return jwt_payload
-    except Exception:  # pylint: disable=broad-except
-        if waffle.switch_is_active('jwt_decode_handler.log_exception.ecommerce-original'):
-            logger.info('Failed to use original jwt_decode_handler.', exc_info=True)
-        raise
+    else:
+
+        # first, try jwt_decode_handler from edx_drf_extensions
+        try:
+            jwt_payload = edx_drf_extensions_jwt_decode_handler(token)
+            monitoring_utils.set_custom_metric(JWT_DECODE_HANDLER_METRIC_KEY, 'edx-drf-extensions')
+            return jwt_payload
+        except Exception:  # pylint: disable=broad-except
+            # continue and try again
+            if waffle.switch_is_active('jwt_decode_handler.log_exception.edx-drf-extensions'):
+                logger.info('Failed to use edx-drf-extensions jwt_decode_handler.', exc_info=True)
+
+        # next, try temporary ecommerce decoder which matches expected config
+        # format of edx-drf-extensions
+        try:
+            jwt_payload = _ecommerce_jwt_decode_handler_updated_configs(token)
+            monitoring_utils.set_custom_metric(JWT_DECODE_HANDLER_METRIC_KEY, 'ecommerce-updated-config')
+            return jwt_payload
+        except Exception:  # pylint: disable=broad-except
+            if waffle.switch_is_active('jwt_decode_handler.log_exception.ecommerce-updated-config'):
+                logger.info('Failed to use custom jwt_decode_handler with updated configs.', exc_info=True)
+            raise

--- a/ecommerce/extensions/api/tests/test_handlers.py
+++ b/ecommerce/extensions/api/tests/test_handlers.py
@@ -10,28 +10,33 @@ from waffle.testutils import override_switch
 
 from ecommerce.extensions.api.handlers import jwt_decode_handler
 
-ISSUERS = ('test-issuer', 'another-issuer',)
-SIGNING_KEYS = ('insecure-secret-key', 'secret', 'another-secret',)
 
-
-def generate_jwt_token(payload, signing_key=None):
+def generate_jwt_token(payload, signing_key):
     """Generate a valid JWT token for authenticated requests."""
-    signing_key = signing_key or settings.JWT_AUTH['JWT_SECRET_KEY']
     return jwt.encode(payload, signing_key).decode('utf-8')
 
 
-def generate_jwt_payload(user, issuer=None):
+def generate_jwt_payload(user, issuer_name):
     """Generate a valid JWT payload given a user."""
     now = int(time())
     ttl = 5
-    issuer = issuer or settings.JWT_AUTH['JWT_ISSUERS'][0]
     return {
-        'iss': issuer,
+        'iss': issuer_name,
         'username': user.username,
         'email': user.email,
         'iat': now,
         'exp': now + ttl
     }
+
+
+def generate_jwt_payload_from_legacy_issuers(user):
+    """ Returns jwt payload using legacy configuration """
+    return generate_jwt_payload(user, issuer_name=settings.JWT_AUTH['JWT_ISSUERS'][0])
+
+
+def generate_jwt_token_from_legacy_secret(payload):
+    """ Returns jwt token using legacy configuration """
+    return generate_jwt_token(payload, signing_key=settings.JWT_AUTH['JWT_SECRET_KEY'])
 
 
 class JWTDecodeHandlerTests(TestCase):
@@ -40,36 +45,75 @@ class JWTDecodeHandlerTests(TestCase):
     def setUp(self):
         super(JWTDecodeHandlerTests, self).setUp()
         self.user = UserFactory()
-        self.payload = generate_jwt_payload(self.user)
-        self.jwt = generate_jwt_token(self.payload)
 
+    @override_settings(
+        JWT_AUTH={
+            # legacy JWT_ISSUERS config included just the names
+            'JWT_ISSUERS': ('test-issuer',),
+            'JWT_SECRET_KEY': 'test-secret-key',
+            'JWT_SECRET_KEYS': (),
+            'JWT_VERIFY_AUDIENCE': False,
+        }
+    )
     @mock.patch('edx_django_utils.monitoring.set_custom_metric')
     @mock.patch('ecommerce.extensions.api.handlers.logger')
-    def test_decode_success(self, mock_logger, mock_set_custom_metric):
-        self.assertEqual(jwt_decode_handler(self.jwt), self.payload)
+    def test_decode_success_legacy(self, mock_logger, mock_set_custom_metric):
+        payload = generate_jwt_payload_from_legacy_issuers(self.user)
+        token = generate_jwt_token_from_legacy_secret(payload)
+        self.assertEqual(jwt_decode_handler(token), payload)
         mock_set_custom_metric.assert_called_with('ecom_jwt_decode_handler', 'ecommerce-original')
+        mock_logger.info.assert_not_called()
+        mock_logger.warning.assert_not_called()
+        mock_logger.error.assert_not_called()
         mock_logger.exception.assert_not_called()
 
-    def test_decode_success_with_multiple_issuers(self):
-        settings.JWT_AUTH['JWT_ISSUERS'] = ISSUERS
+    @override_settings(
+        JWT_AUTH={
+            # legacy JWT_ISSUERS config included just the names
+            'JWT_ISSUERS': ('test-issuer', 'another-issuer',),
+            'JWT_SECRET_KEY': 'test-secret-key',
+            'JWT_SECRET_KEYS': (),
+            'JWT_VERIFY_AUDIENCE': False,
+        }
+    )
+    @override_switch('jwt_decode_handler.log_exception.edx-drf-extensions', active=True)
+    @mock.patch('ecommerce.extensions.api.handlers.logger')
+    def test_decode_success_with_multiple_legacy_issuers(self, mock_logger):
+        payload = generate_jwt_payload_from_legacy_issuers(self.user)
+        for issuer in settings.JWT_AUTH['JWT_ISSUERS']:
+            payload['iss'] = issuer
+            token = generate_jwt_token_from_legacy_secret(payload)
+            self.assertEqual(jwt_decode_handler(token), payload)
+            mock_logger.info.assert_called_with('Failed to use edx-drf-extensions jwt_decode_handler.', exc_info=True)
 
-        for issuer in ISSUERS:
-            self.payload['iss'] = issuer
-            token = generate_jwt_token(self.payload)
-            self.assertEqual(jwt_decode_handler(token), self.payload)
-
+    @override_settings(
+        JWT_AUTH={
+            'JWT_ISSUERS': ('test-issuer',),
+            'JWT_SECRET_KEYS': ('test-secret-key', 'secret', 'another-secret',),
+            'JWT_VERIFY_AUDIENCE': False,
+        }
+    )
     def test_decode_success_with_multiple_signing_keys(self):
-        settings.JWT_AUTH['JWT_SECRET_KEYS'] = SIGNING_KEYS
+        payload = generate_jwt_payload_from_legacy_issuers(self.user)
+        for signing_key in settings.JWT_AUTH['JWT_SECRET_KEYS']:
+            token = generate_jwt_token(payload, signing_key)
+            self.assertEqual(jwt_decode_handler(token), payload)
 
-        for signing_key in SIGNING_KEYS:
-            token = generate_jwt_token(self.payload, signing_key)
-            self.assertEqual(jwt_decode_handler(token), self.payload)
-
+    @override_settings(
+        JWT_AUTH={
+            # legacy JWT_ISSUERS config included just the names
+            'JWT_ISSUERS': ('test-issuer',),
+            'JWT_SECRET_KEY': 'test-secret-key',
+            'JWT_SECRET_KEYS': (),
+            'JWT_VERIFY_AUDIENCE': False,
+        }
+    )
     @override_switch('jwt_decode_handler.log_exception.ecommerce-original', active=True)
-    def test_decode_error(self):
+    def test_decode_error_legacy(self):
+        payload = generate_jwt_payload_from_legacy_issuers(self.user)
         # Update the payload to ensure a validation error
-        self.payload['exp'] = 0
-        token = generate_jwt_token(self.payload)
+        payload['exp'] = 0
+        token = generate_jwt_token_from_legacy_secret(payload)
 
         with mock.patch('ecommerce.extensions.api.handlers.logger') as mock_logger:
             with self.assertRaises(jwt.InvalidTokenError):
@@ -97,8 +141,9 @@ class JWTDecodeHandlerTests(TestCase):
         the way that edx-drf-extensions is expected, and using the secret-key
         of the first configured issuer.
         """
-        payload = generate_jwt_payload(self.user, issuer='test-issuer')
-        token = generate_jwt_token(payload, 'test-secret-key')
+        first_issuer = settings.JWT_AUTH['JWT_ISSUERS'][0]
+        payload = generate_jwt_payload(self.user, issuer_name=first_issuer['ISSUER'])
+        token = generate_jwt_token(payload, first_issuer['SECRET_KEY'])
         self.assertDictContainsSubset(payload, jwt_decode_handler(token))
         mock_set_custom_metric.assert_called_with('ecom_jwt_decode_handler', 'edx-drf-extensions')
 
@@ -134,8 +179,9 @@ class JWTDecodeHandlerTests(TestCase):
         the way that edx-drf-extensions is expected, but when the token was
         generated from the second issuer.
         """
-        payload = generate_jwt_payload(self.user, issuer='test-issuer-2')
-        token = generate_jwt_token(payload, 'test-secret-key-2')
+        non_first_issuer = settings.JWT_AUTH['JWT_ISSUERS'][2]
+        payload = generate_jwt_payload(self.user, issuer_name=non_first_issuer['ISSUER'])
+        token = generate_jwt_token(payload, non_first_issuer['SECRET_KEY'])
         self.assertDictContainsSubset(payload, jwt_decode_handler(token))
         mock_set_custom_metric.assert_called_with('ecom_jwt_decode_handler', 'ecommerce-updated-config')
         mock_logger.exception.assert_not_called()
@@ -155,11 +201,11 @@ class JWTDecodeHandlerTests(TestCase):
                 },
             ],
             'JWT_VERIFY_AUDIENCE': False,
-            'JWT_SECRET_KEYS': SIGNING_KEYS
+            'JWT_SECRET_KEYS': ('test-secret-key', 'test-secret-key-2'),
         }
     )
-    @mock.patch('ecommerce.extensions.api.handlers.logger')
     @override_switch('jwt_decode_handler.log_exception.ecommerce-updated-config', active=True)
+    @mock.patch('ecommerce.extensions.api.handlers.logger')
     def test_decode_error_invalid_token(self, mock_logger):
         """
         Should fail ``_ecommerce_jwt_decode_handler_updated_configs`` due to
@@ -170,7 +216,7 @@ class JWTDecodeHandlerTests(TestCase):
         code is first removed from the codebase.
         """
         # Update the payload to ensure a validation error
-        payload = generate_jwt_payload(self.user, issuer='test-issuer-2')
+        payload = generate_jwt_payload(self.user, issuer_name='test-issuer-2')
         payload['exp'] = 0
         token = generate_jwt_token(payload, 'test-secret-key-2')
         with self.assertRaises(jwt.InvalidTokenError):
@@ -181,9 +227,3 @@ class JWTDecodeHandlerTests(TestCase):
                 'Failed to use custom jwt_decode_handler with updated configs.',
                 exc_info=True,
             )
-
-    @mock.patch('ecommerce.extensions.api.handlers.logger')
-    @override_switch('jwt_decode_handler.log_exception.edx-drf-extensions', active=True)
-    def test_decode_with_edx_drf_extensions_log(self, mock_logger):
-        self.assertEqual(jwt_decode_handler(self.jwt), self.payload)
-        mock_logger.info.assert_called_with('Failed to use edx-drf-extensions jwt_decode_handler.', exc_info=True)

--- a/ecommerce/extensions/api/v2/tests/views/test_courses.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_courses.py
@@ -79,7 +79,7 @@ class CourseViewSetTests(ProductSerializerMixin, DiscoveryTestMixin, TestCase):
             'administrator': True,
             'username': username,
             'email': email,
-            'iss': settings.JWT_AUTH['JWT_ISSUERS'][0]
+            'iss': settings.JWT_AUTH['JWT_ISSUERS'][0]['ISSUER']
         }
         auth_header = "JWT {token}".format(token=jwt.encode(payload, settings.JWT_AUTH['JWT_SECRET_KEY']))
         self.assertFalse(User.objects.filter(username=username).exists())

--- a/ecommerce/settings/local.py
+++ b/ecommerce/settings/local.py
@@ -49,11 +49,24 @@ SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
 
 JWT_AUTH.update({
     'JWT_SECRET_KEY': 'insecure-secret-key',
-    'JWT_ISSUERS': (
-        'http://127.0.0.1:8000/oauth2',
-        # Must match the value of JWT_ISSUER configured for the ecommerce worker.
-        'ecommerce_worker',
-    ),
+    'JWT_ISSUERS': [
+        {
+            'SECRET_KEY': 'lms-secret',
+            'AUDIENCE': 'lms-key',
+            'ISSUER': 'http://edx.devstack.lms:18000/oauth2'
+        },
+        {
+            # TODO: ARCH-277: Remove this second issuer once we are no longer
+            # using multiple issuers.
+            'SECRET_KEY': 'insecure-secret-key',
+            # NOTE: This value of AUDIENCE doesn't make sense, even for the
+            # LMS, but we are just making it match for now until AUDIENCE is
+            # potentially removed altogether.
+            'AUDIENCE': 'lms-key',
+            # Must match the value of JWT_ISSUER configured for the ecommerce worker.
+            'ISSUER': 'ecommerce_worker'
+        },
+    ],
 })
 # END AUTHENTICATION
 

--- a/ecommerce/settings/test.py
+++ b/ecommerce/settings/test.py
@@ -51,8 +51,12 @@ DATABASES = {
 ENABLE_AUTO_AUTH = True
 
 JWT_AUTH.update({
-    'JWT_SECRET_KEY': 'insecure-secret-key',
-    'JWT_ISSUERS': ('test-issuer',),
+    'JWT_SECRET_KEY': 'test-secret-key',
+    'JWT_ISSUERS': [{
+        'SECRET_KEY': 'test-secret-key',
+        'AUDIENCE': 'test-audience',
+        'ISSUER': 'test-issuer'
+    }],
 })
 
 PASSWORD_HASHERS = (

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -69,7 +69,7 @@ class UserMixin(object):
         payload = {
             'username': user.username,
             'email': user.email,
-            'iss': settings.JWT_AUTH['JWT_ISSUERS'][0]
+            'iss': settings.JWT_AUTH['JWT_ISSUERS'][0]['ISSUER']
         }
         return "JWT {token}".format(token=jwt.encode(payload, secret))
 
@@ -87,7 +87,7 @@ class ThrottlingMixin(object):
 class JwtMixin(object):
     """ Mixin with JWT-related helper functions. """
     JWT_SECRET_KEY = settings.JWT_AUTH['JWT_SECRET_KEY']
-    issuer = settings.JWT_AUTH['JWT_ISSUERS'][0]
+    issuer = settings.JWT_AUTH['JWT_ISSUERS'][0]['ISSUER']
 
     def generate_token(self, payload, secret=None):
         """Generate a JWT token with the provided payload."""


### PR DESCRIPTION
Update ecommerce default configs to use the updated format of
JWT_ISSUERS which is a dict including audience, secret-key, and
issuer (name), to match the format used by the edx-drf-extensions
jwt_decode_handler.

ARCH-275