### PR TITLE
Adds username replacement API

### DIFF
--- a/ecommerce/extensions/api/permissions.py
+++ b/ecommerce/extensions/api/permissions.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from oscar.core.loading import get_model
 from requests.exceptions import ConnectionError, Timeout
 from rest_framework import permissions
@@ -11,6 +12,8 @@ from ecommerce.extensions.api.serializers import retrieve_enterprise_condition
 Product = get_model('catalogue', 'Product')
 
 LOGGER = logging.getLogger(__name__)
+
+USERNAME_REPLACEMENT_GROUP = "username_replacement_admin"
 
 
 class CanActForUser(permissions.IsAdminUser):
@@ -100,5 +103,12 @@ class HasDataAPIDjangoGroupAccess(permissions.BasePermission):
                 return False
             enterprise_condition = retrieve_enterprise_condition(coupon)
             enterprise_id = enterprise_condition and enterprise_condition.enterprise_customer_uuid
-
         return self._request_is_permitted_for_enterprise(request, enterprise_id)
+
+
+class CanReplaceUsername(permissions.BasePermission):
+    """
+    Grants access to the Username Replacement API for a the service user.
+    """
+    def has_permission(self, request, view):
+        return request.user.username == getattr(settings, 'USERNAME_REPLACEMENT_WORKER')

--- a/ecommerce/extensions/api/v2/tests/views/test_user_management.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_user_management.py
@@ -1,0 +1,92 @@
+import json
+
+import ddt
+import mock
+from django.urls import reverse
+from oscar.test import factories
+
+from ecommerce.tests.testcases import TestCase
+
+JSON_CONTENT_TYPE = 'application/json'
+
+
+@ddt.ddt
+@mock.patch('django.conf.settings.USERNAME_REPLACEMENT_WORKER', 'test_replace_username_service_worker')
+class UsernameReplacementViewTests(TestCase):
+    """ Tests UsernameReplacementView """
+    SERVICE_USERNAME = 'test_replace_username_service_worker'
+
+    def setUp(self):
+        super(UsernameReplacementViewTests, self).setUp()
+        self.service_user = factories.UserFactory(username=self.SERVICE_USERNAME)
+        self.url = reverse("api:v2:user_management:username_replacement")
+
+    def build_jwt_headers(self, user):
+        """
+        Helper function for creating headers for the JWT authentication.
+        """
+        token = self.generate_jwt_token_header(user)
+        headers = {'HTTP_AUTHORIZATION': token}
+        return headers
+
+    def call_api(self, user, data):
+        """ Helper function to call API with data """
+        data = json.dumps(data)
+        headers = self.build_jwt_headers(user)
+        return self.client.post(self.url, data, content_type=JSON_CONTENT_TYPE, **headers)
+
+    def test_auth(self):
+        """ Verify the endpoint only works with the service worker """
+        data = {
+            "username_mappings": [
+                {"test_username_1": "test_new_username_1"},
+                {"test_username_2": "test_new_username_2"}
+            ]
+        }
+
+        # Test unauthenticated
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, 401)
+
+        # Test non-service worker
+        random_user = factories.UserFactory()
+        response = self.call_api(random_user, data)
+        self.assertEqual(response.status_code, 403)
+
+        # Test service worker
+        response = self.call_api(self.service_user, data)
+        self.assertEqual(response.status_code, 200)
+
+    @ddt.data(
+        [{}, {}],
+        {},
+        [{"test_key": "test_value", "test_key_2": "test_value_2"}]
+    )
+    def test_bad_schema(self, mapping_data):
+        """ Verify the endpoint rejects bad data schema """
+        data = {
+            "username_mappings": mapping_data
+        }
+        response = self.call_api(self.service_user, data)
+        self.assertEqual(response.status_code, 400)
+
+    def test_existing_and_non_existing_users(self):
+        """
+        Tests a mix of existing and non existing users. Users that don't exist
+        in this service are also treated as a success because no work needs to
+        be done changing their username.
+        """
+        random_users = [factories.UserFactory() for _ in range(5)]
+        fake_usernames = ["myname_" + str(x) for x in range(5)]
+        existing_users = [{user.username: user.username + '_new'} for user in random_users]
+        non_existing_users = [{username: username + '_new'} for username in fake_usernames]
+        data = {
+            "username_mappings": existing_users + non_existing_users
+        }
+        expected_response = {
+            'failed_replacements': [],
+            'successful_replacements': existing_users + non_existing_users
+        }
+        response = self.call_api(self.service_user, data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, expected_response)

