### PR TITLE
Add revenue field to order completed event

### DIFF
--- a/ecommerce/extensions/checkout/signals.py
+++ b/ecommerce/extensions/checkout/signals.py
@@ -34,6 +34,9 @@ def track_completed_order(sender, order=None, **kwargs):  # pylint: disable=unus
     properties = {
         'orderId': order.number,
         'total': str(order.total_excl_tax),
+        # For Rockerbox integration, we need a field named revenue since they cannot parse a field named total.
+        # TODO: DE-1188: Remove / move Rockerbox integration code.
+        'revenue': str(order.total_excl_tax),
         'currency': order.currency,
         'discount': str(order.total_discount_incl_tax),
         'products': [

--- a/ecommerce/extensions/checkout/tests/test_mixins.py
+++ b/ecommerce/extensions/checkout/tests/test_mixins.py
@@ -155,7 +155,8 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin,
                 self.order.number,
                 self.order.currency,
                 self.order.user.email,
-                self.order.total_excl_tax
+                self.order.total_excl_tax,
+                self.order.total_excl_tax        # value for revenue field is same as total.
             )
             l.check(
                 (
@@ -239,7 +240,8 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin,
             self.order.number,
             self.order.currency,
             self.order.user.email,
-            self.order.total_excl_tax
+            self.order.total_excl_tax,
+            self.order.total_excl_tax            # value for revenue field is same as total.
         )
 
     def test_handle_successful_order_no_segment_key(self, mock_track):

--- a/ecommerce/extensions/checkout/tests/test_signals.py
+++ b/ecommerce/extensions/checkout/tests/test_signals.py
@@ -134,6 +134,7 @@ class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
         properties = {
             'orderId': order.number,
             'total': str(order.total_excl_tax),
+            'revenue': str(order.total_excl_tax),
             'currency': order.currency,
             'coupon': coupon,
             'discount': str(order.total_discount_incl_tax),

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -198,7 +198,7 @@ class BusinessIntelligenceMixin(object):
 
     def assert_correct_event(
             self, mock_track, instance, expected_user_id, expected_client_id, expected_ip, order_number, currency,
-            email, total, coupon=None, discount='0.00'
+            email, total, revenue, coupon=None, discount='0.00'
     ):
         """Check that the tracking context was correctly reflected in the emitted event."""
         (event_user_id, event_name, event_payload), kwargs = mock_track.call_args
@@ -211,11 +211,11 @@ class BusinessIntelligenceMixin(object):
         }
         self.assertEqual(kwargs['context'], expected_context)
         self.assert_correct_event_payload(
-            instance, event_payload, order_number, currency, email, total, coupon, discount
+            instance, event_payload, order_number, currency, email, total, revenue, coupon, discount
         )
 
     def assert_correct_event_payload(
-            self, instance, event_payload, order_number, currency, email, total,
+            self, instance, event_payload, order_number, currency, email, total, revenue,
             coupon, discount
     ):
         """
@@ -223,7 +223,7 @@ class BusinessIntelligenceMixin(object):
         completed order or refund.
         """
         self.assertEqual(
-            ['coupon', 'currency', 'discount', 'email', 'orderId', 'products', 'total'],
+            ['coupon', 'currency', 'discount', 'email', 'orderId', 'products', 'revenue', 'total'],
             sorted(event_payload.keys())
         )
         self.assertEqual(event_payload['orderId'], order_number)
@@ -240,6 +240,9 @@ class BusinessIntelligenceMixin(object):
 
         if model_name == 'Order':
             self.assertEqual(event_payload['total'], str(total))
+            self.assertEqual(event_payload['revenue'], str(revenue))
+            # value of revenue field should be the same as total.
+            self.assertEqual(event_payload['revenue'], str(total))
 
             for line in lines:
                 tracked_product = tracked_products_dict.get(line.partner_sku)


### PR DESCRIPTION
For Rockerbox integration, we need to add some fields in events being emitted from platform & ecommerce. This PR adds revenue field to order completed event.