### PR TITLE
ENT-1384/ENT-1461 Add Enterprise Coupon Code Revoke API

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -23,6 +23,7 @@ from ecommerce.enterprise.conditions import AssignableEnterpriseCustomerConditio
 from ecommerce.enterprise.constants import ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
+from ecommerce.extensions.offer.constants import OFFER_ASSIGNMENT_REVOKED
 from ecommerce.invoice.models import Invoice
 from ecommerce.programs.custom import class_path
 from ecommerce.tests.mixins import ThrottlingMixin
@@ -171,7 +172,7 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         """
         enterprise_id = ''
         enterprise_name = 'ToyX'
-        if data and data.get('enterprise_customer'):
+        if data and isinstance(data, dict) and data.get('enterprise_customer'):
             enterprise_id = data['enterprise_customer']['id']
             enterprise_name = data['enterprise_customer']['name']
 
@@ -885,3 +886,171 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
 
         for code in assigned_codes:
             assert OfferAssignment.objects.filter(code=code).count() in assignments_per_code
+
+    @ddt.data(
+        (Voucher.SINGLE_USE, 2, None, True),
+        (Voucher.MULTI_USE_PER_CUSTOMER, 2, 3, False),
+        (Voucher.MULTI_USE, 1, None, True),
+        (Voucher.ONCE_PER_CUSTOMER, 2, 2, False),
+    )
+    @ddt.unpack
+    def test_coupon_codes_revoke_success(self, voucher_type, quantity, max_uses, send_email):
+        """Test revoking codes from users."""
+        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': True})
+
+        email = 'test1@example.com'
+        coupon_post_data = dict(self.data, voucher_type=voucher_type, quantity=quantity, max_uses=max_uses)
+        coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
+        coupon = coupon.json()
+        coupon_id = coupon['coupon_id']
+        with mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email.delay'):
+            self.get_response(
+                'POST',
+                '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
+                {'template': 'Test template', 'emails': [email]}
+            )
+
+        offer_assignment = OfferAssignment.objects.filter(user_email=email).first()
+        payload = {'assignments': [{'email': email, 'code': offer_assignment.code}]}
+        if send_email:
+            payload['template'] = 'Test template'
+        with mock.patch('ecommerce.extensions.offer.utils.send_offer_update_email.delay') as mock_send_email:
+            response = self.get_response(
+                'POST',
+                '/api/v2/enterprise/coupons/{}/revoke/'.format(coupon_id),
+                payload
+            )
+
+        response = response.json()
+        assert response == [{'code': offer_assignment.code, 'email': email, 'detail': 'success'}]
+        assert mock_send_email.call_count == (1 if send_email else 0)
+        for offer_assignment in OfferAssignment.objects.filter(user_email=email):
+            assert offer_assignment.status == OFFER_ASSIGNMENT_REVOKED
+
+    def test_coupon_codes_revoke_invalid_request(self):
+        """Test that revoke fails when the request format is incorrect."""
+        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': True})
+        email = 'test1@example.com'
+        coupon_post_data = dict(self.data, voucher_type=Voucher.SINGLE_USE, quantity=1)
+        coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
+        coupon = coupon.json()
+        coupon_id = coupon['coupon_id']
+
+        response = self.get_response(
+            'POST',
+            '/api/v2/enterprise/coupons/{}/revoke/'.format(coupon_id),
+            {'template': 'Test template', 'assignments': {'email': email, 'code': 'RANDOMCODE'}}
+        )
+
+        response = response.json()
+        assert response == {'non_field_errors': ['Expected a list of items but got type "dict".']}
+
+    def test_coupon_codes_revoke_code_not_in_coupon(self):
+        """Test that revoke fails when the specified code is not associated with the Coupon."""
+        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': True})
+        email = 'test1@example.com'
+        coupon_post_data = dict(self.data, voucher_type=Voucher.SINGLE_USE, quantity=1)
+        coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
+        coupon = coupon.json()
+        coupon_id = coupon['coupon_id']
+
+        response = self.get_response(
+            'POST',
+            '/api/v2/enterprise/coupons/{}/revoke/'.format(coupon_id),
+            {'template': 'Test template', 'assignments': [{'email': email, 'code': 'RANDOMCODE'}]}
+        )
+
+        response = response.json()
+        assert response == [
+            {'non_field_errors': ['Code RANDOMCODE is not associated with this Coupon']}
+        ]
+
+    def test_coupon_codes_revoke_no_assignment_exists(self):
+        """Test that revoke fails when the user has no existing assignments for the code."""
+        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': True})
+        email = 'test1@example.com'
+        coupon_post_data = dict(self.data, voucher_type=Voucher.SINGLE_USE, quantity=1)
+        coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
+        coupon = coupon.json()
+        coupon_id = coupon['coupon_id']
+
+        voucher = Product.objects.get(id=coupon_id).attr.coupon_vouchers.vouchers.first()
+        response = self.get_response(
+            'POST',
+            '/api/v2/enterprise/coupons/{}/revoke/'.format(coupon_id),
+            {'template': 'Test template', 'assignments': [{'email': email, 'code': voucher.code}]}
+        )
+
+        response = response.json()
+        assert response == [
+            {'non_field_errors': ['No assignments exist for user {} and code {}'.format(email, voucher.code)]}
+        ]
+
+    def test_coupon_codes_revoke_email_failure(self):
+        """Test revoking a code for a user with an email failure."""
+        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': True})
+
+        email = 'test1@example.com'
+        coupon_post_data = dict(self.data, voucher_type=Voucher.SINGLE_USE, quantity=1)
+        coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
+        coupon = coupon.json()
+        coupon_id = coupon['coupon_id']
+        with mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email.delay'):
+            self.get_response(
+                'POST',
+                '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
+                {'template': 'Test template', 'emails': [email]}
+            )
+
+        offer_assignment = OfferAssignment.objects.filter(user_email=email).first()
+        with mock.patch(
+            'ecommerce.extensions.offer.utils.send_offer_update_email.delay',
+            side_effect=Exception('email_dispatch_failed')
+        ) as mock_send_email:
+            response = self.get_response(
+                'POST',
+                '/api/v2/enterprise/coupons/{}/revoke/'.format(coupon_id),
+                {'template': 'Test template', 'assignments': [{'email': email, 'code': offer_assignment.code}]}
+            )
+
+        response = response.json()
+        assert response == [{'email': email, 'code': offer_assignment.code, 'detail': 'email_dispatch_failed'}]
+        assert mock_send_email.call_count == 1
+        for offer_assignment in OfferAssignment.objects.filter(user_email=email):
+            assert offer_assignment.status == OFFER_ASSIGNMENT_REVOKED
+
+    def test_coupon_codes_revoke_bulk(self):
+        """Test sending multiple revoke requests (bulk use case)."""
+        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': True})
+
+        emails = ['test1@example.com', 'test2@example.com']
+        coupon_post_data = dict(self.data, voucher_type=Voucher.SINGLE_USE, quantity=2)
+        coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
+        coupon = coupon.json()
+        coupon_id = coupon['coupon_id']
+        with mock.patch('ecommerce.extensions.offer.utils.send_offer_update_email.delay'):
+            self.get_response(
+                'POST',
+                '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
+                {'template': 'Test template', 'emails': emails}
+            )
+
+        offer_assignment = OfferAssignment.objects.filter(user_email__in=emails).first()
+        with mock.patch('ecommerce.extensions.offer.utils.send_offer_update_email.delay') as mock_send_email:
+            response = self.get_response(
+                'POST',
+                '/api/v2/enterprise/coupons/{}/revoke/'.format(coupon_id),
+                {'template': 'Test template', 'assignments': [
+                    {'email': offer_assignment.user_email, 'code': offer_assignment.code},
+                    {'email': 'test3@example.com', 'code': 'RANDOMCODE'},
+                ]}
+            )
+
+        response = response.json()
+        assert response == [
+            {'email': offer_assignment.user_email, 'code': offer_assignment.code, 'detail': 'success'},
+            {'non_field_errors': ['Code RANDOMCODE is not associated with this Coupon']},
+        ]
+        assert mock_send_email.call_count == 1
+        for offer_assignment in OfferAssignment.objects.filter(user_email=offer_assignment.user_email):
+            assert offer_assignment.status == OFFER_ASSIGNMENT_REVOKED

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -15,6 +15,7 @@ from ecommerce.enterprise.constants import ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH
 from ecommerce.enterprise.utils import get_enterprise_customers
 from ecommerce.extensions.api.serializers import (
     CouponCodeAssignmentSerializer,
+    CouponCodeRevokeSerializer,
     CouponSerializer,
     CouponVoucherSerializer,
     EnterpriseCouponListSerializer,
@@ -263,4 +264,22 @@ class EnterpriseCouponViewSet(CouponViewSet):
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data, status=status.HTTP_200_OK)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    @detail_route(methods=['post'])
+    def revoke(self, request, pk):  # pylint: disable=unused-argument
+        """
+        Revoke users by email from codes within the Coupon.
+        """
+        coupon = self.get_object()
+        email_template = request.data.pop('template', None)
+        serializer = CouponCodeRevokeSerializer(
+            data=request.data.get('assignments'),
+            many=True,
+            context={'coupon': coupon, 'template': email_template}
+        )
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_200_OK)
+
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/ecommerce/extensions/offer/utils.py
+++ b/ecommerce/extensions/offer/utils.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 from django.conf import settings
 from django.shortcuts import render
 from django.utils.translation import ugettext_lazy as _
-from ecommerce_worker.sailthru.v1.tasks import send_offer_assignment_email
+from ecommerce_worker.sailthru.v1.tasks import send_offer_assignment_email, send_offer_update_email
 from oscar.core.loading import get_model
 
 from ecommerce.extensions.checkout.utils import add_currency
@@ -144,3 +144,23 @@ def send_assigned_offer_email(
         EXPIRATION_DATE=code_expiration_date
     )
     send_offer_assignment_email.delay(learner_email, offer_assignment_id, email_subject, email_body)
+
+
+def send_revoked_offer_email(template, learner_email, code):
+    """
+    Arguments:
+        *template*
+            The email template with placeholders that will receive the following tokens
+        *learner_email*
+            Email of the customer who will receive the code.
+        *code*
+            Code for the user.
+    """
+
+    email_subject = settings.OFFER_REVOKE_EMAIL_DEFAULT_SUBJECT
+
+    email_body = template.format(
+        user_email=learner_email,
+        code=code,
+    )
+    send_offer_update_email.delay(learner_email, email_subject, email_body)

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -648,6 +648,7 @@ OFFER_ASSIGNMENT_EMAIL_DEFAULT_TEMPLATE = '''
     For any questions, please reach out to your Learning Manager.
 '''
 OFFER_ASSIGNMENT_EMAIL_DEFAULT_SUBJECT = 'New edX course assignment'
+OFFER_REVOKE_EMAIL_DEFAULT_SUBJECT = 'edX Course Assignment Revoked'
 
 #SAILTHRU settings
 SAILTHRU_KEY = None


### PR DESCRIPTION
**Description**
This PR introduces an api endpoint for revoking codes from users. The endpoint accepts an email template, and a list of email/code combinations. Each of these is evaluated independently, so if one email/code combination is not valid, others specified will still go through if they are valid. The response will indicate the success of each email/code pair sent. Upon success, all active assignments for that code/user are set to revoked status.

**Testing Instructions**
Deployed on the business sandbox.

Hitting the endpoint with a code that is not part of the Coupon should fail.
Request:
```POST /api/v2/enterprise/coupons/419/revoke/ HTTP/1.1
Host: ecommerce-business.sandbox.edx.org
Authorization: JWT {jwt_token}
Content-Type: application/json
{"template":"", "assignments":[{"email":"bexline+revoke@edx.org", "code":"abcdef"}]}
```

Response:
```[
    {
        "non_field_errors": [
            "Code abcdef is not associated with this Coupon"
        ]
    }
]
```

Hitting the endpoint with a code/email that do not have an active assignment should fail.
Request:
```POST /api/v2/enterprise/coupons/419/revoke/ HTTP/1.1
Host: ecommerce-business.sandbox.edx.org
Authorization: JWT {jwt_token}
Content-Type: application/json
{"template":"", "assignments":[{"email":"bexline+revoke@edx.org", "code":"TDXSDBTU3YSVCK3X"}]}
```

Response:
```[
    {
        "non_field_errors": [
            "No assignments exist for user bexline+revoke@edx.org and code TDXSDBTU3YSVCK3X"
        ]
    }
]
```

Hitting the endpoint for SINGLE_USE or ONCE_PER_CUSTOMER Coupons should set exactly one OfferAssignment object to have the status of REVOKED. This is because only one active OfferAssignment should exist for that email/code combination.
Assign a code to a user:
```POST /api/v2/enterprise/coupons/419/assign/ HTTP/1.1
Host: ecommerce-business.sandbox.edx.org
Authorization: JWT {JWT_TOKEN}
Content-Type: application/json
cache-control: no-cache
{"template":"", "emails": ["bexline@edx.org”]}
{
    "offer_assignments": [
        {
            "status": "email_dispatch_failed",
            "code": "WYZIOEZT2N7VYJ5K",
            "id": 47,
            "user_email": "bexline@edx.org"
        }
    ]
}
```

Revoke the code:
``` POST /api/v2/enterprise/coupons/419/revoke/ HTTP/1.1
Host: ecommerce-business.sandbox.edx.org
Authorization: JWT {JWT_TOKEN}
Content-Type: application/json
{"template":"", "assignments": [{"email":"bexline@edx.org", "code": "WYZIOEZT2N7VYJ5K"}]}
[
    {
        "code": "WYZIOEZT2N7VYJ5K",
        "email": "bexline@edx.org",
        "detail": "success"
    }
]
```

Once this code/email have been revoked, the code should be assignable and redeemable by a different user.

Hitting the endpoint for MULTI_USE or MULTI_USE_PER_CUSTOMER Coupons should set all active OfferAssignment objects for that code/email combination to have the status of REVOKED. 
Assign a MULTI_USE_PER_CUSTOMER code:
```POST /api/v2/enterprise/coupons/399/assign/ HTTP/1.1
Host: ecommerce-business.sandbox.edx.org
Authorization: JWT {jwt_token}
Content-Type: application/json
{"template":"", "emails":["bexline+revoke@edx.org”]}
{
    "offer_assignments": [
        {
            "status": "email_dispatch_failed",
            "code": "32XIB7PHKBHR5S7L",
            "id": 49,
            "user_email": "bexline+revoke@edx.org"
        },
        {
            "status": "email_dispatch_failed",
            "code": "32XIB7PHKBHR5S7L",
            "id": 50,
            "user_email": "bexline+revoke@edx.org"
        },
        {
            "status": "email_dispatch_failed",
            "code": "32XIB7PHKBHR5S7L",
            "id": 51,
            "user_email": "bexline+revoke@edx.org"
        },
        {
            "status": "email_dispatch_failed",
            "code": "32XIB7PHKBHR5S7L",
            "id": 52,
            "user_email": "bexline+revoke@edx.org"
        },
        {
            "status": "email_dispatch_failed",
            "code": "32XIB7PHKBHR5S7L",
            "id": 53,
            "user_email": "bexline+revoke@edx.org"
        }
    ]
}
```
Revoke the code:
```POST /api/v2/enterprise/coupons/399/revoke/ HTTP/1.1
Host: ecommerce-business.sandbox.edx.org
Authorization: JWT {jwt_token}
Content-Type: application/json
{"template":"", "assignments":[{"email":"bexline+revoke@edx.org", "code":"32XIB7PHKBHR5S7L"}]}
[
    {
        "code": "32XIB7PHKBHR5S7L",
        "email": "bexline+revoke@edx.org",
        "detail": "success"
    }
]
```

Once this code/email have been revoked, MULTI_USE codes should be assignable and redeemable, MUTLI_USE_PER_CUSTOMER codes should not be assignable or redeemable.