### PR TITLE
Add prospectus worker to ecommerce throttle

### DIFF
--- a/ecommerce/extensions/api/throttles.py
+++ b/ecommerce/extensions/api/throttles.py
@@ -3,12 +3,13 @@ from rest_framework.throttling import UserRateThrottle
 
 
 class ServiceUserThrottle(UserRateThrottle):
-    """A throttle allowing the service user to override rate limiting"""
+    """A throttle allowing service users to override rate limiting"""
 
     def allow_request(self, request, view):
-        """Returns True if the request is coming from the service user, and
-        defaults to UserRateThrottle's configured setting otherwise.
+        """Returns True if the request is coming from one of the service users
+        and defaults to UserRateThrottle's configured setting otherwise.
         """
-        if request.user.username == settings.ECOMMERCE_SERVICE_WORKER_USERNAME:
+        service_users = [settings.ECOMMERCE_SERVICE_WORKER_USERNAME, settings.PROSPECTUS_WORKER_USERNAME]
+        if request.user.username in service_users:
             return True
         return super(ServiceUserThrottle, self).allow_request(request, view)

--- a/ecommerce/extensions/api/v2/tests/views/test_baskets.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_baskets.py
@@ -390,7 +390,7 @@ class BasketDestroyViewTests(TestCase):
         self.assertFalse(Basket.objects.filter(id=self.basket.id).exists())
 
 
-class BasketCalculateViewTests(ProgramTestMixin, TestCase):
+class BasketCalculateViewTests(ProgramTestMixin, ThrottlingMixin, TestCase):
     def setUp(self):
         super(BasketCalculateViewTests, self).setUp()
         self.products = ProductFactory.create_batch(3, stockrecords__partner=self.partner, categories=[])

--- a/ecommerce/extensions/api/v2/views/baskets.py
+++ b/ecommerce/extensions/api/v2/views/baskets.py
@@ -358,6 +358,7 @@ class BasketDestroyView(generics.DestroyAPIView):
 
 class BasketCalculateView(generics.GenericAPIView):
     permission_classes = (IsAuthenticated,)
+    throttle_classes = (ServiceUserThrottle,)
     MARKETING_USER = 'marketing_site_worker'
 
     def _calculate_temporary_basket_atomic(self, user, request, products, voucher, skus, code):

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -419,6 +419,9 @@ JWT_AUTH = {
 # Service user for worker processes.
 ECOMMERCE_SERVICE_WORKER_USERNAME = 'ecommerce_worker'
 
+# Worker user used by prospectus to query ecommerce
+PROSPECTUS_WORKER_USERNAME = 'prospectus_worker'
+
 # Used to access the Enrollment API. Set this to the same value used by the LMS.
 EDX_API_KEY = None
 


### PR DESCRIPTION
DISCO-559

This won't actually be used until after the worker is created and prospectus is updated, but it doesn't hurt to go ahead and add it for when we hit http://ecommerce-proxy:8080/api/v2/baskets/calculate/ in prospectus