### PR TITLE
Re-add DOP deprecation commits with the backends fix

### DIFF
--- a/docs/install_ecommerce.rst
+++ b/docs/install_ecommerce.rst
@@ -14,9 +14,7 @@ following steps.
 .. note::
  These steps assume that you are running Open edX `devstack`_. If you prefer to
  run the E-Commerce service locally on your computer instead of on the virtual
- machine (VM) that devstack uses, see :ref:`Development Outside Devstack`.
-
-.. _Set Up a Virtual Environment:
+ machine (VM) that devstack uses, see :`Development Outside Devstack`_.
 
 ****************************
 Set Up a Virtual Environment
@@ -60,60 +58,39 @@ To set up the ``ecommerce`` database, you must run migrations.
 
 When you run migrations, the E-Commerce service adds a default site to your installation.
 
-.. _Configure OIDC:
+***************
+Configure OAuth
+***************
 
-***********************************
-Configure edX OpenID Connect (OIDC)
-***********************************
+The E-Commerce service relies on the LMS, which serves as the OAuth 2.0 authentication provider.
 
-The E-Commerce service relies on the edX `OpenID Connect`_ (OIDC)
-authentication provider for login. OIDC is built on top of OAuth 2.0.
-Currently, the LMS serves as the authentication provider.
-
-To configure the E-Commerce service to work with OIDC, complete the following
+To configure the E-Commerce service to work with OAuth, complete the following
 procedures.
 
 .. contents::
    :depth: 1
    :local:
 
-.. _Create Register Client:
-
 ============================
 Create and Register a Client
 ============================
 
-To create and register a new OIDC client, follow these steps.
+To create and register a new OAuth client, follow these steps.
 
 #. Start the LMS.
-#. In your browser, go to ``http://127.0.0.1:8000/admin/oauth2/client/``.
+#. In your browser, go to ``http://127.0.0.1:8000/admin/oauth2_provider/application/``.
 #. Select **Add client**.
 #. Leave the **User** field blank.
 #. For **Client Name**, enter ``E-Commerce Service``.
 #. For **URL**, enter ``http://localhost:8002/``.
-#. For **Redirect URL**, enter ``http://127.0.0.1:8002/complete/edx-oidc/``.
-   This is the OIDC client endpoint.
+#. For **Redirect URL**, enter ``http://127.0.0.1:8002/complete/edx-oauth2/``.
+   This is the OAuth client endpoint.
 
    The system automatically generates values in the **Client ID** and **Client
    Secret** fields.
 
-#. For **Client Type**, select **Confidential (Web applications)**.
-#. Select **Save**.
-
-===============================
-Designate the Client as Trusted
-===============================
-
-After you create your client, designate it as trusted. Trusted clients
-bypass the user consent form that usually appears after the system validates
-the user's credentials.
-
-To designate your client as trusted, follow these steps.
-
-#. In your browser, go to
-   ``http://127.0.0.1:8000/admin/edx_oauth2_provider/trustedclient/add/``.
-#. In the **OAuth 2.0 clients** list, select the redirect URL for the client
-   that you just created.
+#. For **Client Type**, select **Authorization code**.
+#. Enable **Skip authorization**.
 #. Select **Save**.
 
 .. _Configure a Site Partner and Site Configuration:
@@ -122,13 +99,13 @@ To designate your client as trusted, follow these steps.
 Configure a Site, Partner, and Site Configuration
 *************************************************
 
-To finish creating and configuring your OIDC client, you must configure a
+To finish creating and configuring your OAuth client, you must configure a
 partner, site, and site configuration for the E-Commerce service to use. The
 site that you configure is the default site that the E-Commerce service adds
 when you run migrations. You must update this default site to match the domain
 that you will use to access the E-Commerce service. You must also set up a site
 configuration that contains an ``oauth_settings`` JSON field that stores your
-OIDC client's settings, as follows.
+OAuth client's settings, as follows.
 
 .. list-table::
    :widths: 25 60 20