--- a/ecommerce/extensions/api/v2/urls.py
+++ b/ecommerce/extensions/api/v2/urls.py
@@ -20,6 +20,7 @@ from ecommerce.extensions.api.v2.views import refunds as refund_views
 from ecommerce.extensions.api.v2.views import retirement as retirement_views
 from ecommerce.extensions.api.v2.views import sdn as sdn_views
 from ecommerce.extensions.api.v2.views import stockrecords as stockrecords_views
+from ecommerce.extensions.api.v2.views import user_management as user_management_views
 from ecommerce.extensions.api.v2.views import vouchers as voucher_views
 from ecommerce.extensions.voucher.views import CouponReportCSVView
 
@@ -93,6 +94,10 @@ ASSIGNMENT_EMAIL_URLS = [
     url(r'^bounce$', assignment_email.AssignmentEmailBounce.as_view(), name='receive_bounce')
 ]
 
+USER_MANAGEMENT_URLS = [
+    url(r'^replace_usernames/$', user_management_views.UsernameReplacementView.as_view(), name='username_replacement'),
+]
+
 urlpatterns = [
     url(r'^baskets/', include(BASKET_URLS, namespace='baskets')),
     url(r'^checkout/', include(CHECKOUT_URLS, namespace='checkout')),
@@ -103,6 +108,7 @@ urlpatterns = [
     url(r'^publication/', include(ATOMIC_PUBLICATION_URLS, namespace='publication')),
     url(r'^refunds/', include(REFUND_URLS, namespace='refunds')),
     url(r'^retirement/', include(RETIREMENT_URLS, namespace='retirement')),
+    url(r'^user_management/', include(USER_MANAGEMENT_URLS, namespace='user_management')),
     url(r'^sdn/', include(SDN_URLS, namespace='sdn')),
     url(r'^assignment-email/', include(ASSIGNMENT_EMAIL_URLS, namespace='assignment-email')),
 ]

--- a/ecommerce/extensions/api/v2/views/user_management.py
+++ b/ecommerce/extensions/api/v2/views/user_management.py
@@ -1,0 +1,146 @@
+import logging
+
+from django.apps import apps
+from django.db import transaction
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from rest_framework import permissions, status
+from rest_framework.response import Response
+from rest_framework.serializers import ValidationError
+from rest_framework.views import APIView
+
+from ecommerce.extensions.api.permissions import CanReplaceUsername
+
+log = logging.getLogger(__name__)
+
+
+class UsernameReplacementView(APIView):
+    """
+    WARNING: This API is only meant to be used as part of a larger job that
+    updates usernames across all services. DO NOT run this alone or users will
+    not match across the system and things will be broken. This API should be
+    called from the LMS endpoint which verifies uniqueness of the username
+    first.
+
+    API will recieve a list of current usernames and their new username.
+    """
+
+    authentication_classes = (JwtAuthentication, )
+    permission_classes = (permissions.IsAuthenticated, CanReplaceUsername)
+
+    def post(self, request):
+        """
+        **POST Parameters**
+
+        A POST request must include the following parameter.
+
+        * username_mappings: Required. A list of objects that map the current username (key)
+          to the new username (value)
+            {
+                "username_mappings": [
+                    {"current_username_1": "new_username_1"},
+                    {"current_username_2": "new_username_2"}
+                ]
+            }
+
+        **POST Response Values**
+
+        As long as data validation passes, the request will return a 200 with a new mapping
+        of old usernames (key) to new username (value)
+
+        {
+            "successful_replacements": [
+                {"old_username_1": "new_username_1"}
+            ],
+            "failed_replacements": [
+                {"old_username_2": "new_username_2"}
+            ]
+        }
+
+        """
+
+        # (model_name, column_name)
+        MODELS_WITH_USERNAME = (
+            ('core.user', 'username'),
+            ('payment.sdncheckfailure', 'username')
+        )
+
+        username_mappings = request.data.get("username_mappings")
+        replacement_locations = self._load_models(MODELS_WITH_USERNAME)
+
+        if not self._has_valid_schema(username_mappings):
+            raise ValidationError("Request data does not match schema")
+
+        successful_replacements, failed_replacements = [], []
+
+        for username_pair in username_mappings:
+            current_username = list(username_pair.keys())[0]
+            new_username = list(username_pair.values())[0]
+            successfully_replaced = self._replace_username_for_all_models(
+                current_username,
+                new_username,
+                replacement_locations
+            )
+            if successfully_replaced:
+                successful_replacements.append({current_username: new_username})
+            else:
+                failed_replacements.append({current_username: new_username})  # pragma: no cover
+        return Response(
+            status=status.HTTP_200_OK,
+            data={
+                "successful_replacements": successful_replacements,
+                "failed_replacements": failed_replacements
+            }
+        )
+
+    def _load_models(self, models_with_fields):
+        """ Takes tuples that contain a model path and returns the list with a loaded version of the model """
+        replacement_locations = [(apps.get_model(model), column) for (model, column) in models_with_fields]
+        return replacement_locations
+
+    def _has_valid_schema(self, post_data):
+        """ Verifies the data is a list of objects with a single key:value pair """
+        if not isinstance(post_data, list):
+            return False
+        for obj in post_data:
+            if not (isinstance(obj, dict) and len(obj) == 1):
+                return False
+        return True
+
+    def _replace_username_for_all_models(self, current_username, new_username, replacement_locations):
+        """
+        Replaces current_username with new_username for all (model, column) pairs in replacement locations.
+        Returns if it was successful or not. Usernames that don't exist in this service will be treated as
+        a success because no work needs to be done changing their username.
+        """
+        try:
+            with transaction.atomic():
+                num_rows_changed = 0
+                for (model, column) in replacement_locations:
+                    num_rows_changed += model.objects.filter(
+                        **{column: current_username}
+                    ).update(
+                        **{column: new_username}
+                    )
+        except Exception as exc:   # pragma: no cover pylint: disable=broad-except
+            log.exception(
+                "Unable to change username from %s to %s. Failed on table %s because %s",
+                current_username,
+                new_username,
+                model.__class__.__name__,
+                exc,
+            )
+            return False  # pragma: no cover
+        if num_rows_changed == 0:
+            log.info(
+                "Unable to change username from %s to %s because %s doesn't exist.",
+                current_username,
+                new_username,
+                current_username,
+            )
+        else:
+            log.info(
+                "Successfully changed username from %s to %s.",
+                current_username,
+                new_username,
+            )
+        return True

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -659,7 +659,7 @@ OFFER_REVOKE_EMAIL_DEFAULT_SUBJECT = 'edX Course Assignment Revoked'
 OFFER_ASSIGNMENT_EMAIL_REMINDER_DEFAULT_TEMPLATE = '''
     This is a reminder email that your learning manager has provided you with a access code to take a course at edX.
     You have redeemed this code {REDEEMED_OFFER_COUNT} of times out of {TOTAL_OFFER_COUNT} number of available course redemptions.
-    
+
     edX login: {USER_EMAIL}
     Access Code: {CODE}
     Expiration date: {EXPIRATION_DATE}
@@ -674,3 +674,4 @@ OFFER_ASSIGNMENT_EMAIL_REMINDER_DEFAULT_SUBJECT = 'Reminder on edX course assign
 SAILTHRU_KEY = None
 SAILTHRU_SECRET = None
 
+USERNAME_REPLACEMENT_WORKER = "replace with valid username"


### PR DESCRIPTION
New API replaces all copies of username in LMS a desired username. 
Requires user be in username_replacement_admin group. Should only be ran as a larger job  to update usernames across all services,  otherwise the system will be left in a broken state for those users.