### PR TITLE
ENT-1417: Update assignment endpoint to trigger emails

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -701,14 +701,14 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
         coupon = coupon.json()
         coupon_id = coupon['coupon_id']
-
-        response = self.get_response(
-            'POST',
-            '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
-            {'emails': emails}
-        )
+        with mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email.delay') as mock_send_email:
+            response = self.get_response(
+                'POST',
+                '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
+                {'template': 'Test template', 'emails': emails}
+            )
         response = response.json()
-
+        assert mock_send_email.call_count == len(emails)
         for i, email in enumerate(emails):
             if voucher_type != Voucher.MULTI_USE_PER_CUSTOMER:
                 assert response['offer_assignments'][i]['user_email'] == email
@@ -736,14 +736,14 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         codes_param = codes[3:]
 
         emails = ['t1@example.com', 't2@example.com']
-
-        response = self.get_response(
-            'POST',
-            '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
-            {'emails': emails, 'codes': codes_param}
-        )
+        with mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email.delay') as mock_send_email:
+            response = self.get_response(
+                'POST',
+                '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
+                {'template': 'Test template', 'emails': emails, 'codes': codes_param}
+            )
         response = response.json()
-
+        assert mock_send_email.call_count == len(emails)
         for i, email in enumerate(emails):
             assert response['offer_assignments'][i]['user_email'] == email
             assert response['offer_assignments'][i]['code'] in codes_param
@@ -769,14 +769,14 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             used_codes.append(voucher.code)
         unused_codes = [voucher.code for voucher in vouchers[3:]]
         emails = ['t1@example.com', 't2@example.com']
-
-        response = self.get_response(
-            'POST',
-            '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
-            {'emails': emails}
-        )
+        with mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email.delay') as mock_send_email:
+            response = self.get_response(
+                'POST',
+                '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
+                {'template': 'Test template', 'emails': emails}
+            )
         response = response.json()
-
+        assert mock_send_email.call_count == len(emails)
         for i, email in enumerate(emails):
             assert response['offer_assignments'][i]['user_email'] == email
             assert response['offer_assignments'][i]['code'] in unused_codes
@@ -806,14 +806,14 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             user_email='t2@example.com',
         )
         emails = ['t1@example.com', 't2@example.com', 't3@example.com']
-
-        response = self.get_response(
-            'POST',
-            '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
-            {'emails': emails}
-        )
+        with mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email.delay') as mock_send_email:
+            response = self.get_response(
+                'POST',
+                '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
+                {'template': 'Test template', 'emails': emails}
+            )
         response = response.json()
-
+        assert mock_send_email.call_count == len(emails)
         for i, email in enumerate(emails):
             assert response['offer_assignments'][i]['user_email'] == email
             assert response['offer_assignments'][i]['code'] == unused_voucher.code
@@ -835,11 +835,53 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
         coupon = coupon.json()
         coupon_id = coupon['coupon_id']
-
-        response = self.get_response(
-            'POST',
-            '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
-            {'emails': emails}
-        )
+        with mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email.delay') as mock_send_email:
+            response = self.get_response(
+                'POST',
+                '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
+                {'template': 'Test template', 'emails': emails}
+            )
         response = response.json()
         assert response['non_field_errors'] == ['Not enough available codes for assignment!']
+        assert mock_send_email.call_count == 0
+
+    @ddt.data(
+        (Voucher.SINGLE_USE, 2, None, ['test1@example.com', 'test2@example.com'], [1]),
+        (Voucher.MULTI_USE_PER_CUSTOMER, 2, 3, ['test1@example.com', 'test2@example.com'], [3]),
+        (Voucher.MULTI_USE, 1, None, ['test1@example.com', 'test2@example.com'], [2]),
+        (Voucher.MULTI_USE, 2, 3, ['t1@example.com', 't2@example.com', 't3@example.com', 't4@example.com'], [3, 1]),
+        (Voucher.ONCE_PER_CUSTOMER, 2, 2, ['test1@example.com', 'test2@example.com'], [2]),
+    )
+    @ddt.unpack
+    def test_codes_assignment_email_failure(self, voucher_type, quantity, max_uses, emails, assignments_per_code):
+        """Test assigning codes to users."""
+        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': True})
+
+        coupon_post_data = dict(self.data, voucher_type=voucher_type, quantity=quantity, max_uses=max_uses)
+        coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
+        coupon = coupon.json()
+        coupon_id = coupon['coupon_id']
+        with mock.patch(
+            'ecommerce.extensions.offer.utils.send_offer_assignment_email.delay', side_effect=Exception()
+        ) as mock_send_email:
+            response = self.get_response(
+                'POST',
+                '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
+                {'template': 'Test template', 'emails': emails}
+            )
+        response = response.json()
+        assert mock_send_email.call_count == len(emails)
+        for i, email in enumerate(emails):
+            if voucher_type != Voucher.MULTI_USE_PER_CUSTOMER:
+                assert response['offer_assignments'][i]['user_email'] == email
+            else:
+                for j in range(max_uses):
+                    assert response['offer_assignments'][(i * max_uses) + j]['user_email'] == email
+
+        assigned_codes = []
+        for assignment in response['offer_assignments']:
+            if assignment['code'] not in assigned_codes:
+                assigned_codes.append(assignment['code'])
+
+        for code in assigned_codes:
+            assert OfferAssignment.objects.filter(code=code).count() in assignments_per_code

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 import logging
-
 import waffle
 from django.core.exceptions import ValidationError
 from oscar.core.loading import get_model
