### PR TITLE
update remind/revoke response

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -1172,7 +1172,12 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
 
         response = response.json()
         assert response == [
-            {'non_field_errors': ['Code RANDOMCODE is not associated with this Coupon']}
+            {
+                'code': 'RANDOMCODE',
+                'email': 'test1@example.com',
+                'detail': 'failure',
+                'message': 'Code RANDOMCODE is not associated with this Coupon',
+            }
         ]
 
     def test_coupon_codes_revoke_no_assignment_exists(self):
@@ -1193,7 +1198,12 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
 
         response = response.json()
         assert response == [
-            {'non_field_errors': ['No assignments exist for user {} and code {}'.format(email, voucher.code)]}
+            {
+                'code': voucher.code,
+                'email': email,
+                'detail': 'failure',
+                'message': 'No assignments exist for user {} and code {}'.format(email, voucher.code),
+            }
         ]
 
     def test_coupon_codes_revoke_email_failure(self):
@@ -1259,7 +1269,12 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         response = response.json()
         assert response == [
             {'email': offer_assignment.user_email, 'code': offer_assignment.code, 'detail': 'success'},
-            {'non_field_errors': ['Code RANDOMCODE is not associated with this Coupon']},
+            {
+                'code': 'RANDOMCODE',
+                'email': 'test3@example.com',
+                'detail': 'failure',
+                'message': 'Code RANDOMCODE is not associated with this Coupon',
+            },
         ]
         assert mock_send_email.call_count == 1
         for offer_assignment in OfferAssignment.objects.filter(user_email=offer_assignment.user_email):
@@ -1313,9 +1328,15 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             '/api/v2/enterprise/coupons/{}/remind/'.format(coupon_id),
             {'template': 'Test template', 'assignments': [{'email': email, 'code': 'RANDOMCODE'}]}
         )
+
         response = response.json()
         assert response == [
-            {'non_field_errors': ['Code RANDOMCODE is not associated with this Coupon']}
+            {
+                'code': 'RANDOMCODE',
+                'email': 'test1@example.com',
+                'detail': 'failure',
+                'message': 'Code RANDOMCODE is not associated with this Coupon',
+            }
         ]
 
     def test_coupon_codes_remind_no_assignment_exists(self):
@@ -1332,9 +1353,15 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             '/api/v2/enterprise/coupons/{}/remind/'.format(coupon_id),
             {'template': 'Test template', 'assignments': [{'email': email, 'code': voucher.code}]}
         )
+
         response = response.json()
         assert response == [
-            {'non_field_errors': ['No assignments exist for user {} and code {}'.format(email, voucher.code)]}
+            {
+                'code': voucher.code,
+                'email': email,
+                'detail': 'failure',
+                'message': 'No assignments exist for user {} and code {}'.format(email, voucher.code),
+            }
         ]
 
     def test_coupon_codes_remind_email_failure(self):
@@ -1391,9 +1418,15 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
                     {'email': 'test3@example.com', 'code': 'RANDOMCODE'},
                 ]}
             )
+
         response = response.json()
         assert response == [
             {'email': offer_assignment.user_email, 'code': offer_assignment.code, 'detail': 'success'},
-            {'non_field_errors': ['Code RANDOMCODE is not associated with this Coupon']},
+            {
+                'code': 'RANDOMCODE',
+                'email': 'test3@example.com',
+                'detail': 'failure',
+                'message': 'Code RANDOMCODE is not associated with this Coupon',
+            },
         ]
         assert mock_send_email.call_count == 1


### PR DESCRIPTION
[ENT-1522](https://openedx.atlassian.net/browse/ENT-1522)

This updates the remind/revoke response and now the response format would be same in case of error or success.

Failure response for a single assignment
```python
{
    'code': 'AWESOME', 
    'email': 'ma@edx.org', 
    'detail': 'failure', 
    'message': 'Code AWESOME is too AWESOME to handle'
}
```

Success response for a single assignment
```python
{
    'code': 'NOT_AWESOME', 
    'email': 'none@secret.corp', 
    'detail': 'success'
}
```

Success and failure response for multiple assignments
```python
[
    {
        'code': 'AVENGERS', 
        'email': 'nick.fury@avengers.marvel', 
        'detail': 'success'
    },
    {
        'code': 'SET_PRICE_TO_ZERO',
        'email': 'bruce@wayne.corp',
        'detail': 'failure',
        'message': 'Bruce, Do you really need a discount? What are you gonna do with all of your wealth?'
    }
]
```