### PR TITLE
Rename `has_error` key to `errors` to return a list of OfferAssignment errors

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -810,7 +810,7 @@ class EnterpriseCouponOverviewListSerializer(serializers.ModelSerializer):
     Serializer for Enterprise Coupons list overview.
     """
     end_date = serializers.SerializerMethodField()
-    has_error = serializers.SerializerMethodField()
+    errors = serializers.SerializerMethodField()
     max_uses = serializers.SerializerMethodField()
     num_codes = serializers.SerializerMethodField()
     num_unassigned = serializers.SerializerMethodField()
@@ -831,16 +831,15 @@ class EnterpriseCouponOverviewListSerializer(serializers.ModelSerializer):
         ])
         return num_unassigned
 
-    def get_has_error(self, obj):
+    def get_errors(self, obj):
         """
-        Returns True if any assignment associated with coupon is having
-        error, otherwise False.
+        Returns a list of OfferAssignment errors associated with coupon.
         """
         offer = retrieve_offer(obj)
         offer_assignments_with_error = offer.offerassignment_set.filter(
             status=OFFER_ASSIGNMENT_EMAIL_BOUNCED
         )
-        return offer_assignments_with_error.exists()
+        return OfferAssignmentSerializer(offer_assignments_with_error, many=True).data
 
     # Max number of codes available (Maximum Coupon Usage).
     def get_max_uses(self, obj):
@@ -881,7 +880,7 @@ class EnterpriseCouponOverviewListSerializer(serializers.ModelSerializer):
     class Meta(object):
         model = Product
         fields = (
-            'end_date', 'has_error', 'id', 'max_uses', 'num_codes', 'num_unassigned',
+            'end_date', 'errors', 'id', 'max_uses', 'num_codes', 'num_unassigned',
             'num_uses', 'start_date', 'title', 'usage_limitation'
         )
 

--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -152,7 +152,7 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         coupon = Product.objects.get(title=coupon_title)
         return {
             'end_date': self.get_coupon_voucher_end_date(coupon),
-            'has_error': False,
+            'errors': [],
             'id': coupon.id,
             'max_uses': 2,
             'num_codes': 2,
@@ -936,7 +936,7 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             'max_uses': None,
             'code_assignments': [0, 0, 0],
             'code_redemptions': [0, 0, 0],
-            'expected_response': {'max_uses': 3, 'num_codes': 3, 'num_unassigned': 3, 'num_uses': 0, 'has_error': False}
+            'expected_response': {'max_uses': 3, 'num_codes': 3, 'num_unassigned': 3, 'num_uses': 0, 'errors': []}
         },
         {
             'voucher_type': Voucher.SINGLE_USE,
@@ -944,7 +944,7 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             'max_uses': None,
             'code_assignments': [1, 0, 0],
             'code_redemptions': [0, 1, 0],
-            'expected_response': {'max_uses': 3, 'num_codes': 3, 'num_unassigned': 1, 'num_uses': 1, 'has_error': False}
+            'expected_response': {'max_uses': 3, 'num_codes': 3, 'num_unassigned': 1, 'num_uses': 1, 'errors': []}
         },
         {
             'voucher_type': Voucher.SINGLE_USE,
@@ -953,7 +953,7 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             'code_assignments': [1, 1, 1],
             'code_redemptions': [0, 1, 1],
             'assignment_has_error': True,
-            'expected_response': {'max_uses': 3, 'num_codes': 3, 'num_unassigned': 0, 'num_uses': 2, 'has_error': True}
+            'expected_response': {'max_uses': 3, 'num_codes': 3, 'num_unassigned': 0, 'num_uses': 2, 'errors': True}
         },
         {
             'voucher_type': Voucher.MULTI_USE_PER_CUSTOMER,
@@ -961,7 +961,7 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             'max_uses': 2,
             'code_assignments': [0, 0, 0],
             'code_redemptions': [0, 0, 0],
-            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 3, 'num_uses': 0, 'has_error': False}
+            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 3, 'num_uses': 0, 'errors': []}
         },
         {
             'voucher_type': Voucher.MULTI_USE_PER_CUSTOMER,
@@ -969,7 +969,7 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             'max_uses': 2,
             'code_assignments': [1, 0, 0],
             'code_redemptions': [0, 1, 0],
-            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 1, 'num_uses': 1, 'has_error': False}
+            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 1, 'num_uses': 1, 'errors': []}
         },
         {
             'voucher_type': Voucher.MULTI_USE_PER_CUSTOMER,
@@ -977,7 +977,7 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             'max_uses': 2,
             'code_assignments': [1, 1, 0],
             'code_redemptions': [0, 2, 0],
-            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 1, 'num_uses': 2, 'has_error': False}
+            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 1, 'num_uses': 2, 'errors': []}
         },
         {
             'voucher_type': Voucher.MULTI_USE_PER_CUSTOMER,
@@ -986,7 +986,7 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             'code_assignments': [1, 1, 1],
             'code_redemptions': [0, 1, 2],
             'assignment_has_error': True,
-            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 0, 'num_uses': 3, 'has_error': True}
+            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 0, 'num_uses': 3, 'errors': True}
         },
         {
             'voucher_type': Voucher.MULTI_USE,
@@ -994,7 +994,7 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             'max_uses': 2,
             'code_assignments': [1, 0, 0],
             'code_redemptions': [0, 1, 0],
-            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 3, 'num_uses': 1, 'has_error': False}
+            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 3, 'num_uses': 1, 'errors': []}
         },
         {
             'voucher_type': Voucher.MULTI_USE,
@@ -1002,7 +1002,7 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             'max_uses': 2,
             'code_assignments': [2, 0, 0],
             'code_redemptions': [0, 2, 0],
-            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 1, 'num_uses': 2, 'has_error': False}
+            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 1, 'num_uses': 2, 'errors': []}
         },
         {
             'voucher_type': Voucher.MULTI_USE,
@@ -1010,7 +1010,7 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             'max_uses': 2,
             'code_assignments': [2, 1, 1],
             'code_redemptions': [2, 0, 1],
-            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 1, 'num_uses': 3, 'has_error': False}
+            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 1, 'num_uses': 3, 'errors': []}
         },
         {
             'voucher_type': Voucher.MULTI_USE,
@@ -1018,7 +1018,7 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             'max_uses': 2,
             'code_assignments': [2, 2, 2],
             'code_redemptions': [0, 0, 0],
-            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 0, 'num_uses': 0, 'has_error': False}
+            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 0, 'num_uses': 0, 'errors': []}
         },
         {
             'voucher_type': Voucher.MULTI_USE,
@@ -1028,7 +1028,7 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             'code_redemptions': [1],
             'assignment_has_error': True,
             'expected_response': {
-                'max_uses': 10000, 'num_codes': 1, 'num_unassigned': 1, 'num_uses': 1, 'has_error': True
+                'max_uses': 10000, 'num_codes': 1, 'num_unassigned': 1, 'num_uses': 1, 'errors': True
             }
         },
         {
@@ -1037,7 +1037,7 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             'max_uses': 2,
             'code_assignments': [0, 0, 0],
             'code_redemptions': [0, 0, 0],
-            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 3, 'num_uses': 0, 'has_error': False}
+            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 3, 'num_uses': 0, 'errors': []}
         },
         {
             'voucher_type': Voucher.ONCE_PER_CUSTOMER,
@@ -1046,7 +1046,7 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             'code_assignments': [2, 1, 0],
             'code_redemptions': [0, 0, 1],
             'assignment_has_error': True,
-            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 2, 'num_uses': 1, 'has_error': True}
+            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 2, 'num_uses': 1, 'errors': True}
         },
     )
     @ddt.unpack
@@ -1101,6 +1101,16 @@ class EnterpriseCouponViewSetTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
 
         # Verify that we get correct results.
         for field, value in expected_response.iteritems():
+            if assignment_has_error and field == 'errors':
+                assignment_with_errors = OfferAssignment.objects.filter(status=OFFER_ASSIGNMENT_EMAIL_BOUNCED)
+                value = [
+                    {
+                        'id': assignment.id,
+                        'code': assignment.code,
+                        'user_email': assignment.user_email
+                    }
+                    for assignment in assignment_with_errors
+                ]
             self.assertEqual(coupon_overview_response['results'][0][field], value)
 
     @ddt.data(


### PR DESCRIPTION
This PR renames `has_error` key to `errors`  to include code and user_email of the OfferAssignment with error; e.g: 

```python
errors: [{'code': 'JKAPSIJ', 'user_email': 'test@example.com'}, {'code': 'CHJKNEM': 'user_email': 'test2@example.com'}]
```

[ENT-1612](https://openedx.atlassian.net/browse/ENT-1612)
[ENT-1531](https://openedx.atlassian.net/browse/ENT-1531)

Related frontend PR: https://github.com/edx/edx-portal/pull/190