@@ -256,12 +255,12 @@ class EnterpriseCouponViewSet(CouponViewSet):
         Assign users by email to codes within the Coupon.
         """
         coupon = self.get_object()
+        template = request.data.pop('template')
         serializer = CouponCodeAssignmentSerializer(
             data=request.data,
-            context={'coupon': coupon}
+            context={'coupon': coupon, 'template': template}
         )
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data, status=status.HTTP_200_OK)
-
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/ecommerce/extensions/offer/tests/test_utils.py
+++ b/ecommerce/extensions/offer/tests/test_utils.py
@@ -80,17 +80,6 @@ class UtilTests(DiscoveryTestMixin, TestCase):
                 'code_expiration_date': '2018-12-19'
             },
             None,
-            True,
-        ),
-        (
-            {'offer_assignment_id': 555,
-             'learner_email': 'johndoe@unknown.com',
-             'code': 'GIL7RUEOU7VHBH7Q',
-             'enrollment_url': 'http://tempurl.url/enroll',
-             'redemptions_remaining': 10,
-             'code_expiration_date': '2018-12-19'},
-            Exception(),
-            False,
         ),
     )
     @ddt.unpack
@@ -98,13 +87,13 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             self,
             tokens,
             side_effect,
-            returns,
             mock_sailthru_task,
     ):
+        """ Test that the offer assignment email message is correctly formatted with correct call to async task. """
         email_subject = settings.OFFER_ASSIGNMENT_EMAIL_DEFAULT_SUBJECT
         mock_sailthru_task.delay.side_effect = side_effect
         template = settings.OFFER_ASSIGNMENT_EMAIL_DEFAULT_TEMPLATE
-        status = send_assigned_offer_email(
+        send_assigned_offer_email(
             template,
             tokens.get('offer_assignment_id'),
             tokens.get('learner_email'),
@@ -124,4 +113,3 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             tokens.get('learner_email'),
             tokens.get('offer_assignment_id'),
             email_subject, expected_email_body)
-        self.assertEqual(status, returns)

--- a/ecommerce/extensions/offer/utils.py
+++ b/ecommerce/extensions/offer/utils.py
@@ -136,17 +136,11 @@ def send_assigned_offer_email(
     """
 
     email_subject = settings.OFFER_ASSIGNMENT_EMAIL_DEFAULT_SUBJECT
-    try:
-        email_body = template.format(
-            REDEMPTIONS_REMAINING=redemptions_remaining,
-            USER_EMAIL=learner_email,
-            ENROLLMENT_URL=enrollment_url,
-            CODE=code,
-            EXPIRATION_DATE=code_expiration_date
-        )
-        send_offer_assignment_email.delay(learner_email, offer_assignment_id, email_subject, email_body)
-    except Exception as exc:  # pylint: disable=broad-except
-        logger.exception(
-            '[Offer Assignment] send_offer_assignment_email celery task raised: %r', exc)
-        return False
-    return True
+    email_body = template.format(
+        REDEMPTIONS_REMAINING=redemptions_remaining,
+        USER_EMAIL=learner_email,
+        ENROLLMENT_URL=enrollment_url,
+        CODE=code,
+        EXPIRATION_DATE=code_expiration_date
+    )
+    send_offer_assignment_email.delay(learner_email, offer_assignment_id, email_subject, email_body)


### PR DESCRIPTION
Description: The PR updates the assignment endpoint to take an additional parameter (email template) and triggers the emails to be fired after successful assignments.

The new message formats are:

Request:
```
{
    "template": "Customized template",
    "emails": ["bexline+1@edx.org","bexline+2@edx.org","bexline+3@edx.org"],
    "codes":["GHGSVMQE6XKNZE2V","CYOFOH6XTEEBMKVN","IFXGPNTP6SKRENTC"]
}
```
Response:
```
{
    "offer_assignments": [
        {
            "id": 555 
            "user_email": "bexline+1@edx.org",
            "code": "CYOFOH6XTEEBMKVN",
        },
        {
            "id": 556
            "user_email": "bexline+2@edx.org",
            "code": "IFXGPNTP6SKRENTC"
        },
        {
            "id": 557
            "user_email": "bexline+3@edx.org",
            "code": "GHGSVMQE6XKNZE2V"
        }
    ]
}
```

Dependency: This PR is dependant on https://github.com/edx/ecommerce/pull/1998