### PR TITLE
ENT-1172 Add notification email for enterprise coupons

### DIFF
--- a/ecommerce/coupons/tests/mixins.py
+++ b/ecommerce/coupons/tests/mixins.py
@@ -421,6 +421,12 @@ class CouponMixin(SiteMixin):
                 product_class=pc,
                 type='text'
             )
+            factories.ProductAttributeFactory(
+                product_class=pc,
+                name='Notification Email',
+                code='notify_email',
+                type='text'
+            )
 
         return pc
 

--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -86,6 +86,7 @@ def get_enterprise_customer(site, uuid):
         'enable_data_sharing_consent': response['enable_data_sharing_consent'],
         'enforce_data_sharing_consent': response['enforce_data_sharing_consent'],
         'contact_email': response.get('contact_email', ''),
+        'slug': response.get('slug')
     }
 
     TieredCache.set_all_tiers(

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -828,6 +828,7 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
     last_edited = serializers.SerializerMethodField()
     max_uses = serializers.SerializerMethodField()
     note = serializers.SerializerMethodField()
+    notify_email = serializers.SerializerMethodField()
     num_uses = serializers.SerializerMethodField()
     payment_information = serializers.SerializerMethodField()
     program_uuid = serializers.SerializerMethodField()
@@ -925,6 +926,12 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
         except AttributeError:
             return None
 
+    def get_notify_email(self, obj):
+        try:
+            return obj.attr.notify_email
+        except AttributeError:
+            return None
+
     def get_num_uses(self, obj):
         offer = retrieve_offer(obj)
         return offer.num_applications
@@ -970,7 +977,7 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
             'benefit_type', 'benefit_value', 'catalog_query', 'course_catalog', 'category',
             'client', 'code', 'code_status', 'coupon_type', 'course_seat_types',
             'email_domains', 'end_date', 'enterprise_customer', 'enterprise_customer_catalog',
-            'id', 'last_edited', 'max_uses', 'note', 'num_uses', 'payment_information',
+            'id', 'last_edited', 'max_uses', 'note', 'notify_email', 'num_uses', 'payment_information',
             'program_uuid', 'price', 'quantity', 'seats', 'start_date', 'title', 'voucher_type'
         )
 

--- a/ecommerce/extensions/api/v2/tests/test_utils.py
+++ b/ecommerce/extensions/api/v2/tests/test_utils.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import mock
+
+from ecommerce.extensions.api.v2.utils import SMTPException, send_new_codes_notification_email
+from ecommerce.tests.testcases import TestCase
+
+
+class ViewUtilsTests(TestCase):
+    """
+    Tests for view utils
+    """
+
+    def setUp(self):
+        self.email_address = 'batman@gotham.comics'
+        self.enterprise_id = '6ae013d4-c5c4-474d-8da9-0e559b2448e2'
+        self.coupon_id = '777'
+
+        get_enterprise_customer_patcher = mock.patch('ecommerce.extensions.api.v2.utils.get_enterprise_customer')
+        self.get_enterprise_customer_patcher = get_enterprise_customer_patcher.start()
+        self.get_enterprise_customer_patcher.return_value = {
+            'name': 'batman',
+            'enterprise_customer_uuid': self.enterprise_id,
+            'slug': 'batman',
+        }
+        self.addCleanup(get_enterprise_customer_patcher.stop)
+
+    def test_send_new_codes_notification_email_info_log(self):
+        """
+        Verify that info log message is correct.
+        """
+        with mock.patch('ecommerce.extensions.api.v2.utils.logger') as mock_logger:
+            send_new_codes_notification_email({}, self.email_address, self.enterprise_id, self.coupon_id)
+            mock_logger.info.assert_called_with(
+                'New codes email sent to enterprise customer [%s] for coupon [%s]',
+                self.enterprise_id,
+                self.coupon_id
+            )
+
+    def test_send_new_codes_notification_email_exception_log(self):
+        """
+        Verify that exception log message is correct.
+        """
+        with mock.patch('ecommerce.extensions.api.v2.utils.send_mail', side_effect=SMTPException):
+            with mock.patch('ecommerce.extensions.api.v2.utils.logger') as mock_logger:
+                send_new_codes_notification_email({}, self.email_address, self.enterprise_id, self.coupon_id)
+                mock_logger.exception.assert_called_with(
+                    'New codes email failed for enterprise customer [%s] for coupon [%s]',
+                    self.enterprise_id,
+                    self.coupon_id
+                )

