### PR TITLE
ENT-1370. Cache enterprise customer response

### DIFF
--- a/ecommerce/enterprise/tests/test_utils.py
+++ b/ecommerce/enterprise/tests/test_utils.py
@@ -6,6 +6,8 @@ import ddt
 import httpretty
 from django.conf import settings
 from django.http.response import HttpResponse
+from edx_django_utils.cache import TieredCache
+from mock import patch
 from oscar.test.factories import VoucherFactory
 
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
@@ -50,9 +52,18 @@ class EnterpriseUtilsTests(EnterpriseServiceMockMixin, TestCase):
         """
         self.mock_access_token_response()
         self.mock_specific_enterprise_customer_api(TEST_ENTERPRISE_CUSTOMER_UUID)
-        response = get_enterprise_customer(self.site, TEST_ENTERPRISE_CUSTOMER_UUID)
 
-        self.assertEqual(TEST_ENTERPRISE_CUSTOMER_UUID, response.get('id'))
+        # verify the caching
+        with patch.object(TieredCache, 'set_all_tiers', wraps=TieredCache.set_all_tiers) as mocked_set_all_tiers:
+            mocked_set_all_tiers.assert_not_called()
+
+            response = get_enterprise_customer(self.site, TEST_ENTERPRISE_CUSTOMER_UUID)
+            self.assertEqual(TEST_ENTERPRISE_CUSTOMER_UUID, response.get('id'))
+            self.assertEqual(mocked_set_all_tiers.call_count, 2)
+
+            cached_response = get_enterprise_customer(self.site, TEST_ENTERPRISE_CUSTOMER_UUID)
+            self.assertEqual(mocked_set_all_tiers.call_count, 2)
+            self.assertEqual(response, cached_response)
 
     @ddt.data(
         (

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -248,6 +248,9 @@ PROGRAM_CACHE_TIMEOUT = 3600  # Value is in seconds.
 # Cache catalog results from the enterprise and discovery service.
 CATALOG_RESULTS_CACHE_TIMEOUT = 86400
 
+# Cache timeout for enterprise customer results from the enterprise service.
+ENTERPRISE_CUSTOMER_RESULTS_CACHE_TIMEOUT = 3600  # Value is in seconds
+
 # PROVIDER DATA PROCESSING
 PROVIDER_DATA_PROCESSING_TIMEOUT = 15  # Value is in seconds.
 CREDIT_PROVIDER_CACHE_TIMEOUT = 600


### PR DESCRIPTION
[ENT-1370](https://openedx.atlassian.net/browse/ENT-1370)

This caches the `enterprise customer` response from `enterprise` to avoid unnecessary GET requests.

Testing Instructions
1. Create a coupon with lot of vouchers like [here](https://ecommerce-business.sandbox.edx.org/coupons/386/edit/) 
2. Edit the coupon and change the `Valid Until` date and save it.
3. Coupon should be saved successfully without any error. 