### PR TITLE
ENT-1413 Fix the ability to unset certain coupon fields stored on the offer

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -379,6 +379,7 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             'voucher_type': Voucher.MULTI_USE,
             'max_uses': 10,
             'benefit_value': 10,
+            'email_domains': 'edx.org'
         })
 
         self.get_response('POST', COUPONS_LINK, self.data)
@@ -389,13 +390,14 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             offer = voucher.offers.first()
             offers[offer.name] = offer
             self.assertEqual(offer.max_global_applications, 10)
+            self.assertEqual(offer.email_domains, 'edx.org')
             self.assertEqual(offer.benefit.value, 10)
         self.assertEqual(len(offers.keys()), 5)
 
         self.get_response_json(
             'PUT',
             reverse('api:v2:coupons-detail', kwargs={'pk': coupon.id}),
-            data={'benefit_value': 20}
+            data={'benefit_value': 20, 'email_domains': '', 'max_uses': None}
         )
         updated_coupon = Product.objects.get(title=self.data['title'])
         self.assertEqual(coupon.id, updated_coupon.id)
@@ -404,8 +406,9 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         for voucher in vouchers:
             offer = voucher.offers.first()
             offers[offer.name] = offer
-            self.assertEqual(offer.max_global_applications, 10)
+            self.assertEqual(offer.max_global_applications, None)
             self.assertEqual(offer.benefit.value, 20)
+            self.assertEqual(offer.email_domains, '')
         self.assertEqual(len(offers.keys()), 5)
 
     def _create_enterprise_coupon(self, enterprise_customer_id, enterprise_catalog_id, enterprise_name):

--- a/ecommerce/extensions/voucher/utils.py
+++ b/ecommerce/extensions/voucher/utils.py
@@ -831,8 +831,8 @@ def update_voucher_with_enterprise_offer(offer, benefit_value, enterprise_custom
         enterprise_customer=enterprise_customer or offer.condition.enterprise_customer_uuid,
         enterprise_customer_catalog=enterprise_catalog or offer.condition.enterprise_customer_catalog_uuid,
         offer_name=offer.name,
-        max_uses=max_uses or offer.max_global_applications,
-        email_domains=email_domains or offer.email_domains,
+        max_uses=max_uses,
+        email_domains=email_domains,
         site=site or offer.site,
     )
 
@@ -865,8 +865,8 @@ def update_voucher_offer(offer, benefit_value, benefit_type=None, max_uses=None,
             offer.benefit.proxy(), 'benefit_class_type', None
         ),
         offer_name=offer.name,
-        max_uses=max_uses or offer.max_global_applications,
-        email_domains=email_domains or offer.email_domains,
+        max_uses=max_uses,
+        email_domains=email_domains,
         program_uuid=program_uuid or offer.condition.program_uuid,
         site=site or offer.site,
     )


### PR DESCRIPTION
**Description**
A bug was reported that trying to unset the email_domains field on the Coupon form was saving, but not actually getting rid of the value that was set. This PR addresses that bug, as well as a similar bug for the max_uses field.

The fix relies on the fact that we currently sending all fields when we save the Coupon, instead of only changed fields, which was the previous behavior. With the previous behavior, if reinstated, it will be tricky to differentiate unsetting a field vs. it not being sent because it didn't change.

**Testing instructions**
Deployed to the business sandbox.
Find or create a Coupon that has email domains and/or max uses set. Edit the coupon to unset the value, then click back into the edit screen. The values should be unset.