### PR TITLE
Remove pulling CORS from env as this is already handled above

### DIFF
--- a/ecommerce/settings/production.py
+++ b/ecommerce/settings/production.py
@@ -86,9 +86,6 @@ for __, configs in PAYMENT_PROCESSOR_CONFIG.iteritems():
 
 ENTERPRISE_API_URL = urljoin(ENTERPRISE_SERVICE_URL, 'api/v1/')
 
-CORS_ORIGIN_WHITELIST = environ.get('CORS_ORIGIN_WHITELIST', ())
-CORS_URLS_REGEX = r'{regex}'.format(regex=environ.get('CORS_URLS_REGEX', ''))
 CORS_ALLOW_HEADERS = corsheaders_default_headers + (
     'use-jwt-cookie',
 )
-CORS_ALLOW_CREDENTIALS = environ.get('CORS_ALLOW_CREDENTIALS', False)


### PR DESCRIPTION
The config file looping above already sets up top level variables
for each of these, so trying to then pull from the environment was
overriding them with empty values. Removing this will let these variables
come through the config file