### PR TITLE
fix assignment status update

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_assignmentemail.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_assignmentemail.py
@@ -224,6 +224,7 @@ class AssignmentEmailBounceTests(TestCase):
             offer=enterprise_offer,
             code='jfhrmndk554lwre',
             user_email='johndoe@unknown.com',
+            status=OFFER_ASSIGNED
         )
         OfferAssignmentEmailAttempt.objects.create(offer_assignment=offer_assignment, send_id=post_data.get('send_id'))
         with LogCapture(level=logging.INFO) as log:

--- a/ecommerce/extensions/api/v2/views/assignmentemail.py
+++ b/ecommerce/extensions/api/v2/views/assignmentemail.py
@@ -11,7 +11,11 @@ from rest_framework.views import APIView
 from sailthru.sailthru_client import SailthruClient
 
 from ecommerce.extensions.api.permissions import IsStaffOrOwner
-from ecommerce.extensions.offer.constants import OFFER_ASSIGNED, OFFER_ASSIGNMENT_EMAIL_BOUNCED
+from ecommerce.extensions.offer.constants import (
+    OFFER_ASSIGNED,
+    OFFER_ASSIGNMENT_EMAIL_BOUNCED,
+    OFFER_ASSIGNMENT_EMAIL_PENDING
+)
 from ecommerce.extensions.offer.models import OfferAssignment, OfferAssignmentEmailAttempt
 
 logger = logging.getLogger(__name__)
@@ -39,7 +43,8 @@ class AssignmentEmailStatus(APIView):
         with transaction.atomic():
             OfferAssignment.objects.select_for_update().filter(
                 user_email=assigned_offer.user_email,
-                code=assigned_offer.code
+                code=assigned_offer.code,
+                status=OFFER_ASSIGNMENT_EMAIL_PENDING
             ).update(status=OFFER_ASSIGNED)
             OfferAssignmentEmailAttempt.objects.create(offer_assignment=assigned_offer, send_id=send_id)
 
@@ -122,7 +127,8 @@ class AssignmentEmailBounce(APIView):
         with transaction.atomic():
             OfferAssignment.objects.select_for_update().filter(
                 user_email=assigned_offer.user_email,
-                code=assigned_offer.code
+                code=assigned_offer.code,
+                status=OFFER_ASSIGNED
             ).update(status=OFFER_ASSIGNMENT_EMAIL_BOUNCED)
 
     def post(self, request):


### PR DESCRIPTION
[ENT-1574 
](https://openedx.atlassian.net/browse/ENT-1574)[ENT-1586](https://openedx.atlassian.net/browse/ENT-1586)

This PR will do the following
- Set an offer assignment status to `OFFER_ASSIGNED` only if the current status is `OFFER_ASSIGNMENT_EMAIL_PENDING`
- Set an offer assignment status to `OFFER_ASSIGNMENT_EMAIL_BOUNCED` only if current status is `OFFER_ASSIGNED`