### PR TITLE
ARCH-279: Remove jwt_decode_handler for old config format.

### DIFF
--- a/ecommerce/extensions/api/handlers.py
+++ b/ecommerce/extensions/api/handlers.py
@@ -1,4 +1,10 @@
-"""Handler overrides for JWT authentication."""
+"""
+Handler overrides for JWT authentication.
+
+See ARCH-276 for details of removing additional issuers and retiring this
+custom jwt_decode_handler.
+
+"""
 import logging
 
 import jwt
@@ -7,24 +13,26 @@ from django.conf import settings
 from edx_django_utils import monitoring as monitoring_utils
 from edx_rest_framework_extensions.auth.jwt.decoder import jwt_decode_handler as edx_drf_extensions_jwt_decode_handler
 from rest_framework_jwt.settings import api_settings
-from six import string_types
 
 logger = logging.getLogger(__name__)
 
 JWT_DECODE_HANDLER_METRIC_KEY = 'ecom_jwt_decode_handler'
 
 
-def _ecommerce_jwt_decode_handler_updated_configs(token):
+def _ecommerce_jwt_decode_handler_multiple_issuers(token):
     """
-    Same as original with minor modifications to expect
-    configuration format matching the expectations of
-    edx-drf-extensions decoder.
+    Unlike the edx-drf-extensions jwt_decode_handler implementation, this
+    jwt_decode_handler loops over multiple issuers using the same config
+    format as the edx-drf-extensions decoder.  Example::
 
       JWT_AUTH:
         JWT_ISSUERS:
           - AUDIENCE: '{{ COMMON_JWT_AUDIENCE }}'
             ISSUER: '{{ COMMON_JWT_ISSUER }}'
             SECRET_KEY: '{{ COMMON_JWT_SECRET_KEY }}'
+
+    See ARCH-276 for details of removing additional issuers and retiring this
+    custom jwt_decode_handler.
 
     """
     options = {
@@ -37,8 +45,6 @@ def _ecommerce_jwt_decode_handler_updated_configs(token):
     # using the `api_settings` object without overriding DRF-JWT's defaults.
     issuers = settings.JWT_AUTH['JWT_ISSUERS']
 
-    # Unlike the original two secret-key/issuer loops, here we have a single
-    # loop because the secret key is now part of the issuer config.
     for issuer in issuers:
         try:
             return jwt.decode(
@@ -66,46 +72,9 @@ def _ecommerce_jwt_decode_handler_updated_configs(token):
     )
 
 
-def _ecommerce_jwt_decode_handler_original(token):
-    options = {
-        'verify_exp': api_settings.JWT_VERIFY_EXPIRATION,
-        'verify_aud': settings.JWT_AUTH['JWT_VERIFY_AUDIENCE'],
-    }
-
-    # JWT_ISSUERS is not one of DRF-JWT's default settings, and cannot be accessed
-    # using the `api_settings` object without overriding DRF-JWT's defaults.
-    issuers = settings.JWT_AUTH['JWT_ISSUERS']
-    secret_keys = settings.JWT_AUTH['JWT_SECRET_KEYS'] or (api_settings.JWT_SECRET_KEY,)
-
-    # TODO (CCB): The usage of multiple issuers complicates matters. We should only have one issuer.
-    # Update ecommerce-worker to properly use client credentials, and remove the internal loop. (ECOM-4477)
-    for secret_key in secret_keys:
-        for issuer in issuers:
-            try:
-                return jwt.decode(
-                    token,
-                    secret_key,
-                    api_settings.JWT_VERIFY,
-                    options=options,
-                    leeway=api_settings.JWT_LEEWAY,
-                    audience=api_settings.JWT_AUDIENCE,
-                    issuer=issuer,
-                    algorithms=[api_settings.JWT_ALGORITHM]
-                )
-            except jwt.InvalidIssuerError:
-                # Ignore these errors since we have multiple issuers
-                pass
-            except jwt.DecodeError:
-                # Ignore these errors since we have multiple signing keys
-                pass
-            except jwt.InvalidTokenError:
-                logger.exception('Original JWT decode failed!')
-
-    raise jwt.InvalidTokenError('All combinations of JWT issuers and secret keys failed to validate the token.')
-
-
 def jwt_decode_handler(token):
-    """Attempt to decode the given token with each of the configured JWT issuers.
+    """
+    Attempt to decode the given token with each of the configured JWT issuers.
 
     Args:
         token (str): The JWT to decode.
@@ -119,41 +88,26 @@ def jwt_decode_handler(token):
 
     """
 
-    # The following versions of decoding are part of a larger rollout plan that
-    # will ultimately end in retiring this ecommerce jwt_decode_handler
-    # altogether.  See ARCH-261 for detailed plan.
+    # first, try jwt_decode_handler from edx_drf_extensions
+    # Note: this jwt_decode_handler can handle asymmetric keys, but only a
+    #   single issuer. Therefore, the LMS must be the first configured issuer.
+    try:
+        jwt_payload = edx_drf_extensions_jwt_decode_handler(token)
+        monitoring_utils.set_custom_metric(JWT_DECODE_HANDLER_METRIC_KEY, 'edx-drf-extensions')
+        return jwt_payload
+    except Exception:  # pylint: disable=broad-except
+        # continue and try again
+        if waffle.switch_is_active('jwt_decode_handler.log_exception.edx-drf-extensions'):
+            logger.info('Failed to use edx-drf-extensions jwt_decode_handler.', exc_info=True)
 
-    use_original_jwt_decode_handler = isinstance(settings.JWT_AUTH['JWT_ISSUERS'][0], string_types)
-    if use_original_jwt_decode_handler:
-
-        try:
-            jwt_payload = _ecommerce_jwt_decode_handler_original(token)
-            monitoring_utils.set_custom_metric(JWT_DECODE_HANDLER_METRIC_KEY, 'ecommerce-original')
-            return jwt_payload
-        except Exception:  # pylint: disable=broad-except
-            if waffle.switch_is_active('jwt_decode_handler.log_exception.ecommerce-original'):  # pragma: no cover
-                logger.info('Failed to use original jwt_decode_handler.', exc_info=True)
-            raise
-
-    else:
-
-        # first, try jwt_decode_handler from edx_drf_extensions
-        try:
-            jwt_payload = edx_drf_extensions_jwt_decode_handler(token)
-            monitoring_utils.set_custom_metric(JWT_DECODE_HANDLER_METRIC_KEY, 'edx-drf-extensions')
-            return jwt_payload
-        except Exception:  # pylint: disable=broad-except
-            # continue and try again
-            if waffle.switch_is_active('jwt_decode_handler.log_exception.edx-drf-extensions'):
-                logger.info('Failed to use edx-drf-extensions jwt_decode_handler.', exc_info=True)
-
-        # next, try temporary ecommerce decoder which matches expected config
-        # format of edx-drf-extensions
-        try:
-            jwt_payload = _ecommerce_jwt_decode_handler_updated_configs(token)
-            monitoring_utils.set_custom_metric(JWT_DECODE_HANDLER_METRIC_KEY, 'ecommerce-updated-config')
-            return jwt_payload
-        except Exception:  # pylint: disable=broad-except
-            if waffle.switch_is_active('jwt_decode_handler.log_exception.ecommerce-updated-config'):
-                logger.info('Failed to use custom jwt_decode_handler with updated configs.', exc_info=True)
-            raise
+    # next, try ecommerce decoder that handles multiple issuers.
+    # See ARCH-276 for details of removing additional issuers and retiring this
+    # custom jwt_decode_handler.
+    try:
+        jwt_payload = _ecommerce_jwt_decode_handler_multiple_issuers(token)
+        monitoring_utils.set_custom_metric(JWT_DECODE_HANDLER_METRIC_KEY, 'ecommerce-multiple-issuers')
+        return jwt_payload
+    except Exception:  # pylint: disable=broad-except
+        if waffle.switch_is_active('jwt_decode_handler.log_exception.ecommerce-multiple-issuers'):
+            logger.info('Failed to use ecommerce multiple issuer jwt_decode_handler.', exc_info=True)
+        raise

--- a/ecommerce/extensions/api/tests/test_handlers.py
+++ b/ecommerce/extensions/api/tests/test_handlers.py
@@ -29,95 +29,12 @@ def generate_jwt_payload(user, issuer_name):
     }
 
 
-def generate_jwt_payload_from_legacy_issuers(user):
-    """ Returns jwt payload using legacy configuration """
-    return generate_jwt_payload(user, issuer_name=settings.JWT_AUTH['JWT_ISSUERS'][0])
-
-
-def generate_jwt_token_from_legacy_secret(payload):
-    """ Returns jwt token using legacy configuration """
-    return generate_jwt_token(payload, signing_key=settings.JWT_AUTH['JWT_SECRET_KEY'])
-
-
 class JWTDecodeHandlerTests(TestCase):
     """ Tests for the `jwt_decode_handler` utility function. """
 
     def setUp(self):
         super(JWTDecodeHandlerTests, self).setUp()
         self.user = UserFactory()
-
-    @override_settings(
-        JWT_AUTH={
-            # legacy JWT_ISSUERS config included just the names
-            'JWT_ISSUERS': ('test-issuer',),
-            'JWT_SECRET_KEY': 'test-secret-key',
-            'JWT_SECRET_KEYS': (),
-            'JWT_VERIFY_AUDIENCE': False,
-        }
-    )
-    @mock.patch('edx_django_utils.monitoring.set_custom_metric')
-    @mock.patch('ecommerce.extensions.api.handlers.logger')
-    def test_decode_success_legacy(self, mock_logger, mock_set_custom_metric):
-        payload = generate_jwt_payload_from_legacy_issuers(self.user)
-        token = generate_jwt_token_from_legacy_secret(payload)
-        self.assertEqual(jwt_decode_handler(token), payload)
-        mock_set_custom_metric.assert_called_with('ecom_jwt_decode_handler', 'ecommerce-original')
-        mock_logger.info.assert_not_called()
-        mock_logger.warning.assert_not_called()
-        mock_logger.error.assert_not_called()
-        mock_logger.exception.assert_not_called()
-
-    @override_settings(
-        JWT_AUTH={
-            # legacy JWT_ISSUERS config included just the names
-            'JWT_ISSUERS': ('test-issuer', 'another-issuer',),
-            'JWT_SECRET_KEY': 'test-secret-key',
-            'JWT_SECRET_KEYS': (),
-            'JWT_VERIFY_AUDIENCE': False,
-        }
-    )
-    def test_decode_success_with_multiple_legacy_issuers(self):
-        payload = generate_jwt_payload_from_legacy_issuers(self.user)
-        for issuer in settings.JWT_AUTH['JWT_ISSUERS']:
-            payload['iss'] = issuer
-            token = generate_jwt_token_from_legacy_secret(payload)
-            self.assertEqual(jwt_decode_handler(token), payload)
-
-    @override_settings(
-        JWT_AUTH={
-            'JWT_ISSUERS': ('test-issuer',),
-            'JWT_SECRET_KEYS': ('test-secret-key', 'secret', 'another-secret',),
-            'JWT_VERIFY_AUDIENCE': False,
-        }
-    )
-    def test_decode_success_with_multiple_signing_keys(self):
-        payload = generate_jwt_payload_from_legacy_issuers(self.user)
-        for signing_key in settings.JWT_AUTH['JWT_SECRET_KEYS']:
-            token = generate_jwt_token(payload, signing_key)
-            self.assertEqual(jwt_decode_handler(token), payload)
-
-    @override_settings(
-        JWT_AUTH={
-            # legacy JWT_ISSUERS config included just the names
-            'JWT_ISSUERS': ('test-issuer',),
-            'JWT_SECRET_KEY': 'test-secret-key',
-            'JWT_SECRET_KEYS': (),
-            'JWT_VERIFY_AUDIENCE': False,
-        }
-    )
-    @override_switch('jwt_decode_handler.log_exception.ecommerce-original', active=True)
-    def test_decode_error_legacy(self):
-        payload = generate_jwt_payload_from_legacy_issuers(self.user)
-        # Update the payload to ensure a validation error
-        payload['exp'] = 0
-        token = generate_jwt_token_from_legacy_secret(payload)
-
-        with mock.patch('ecommerce.extensions.api.handlers.logger') as mock_logger:
-            with self.assertRaises(jwt.InvalidTokenError):
-                jwt_decode_handler(token)
-
-            mock_logger.exception.assert_called_with('Original JWT decode failed!')
-            mock_logger.info.assert_called_with('Failed to use original jwt_decode_handler.', exc_info=True)
 
     @override_settings(
         JWT_AUTH={
@@ -169,20 +86,22 @@ class JWTDecodeHandlerTests(TestCase):
     @override_switch('jwt_decode_handler.log_exception.edx-drf-extensions', active=True)
     @mock.patch('edx_django_utils.monitoring.set_custom_metric')
     @mock.patch('ecommerce.extensions.api.handlers.logger')
-    def test_decode_success_updated_config(self, mock_logger, mock_set_custom_metric):
+    def test_decode_success_multiple_issuers(self, mock_logger, mock_set_custom_metric):
         """
-        Should pass using ``_ecommerce_jwt_decode_handler_updated_configs``.
+        Should pass using ``_ecommerce_jwt_decode_handler_multiple_issuers``.
 
         This would happen with the combination of the JWT_ISSUERS configured in
         the way that edx-drf-extensions is expected, but when the token was
-        generated from the second issuer.
+        generated from the second (or third+) issuer.
         """
         non_first_issuer = settings.JWT_AUTH['JWT_ISSUERS'][2]
         payload = generate_jwt_payload(self.user, issuer_name=non_first_issuer['ISSUER'])
         token = generate_jwt_token(payload, non_first_issuer['SECRET_KEY'])
         self.assertDictContainsSubset(payload, jwt_decode_handler(token))
-        mock_set_custom_metric.assert_called_with('ecom_jwt_decode_handler', 'ecommerce-updated-config')
+        mock_set_custom_metric.assert_called_with('ecom_jwt_decode_handler', 'ecommerce-multiple-issuers')
         mock_logger.exception.assert_not_called()
+        mock_logger.warning.assert_not_called()
+        mock_logger.error.assert_not_called()
         mock_logger.info.assert_called_with('Failed to use edx-drf-extensions jwt_decode_handler.', exc_info=True)
 
     @override_settings(
@@ -200,19 +119,14 @@ class JWTDecodeHandlerTests(TestCase):
                 },
             ],
             'JWT_VERIFY_AUDIENCE': False,
-            'JWT_SECRET_KEYS': ('test-secret-key', 'test-secret-key-2'),
         }
     )
-    @override_switch('jwt_decode_handler.log_exception.ecommerce-updated-config', active=True)
+    @override_switch('jwt_decode_handler.log_exception.ecommerce-multiple-issuers', active=True)
     @mock.patch('ecommerce.extensions.api.handlers.logger')
     def test_decode_error_invalid_token(self, mock_logger):
         """
-        Should fail ``_ecommerce_jwt_decode_handler_updated_configs`` due to
+        Should fail ``_ecommerce_jwt_decode_handler_multiple_issuers`` due to
         invalid token, not because it is not configured properly.
-
-        IMPORTANT: The original decode_handler still requires JWT_SECRET_KEYS.
-        JWT_SECRET_KEYS cannot be removed from config until the original decode_handler
-        code is first removed from the codebase.
         """
         # Update the payload to ensure a validation error
         payload = generate_jwt_payload(self.user, issuer_name='test-issuer-2')
@@ -229,6 +143,6 @@ class JWTDecodeHandlerTests(TestCase):
 
             mock_logger.exception.assert_called_with('Custom config JWT decode failed!')
             mock_logger.info.assert_called_with(
-                'Failed to use custom jwt_decode_handler with updated configs.',
+                'Failed to use ecommerce multiple issuer jwt_decode_handler.',
                 exc_info=True,
             )

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -406,7 +406,6 @@ JWT_AUTH = {
     'JWT_ISSUERS': (),
     # NOTE (CCB): This is temporarily set to False until we decide what values are acceptable.
     'JWT_VERIFY_AUDIENCE': False,
-    'JWT_SECRET_KEYS': (),
 }
 
 # Service user for worker processes.

--- a/ecommerce/settings/local.py
+++ b/ecommerce/settings/local.py
@@ -56,7 +56,7 @@ JWT_AUTH.update({
             'ISSUER': 'http://edx.devstack.lms:18000/oauth2'
         },
         {
-            # TODO: ARCH-277: Remove this second issuer once we are no longer
+            # TODO: ARCH-276: Remove this second issuer once we are no longer
             # using multiple issuers.
             'SECRET_KEY': 'insecure-secret-key',
             # NOTE: This value of AUDIENCE doesn't make sense, even for the


### PR DESCRIPTION
The original jwt_decode_handler code for ecommerce had JWT_ISSUERS
configured as a list of issuer names, and the secret keys were in a
separate config JWT_SECRET_KEYS. The newer config that consolidates
these into an array of issuer objects under JWT_ISSUERS is now complete,
so we are removing all the code that relied on the original
configuration that is no longer in use.

NOTE: Top-level JWT_SECRET_KEY config in JWT_AUTH could probably also
be cleaned up, but leaving that to a separate effort.

ARCH-279