--- a/ecommerce/extensions/api/v2/utils.py
+++ b/ecommerce/extensions/api/v2/utils.py
@@ -1,0 +1,40 @@
+import logging
+from smtplib import SMTPException
+
+from django.conf import settings
+from django.core.mail import send_mail
+
+from ecommerce.enterprise.utils import get_enterprise_customer
+
+logger = logging.getLogger(__name__)
+
+
+def send_new_codes_notification_email(site, email_address, enterprise_id, coupon_id):
+    """
+    Send new codes email notification to an enterprise customer.
+
+    Arguments:
+        site (str): enterprise customer site
+        email_address (str): recipient email address of the enterprise customer
+        enterprise_id (str): enterprise customer uuid
+        coupon_id (str): id of the newly created coupon
+    """
+    enterprise_customer_object = get_enterprise_customer(site, enterprise_id)
+    enterprise_slug = enterprise_customer_object.get('slug')
+
+    try:
+        send_mail(
+            subject=settings.NEW_CODES_EMAIL_CONFIG['email_subject'],
+            message=settings.NEW_CODES_EMAIL_CONFIG['email_body'].format(enterprise_slug=enterprise_slug),
+            from_email=settings.NEW_CODES_EMAIL_CONFIG['from_email'],
+            recipient_list=[email_address],
+            fail_silently=False
+        )
+    except SMTPException:
+        logger.exception(
+            'New codes email failed for enterprise customer [%s] for coupon [%s]',
+            enterprise_id,
+            coupon_id
+        )
+
+    logger.info('New codes email sent to enterprise customer [%s] for coupon [%s]', enterprise_id, coupon_id)

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -5,6 +5,7 @@ import logging
 import waffle
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
 from django.db import IntegrityError, transaction
 from django.http import Http404
 from django.shortcuts import get_object_or_404
@@ -125,10 +126,20 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
                 response_data = self.create_order_for_invoice(
                     basket, coupon_id=coupon_product.id, client=client, invoice_data=invoice_data
                 )
-
+                if cleaned_voucher_data['notify_email']:
+                    self.send_codes_availability_email(
+                        self.request.site,
+                        cleaned_voucher_data['notify_email'],
+                        cleaned_voucher_data['enterprise_customer'],
+                        coupon_product.id
+                    )
                 return Response(response_data, status=status.HTTP_200_OK)
         except ValidationError as e:
             raise serializers.ValidationError(e.message)
+
+    @staticmethod
+    def send_codes_availability_email(site, email_address, enterprise_id, coupon_id):
+        pass
 
     def create_coupon_and_vouchers(self, cleaned_voucher_data):
         return create_coupon_product(
@@ -183,6 +194,7 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
         stock_record_ids = request_data.get('stock_record_ids')
         voucher_type = request_data.get('voucher_type')
         program_uuid = request_data.get('program_uuid')
+        notify_email = request_data.get('notify_email')
 
         if benefit_type not in (Benefit.PERCENTAGE, Benefit.FIXED,):
             raise ValidationError('Benefit type [{type}] is not allowed'.format(type=benefit_type))
@@ -221,6 +233,12 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
             validation_message = 'Unexpected EnterpriseCustomer data format received for coupon.'
             raise ValidationError(validation_message)
 
+        if notify_email:
+            try:
+                validate_email(notify_email)
+            except ValidationError:
+                raise ValidationError('Notification email must be a valid email address.')
+
         coupon_catalog = cls.get_coupon_catalog(stock_record_ids, partner)
 
         return {
@@ -246,6 +264,7 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
             'title': request_data.get('title'),
             'voucher_type': voucher_type,
             'program_uuid': program_uuid,
+            'notify_email': notify_email,
         }
 
     @classmethod
@@ -442,6 +461,10 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
         note = request_data.get('note')
         if note is not None:
             coupon.attr.note = note
+            coupon.save()
+
+        if 'notify_email' in request_data:
+            coupon.attr.notify_email = request_data.get('notify_email')
             coupon.save()
 
     def update_offer_data(self, request_data, vouchers, site):

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -21,6 +21,7 @@ from ecommerce.extensions.api.serializers import (
     EnterpriseCouponListSerializer,
     EnterpriseCouponOverviewListSerializer
 )
+from ecommerce.extensions.api.v2.utils import send_new_codes_notification_email
 from ecommerce.extensions.api.v2.views.coupons import CouponViewSet
 from ecommerce.extensions.catalogue.utils import (
     attach_vouchers_to_coupon_product,
@@ -80,6 +81,10 @@ class EnterpriseCouponViewSet(CouponViewSet):
         if not waffle.switch_is_active(ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH):
             raise ValidationError('This endpoint will be available once the enterprise offers switch is on.')
 
+    @staticmethod
+    def send_codes_availability_email(site, email_address, enterprise_id, coupon_id):
+        send_new_codes_notification_email(site, email_address, enterprise_id, coupon_id)
+
     def create_coupon_and_vouchers(self, cleaned_voucher_data):
         coupon_product = create_coupon_product_and_stockrecord(
             cleaned_voucher_data['title'],
@@ -105,7 +110,12 @@ class EnterpriseCouponViewSet(CouponViewSet):
             name=cleaned_voucher_data['title']
         )
 
-        attach_vouchers_to_coupon_product(coupon_product, vouchers, cleaned_voucher_data['note'])
+        attach_vouchers_to_coupon_product(
+            coupon_product,
+            vouchers,
+            cleaned_voucher_data['note'],
+            cleaned_voucher_data.get('notify_email')
+        )
         return coupon_product
 
     def update(self, request, *args, **kwargs):

--- a/ecommerce/extensions/catalogue/migrations/0036_coupon_notify_email_attribute.py
+++ b/ecommerce/extensions/catalogue/migrations/0036_coupon_notify_email_attribute.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from oscar.core.loading import get_model
+
+from ecommerce.core.constants import COUPON_PRODUCT_CLASS_NAME
+
+ProductAttribute = get_model("catalogue", "ProductAttribute")
+ProductClass = get_model("catalogue", "ProductClass")
+
+
+def create_notify_email_attribute(apps, schema_editor):
+    """Create coupon notify_email attribute."""
+    coupon = ProductClass.objects.get(name=COUPON_PRODUCT_CLASS_NAME)
+    ProductAttribute.objects.create(
+        product_class=coupon,
+        name='Notification Email',
+        code='notify_email',
+        type='text',
+        required=False
+    )
+
+
+def remove_notify_email_attribute(apps, schema_editor):
+    """Remove coupon notify_email attribute."""
+    coupon = ProductClass.objects.get(name=COUPON_PRODUCT_CLASS_NAME)
+    ProductAttribute.objects.get(product_class=coupon, code='notify_email').delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('catalogue', '0035_add_partner_no_rev_coupon_categories')
+    ]
+    operations = [
+        migrations.RunPython(create_notify_email_attribute, remove_notify_email_attribute)
+    ]

--- a/ecommerce/extensions/catalogue/models.py
+++ b/ecommerce/extensions/catalogue/models.py
@@ -1,3 +1,5 @@
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
 from django.db import models
 from django.db.models.signals import post_init, post_save
 from django.dispatch import receiver
@@ -51,6 +53,17 @@ class Product(AbstractProduct):
                 )
         except AttributeError:
             pass
