### PR TITLE
Add host information to Segment events.

### DIFF
--- a/ecommerce/extensions/analytics/tests/test_utils.py
+++ b/ecommerce/extensions/analytics/tests/test_utils.py
@@ -87,7 +87,10 @@ class UtilsTest(DiscoveryTestMixin, BasketMixin, TransactionTestCase):
             'ip': lms_ip,
             'Google Analytics': {
                 'clientId': ga_client_id
-            }
+            },
+            'page': {
+                'url': 'https://testserver.fake/'
+            },
         }
         with mock.patch.object(Client, 'track') as mock_track:
             track_segment_event(self.site, user, event, properties)

--- a/ecommerce/extensions/analytics/utils.py
+++ b/ecommerce/extensions/analytics/utils.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from functools import wraps
+from urlparse import urlunsplit
 
 from ecommerce.courses.utils import mode_for_product
 
@@ -144,10 +145,24 @@ def track_segment_event(site, user, event, properties):
         return False, msg
 
     user_tracking_id, ga_client_id, lms_ip = parse_tracking_context(user)
+    # construct a URL, so that hostname can be sent to GA.
+    # For now, send a dummy value for path.  Segment parses the URL and sends
+    # the host and path separately. When needed, the path can be fetched by adding:
+    # request = crum.get_current_request()
+    # if request:
+    #     path = request.META.get('PATH_INFO')
+    hostname = site.domain
+    path = '/'
+    parts = ("https", hostname, path, "", "")
+    page = urlunsplit(parts)
+
     context = {
         'ip': lms_ip,
         'Google Analytics': {
-            'clientId': ga_client_id
+            'clientId': ga_client_id,
+        },
+        'page': {
+            'url': page,
         }
     }
     return site.siteconfiguration.segment_client.track(user_tracking_id, event, properties, context=context)

--- a/ecommerce/extensions/basket/tests/test_models.py
+++ b/ecommerce/extensions/basket/tests/test_models.py
@@ -127,7 +127,10 @@ class BasketTests(CatalogMixin, BasketMixin, TestCase):
             'ip': lms_ip,
             'Google Analytics': {
                 'clientId': ga_client_id
-            }
+            },
+            'page': {
+                'url': 'https://testserver.fake/'
+            },
         }
 
         with mock.patch.object(Client, 'track') as mock_track:

--- a/ecommerce/extensions/checkout/tests/test_mixins.py
+++ b/ecommerce/extensions/checkout/tests/test_mixins.py
@@ -381,7 +381,10 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin,
             'ip': lms_ip,
             'Google Analytics': {
                 'clientId': ga_client_id
-            }
+            },
+            'page': {
+                'url': 'https://testserver.fake/'
+            },
         }
 
         mixin.handle_payment({}, basket)

--- a/ecommerce/extensions/refund/tests/test_signals.py
+++ b/ecommerce/extensions/refund/tests/test_signals.py
@@ -29,11 +29,18 @@ class RefundTrackingTests(RefundTestMixin, TestCase):
                 'ip': tracking_context['lms_ip'],
                 'Google Analytics': {
                     'clientId': tracking_context['ga_client_id']
-                }
+                },
+                'page': {
+                    'url': 'https://testserver.fake/'
+                },
             }
         else:
             expected_event_user_id = ECOM_TRACKING_ID_FMT.format(refund.user.id)
-            expected_context = {'ip': None, 'Google Analytics': {'clientId': None}}
+            expected_context = {
+                'ip': None,
+                'Google Analytics': {'clientId': None},
+                'page': {'url': 'https://testserver.fake/'}
+            }
 
         self.assertEqual(event_user_id, expected_event_user_id)
         self.assertEqual(kwargs['context'], expected_context)

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -204,7 +204,12 @@ class BusinessIntelligenceMixin(object):
         (event_user_id, event_name, event_payload), kwargs = mock_track.call_args
         self.assertEqual(event_user_id, expected_user_id)
         self.assertEqual(event_name, 'Order Completed')
-        self.assertEqual(kwargs['context'], {'ip': expected_ip, 'Google Analytics': {'clientId': expected_client_id}})
+        expected_context = {
+            'ip': expected_ip,
+            'Google Analytics': {'clientId': expected_client_id},
+            'page': {'url': 'https://testserver.fake/'},
+        }
+        self.assertEqual(kwargs['context'], expected_context)
         self.assert_correct_event_payload(
             instance, event_payload, order_number, currency, total, coupon, discount
         )


### PR DESCRIPTION
Addressing DE-1140.

Passes url context to Segment, so that Segment can pass hostname (and path) to GA.  