@@ -137,25 +114,27 @@ OIDC client's settings, as follows.
    * - Setting
      - Description
      - Value
-   * - ``SOCIAL_AUTH_EDX_OIDC_KEY``
+   * - ``BACKEND_SERVICE_EDX_OAUTH2_KEY``
      - OAuth 2.0 client key
-     - The **Client ID** field in the :ref:`Create
-       Register Client` section.
-   * - ``SOCIAL_AUTH_EDX_OIDC_SECRET``
+     - The **Client ID** field in the `Create and Register a Client`_
+       section for backend server-to-server calls.
+   * - ``BACKEND_SERVICE_EDX_OAUTH2_SECRET``
      - OAuth 2.0 client secret
-     - The value from the **Client Secret** field in the :ref:`Create
-       Register Client` section.
-   * - ``SOCIAL_AUTH_EDX_OIDC_URL_ROOT``
+     - The **Client Secret** field in the `Create and Register a Client`_
+       ection for backend server-to-server calls.
+   * - ``SOCIAL_AUTH_EDX_OAUTH2_KEY``
+     - OAuth 2.0 client key
+     - The **Client ID** field in the `Create and Register a Client`_ section.
+   * - ``SOCIAL_AUTH_EDX_OAUTH2_SECRET``
+     - OAuth 2.0 client secret
+     - The **Client Secret** field in the `Create and Register a Client`_ section.
+   * - ``SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT``
      - OAuth 2.0 authentication URL
-     - For example, ``http://127.0.0.1:8000/oauth2``.
-   * - ``SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY``
-     - OIDC ID token decryption key, used to validate the ID
-       token
-     - The same value as ``SOCIAL_AUTH_EDX_OIDC_SECRET``.
-   * - ``SOCIAL_AUTH_EDX_OIDC_ISSUER``
-     - OIDC ID token issuer
-     - For example, ``http://127.0.0.1:8000/oauth2``.
-   * - ``SOCIAL_AUTH_EDX_OIDC_LOGOUT_URL``
+     - For example, ``http://127.0.0.1:8000``.
+   * - ``SOCIAL_AUTH_EDX_OAUTH2_ISSUER``
+     - OAuth token issuer
+     - For example, ``http://127.0.0.1:8000``.
+   * - ``SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL``
      - User logout URL
      - For example, ``http://127.0.0.1:8000/logout``.
 
@@ -169,7 +148,7 @@ partner and site configuration with the specified options.
     .. code-block:: bash
 
       $ sudo su ecommerce
-      $ python manage.py create_or_update_site --site-id=1 --site-domain=localhost:8002 --partner-code=edX --partner-name='Open edX' --lms-url-root=localhost:8000 --theme-scss-path=sass/themes/edx.scss --payment-processors=cybersource,paypal --client-id=[change to OIDC client ID] --client-secret=[change to OIDC client secret]
+      $ python manage.py create_or_update_site --site-id=1 --site-domain=localhost:8002 --partner-code=edX --partner-name='Open edX' --lms-url-root=localhost:8000 --theme-scss-path=sass/themes/edx.scss --payment-processors=cybersource,paypal --backend-service-client-id=[Change to OAuth Client ID for backend service calls] --backend-service-client-key=[Change to OAuth Client Secret for backend service calls] --sso-client-id=[Change to OAuth Client ID for SSO calls] --sso-client-key=[Change to OAuth Client Secret for SSO calls]
 
 .. _Add Another Site Partner and Site Configuration:
 
@@ -224,11 +203,11 @@ this command.
      - ``--payment-processors=cybersource,paypal``
    * - ``--client-id``
      - Yes
-     - OIDC client ID.
+     - OAuth client ID.
      - ``--client-id=ecommerce-key``
    * - ``--client-secret``
      - Yes
