### PR TITLE
for multi-use, only revoke a single offer assignment

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -1399,6 +1399,15 @@ class CouponCodeRevokeSerializer(CouponCodeMixin, serializers.Serializer):  # py
         offer_assignments = self.get_unredeemed_offer_assignments(code, email)
         if not offer_assignments.exists():
             raise serializers.ValidationError('No assignments exist for user {} and code {}'.format(email, code))
+
+        # Only revoke a single assignment, Consider the below sample assignments,
+        # in case of single revoke, it should only revoke a single assignment
+        # code = ABC101   email = batman@abc.com
+        # code = ABC101   email = batman@abc.com
+        # code = ABC101   email = batman@abc.com
+        if coupon.attr.coupon_vouchers.vouchers.first().usage == Voucher.MULTI_USE:
+            offer_assignments = offer_assignments[0:1]
+
         data['offer_assignments'] = offer_assignments
         return data
 


### PR DESCRIPTION
[ENT-1574 
](https://openedx.atlassian.net/browse/ENT-1574)[ENT-1586](https://openedx.atlassian.net/browse/ENT-1586)

**Description:**
In case of `MULTI_USE` coupon, for multiple assignments for a user for a same code should only revoke a single assignment instead of all the assignments.

Consider the below sample assignments, Without the changes in this PR, a revoke request for (`ABC101`, `batman@abc.com`) will revoke all the assignments which should no happen.
 ```python
code = ABC101 email = batman@abc.com
code = ABC101 email = batman@abc.com
code = ABC101 email = batman@abc.com
```
