### PR TITLE
Enable JWT cookies

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -211,12 +211,14 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
+    'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.contrib.sites.middleware.CurrentSiteMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
     'waffle.middleware.WaffleMiddleware',
     # NOTE: The overridden BasketMiddleware relies on request.site. This middleware
     # MUST appear AFTER CurrentSiteMiddleware.
@@ -402,6 +404,7 @@ AUTH_USER_MODEL = 'core.User'
 JWT_AUTH = {
     'JWT_SECRET_KEY': None,
     'JWT_ALGORITHM': 'HS256',
+    'JWT_AUTH_COOKIE': 'edx-jwt-cookie',
     'JWT_VERIFY_EXPIRATION': True,
     'JWT_LEEWAY': 1,
     'JWT_DECODE_HANDLER': 'ecommerce.extensions.api.handlers.jwt_decode_handler',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -47,7 +47,7 @@ edx-auth-backends==1.1.3
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==1.0.1
-edx-drf-extensions==2.0.0
+edx-drf-extensions==2.0.1
 edx-ecommerce-worker==0.7.0
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -60,7 +60,7 @@ edx-auth-backends==1.1.3
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==1.0.1
-edx-drf-extensions==2.0.0
+edx-drf-extensions==2.0.1
 edx-ecommerce-worker==0.7.0
 edx-i18n-tools
 edx-opaque-keys==0.4.4

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -49,7 +49,7 @@ edx-auth-backends==1.1.3
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==1.0.1
-edx-drf-extensions==2.0.0
+edx-drf-extensions==2.0.1
 edx-ecommerce-worker==0.7.0
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -57,7 +57,7 @@ edx-auth-backends==1.1.3
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==1.0.1
-edx-drf-extensions==2.0.0
+edx-drf-extensions==2.0.1
 edx-ecommerce-worker==0.7.0
 edx-opaque-keys==0.4.4
 edx-rest-api-client==1.8.2


### PR DESCRIPTION
[ENT-1364](https://openedx.atlassian.net/browse/ENT-1364
)

The purpose of this PR is to Enable JWT cookies for ecommerce.

1. Set `JWT_AUTH_COOKIE` setting.
2. Add `JwtAuthCookieMiddleware`.
3. Upgrade `edx-drf-extensions` to `2.0.1+`.

From edx-drf-extensions:
> 1. EnsureJWTAuthSettingsMiddleware: Ensures proper JWT auth settings
>    for endpoints.
> 2. JwtAuthCookieMiddleware: Combines the JWT auth cookie parts into a
>    JWT auth cookie.

Reference: [ARCH-233](https://openedx.atlassian.net/browse/ARCH-233)
Reference PRs:
- Set JWT_AUTH_COOKIE setting - https://github.com/edx/edx-analytics-data-api/pull/221
- ARCH-233: Add JWT Auth Middleware - https://github.com/edx/edx-analytics-data-api/pull/213
- Add JwtAuthCookieMiddleware (*before AuthenticationMiddleware*) - https://github.com/edx/edx-analytics-data-api/pull/222
- Upgrade edx-drf-extensions to 2.0.1+ - https://github.com/edx/edx-analytics-data-api/pull/229