-     - OIDC client secret.
+     - OAuth client secret.
      - ``--client-secret=ecommerce-secret``
    * - ``--from-email``
      - Yes
@@ -258,7 +237,7 @@ configuration with the options that you specify.
     .. code-block:: bash
 
       $ sudo su ecommerce
-      $ python manage.py create_or_update_site --site-domain=[change me] --partner-code=[change me] --partner-name=[change me] --lms-url-root=[change me] --client-id=[OIDC client ID] --client-secret=[OIDC client secret] --from-email=[from email]
+      $ python manage.py create_or_update_site --site-domain=[change me] --partner-code=[change me] --partner-name=[change me] --lms-url-root=[change me] --client-id=[OAuth client ID] --client-secret=[OAuth client secret] --from-email=[from email]
 
 ****************
 Start the Server
@@ -288,9 +267,9 @@ steps.
      $ python manage.py runserver 8002
 
    .. note::
-     If you use a different port, make sure you update the OIDC client by using
+     If you use a different port, make sure you update the OAuth client by using
      the Django administration panel in the LMS. For more information about
-     configuring the OIDC client, see :ref:`Configure OIDC`.
+     configuring the OAuth client, see `Configure OAuth`_.
 
 *****************************************
 Switch from ShoppingCart to E-Commerce
@@ -320,8 +299,6 @@ instead of ShoppingCart, follow these steps.
 #. Select the site for which you want to enable the E-Commerce service.
 
 #. Select **Save**.
-
-.. _Development Outside Devstack:
 
 ****************************
 Development Outside Devstack

--- a/docs/links/links.rst
+++ b/docs/links/links.rst
@@ -233,7 +233,6 @@
 .. _Communications API: http://django-oscar.readthedocs.org/en/latest/howto/how_to_customise_oscar_communications.html#communications-api
 .. _django-compressor: http://django-compressor.readthedocs.org/
 .. _RequireJS: http://requirejs.org/
-.. _OpenID Connect: http://openid.net/specs/openid-connect-core-1_0.html
 .. _devstack: https://github.com/edx/configuration/wiki/edX-Developer-Stack
 .. _Testing in Django: https://docs.djangoproject.com/en/1.8/topics/testing/
 .. _Django sites framework: https://docs.djangoproject.com/en/1.8/ref/contrib/sites

--- a/docs/test_ecommerce.rst
+++ b/docs/test_ecommerce.rst
@@ -156,7 +156,6 @@ To configure the LMS, follow these steps.
       "ECOMMERCE_PUBLIC_URL_ROOT": "http://localhost:8002/"
       "JWT_ISSUER": "http://127.0.0.1:8000/oauth2" // Must match the E-Commerce JWT_ISSUER setting
       "OAUTH_ENFORCE_SECURE": false
-      "OAUTH_OIDC_ISSUER": "http://127.0.0.1:8000/oauth2"
 
 #. Verify that the following settings in ``lms.auth.json`` are correct.
 
@@ -183,16 +182,17 @@ To configure the LMS, follow these steps.
 #. In the Django administration panel, verify that an OAuth2 client with the
    following attributes exists. If one does not already exist, :ref:`create a
    new one <Create Register Client>`. The client ID and secret must match the
-   values of the E-Commerce ``SOCIAL_AUTH_EDX_OIDC_KEY`` and
-   ``SOCIAL_AUTH_EDX_OIDC_SECRET`` settings, respectively.
+   values of the E-Commerce ``SOCIAL_AUTH_EDX_OAUTH2_KEY`` and
+   ``SOCIAL_AUTH_EDX_OAUTH2_SECRET`` settings, respectively.
 
    .. code-block:: bash
 
       URL:  http://localhost:8002/
-      Redirect URI: http://localhost:8002/complete/edx-oidc/
-      Client ID: 'replace-me'
-      Client Secret: 'replace-me'
-      Client Type: Confidential
+      Redirect uris: http://localhost:8002/complete/edx-oauth2/
+      Client id: 'replace-me'
+      Client secret: 'replace-me'
+      Client type: Confidentials
+      Authorization grant type: Authorization code
 
 #. In the Django administration panel, verify that the OAuth2 client referred
    to above is designated as a trusted client. If this isn't already the case,

