### PR TITLE
Enterprise coupons overview

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -714,6 +714,59 @@ class CouponListSerializer(serializers.ModelSerializer):
         fields = ('category', 'client', 'code', 'id', 'title', 'date_created')
 
 
+class EnterpriseCouponOverviewListSerializer(serializers.ModelSerializer):
+    """
+    Serializer for Enterprise Coupons list overview.
+    """
+    end_date = serializers.SerializerMethodField()
+    has_error = serializers.SerializerMethodField()
+    max_uses = serializers.SerializerMethodField()
+    num_codes = serializers.SerializerMethodField()
+    num_unassigned = serializers.SerializerMethodField()
+    num_uses = serializers.SerializerMethodField()
+    start_date = serializers.SerializerMethodField()
+    usage_limitation = serializers.SerializerMethodField()
+
+    # TODO: ENT-1184
+    def get_num_unassigned(self, obj):  # pylint: disable=unused-argument
+        return 0
+
+    # TODO: ENT-1184
+    def get_has_error(self, obj):   # pylint: disable=unused-argument
+        return False
+
+    # Max number of codes available (Maximum Coupon Usage).
+    def get_max_uses(self, obj):
+        offer = retrieve_offer(obj)
+        return offer.max_global_applications
+
+    # Redemption count.
+    def get_num_uses(self, obj):
+        voucher = retrieve_voucher(obj)
+        return voucher.num_orders
+
+    # Number of codes.
+    def get_num_codes(self, obj):
+        return retrieve_quantity(obj)
+
+    # Usage Limitation (Maximum # of usages per code).
+    def get_usage_limitation(self, obj):
+        return retrieve_voucher_usage(obj)
+
+    def get_start_date(self, obj):
+        return retrieve_start_date(obj)
+
+    def get_end_date(self, obj):
+        return retrieve_end_date(obj)
+
+    class Meta(object):
+        model = Product
+        fields = (
+            'end_date', 'has_error', 'id', 'max_uses', 'num_codes', 'num_unassigned',
+            'num_uses', 'start_date', 'title', 'usage_limitation'
+        )
+
+
 class EnterpriseCouponListSerializer(serializers.ModelSerializer):
     client = serializers.SerializerMethodField()
     enterprise_customer = serializers.SerializerMethodField()

--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -68,14 +68,14 @@ class TestEnterpriseCustomerView(EnterpriseServiceMockMixin, TestCase):
         )
         url = reverse('api:v2:enterprise:enterprise_customers')
         result = self.client.get(url)
-        self.assertEqual(result.status_code, 401)
+        self.assertEqual(result.status_code, status.HTTP_401_UNAUTHORIZED)
 
         user = self.create_user(is_staff=True)
 
         self.client.login(username=user.username, password=self.password)
 
         result = self.client.get(url)
