### PR TITLE
EG-43: Cache catalog query contains call

### DIFF
--- a/ecommerce/enterprise/migrations/0004_add_enterprise_offers_for_coupons.py
+++ b/ecommerce/enterprise/migrations/0004_add_enterprise_offers_for_coupons.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations
+
 from ecommerce.enterprise.constants import ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH
 
 

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -25,7 +25,9 @@ from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
 from ecommerce.extensions.payment.processors.invoice import InvoicePayment
 from ecommerce.extensions.voucher.models import CouponVouchers
 from ecommerce.extensions.voucher.utils import (
-    get_or_create_enterprise_offer, update_voucher_offer, update_voucher_with_enterprise_offer
+    get_or_create_enterprise_offer,
+    update_voucher_offer,
+    update_voucher_with_enterprise_offer
 )
 from ecommerce.invoice.models import Invoice
 

--- a/ecommerce/extensions/basket/middleware.py
+++ b/ecommerce/extensions/basket/middleware.py
@@ -1,6 +1,5 @@
 import newrelic.agent
 import waffle
-
 from oscar.apps.basket.middleware import BasketMiddleware as OscarBasketMiddleware
 from oscar.core.loading import get_class, get_model
 

--- a/ecommerce/extensions/offer/tests/test_models.py
+++ b/ecommerce/extensions/offer/tests/test_models.py
@@ -589,8 +589,12 @@ class BenefitTests(DiscoveryTestMixin, DiscoveryMockMixin, TestCase):
             query=self.benefit.range.catalog_query, discovery_api_url=self.site_configuration.discovery_api_url
         )
 
-        self.assertEqual(self.benefit.get_applicable_lines(self.offer, basket), applicable_lines)
+        with patch.object(TieredCache, 'set_all_tiers', wraps=TieredCache.set_all_tiers) as mocked_set_all_tiers:
+            mocked_set_all_tiers.assert_not_called()
+            self.assertEqual(self.benefit.get_applicable_lines(self.offer, basket), applicable_lines)
+            self.assertEqual(mocked_set_all_tiers.call_count, 3)
 
-        # Verify that the API return value is cached
-        httpretty.disable()
-        self.assertEqual(self.benefit.get_applicable_lines(self.offer, basket), applicable_lines)
+            # Verify that the API return value is cached
+            httpretty.disable()
+            self.assertEqual(self.benefit.get_applicable_lines(self.offer, basket), applicable_lines)
+            self.assertEqual(mocked_set_all_tiers.call_count, 3)

--- a/ecommerce/extensions/voucher/models.py
+++ b/ecommerce/extensions/voucher/models.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
-import waffle
 
+import waffle
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.db import models
 from oscar.apps.voucher.abstract_models import AbstractVoucher  # pylint: disable=ungrouped-imports

--- a/ecommerce/extensions/voucher/tests/test_models.py
+++ b/ecommerce/extensions/voucher/tests/test_models.py
@@ -5,9 +5,9 @@ from django.core.exceptions import ValidationError
 from django.utils.timezone import now
 from oscar.core.loading import get_model
 from waffle.models import Switch
+
 from ecommerce.enterprise.constants import ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH
 from ecommerce.extensions.test import factories
-
 from ecommerce.tests.testcases import TestCase
 
 ConditionalOffer = get_model('offer', 'ConditionalOffer')

--- a/ecommerce/journals/fulfillment/modules.py
+++ b/ecommerce/journals/fulfillment/modules.py
@@ -1,8 +1,8 @@
 import logging
 
 from requests.exceptions import ConnectionError, Timeout
-
 from slumber.exceptions import HttpClientError
+
 from ecommerce.extensions.analytics.utils import audit_log
 from ecommerce.extensions.fulfillment.modules import BaseFulfillmentModule
 from ecommerce.extensions.fulfillment.status import LINE

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -244,6 +244,7 @@ COMMERCE_API_TIMEOUT = 7
 # Cache course info from course API.
 COURSES_API_CACHE_TIMEOUT = 3600  # Value is in seconds
 PROGRAM_CACHE_TIMEOUT = 3600  # Value is in seconds.
+CATALOG_QUERY_CONTAINS_TIMEOUT = 3600  # Value is in seconds.
 
 # Cache catalog results from the enterprise and discovery service.
 CATALOG_RESULTS_CACHE_TIMEOUT = 86400


### PR DESCRIPTION
This PR will cache the response from CatalogQueryContainsViewSet from the course-discovery IDA.

https://openedx.atlassian.net/browse/EG-43

https://rpm.newrelic.com/accounts/88178/key_transactions/35300/x_rays/4669#id=75ca5033-f190-11e8-8af5-0242ac11000a_36532_39981&tab-detail_75ca5033-f190-11e8-8af5-0242ac11000a_36532_39981=database_queries