+
+        try:
+            if self.attr.notify_email is not None:
+                validate_email(self.attr.notify_email)
+        except ValidationError:
+            log_message_and_raise_validation_error(
+                'Notification email must be a valid email address.'
+            )
+        except AttributeError:
+            pass
+
         super(Product, self).save(*args, **kwargs)  # pylint: disable=bad-super-call
 
 

--- a/ecommerce/extensions/catalogue/utils.py
+++ b/ecommerce/extensions/catalogue/utils.py
@@ -130,11 +130,13 @@ def create_coupon_product_and_stockrecord(title, category, partner, price):
     return coupon_product
 
 
-def attach_vouchers_to_coupon_product(coupon_product, vouchers, note):
+def attach_vouchers_to_coupon_product(coupon_product, vouchers, note, notify_email=None):
     coupon_vouchers, __ = CouponVouchers.objects.get_or_create(coupon=coupon_product)
     coupon_vouchers.vouchers.add(*vouchers)
     coupon_product.attr.coupon_vouchers = coupon_vouchers
     coupon_product.attr.note = note
+    if notify_email:
+        coupon_product.attr.notify_email = notify_email
     coupon_product.save()
 
 

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -607,3 +607,19 @@ if os.environ.get('ENABLE_DJANGO_TOOLBAR', False):
 
 # Determines if events are actually sent to Segment. This should only be set to False for testing purposes.
 SEND_SEGMENT_EVENTS = True
+
+NEW_CODES_EMAIL_CONFIG = {
+    'email_subject': 'New edX codes available',
+    'from_email': 'customersuccess@edx.org',
+    'email_body': '''
+        Hello,
+
+        This message is to inform you that a new order has been processed for your organization. Please visit the
+        following page, in your Admin Dashboard, to find new codes ready for use.
+
+        https://portal.edx.org/{enterprise_slug}/admin/codes
+
+        Having trouble accessing your codes? Please contact edX Enterprise Support at customersuccess@edx.org.
+        Thank you.
+    '''
+}

