### PR TITLE
ARCH-283: Use suppress logging in jwt_decode_handler.

### DIFF
--- a/ecommerce/extensions/api/handlers.py
+++ b/ecommerce/extensions/api/handlers.py
@@ -92,7 +92,7 @@ def jwt_decode_handler(token):
     # Note: this jwt_decode_handler can handle asymmetric keys, but only a
     #   single issuer. Therefore, the LMS must be the first configured issuer.
     try:
-        jwt_payload = edx_drf_extensions_jwt_decode_handler(token)
+        jwt_payload = edx_drf_extensions_jwt_decode_handler(token, suppress_logging=True)
         monitoring_utils.set_custom_metric(JWT_DECODE_HANDLER_METRIC_KEY, 'edx-drf-extensions')
         return jwt_payload
     except Exception:  # pylint: disable=broad-except

--- a/ecommerce/extensions/api/tests/test_handlers.py
+++ b/ecommerce/extensions/api/tests/test_handlers.py
@@ -85,8 +85,9 @@ class JWTDecodeHandlerTests(TestCase):
     )
     @override_switch('jwt_decode_handler.log_exception.edx-drf-extensions', active=True)
     @mock.patch('edx_django_utils.monitoring.set_custom_metric')
+    @mock.patch('edx_rest_framework_extensions.auth.jwt.decoder.logger')
     @mock.patch('ecommerce.extensions.api.handlers.logger')
-    def test_decode_success_multiple_issuers(self, mock_logger, mock_set_custom_metric):
+    def test_decode_success_multiple_issuers(self, mock_logger, mock_drf_logger, mock_set_custom_metric):
         """
         Should pass using ``_ecommerce_jwt_decode_handler_multiple_issuers``.
 
@@ -99,10 +100,11 @@ class JWTDecodeHandlerTests(TestCase):
         token = generate_jwt_token(payload, non_first_issuer['SECRET_KEY'])
         self.assertDictContainsSubset(payload, jwt_decode_handler(token))
         mock_set_custom_metric.assert_called_with('ecom_jwt_decode_handler', 'ecommerce-multiple-issuers')
-        mock_logger.exception.assert_not_called()
-        mock_logger.warning.assert_not_called()
-        mock_logger.error.assert_not_called()
         mock_logger.info.assert_called_with('Failed to use edx-drf-extensions jwt_decode_handler.', exc_info=True)
+        mock_drf_logger.info.assert_not_called()
+        mock_drf_logger.warn.assert_not_called()
+        mock_drf_logger.error.assert_not_called()
+        mock_drf_logger.exception.assert_not_called()
 
     @override_settings(
         JWT_AUTH={

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -47,7 +47,8 @@ edx-auth-backends==1.1.3
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==1.0.1
-edx-drf-extensions==2.0.0
+#edx-drf-extensions==2.0.2
+-e git+https://github.com/edx/edx-drf-extensions.git@robrap/ARCH-283-allow-suppress-logging#egg=edx_rest_framework_extensions
 edx-ecommerce-worker==0.7.0
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -60,7 +60,8 @@ edx-auth-backends==1.1.3
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==1.0.1
-edx-drf-extensions==2.0.0
+#edx-drf-extensions==2.0.2
+-e git+https://github.com/edx/edx-drf-extensions.git@robrap/ARCH-283-allow-suppress-logging#egg=edx_rest_framework_extensions
 edx-ecommerce-worker==0.7.0
 edx-i18n-tools==0.4.4
 edx-opaque-keys==0.4.4

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -49,7 +49,8 @@ edx-auth-backends==1.1.3
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==1.0.1
-edx-drf-extensions==2.0.0
+#edx-drf-extensions==2.0.2
+-e git+https://github.com/edx/edx-drf-extensions.git@robrap/ARCH-283-allow-suppress-logging#egg=edx_rest_framework_extensions
 edx-ecommerce-worker==0.7.0
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -57,7 +57,8 @@ edx-auth-backends==1.1.3
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==1.0.1
-edx-drf-extensions==2.0.0
+#edx-drf-extensions==2.0.2
+-e git+https://github.com/edx/edx-drf-extensions.git@robrap/ARCH-283-allow-suppress-logging#egg=edx_rest_framework_extensions
 edx-ecommerce-worker==0.7.0
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2


### PR DESCRIPTION
Temporarily, ecommerce is delegating to the edx-drf-extensions
jwt_decode_handler, with its own fallback to allow for multiple issuers.
Logging suppression inside the edx-drf-extensions jwt_decode_handler is
required until ecommerce is down to a single issuer and can use the
edx-drf-extensions jwt_decode_handler directly.

Note: this should be reverted as part of ARCH-276.

ARCH-283