### PR TITLE
Handle AuthStateMissing exception on oauth redirect

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -233,6 +233,7 @@ MIDDLEWARE_CLASSES = (
     'edx_django_utils.cache.middleware.TieredCacheMiddleware',
     'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
     'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
+    'ecommerce.social_auth.middleware.ExceptionMiddleware'
 )
 # END MIDDLEWARE CONFIGURATION
 

--- a/ecommerce/social_auth/middleware.py
+++ b/ecommerce/social_auth/middleware.py
@@ -1,0 +1,36 @@
+"""Middleware classes for social_auth."""
+
+import logging
+
+from django.shortcuts import redirect
+from django.urls import reverse
+from social_core.exceptions import AuthStateMissing
+from social_django.middleware import SocialAuthExceptionMiddleware
+
+log = logging.getLogger(__name__)
+
+
+class ExceptionMiddleware(SocialAuthExceptionMiddleware):
+    """Custom middleware that handles conditional redirection."""
+
+    def process_exception(self, request, exception):
+        """Handles specific exception raised by Python Social Auth eg AuthStateMissing."""
+
+        request_path = request.path
+        if request_path and isinstance(exception, AuthStateMissing):
+            if request_path == reverse('social:complete', args=['edx-oidc']):
+
+                from django.conf import settings
+                redirect_url = settings.SOCIAL_AUTH_EDX_OIDC_LOGOUT_URL
+                exception_logs = 'AuthStateMissing exception'
+
+                redirect_url = redirect_url if redirect_url else '/'
+                if redirect_url != '/':
+                    exception_logs += ', redirecting learner to lms logout url.'
+                else:
+                    exception_logs += ', redirecting learner to ecommerce index page.'
+
+                log.info(exception_logs)
+                return redirect(redirect_url)
+
+        return super(ExceptionMiddleware, self).process_exception(request, exception)

--- a/ecommerce/social_auth/tests/test_middleware.py
+++ b/ecommerce/social_auth/tests/test_middleware.py
@@ -1,0 +1,63 @@
+"""
+Tests for social auth middleware
+"""
+
+from django.test.client import RequestFactory
+from django.test.utils import override_settings
+from django.urls import reverse
+from social_core.exceptions import AuthStateMissing
+from testfixtures import LogCapture
+
+from ecommerce.social_auth.middleware import ExceptionMiddleware
+from ecommerce.tests.testcases import TestCase
+
+
+class SocialAuthMiddlewareTests(TestCase):
+    """Tests that ExceptionMiddleware is correctly redirected"""
+
+    def setUp(self):
+        self.request = RequestFactory().get("dummy_url")
+        self.request.path = reverse('social:complete', args=['edx-oidc'])
+
+    @override_settings(SOCIAL_AUTH_EDX_OIDC_LOGOUT_URL='example.com/logout')
+    def test_auth_state_missing_exception_lms_redirection(self):
+        """
+        Test ExceptionMiddleware is correctly redirected to lms
+        logout page when PSA raises AuthStateMissing exception with
+        SOCIAL_AUTH_EDX_OIDC_LOGOUT_URL correctly set.
+        """
+
+        logger_name = 'ecommerce.social_auth.middleware'
+        with LogCapture(logger_name) as l:
+            response = ExceptionMiddleware().process_exception(
+                self.request, AuthStateMissing('test-backend')
+            )
+            target_url = response.url
+
+            self.assertEqual(response.status_code, 302)
+            self.assertTrue(target_url.endswith('/logout'))
+
+            l.check(
+                (logger_name, 'INFO', 'AuthStateMissing exception, redirecting learner to lms logout url.')
+            )
+
+    @override_settings(SOCIAL_AUTH_EDX_OIDC_LOGOUT_URL=None)
+    def test_auth_state_missing_exception_ecom_redirection(self):
+        """
+        Test ExceptionMiddleware is correctly redirected to ecommerce
+        / page when PSA raises AuthStateMissing exception and finds
+        SOCIAL_AUTH_EDX_OIDC_LOGOUT_URL not set.
+        """
+
+        logger_name = 'ecommerce.social_auth.middleware'
+        with LogCapture(logger_name) as l:
+            response = ExceptionMiddleware().process_exception(
+                self.request, AuthStateMissing('test-backend')
+            )
+            target_url = response.url
+
+            self.assertEqual(response.status_code, 302)
+            self.assertTrue(target_url.endswith('/'))
+            l.check(
+                (logger_name, 'INFO', 'AuthStateMissing exception, redirecting learner to ecommerce index page.')
+            )


### PR DESCRIPTION
This patch would enable ecommerce to handle
AuthStateMissing exception raised on oauth
redirection from lms.

[LEARNER-6993](https://openedx.atlassian.net/browse/LEARNER-6993)