--- a/ecommerce/settings/devstack.py
+++ b/ecommerce/settings/devstack.py
@@ -63,6 +63,8 @@ PAYMENT_PROCESSOR_CONFIG = {
 # Language cookie
 LANGUAGE_COOKIE_NAME = 'openedx-language-preference'
 
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
 #####################################################################
 # Lastly, see if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):

--- a/ecommerce/static/js/models/enterprise_coupon_model.js
+++ b/ecommerce/static/js/models/enterprise_coupon_model.js
@@ -14,7 +14,8 @@ define([
         _.extend(Backbone.Validation.messages, {
             required: gettext('This field is required.'),
             number: gettext('This value must be a number.'),
-            date: gettext('This value must be a date.')
+            date: gettext('This value must be a date.'),
+            email: gettext('This value must be a valid email.')
         });
         _.extend(Backbone.Model.prototype, Backbone.Validation.mixin);
 
@@ -32,7 +33,11 @@ define([
 
             couponValidation: {
                 enterprise_customer: {required: true},
-                enterprise_customer_catalog: {required: true}
+                enterprise_customer_catalog: {required: true},
+                notify_email: {
+                    pattern: 'email',
+                    required: false
+                }
             },
 
             initialize: function() {

--- a/ecommerce/static/js/test/mock_data/coupons.js
+++ b/ecommerce/static/js/test/mock_data/coupons.js
@@ -258,7 +258,8 @@ define([], function() {
             end_date: '2016-01-01T00:00:00Z',
             voucher_type: 'Single use',
             enterprise_customer: {id: '349bef52-c0fb-4901-a5b5-26e9b70a4102', name: 'test client'},
-            enterprise_customer_catalog: 'f9098aab-1842-45c8-81a2-0e53d8e7609a'
+            enterprise_customer_catalog: 'f9098aab-1842-45c8-81a2-0e53d8e7609a',
+            notify_email: 'batman@gotham.comics'
         },
         couponAPIResponseData = {
             count: 1,

--- a/ecommerce/static/js/test/specs/models/enterprise_coupon_model_spec.js
+++ b/ecommerce/static/js/test/specs/models/enterprise_coupon_model_spec.js
@@ -45,6 +45,12 @@ define([
                     model.validate();
                     expect(model.isValid()).toBeFalsy();
                 });
+
+                it('should validate notify email is correct', function() {
+                    model.set('notify_email', 'batman');
+                    model.validate();
+                    expect(model.isValid()).toBeFalsy();
+                });
             });
 
             describe('save', function() {
@@ -59,6 +65,7 @@ define([
                     expect(ajaxData.enterprise_customer).toEqual(enterpriseCouponData.enterprise_customer);
                     expect(ajaxData.enterprise_customer_catalog)
                         .toEqual(enterpriseCouponData.enterprise_customer_catalog);
+                    expect(ajaxData.notify_email).toEqual(enterpriseCouponData.notify_email);
                 });
 
                 it('should call Coupon model when saved', function() {

--- a/ecommerce/static/js/views/enterprise_coupon_form_view.js
+++ b/ecommerce/static/js/views/enterprise_coupon_form_view.js
@@ -68,6 +68,12 @@ define([
                 },
                 'input[name=enterprise_customer_catalog]': {
                     observe: 'enterprise_customer_catalog'
+                },
+                'input[name=notify_email]': {
+                    observe: 'notify_email',
+                    onSet: function(val) {
+                        return val === '' ? null : val;
+                    }
                 }
             },
 
@@ -88,6 +94,7 @@ define([
                     'end_date',
                     'enterprise_customer',
                     'enterprise_customer_catalog',
+                    'notify_email',
                     'invoice_discount_type',
                     'invoice_discount_value',
                     'invoice_number',

--- a/ecommerce/static/templates/enterprise_coupon_detail.html
+++ b/ecommerce/static/templates/enterprise_coupon_detail.html
@@ -43,6 +43,12 @@
             <div class="value"><%= coupon.note %></div><br />
         </div>
         <%}%>
+        <% if(coupon.notify_email) {%>
+        <div class="info-item grid-item notify_email">
+            <div class="heading"><%= gettext('Notification Email') %></div>
+            <div class="value"><%= coupon.notify_email %></div><br />
+        </div>
+        <%}%>
         <div class="info-item grid-item discount-value">
             <div class="heading"><%= gettext('Discount Value:') %></div>
             <div class="value"><%= discountValue %></div>

--- a/ecommerce/static/templates/enterprise_coupon_form.html
+++ b/ecommerce/static/templates/enterprise_coupon_form.html
@@ -172,6 +172,11 @@
             <input id="note" type="text" class="form-control" name="note" maxlength="100">
             <p class="help-block"></p>
         </div>
+        <div class="form-group">
+            <label for="notify-email"><%= gettext('Notification Email') %></label>
+            <input id="notify-email" class="form-control" type="text" name="notify_email">
+            <p class="help-block"></p>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
**Description:** 
This PR adds a notification email field to https://ecommerce-business.sandbox.edx.org/enterprise/coupons/new/ and sends the email to that address whenever an enterprise coupon is created.

**Test Instructions:**
Deployed to sandbox

1: Open https://ecommerce-business.sandbox.edx.org/enterprise/coupons/new/ in a browser
2: Create a new coupon and supply a notification email **[This is failing currently because AWS SES is not working for sandbox]**
3: Verify that the notification email is received on the supplied notification email address