-        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.status_code, status.HTTP_200_OK)
         self.assertJSONEqual(
             result.content.decode('utf-8'),
             {
@@ -95,7 +95,9 @@ class TestEnterpriseCustomerView(EnterpriseServiceMockMixin, TestCase):
 
 @ddt.ddt
 class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMockMixin, ThrottlingMixin, TestCase):
-    """Test the enterprise coupon order creation functionality."""
+    """
+    Test the enterprise coupon order functionality.
+    """
     def setUp(self):
         super(EnterpriseCouponViewSetTest, self).setUp()
         self.user = self.create_user(is_staff=True)
@@ -119,11 +121,58 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         self.course = CourseFactory(id='course-v1:test-org+course+run', partner=self.partner)
         self.verified_seat = self.course.create_or_update_seat('verified', False, 100)
 
+    def get_coupon_voucher(self, coupon):
+        """
+        Helper method to get coupon voucher.
+        """
+        return coupon.attr.coupon_vouchers.vouchers.first()
+
+    def get_coupon_data(self, coupon_title):
+        """
+        Helper method to return coupon data by coupon title.
+        """
+        coupon = Product.objects.get(title=coupon_title)
+        return {
+            'end_date': self.get_coupon_voucher_end_date(coupon),
+            'has_error': False,
+            'id': coupon.id,
+            'max_uses': None,
+            'num_codes': 2,
+            'num_unassigned': 0,
+            'num_uses': 0,
+            'start_date': self.get_coupon_voucher_start_date(coupon),
+            'title': coupon.title,
+            'usage_limitation': 'Single use'
+        }
+
+    def get_coupon_voucher_start_date(self, coupon):
+        """
+        Helper method to return coupon voucher start date.
+        """
+        return self.get_coupon_voucher(coupon).start_datetime.isoformat().replace('+00:00', 'Z')
+
+    def get_coupon_voucher_end_date(self, coupon):
+        """
+        Helper method to return coupon voucher end date.
+        """
+        return self.get_coupon_voucher(coupon).end_datetime.isoformat().replace('+00:00', 'Z')
+
     def get_response(self, method, path, data=None):
-        """Helper method for sending requests and returning the response."""
+        """
+        Helper method for sending requests and returning the response.
+        """
+        enterprise_id = ''
+        enterprise_name = 'ToyX'
+        if data and data.get('enterprise_customer'):
+            enterprise_id = data['enterprise_customer']['id']
+            enterprise_name = data['enterprise_customer']['name']
+
         with mock.patch(
-            "ecommerce.extensions.voucher.utils.get_enterprise_customer",
-            mock.Mock(return_value={'name': 'Fake enterprise'})
+            'ecommerce.extensions.voucher.utils.get_enterprise_customer',
+            mock.Mock(return_value={
+                'name': enterprise_name,
+                'enterprise_customer_uuid': enterprise_id
+            })
         ):
             if method == 'GET':
                 return self.client.get(path)
@@ -131,6 +180,15 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
                 return self.client.post(path, json.dumps(data), 'application/json')
             elif method == 'PUT':
                 return self.client.put(path, json.dumps(data), 'application/json')
+        return None
+
+    def get_response_json(self, method, path, data=None):
+        """
+        Helper method for sending requests and returning JSON response content.
+        """
+        response = self.get_response(method, path, data)
+        if response:
+            return json.loads(response.content)
         return None
 
     def test_list_enterprise_coupons(self):
@@ -501,3 +559,58 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
                 'previous': None,
             }
         )
+
+    @ddt.data(
+        (
+            '85b08dde-0877-4474-a4e9-8408fe47ce88',
+            ['coupon-1', 'coupon-2']
+        ),
+        (
+            'f5c9149f-8dce-4410-bb0f-85c0f2dda864',
+            ['coupon-3']
+        ),
+        (
+            'f5c9149f-8dce-4410-bb0f-85c0f2dda860',
+            []
+        ),
+    )
+    @ddt.unpack
+    def test_get_enterprise_coupon_overview_data(self, enterprise_id, expected_coupons):
+        """
+        Test if we get correct enterprise coupon overview data.
+        """
+        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': True})
+        coupons_data = [{
+            'title': 'coupon-1',
+            'enterprise_customer': {'name': 'LOTRx', 'id': '85b08dde-0877-4474-a4e9-8408fe47ce88'}
+        }, {
+            'title': 'coupon-2',
+            'enterprise_customer': {'name': 'LOTRx', 'id': '85b08dde-0877-4474-a4e9-8408fe47ce88'}
+        }, {
+            'title': 'coupon-3',
+            'enterprise_customer': {'name': 'HPx', 'id': 'f5c9149f-8dce-4410-bb0f-85c0f2dda864'}
+        }]
+
+        # Create coupons.
+        for coupon_data in coupons_data:
+            self.get_response('POST', ENTERPRISE_COUPONS_LINK, dict(self.data, **coupon_data))
+
+        # Build expected results.
+        expected_results = []
+        for coupon_title in expected_coupons:
+            expected_results.append(self.get_coupon_data(coupon_title))
+
+        overview_response = self.get_response_json(
+            'GET',
+            reverse(
+                'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/overview-list',
+                kwargs={'enterprise_id': enterprise_id}
+            )
+        )
+
+        # Verify that we get correct number of results related enterprise id.
+        self.assertEqual(overview_response['count'], len(expected_results))
+
+        # Verify that we get correct results.
+        for actual_result in overview_response['results']:
+            self.assertIn(actual_result, expected_results)

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -6,7 +6,7 @@ import waffle
 from django.core.exceptions import ValidationError
 from oscar.core.loading import get_model
 from rest_framework import generics, serializers
