### PR TITLE
ARCH-283: Fix logging issue in jwt_decode_handler.

### DIFF
--- a/ecommerce/extensions/api/tests/test_handlers.py
+++ b/ecommerce/extensions/api/tests/test_handlers.py
@@ -47,14 +47,15 @@ class JWTDecodeHandlerTests(TestCase):
         }
     )
     @mock.patch('edx_django_utils.monitoring.set_custom_metric')
-    def test_decode_success_edx_drf_extensions(self, mock_set_custom_metric):
+    @mock.patch('ecommerce.extensions.api.handlers._ecommerce_jwt_decode_handler_multiple_issuers')
+    def test_decode_success_edx_drf_extensions(self, mock_multiple_issuer_decoder, mock_set_custom_metric):
         """
         Should pass using the edx-drf-extensions jwt_decode_handler.
 
-        This would happen with the combination of the JWT_ISSUERS configured in
-        the way that edx-drf-extensions is expected, and using the secret-key
-        of the first configured issuer.
+        This would happen if ``_ecommerce_jwt_decode_handler_multiple_issuers``
+        should fail (e.g. using asymmetric tokens).
         """
+        mock_multiple_issuer_decoder.side_effect = jwt.InvalidTokenError()
         first_issuer = settings.JWT_AUTH['JWT_ISSUERS'][0]
         payload = generate_jwt_payload(self.user, issuer_name=first_issuer['ISSUER'])
         token = generate_jwt_token(payload, first_issuer['SECRET_KEY'])
@@ -83,7 +84,6 @@ class JWTDecodeHandlerTests(TestCase):
             'JWT_VERIFY_AUDIENCE': False,
         }
     )
-    @override_switch('jwt_decode_handler.log_exception.edx-drf-extensions', active=True)
     @mock.patch('edx_django_utils.monitoring.set_custom_metric')
     @mock.patch('ecommerce.extensions.api.handlers.logger')
     def test_decode_success_multiple_issuers(self, mock_logger, mock_set_custom_metric):
@@ -102,7 +102,7 @@ class JWTDecodeHandlerTests(TestCase):
         mock_logger.exception.assert_not_called()
         mock_logger.warning.assert_not_called()
         mock_logger.error.assert_not_called()
-        mock_logger.info.assert_called_with('Failed to use edx-drf-extensions jwt_decode_handler.', exc_info=True)
+        mock_logger.info.assert_not_called()
 
     @override_settings(
         JWT_AUTH={
@@ -122,27 +122,22 @@ class JWTDecodeHandlerTests(TestCase):
         }
     )
     @override_switch('jwt_decode_handler.log_exception.ecommerce-multiple-issuers', active=True)
+    @override_switch('jwt_decode_handler.log_exception.edx-drf-extensions', active=True)
     @mock.patch('ecommerce.extensions.api.handlers.logger')
     def test_decode_error_invalid_token(self, mock_logger):
         """
-        Should fail ``_ecommerce_jwt_decode_handler_multiple_issuers`` due to
-        invalid token, not because it is not configured properly.
+        Invalid token will fail both multiple-issuers and the fallback of
+        edx-drf-extensions jwt_decode_handler.
         """
         # Update the payload to ensure a validation error
         payload = generate_jwt_payload(self.user, issuer_name='test-issuer-2')
         payload['exp'] = 0
         token = generate_jwt_token(payload, 'test-secret-key-2')
-        with self.assertRaisesMessage(
-            jwt.InvalidTokenError,
-            (
-                "All combinations of JWT issuers with updated config failed to validate the token. "
-                "Wrong secret_key for issuer test-issuer. Invalid token found using issuer test-issuer-2."
-            )
-        ):
+        with self.assertRaises(jwt.InvalidTokenError):
             jwt_decode_handler(token)
 
-            mock_logger.exception.assert_called_with('Custom config JWT decode failed!')
-            mock_logger.info.assert_called_with(
-                'Failed to use ecommerce multiple issuer jwt_decode_handler.',
-                exc_info=True,
-            )
+        mock_logger.exception.assert_called_with('Custom config JWT decode failed!')
+        mock_logger.info.assert_has_calls(calls=[
+            mock.call('Failed to use ecommerce multiple issuer jwt_decode_handler.', exc_info=True),
+            mock.call('Failed to use edx-drf-extensions jwt_decode_handler.', exc_info=True),
+        ])

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -406,6 +406,7 @@ JWT_AUTH = {
     'JWT_ISSUERS': (),
     # NOTE (CCB): This is temporarily set to False until we decide what values are acceptable.
     'JWT_VERIFY_AUDIENCE': False,
+    'JWT_PUBLIC_SIGNING_JWK_SET': None,
 }
 
 # Service user for worker processes.

--- a/ecommerce/settings/devstack.py
+++ b/ecommerce/settings/devstack.py
@@ -19,6 +19,16 @@ SESSION_COOKIE_SECURE = False
 COMPRESS_OFFLINE = False
 COMPRESS_ENABLED = False
 
+JWT_AUTH.update({
+    # Must match public signing key used in LMS.
+    'JWT_PUBLIC_SIGNING_JWK_SET': (
+        '{"keys": [{"kid": "devstack_key", "e": "AQAB", "kty": "RSA", "n": "smKFSYowG6nNUAdeqH1jQQnH1PmIHphzBmwJ5vRf1vu'
+        '48BUI5VcVtUWIPqzRK_LDSlZYh9D0YFL0ZTxIrlb6Tn3Xz7pYvpIAeYuQv3_H5p8tbz7Fb8r63c1828wXPITVTv8f7oxx5W3lFFgpFAyYMmROC'
+        '4Ee9qG5T38LFe8_oAuFCEntimWxN9F3P-FJQy43TL7wG54WodgiM0EgzkeLr5K6cDnyckWjTuZbWI-4ffcTgTZsL_Kq1owa_J2ngEfxMCObnzG'
+        'y5ZLcTUomo4rZLjghVpq6KZxfS6I1Vz79ZsMVUWEdXOYePCKKsrQG20ogQEkmTf9FT_SouC6jPcHLXw"}]}'
+    ),
+})
+
 # PAYMENT PROCESSING
 PAYMENT_PROCESSOR_CONFIG = {
     'edx': {


### PR DESCRIPTION
Now use ecommerce jwt_decode_handler for multiple issuers first, since
we have more control over the logging, and we can avoid extra logging
from edx-drf-extensions jwt_decode_handler.

Also, added JWT_PUBLIC_SIGNING_JWK_SET to devstack.

ARCH-283