--- a/e2e/test_auth.py
+++ b/e2e/test_auth.py
@@ -10,7 +10,7 @@ def test_login_and_logout(selenium):
 
     LmsHelpers.login(selenium)
 
-    # Visit the Otto dashboard to trigger an OpenID Connect login
+    # Visit the Otto dashboard to trigger a login
     EcommerceHelpers.visit_dashboard(selenium)
 
     # Logging out of Otto should redirect the user to the LMS logout page, which redirects
@@ -24,7 +24,7 @@ def test_provider_logout(selenium):
 
     LmsHelpers.login(selenium)
 
-    # Visit the Otto dashboard to trigger an OpenID Connect login
+    # Visit the Otto dashboard to trigger a login
     EcommerceHelpers.visit_dashboard(selenium)
 
     LmsHelpers.logout(selenium)

--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -379,8 +379,8 @@ class SiteConfiguration(models.Model):
         url = '{root}/access_token'.format(root=self.oauth2_provider_url)
         access_token, expiration_datetime = EdxRestApiClient.get_oauth_access_token(
             url,
-            self.oauth_settings['SOCIAL_AUTH_EDX_OIDC_KEY'],  # pylint: disable=unsubscriptable-object
-            self.oauth_settings['SOCIAL_AUTH_EDX_OIDC_SECRET'],  # pylint: disable=unsubscriptable-object
+            self.oauth_settings['BACKEND_SERVICE_EDX_OAUTH2_KEY'],  # pylint: disable=unsubscriptable-object
+            self.oauth_settings['BACKEND_SERVICE_EDX_OAUTH2_SECRET'],  # pylint: disable=unsubscriptable-object
             token_type='jwt'
         )
 
@@ -470,7 +470,7 @@ class SiteConfiguration(models.Model):
 
 
 class User(AbstractUser):
-    """Custom user model for use with OIDC."""
+    """Custom user model for use with python-social-auth via edx-auth-backends."""
 
     full_name = models.CharField(_('Full Name'), max_length=255, blank=True, null=True)
 

--- a/ecommerce/core/tests/test_views.py
+++ b/ecommerce/core/tests/test_views.py
@@ -93,4 +93,4 @@ class AutoAuthTests(TestCase):
 
 class LogoutViewTests(LogoutViewTestMixin, TestCase):
     def get_redirect_url(self):
-        return self.site.siteconfiguration.build_lms_url('logout')
+        return self.site.siteconfiguration.oauth_settings['SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL']

--- a/ecommerce/core/views.py
+++ b/ecommerce/core/views.py
@@ -2,7 +2,7 @@
 import logging
 import uuid
 
-from auth_backends.views import EdxOpenIdConnectLogoutView
+from auth_backends.views import EdxOAuth2LogoutView
 from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model, login
 from django.contrib.auth.decorators import login_required
@@ -105,8 +105,8 @@ class StaffOnlyMixin(object):
         return super(StaffOnlyMixin, self).dispatch(request, *args, **kwargs)
 
 
-class LogoutView(EdxOpenIdConnectLogoutView):
+class LogoutView(EdxOAuth2LogoutView):
     """ Logout view that redirects the user to the LMS logout page. """
 
     def get_redirect_url(self, *args, **kwargs):
-        return self.request.site.siteconfiguration.build_lms_url('logout')
+        return self.request.site.siteconfiguration.oauth_settings['SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL']

--- a/ecommerce/extensions/api/authentication.py
+++ b/ecommerce/extensions/api/authentication.py
@@ -6,6 +6,9 @@ from ecommerce.core.url_utils import get_oauth2_provider_url
 
 
 class BearerAuthentication(BaseBearerAuthentication):
