### PR TITLE
LEARNER-6788 fix: management view failed to process basket_id

### DIFF
--- a/ecommerce/management/utils.py
+++ b/ecommerce/management/utils.py
@@ -144,7 +144,7 @@ class FulfillFrozenBaskets(EdxOrderPlacementMixin):
             # This will create the order  with out discount but subsequently
             # run the fulfillment to update course mode.
             voucher = basket.vouchers.first()
-            if voucher and not (voucher.is_active() or voucher.is_available_to_user(user=basket.owner)):
+            if voucher and not (voucher.is_active() and voucher.is_available_to_user(user=basket.owner)):
                 basket.clear_vouchers()
             Applicator().apply(basket, user=basket.owner)
 
@@ -193,10 +193,10 @@ class FulfillFrozenBaskets(EdxOrderPlacementMixin):
                     billing_address=None,
                     order_total=order_total,
                 )
-                if voucher and not (voucher.is_active() or voucher.is_available_to_user(user=basket.owner)):
+                if voucher and not (voucher.is_active() and voucher.is_available_to_user(user=basket.owner)):
                     order.notes.create(message='The coupon : {} was used at the time of order placement. '
                                                'Do not refund the order without considering coupon'.format(voucher),
-                                       note_type='INFO')
+                                       note_type='Info')
                     order.save()
 
                 logger.info('Successfully created order for basket %d', basket.id)


### PR DESCRIPTION
JIRA Ticket: https://openedx.atlassian.net/browse/LEARNER-6788

#### Problem : 
When basket id was used in management view to create the order
https://ecommerce.edx.org/management/
the view was unable to create the order

#### Reason :
This was happening because the coupon applied to basket expired after the payment and before fulfillment of basket time.