-from rest_framework.decorators import detail_route
+from rest_framework.decorators import detail_route, list_route
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 
@@ -17,7 +17,8 @@ from ecommerce.enterprise.utils import get_enterprise_customers
 from ecommerce.extensions.api.serializers import (
     CouponSerializer,
     CouponVoucherSerializer,
-    EnterpriseCouponListSerializer
+    EnterpriseCouponListSerializer,
+    EnterpriseCouponOverviewListSerializer
 )
 from ecommerce.extensions.api.v2.views.coupons import CouponViewSet
 from ecommerce.extensions.catalogue.utils import (
@@ -53,7 +54,11 @@ class EnterpriseCouponViewSet(CouponViewSet):
     """ Coupon resource. """
 
     def get_queryset(self):
-        invoices = Invoice.objects.filter(business_client__enterprise_customer_uuid__isnull=False)
+        enterprise_id = self.kwargs.get('enterprise_id')
+        if enterprise_id:
+            invoices = Invoice.objects.filter(business_client__enterprise_customer_uuid=enterprise_id)
+        else:
+            invoices = Invoice.objects.filter(business_client__enterprise_customer_uuid__isnull=False)
         orders = Order.objects.filter(id__in=[invoice.order_id for invoice in invoices])
         basket_lines = Line.objects.filter(basket_id__in=[order.basket_id for order in orders])
         return Product.objects.filter(
@@ -66,6 +71,8 @@ class EnterpriseCouponViewSet(CouponViewSet):
     def get_serializer_class(self):
         if self.action == 'list':
             return EnterpriseCouponListSerializer
+        elif self.action == 'overview':
+            return EnterpriseCouponOverviewListSerializer
         return CouponSerializer
 
     def validate_access_for_enterprise_switch(self, request_data):
@@ -208,4 +215,22 @@ class EnterpriseCouponViewSet(CouponViewSet):
 
         page = self.paginate_queryset(all_coupon_vouchers)
         serializer = CouponVoucherSerializer(page, many=True)
+        return self.get_paginated_response(serializer.data)
+
+    @list_route(url_path=r'(?P<enterprise_id>.+)/overview')
+    def overview(self, request, enterprise_id):     # pylint: disable=unused-argument
+        """
+        Overview of Enterprise coupons.
+        Returns the following data:
+            - Coupon ID
+            - Coupon name.
+            - Max number of codes available (Maximum coupon usage).
+            - Number of codes.
+            - Redemption count.
+            - Valid from.
+            - Valid end.
+        """
+        enterprise_coupons = self.get_queryset()
+        page = self.paginate_queryset(enterprise_coupons)
+        serializer = self.get_serializer(page, many=True)
         return self.get_paginated_response(serializer.data)


### PR DESCRIPTION
The purpose of this PR is to add backend support for listing coupons for an enterprise needed for edx-portal.

From jira story:
> Returns a list of json objects with: Coupon ID (coupon product id), Coupon Name, Valid From and To, # of Codes, Usage Limitation (Maximum # of Usages per code), % of available Code redemptions available that have been redeemed.

Sample endpoint URL: https://ecommerce-entcoupon.sandbox.edx.org/api/v2/coupons/enterprise/cf246b88d5f64908a522fc307e0b0c60/overview/

Sample response:
```python
{
    "count": 2,
    "next": null,
    "previous": null,
    "results": [
        {
            "end_date": "2019-03-12T00:00:00Z",
            "has_error": false,
            "id": 6,
            "max_uses": 2,
            "num_codes": 100,
            "num_unassigned": 0,
            "num_uses": 0,
            "start_date": "2018-11-19T00:00:00Z",
            "title": "Test edX coupon2",
            "usage_limitation": "Once per customer"
        },
        {
            "end_date": "2019-02-21T00:00:00Z",
            "has_error": false,
            "id": 5,
            "max_uses": null,
            "num_codes": 10,
            "num_unassigned": 0,
            "num_uses": 0,
            "start_date": "2018-11-19T00:00:00Z",
            "title": "Test coupon1",
            "usage_limitation": "Single use"
        }
    ]
}
```

[Backend API for Coupon Overview - ENT-1260](https://openedx.atlassian.net/browse/ENT-1260)

[Sandbox](https://ecommerce-entcoupon.sandbox.edx.org/coupons/)

**Test Instructions**
- [Create some coupons](https://ecommerce-entcoupon.sandbox.edx.org/coupons/new/) and associate it with some client (eg: entX).
> After you have created a couple of coupons with `entX` client, You might want to update `client`'s `enterprise_customer_uuid` (eg: cf246b88d5f64908a522fc307e0b0c65) from [django admin](https://ecommerce-entcoupon.sandbox.edx.org/admin/core/businessclient/), since sandbox is not linked with LMS.
- [Observe all coupons](https://ecommerce-entcoupon.sandbox.edx.org/coupons/) list in ecommerce.
- Observe the list of coupons associated with <enterprise_customer_id> at 
https://ecommerce-business.sandbox.edx.org/api/v2/coupons/enterprise/cf246b88d5f64908a522fc307e0b0c65/overview/