+    """
+    NOTE: This authentication class is deprecated, see ARCH-396.
+    """
     def get_user_info_url(self):
         """ Returns the URL, hosted by the OAuth2 provider, from which user information can be pulled. """
         return '{base}/user_info/'.format(base=get_oauth2_provider_url())

--- a/ecommerce/extensions/api/v2/tests/views/test_orders.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_orders.py
@@ -178,8 +178,8 @@ class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
         site_configuration = SiteConfigurationFactory(
             from_email='from@example.com',
             oauth_settings={
-                'SOCIAL_AUTH_EDX_OIDC_KEY': 'key',
-                'SOCIAL_AUTH_EDX_OIDC_SECRET': 'secret'
+                'SOCIAL_AUTH_EDX_OAUTH2_KEY': 'key',
+                'SOCIAL_AUTH_EDX_OAUTH2_SECRET': 'secret'
             },
             partner=self.partner,
             segment_key='fake_segment_key',

--- a/ecommerce/extensions/customer/app.py
+++ b/ecommerce/extensions/customer/app.py
@@ -1,11 +1,11 @@
-from auth_backends.views import EdxOpenIdConnectLoginView
+from auth_backends.views import EdxOAuth2LoginView
 from oscar.apps.customer import app
 
 from ecommerce.core.views import LogoutView
 
 
 class CustomerApplication(app.CustomerApplication):
-    login_view = EdxOpenIdConnectLoginView
+    login_view = EdxOAuth2LoginView
     logout_view = LogoutView
 
 

--- a/ecommerce/extensions/dashboard/app.py
+++ b/ecommerce/extensions/dashboard/app.py
@@ -1,13 +1,14 @@
-from auth_backends.urls import auth_urlpatterns
+from auth_backends.urls import oauth2_urlpatterns
 from django.conf.urls import include, url
 from oscar.apps.dashboard import app
 from oscar.core.loading import get_class
 
 from ecommerce.core.views import LogoutView
 
-# NOTE: This should match AUTH_URLS in ecommerce/urls.py. These are duplicated here because Oscar's
-# dashboard templates, strangely, reference dashboard:login and dashboard:logout instead of login and logout.
-AUTH_URLS = [url(r'^logout/$', LogoutView.as_view(), name='logout'), ] + auth_urlpatterns
+
+# Note: Add ecommerce's logout override first to ensure it is registered by Django as the
+# actual logout view. Ecommerce's logout implementation supports different site configuration.
+AUTH_URLS = [url(r'^logout/$', LogoutView.as_view(), name='logout'), ] + oauth2_urlpatterns
 
 
 class DashboardApplication(app.DashboardApplication):

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -435,18 +435,15 @@ ENABLE_AUTO_AUTH = False
 # If it were not set, we would be unable to automatically remove all auto-auth users.
 AUTO_AUTH_USERNAME_PREFIX = 'AUTO_AUTH_'
 
-AUTHENTICATION_BACKENDS = ('auth_backends.backends.EdXOpenIdConnect',) + AUTHENTICATION_BACKENDS
+AUTHENTICATION_BACKENDS = ('auth_backends.backends.EdXOAuth2',) + AUTHENTICATION_BACKENDS
 
 SOCIAL_AUTH_STRATEGY = 'ecommerce.social_auth.strategies.CurrentSiteDjangoStrategy'
 
-# Set these to the correct values for your OAuth2/OpenID Connect provider
-SOCIAL_AUTH_EDX_OIDC_KEY = None
-SOCIAL_AUTH_EDX_OIDC_SECRET = None
-SOCIAL_AUTH_EDX_OIDC_URL_ROOT = None
-SOCIAL_AUTH_EDX_OIDC_LOGOUT_URL = None
-
-# This value should be the same as SOCIAL_AUTH_EDX_OIDC_SECRET
-SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY = SOCIAL_AUTH_EDX_OIDC_SECRET
+# Set these to the correct values for your OAuth2 provider
+SOCIAL_AUTH_EDX_OAUTH2_KEY = None
+SOCIAL_AUTH_EDX_OAUTH2_SECRET = None
+SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = None
+SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL = None
 
 # Redirect successfully authenticated users to the Oscar dashboard.
 LOGIN_REDIRECT_URL = 'dashboard:index'

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -437,6 +437,12 @@ AUTO_AUTH_USERNAME_PREFIX = 'AUTO_AUTH_'
 
 AUTHENTICATION_BACKENDS = ('auth_backends.backends.EdXOAuth2',) + AUTHENTICATION_BACKENDS
 
+# NOTE: This old auth backend is retained as a temporary fallback in order to
+# support old browser sessions that were established using OIDC.  After a few
+# days, we should be safe to remove this line, along with deleting the rest of
+# the OIDC/DOP settings and keys in the ecommerce site configurations.
+AUTHENTICATION_BACKENDS += ('auth_backends.backends.EdXOpenIdConnect',)
+
 SOCIAL_AUTH_STRATEGY = 'ecommerce.social_auth.strategies.CurrentSiteDjangoStrategy'
 
 # Set these to the correct values for your OAuth2 provider

--- a/ecommerce/social_auth/tests/test_strategies.py
+++ b/ecommerce/social_auth/tests/test_strategies.py
@@ -1,5 +1,7 @@
 """Tests of social auth strategies."""
 import datetime
+import json
+import re
 import uuid
 from calendar import timegm
 
@@ -16,6 +18,8 @@ from ecommerce.tests.testcases import TestCase
 
 User = get_user_model()
 
+CONTENT_TYPE = 'application/json'
+
 
 class CurrentSiteDjangoStrategyTests(TestCase):
     """Tests of the CurrentSiteDjangoStrategy."""
@@ -26,7 +30,7 @@ class CurrentSiteDjangoStrategyTests(TestCase):
 
     def test_get_setting_from_siteconfiguration(self):
         """Test that a setting can be retrieved from the site configuration."""
-        setting_name = 'SOCIAL_AUTH_EDX_OIDC_KEY'
+        setting_name = 'SOCIAL_AUTH_EDX_OAUTH2_KEY'
         expected = str(uuid.uuid4())
         self.site.siteconfiguration.oauth_settings[setting_name] = expected
         self.site.siteconfiguration.save()
@@ -35,7 +39,7 @@ class CurrentSiteDjangoStrategyTests(TestCase):
 
     def test_get_setting_from_django_settings(self):
         """Test that a setting can be retrieved from django settings if it doesn't exist in site configuration."""
-        setting_name = 'SOCIAL_AUTH_EDX_OIDC_SECRET'
+        setting_name = 'SOCIAL_AUTH_EDX_OAUTH2_SECRET'
         expected = str(uuid.uuid4())
 
         if setting_name in self.site.siteconfiguration.oauth_settings:
@@ -50,32 +54,46 @@ class CurrentSiteDjangoStrategyTests(TestCase):
         with self.assertRaises(KeyError):
             self.strategy.get_setting('FAKE_SETTING')
 
-    def create_id_token(self, user):
+    def create_jwt(self, user):
         """
         Creates a signed (JWS) ID token.
 
         Returns:
             str: JWS
         """
-        key = SYMKey(key=self.site.siteconfiguration.oauth_settings['SOCIAL_AUTH_EDX_OIDC_SECRET'])
+        key = SYMKey(key=self.site.siteconfiguration.oauth_settings['SOCIAL_AUTH_EDX_OAUTH2_SECRET'])
         now = datetime.datetime.utcnow()
         expiration_datetime = now + datetime.timedelta(seconds=3600)
         issue_datetime = now
         payload = {
-            'iss': self.site.siteconfiguration.oauth2_provider_url,
+            'iss': self.site.siteconfiguration.lms_url_root,
             'administrator': False,
             'iat': timegm(issue_datetime.utctimetuple()),
-            'given_name': user.first_name,
             'sub': str(uuid.uuid4()),
             'preferred_username': user.username,
-            'aud': self.site.siteconfiguration.oauth_settings['SOCIAL_AUTH_EDX_OIDC_KEY'],
-            'email': user.email,
+            'aud': self.site.siteconfiguration.oauth_settings['SOCIAL_AUTH_EDX_OAUTH2_KEY'],
             'exp': timegm(expiration_datetime.utctimetuple()),
-            'name': user.get_full_name(),
-            'family_name': user.last_name,
         }
         access_token = JWS(payload, jwk=key, alg='HS512').sign_compact()
         return access_token
+
+    def mock_access_token_jwt_response(self, user, status=200):
+        """ Mock the response from the OAuth provider's access token endpoint. """
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock the access token response.'
+
+        # Use a regex to account for the optional trailing slash
+        url = '{root}/access_token/?'.format(root=self.site.siteconfiguration.oauth2_provider_url)
+        url = re.compile(url)
+
+        token = self.create_jwt(user)
+        data = {
+            'access_token': token,
+            'expires_in': 3600,
+        }
+        body = json.dumps(data)
+        httpretty.register_uri(httpretty.POST, url, body=body, content_type=CONTENT_TYPE, status=status)
+
+        return token
 
     @httpretty.activate
     def test_authentication(self):
@@ -83,11 +101,10 @@ class CurrentSiteDjangoStrategyTests(TestCase):
         a UUID. This validates the fix made by https://github.com/python-social-auth/social-core/pull/74.
         """
         self.site.siteconfiguration.oauth_settings = {
-            'SOCIAL_AUTH_EDX_OIDC_KEY': 'test-key',
-            'SOCIAL_AUTH_EDX_OIDC_SECRET': 'test-secret',
-            'SOCIAL_AUTH_EDX_OIDC_URL_ROOT': self.site.siteconfiguration.oauth2_provider_url,
-            'SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY': 'test-secret',
-            'SOCIAL_AUTH_EDX_OIDC_ISSUER': self.site.siteconfiguration.oauth2_provider_url,
+            'SOCIAL_AUTH_EDX_OAUTH2_KEY': 'test-key',
+            'SOCIAL_AUTH_EDX_OAUTH2_SECRET': 'test-secret',
+            'SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT': self.site.siteconfiguration.lms_url_root,
+            'SOCIAL_AUTH_EDX_OAUTH2_ISSUER': self.site.siteconfiguration.lms_url_root,
 
         }
         self.site.siteconfiguration.save()
@@ -101,15 +118,14 @@ class CurrentSiteDjangoStrategyTests(TestCase):
         self.assertEqual(user.social_auth.count(), 0)
 
         # Mock access token endpoint so that it returns an ID token
-        id_token = self.create_id_token(user)
-        self.mock_access_token_response(id_token=id_token)
+        self.mock_access_token_jwt_response(user)
 
         # Simulate login completion
         state = str(uuid.uuid4())
         session = self.client.session
-        session['edx-oidc_state'] = state
+        session['edx-oauth2_state'] = state
         session.save()
-        url = '{host}?state={state}'.format(host=reverse('social:complete', args=['edx-oidc']), state=state)
+        url = '{host}?state={state}'.format(host=reverse('social:complete', args=['edx-oauth2']), state=state)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
 

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -268,11 +268,16 @@ class SiteMixin(object):
         Course.objects.all().delete()
         Partner.objects.all().delete()
         Site.objects.all().delete()
+        lms_url_root = "http://lms.testserver.fake"
         self.site_configuration = SiteConfigurationFactory(
+            lms_url_root=lms_url_root,
             from_email='from@example.com',
             oauth_settings={
-                'SOCIAL_AUTH_EDX_OIDC_KEY': 'key',
-                'SOCIAL_AUTH_EDX_OIDC_SECRET': 'secret'
+                'SOCIAL_AUTH_EDX_OAUTH2_KEY': 'key',
+                'SOCIAL_AUTH_EDX_OAUTH2_SECRET': 'secret',
+                'BACKEND_SERVICE_EDX_OAUTH2_KEY': 'key',
+                'BACKEND_SERVICE_EDX_OAUTH2_SECRET': 'secret',
+                'SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL': lms_url_root + '/logout',
             },
             partner__name='edX',
             partner__short_code='edx',

--- a/ecommerce/urls.py
+++ b/ecommerce/urls.py
@@ -1,6 +1,6 @@
 import os
 
-from auth_backends.urls import auth_urlpatterns
+from auth_backends.urls import oauth2_urlpatterns
 from django.conf import settings
 from django.conf.urls import include, url
 from django.conf.urls.static import static
@@ -43,7 +43,7 @@ admin.site.site_title = admin.site.site_header
 
 # NOTE 1: Add our logout override first to ensure it is registered by Django as the actual logout view.
 # NOTE 2: These same patterns are used for rest_framework's browseable API authentication links.
-AUTH_URLS = [url(r'^logout/$', LogoutView.as_view(), name='logout'), ] + auth_urlpatterns
+AUTH_URLS = [url(r'^logout/$', LogoutView.as_view(), name='logout'), ] + oauth2_urlpatterns
 
 WELL_KNOWN_URLS = [
     url(r'^.well-known/apple-developer-merchantid-domain-association.txt$',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -45,7 +45,7 @@ djangorestframework-csv==2.1.0
 djangorestframework-jwt==1.11.0
 djangorestframework==3.6.4
 drf-extensions==0.3.1
-edx-auth-backends==1.2.1
+edx-auth-backends==1.2.2
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==1.0.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -58,7 +58,7 @@ djangorestframework-jwt==1.11.0
 djangorestframework==3.6.4
 docutils==0.14            # via sphinx
 drf-extensions==0.3.1
-edx-auth-backends==1.2.1
+edx-auth-backends==1.2.2
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==1.0.3

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -47,7 +47,7 @@ djangorestframework-csv==2.1.0
 djangorestframework-jwt==1.11.0
 djangorestframework==3.6.4
 drf-extensions==0.3.1
-edx-auth-backends==1.2.1
+edx-auth-backends==1.2.2
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==1.0.3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -55,7 +55,7 @@ djangorestframework-csv==2.1.0
 djangorestframework-jwt==1.11.0
 djangorestframework==3.6.4
 drf-extensions==0.3.1
-edx-auth-backends==1.2.1
+edx-auth-backends==1.2.2
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==1.0.3


### PR DESCRIPTION
Note that this is a re-do of the two DOP-deprecation commits, but also includes an added third commit:

```
commit d63b9dcaac4bc3017bc5be43d9cd3f0769ce4d90
Author: Troy Sankey <tsankey@edx.org>
Date:   Thu Feb 14 15:13:52 2019 -0500

    Re-add the old EdXOpenIdConnect backend temporarily.
    
    This solves a transient issue during rollout where old browser
    sessions that were established before rollout would fail to authenticate
    with the new ecommerce code because DRF could not find the correct
    backend to assign to the request.
    
    New browser sessions will still use the first listed backend, which
    is still EdXOAuth2.

commit 4183cc87aa50e7a92c5cf1680655347cc7619ee2
Author: Nimisha Asthagiri <nasthagiri@edx.org>
Date:   Fri Feb 8 15:28:14 2019 -0500

    Fix Oscar dashboard's login

commit bf5b268f8f557f74721899e009cd048e913b7b2d
Author: Nimisha Asthagiri <nasthagiri@edx.org>
Date:   Tue Feb 5 16:26:32 2019 -0500

    Replace DOP with DOT for OAuth2 Authentication

```