### PR TITLE
Change travis file to only build on PRs and pushes to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: python
 python:
   - "2.7"
 
+branches:
+  only:
+    - master
+
 sudo: required
 services:
   - docker


### PR DESCRIPTION
I've been working on adding some automation for creating and testing openedx releases, which creates branches in a number of IDA's, and (if desired) deletes them at the end of the tests. For now, the job is in the beginning stages, and just creates a branch, and later deletes it.

The problem is, the branch gets deleted so quickly, that travis gets kicked off, but quickly fails when the branch can't be found. To make matters worse, since the branch doesn't include any new commits, travis gets run (and fails) on the same commit as the tip of the master branch, which overwrites whatever status it previously had to failing (example: [link to failing travis build](https://travis-ci.org/edx/ecommerce/builds/462997615?utm_source=github_status&utm_medium=notification)).

This change fixes that, by following a travis pattern we currently already use in other repos, like these: ([configuration repo](https://github.com/edx/configuration/blob/868a6127610172e26321109f0535c39f49ec05e0/.travis.yml#L6-L8), [devstack repo](https://github.com/edx/devstack/blob/f925e6dc7a01f879b063699eecc08f5062ddfa59/.travis.yml#L8-L10)). This will limit builds to being triggered either by a pull request, or a push to master.

So when any non-master branch gets created or pushed, travis will not be triggered (unless there is an open pull request for that branch).
