### PR TITLE
EG-60 EG-61 Run make upgrade

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,17 +14,17 @@ billiard==3.3.0.23        # via celery
 cached-property==1.5.1    # via zeep
 celery==3.1.26.post2      # via edx-ecommerce-worker
 certifi==2018.11.29       # via requests
-cffi==1.11.5              # via cryptography
+cffi==1.12.2              # via cryptography
 chardet==3.0.4            # via requests
 coreapi==2.3.3
 coreschema==0.0.4         # via coreapi
-cryptography==2.4.2       # via pyopenssl
+cryptography==2.6.1       # via pyopenssl
 cssselect==1.0.3          # via premailer
 cssutils==1.0.2           # via premailer
 defusedxml==0.5.0         # via zeep
-django-appconf==1.0.2     # via django-compressor
+django-appconf==1.0.3     # via django-compressor
 django-compressor==2.2
-django-cors-headers==2.4.0
+django-cors-headers==2.4.1
 django-crispy-forms==1.7.2
 django-extra-views==0.6.4  # via django-oscar
 django-filter==1.0.4
@@ -35,7 +35,7 @@ django-phonenumber-field==1.3.0  # via django-oscar
 django-rest-swagger==2.2.0
 django-solo==1.1.3
 django-tables2==1.21.2    # via django-oscar
-django-threadlocals==0.8
+django-threadlocals==0.10
 django-treebeard==4.3     # via django-oscar
 django-waffle==0.14.0
 django-widget-tweaks==1.4.3  # via django-oscar
@@ -55,12 +55,12 @@ edx-opaque-keys==0.4.4
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography
 factory-boy==2.11.1       # via django-oscar
-faker==1.0.1              # via factory-boy
+faker==1.0.2              # via factory-boy
 funcsigs==1.0.2           # via mock
 future==0.17.1            # via pyjwkest
 gevent==1.0.2
 greenlet==0.4.15          # via gevent
-idna==2.8                 # via cryptography, requests
+idna==2.8                 # via requests
 ipaddress==1.0.22         # via cryptography, faker
 isodate==0.6.0            # via zeep
 itypes==1.1.0             # via coreapi
@@ -68,38 +68,38 @@ jinja2==2.10              # via coreschema
 jsonfield==1.0.3
 kombu==3.0.37             # via celery
 libsass==0.9.2
-lxml==4.2.5               # via premailer, zeep
+lxml==4.3.2               # via premailer, zeep
 markdown==2.6.9
-markupsafe==1.1.0         # via jinja2
+markupsafe==1.1.1         # via jinja2
 mock==2.0.0               # via django-oscar
 ndg-httpsclient==0.5.1
-newrelic==4.8.0.110       # via edx-django-utils
-oauthlib==2.1.0           # via requests-oauthlib, social-auth-core
+newrelic==4.14.0.115      # via edx-django-utils
+oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 path.py==7.2
 paypalrestsdk==1.13.1
-pbr==5.1.1                # via mock, stevedore
-phonenumberslite==8.10.2  # via django-phonenumber-field
-pillow==5.4.0             # via django-oscar
+pbr==5.1.3                # via mock, stevedore
+phonenumberslite==8.10.6  # via django-phonenumber-field
+pillow==5.4.1             # via django-oscar
 premailer==2.9.2
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 purl==1.4                 # via django-oscar
 pyasn1==0.4.5             # via ndg-httpsclient
 pycountry==17.1.8
 pycparser==2.19           # via cffi
-pycryptodomex==3.7.2      # via pyjwkest
+pycryptodomex==3.7.3      # via pyjwkest
 pygments==2.3.1
 pyjwkest==1.3.2           # via edx-drf-extensions, social-auth-core
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pymongo==3.7.2            # via edx-opaque-keys
-pyopenssl==18.0.0         # via ndg-httpsclient, paypalrestsdk
-python-dateutil==2.7.5
+pyopenssl==19.0.0         # via ndg-httpsclient, paypalrestsdk
+python-dateutil==2.8.0
 python-openid==2.2.5      # via social-auth-core
 pytz==2016.10
 pyyaml==3.13              # via edx-django-release-util
 rcssmin==1.0.6            # via django-compressor
-requests-oauthlib==1.0.0  # via social-auth-core
-requests-toolbelt==0.8.0  # via zeep
+requests-oauthlib==1.2.0  # via social-auth-core
+requests-toolbelt==0.9.1  # via zeep
 requests==2.21.0
 rest-condition==1.0.3     # via edx-drf-extensions
 rjsmin==1.0.12            # via django-compressor
@@ -111,7 +111,7 @@ slumber==0.7.1            # via edx-rest-api-client
 social-auth-app-django==1.2.0  # via edx-auth-backends
 social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django
 sorl-thumbnail==12.5.0    # via django-oscar
-stevedore==1.30.0         # via edx-opaque-keys
+stevedore==1.30.1         # via edx-opaque-keys
 stripe==1.70.0
 text-unidecode==1.2       # via faker
 typing==3.6.6             # via django-extensions

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,27 +13,27 @@ asn1crypto==0.24.0        # via cryptography
 astroid==1.4.9            # via pylint
 babel==2.6.0              # via django-oscar, django-phonenumber-field, sphinx
 backports.functools-lru-cache==1.5  # via pylint, soupsieve
-beautifulsoup4==4.7.0     # via webtest
+beautifulsoup4==4.7.1     # via webtest
 billiard==3.3.0.23        # via celery
 cached-property==1.5.1    # via zeep
 celery==3.1.26.post2      # via edx-ecommerce-worker
 certifi==2018.11.29       # via requests
-cffi==1.11.5              # via cryptography
+cffi==1.12.2              # via cryptography
 chardet==3.0.4            # via requests
-configparser==3.5.0       # via pylint
+configparser==3.7.3       # via pylint
 cookies==2.2.1            # via responses
 coreapi==2.3.3
 coreschema==0.0.4         # via coreapi
 coverage==4.3.4
-cryptography==2.4.2       # via pyopenssl
+cryptography==2.6.1       # via pyopenssl
 cssselect==1.0.3          # via premailer
 cssutils==1.0.2           # via premailer
 ddt==1.1.1
 defusedxml==0.5.0         # via zeep
 diff-cover==0.9.6
-django-appconf==1.0.2     # via django-compressor
+django-appconf==1.0.3     # via django-compressor
 django-compressor==2.2
-django-cors-headers==2.4.0
+django-cors-headers==2.4.1
 django-crispy-forms==1.7.2
 django-debug-toolbar==1.7
 django-extra-views==0.6.4  # via django-oscar
@@ -46,7 +46,7 @@ django-phonenumber-field==1.3.0  # via django-oscar
 django-rest-swagger==2.2.0
 django-solo==1.1.3
 django-tables2==1.21.2    # via django-oscar
-django-threadlocals==0.8
+django-threadlocals==0.10
 django-treebeard==4.3     # via django-oscar
 django-waffle==0.14.0
 django-webtest==1.9.2
@@ -70,14 +70,14 @@ edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.0.2
 enum34==1.1.6             # via cryptography
 factory-boy==2.8.1
-faker==1.0.1              # via factory-boy
+faker==1.0.2              # via factory-boy
 freezegun==0.3.7
 funcsigs==1.0.2           # via mock
 future==0.17.1            # via pyjwkest
 gevent==1.0.2
 greenlet==0.4.15          # via gevent
 httpretty==0.8.14
-idna==2.8                 # via cryptography, requests
+idna==2.8                 # via requests
 imagesize==1.1.0          # via sphinx
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography, faker
@@ -92,22 +92,22 @@ lazy-object-proxy==1.3.1  # via astroid
 libsass==0.9.2
 lxml==3.8.0
 markdown==2.6.9
-markupsafe==1.1.0         # via jinja2
+markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 mock-django==0.6.9
 mock==1.3.0
 ndg-httpsclient==0.5.1
-newrelic==4.8.0.110       # via edx-django-utils
+newrelic==4.14.0.115      # via edx-django-utils
 nose-ignore-docstring==0.2
 nose==1.3.7               # via django-nose
-oauthlib==2.1.0           # via requests-oauthlib, social-auth-core
+oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 path.py==7.2
 paypalrestsdk==1.13.1
-pbr==5.1.1                # via mock, stevedore
+pbr==5.1.3                # via mock, stevedore
 pep8==1.6.2
-phonenumberslite==8.10.2  # via django-phonenumber-field
-pillow==5.4.0             # via django-oscar
+phonenumberslite==8.10.6  # via django-phonenumber-field
+pillow==5.4.1             # via django-oscar
 polib==1.1.0              # via edx-i18n-tools
 premailer==2.9.2
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
@@ -116,21 +116,21 @@ purl==1.4                 # via django-oscar
 pyasn1==0.4.5             # via ndg-httpsclient
 pycountry==17.1.8
 pycparser==2.19           # via cffi
-pycryptodomex==3.7.2      # via pyjwkest
+pycryptodomex==3.7.3      # via pyjwkest
 pygments==2.3.1
 pyinotify==0.9.6
 pyjwkest==1.3.2           # via edx-drf-extensions, social-auth-core
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint==1.6.4
 pymongo==3.7.2            # via edx-opaque-keys
-pyopenssl==18.0.0         # via ndg-httpsclient, paypalrestsdk
-python-dateutil==2.7.5
+pyopenssl==19.0.0         # via ndg-httpsclient, paypalrestsdk
+python-dateutil==2.8.0
 python-openid==2.2.5      # via social-auth-core
 pytz==2016.10
 pyyaml==3.13              # via edx-django-release-util, edx-i18n-tools
 rcssmin==1.0.6            # via django-compressor
-requests-oauthlib==1.0.0  # via social-auth-core
-requests-toolbelt==0.8.0  # via zeep
+requests-oauthlib==1.2.0  # via social-auth-core
+requests-toolbelt==0.9.1  # via zeep
 requests==2.21.0
 responses==0.5.1
 rest-condition==1.0.3     # via edx-drf-extensions
@@ -145,10 +145,10 @@ snowballstemmer==1.2.1    # via sphinx
 social-auth-app-django==1.2.0  # via edx-auth-backends
 social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django
 sorl-thumbnail==12.5.0    # via django-oscar
-soupsieve==1.6.1          # via beautifulsoup4
+soupsieve==1.8            # via beautifulsoup4
 sphinx==1.5.3
 sqlparse==0.2.4           # via django-debug-toolbar
-stevedore==1.30.0         # via edx-opaque-keys
+stevedore==1.30.1         # via edx-opaque-keys
 stripe==1.70.0
 testfixtures==4.5.0
 text-unidecode==1.2       # via faker
@@ -158,8 +158,8 @@ unicodecsv==0.14.1
 unidecode==0.4.21         # via django-oscar
 uritemplate==3.0.0        # via coreapi
 urllib3==1.24.1           # via requests, transifex-client
-waitress==1.1.0           # via webtest
-webob==1.8.4              # via webtest
-webtest==2.0.32           # via django-webtest
-wrapt==1.10.11            # via astroid
+waitress==1.2.1           # via webtest
+webob==1.8.5              # via webtest
+webtest==2.0.33           # via django-webtest
+wrapt==1.11.1             # via astroid
 zeep==2.1.1

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -13,9 +13,9 @@ edx-sphinx-theme==1.0.2
 idna==2.8                 # via requests
 imagesize==1.1.0          # via sphinx
 jinja2==2.10              # via sphinx
-markupsafe==1.1.0         # via jinja2
+markupsafe==1.1.1         # via jinja2
 pygments==2.3.1           # via sphinx
-pytz==2018.7              # via babel
+pytz==2018.9              # via babel
 requests==2.21.0          # via sphinx
 six==1.12.0               # via edx-sphinx-theme, sphinx
 snowballstemmer==1.2.1    # via sphinx

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 click==7.0                # via pip-tools
-pip-tools==3.2.0
+pip-tools==3.4.0
 six==1.12.0               # via pip-tools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -15,17 +15,17 @@ boto==2.49.0              # via django-ses
 cached-property==1.5.1    # via zeep
 celery==3.1.26.post2      # via edx-ecommerce-worker
 certifi==2018.11.29       # via requests
-cffi==1.11.5              # via cryptography
+cffi==1.12.2              # via cryptography
 chardet==3.0.4            # via requests
 coreapi==2.3.3
 coreschema==0.0.4         # via coreapi
-cryptography==2.4.2       # via pyopenssl
+cryptography==2.6.1       # via pyopenssl
 cssselect==1.0.3          # via premailer
 cssutils==1.0.2           # via premailer
 defusedxml==0.5.0         # via zeep
-django-appconf==1.0.2     # via django-compressor
+django-appconf==1.0.3     # via django-compressor
 django-compressor==2.2
-django-cors-headers==2.4.0
+django-cors-headers==2.4.1
 django-crispy-forms==1.7.2
 django-extra-views==0.6.4  # via django-oscar
 django-filter==1.0.4
@@ -37,7 +37,7 @@ django-rest-swagger==2.2.0
 django-ses==0.8.2
 django-solo==1.1.3
 django-tables2==1.21.2    # via django-oscar
-django-threadlocals==0.8
+django-threadlocals==0.10
 django-treebeard==4.3     # via django-oscar
 django-waffle==0.14.0
 django-widget-tweaks==1.4.3  # via django-oscar
@@ -57,13 +57,13 @@ edx-opaque-keys==0.4.4
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography
 factory-boy==2.11.1       # via django-oscar
-faker==1.0.1              # via factory-boy
+faker==1.0.2              # via factory-boy
 funcsigs==1.0.2           # via mock
 future==0.17.1            # via pyjwkest
 gevent==1.0.2
 greenlet==0.4.15          # via gevent
 gunicorn==19.7.1
-idna==2.8                 # via cryptography, requests
+idna==2.8                 # via requests
 ipaddress==1.0.22         # via cryptography, faker
 isodate==0.6.0            # via zeep
 itypes==1.1.0             # via coreapi
@@ -71,42 +71,42 @@ jinja2==2.10              # via coreschema
 jsonfield==1.0.3
 kombu==3.0.37             # via celery
 libsass==0.9.2
-lxml==4.2.5               # via premailer, zeep
+lxml==4.3.2               # via premailer, zeep
 markdown==2.6.9
-markupsafe==1.1.0         # via jinja2
+markupsafe==1.1.1         # via jinja2
 mock==2.0.0               # via django-oscar
 mysql-python==1.2.5
 ndg-httpsclient==0.5.1
-newrelic==4.8.0.110
+newrelic==4.14.0.115
 nodeenv==1.1.1
-oauthlib==2.1.0           # via requests-oauthlib, social-auth-core
+oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 path.py==7.2
 paypalrestsdk==1.13.1
-pbr==5.1.1                # via mock, stevedore
-phonenumberslite==8.10.2  # via django-phonenumber-field
-pillow==5.4.0             # via django-oscar
+pbr==5.1.3                # via mock, stevedore
+phonenumberslite==8.10.6  # via django-phonenumber-field
+pillow==5.4.1             # via django-oscar
 premailer==2.9.2
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 purl==1.4                 # via django-oscar
 pyasn1==0.4.5             # via ndg-httpsclient
 pycountry==17.1.8
 pycparser==2.19           # via cffi
-pycryptodomex==3.7.2      # via pyjwkest
+pycryptodomex==3.7.3      # via pyjwkest
 pygments==2.3.1
 pyjwkest==1.3.2           # via edx-drf-extensions, social-auth-core
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pymongo==3.7.2            # via edx-opaque-keys
-pyopenssl==18.0.0         # via ndg-httpsclient, paypalrestsdk
-python-dateutil==2.7.5
+pyopenssl==19.0.0         # via ndg-httpsclient, paypalrestsdk
+python-dateutil==2.8.0
 python-memcached==1.58
 python-openid==2.2.5      # via social-auth-core
 pytz==2016.10
 pyyaml==3.13
 rcssmin==1.0.6            # via django-compressor
 redis==2.10.6
-requests-oauthlib==1.0.0  # via social-auth-core
-requests-toolbelt==0.8.0  # via zeep
+requests-oauthlib==1.2.0  # via social-auth-core
+requests-toolbelt==0.9.1  # via zeep
 requests==2.21.0
 rest-condition==1.0.3     # via edx-drf-extensions
 rjsmin==1.0.12            # via django-compressor
@@ -118,7 +118,7 @@ slumber==0.7.1            # via edx-rest-api-client
 social-auth-app-django==1.2.0  # via edx-auth-backends
 social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django
 sorl-thumbnail==12.5.0    # via django-oscar
-stevedore==1.30.0         # via edx-opaque-keys
+stevedore==1.30.1         # via edx-opaque-keys
 stripe==1.70.0
 text-unidecode==1.2       # via faker
 typing==3.6.6             # via django-extensions

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,27 +12,27 @@ asn1crypto==0.24.0        # via cryptography
 astroid==1.4.9            # via pylint
 babel==2.6.0              # via django-oscar, django-phonenumber-field
 backports.functools-lru-cache==1.5  # via pylint, soupsieve
-beautifulsoup4==4.7.0     # via webtest
+beautifulsoup4==4.7.1     # via webtest
 billiard==3.3.0.23        # via celery
 cached-property==1.5.1    # via zeep
 celery==3.1.26.post2      # via edx-ecommerce-worker
 certifi==2018.11.29       # via requests
-cffi==1.11.5              # via cryptography
+cffi==1.12.2              # via cryptography
 chardet==3.0.4            # via requests
-configparser==3.5.0       # via pylint
+configparser==3.7.3       # via pylint
 cookies==2.2.1            # via responses
 coreapi==2.3.3
 coreschema==0.0.4         # via coreapi
 coverage==4.3.4
-cryptography==2.4.2       # via pyopenssl
+cryptography==2.6.1       # via pyopenssl
 cssselect==1.0.3          # via premailer
 cssutils==1.0.2           # via premailer
 ddt==1.1.1
 defusedxml==0.5.0         # via zeep
 diff-cover==0.9.6
-django-appconf==1.0.2     # via django-compressor
+django-appconf==1.0.3     # via django-compressor
 django-compressor==2.2
-django-cors-headers==2.4.0
+django-cors-headers==2.4.1
 django-crispy-forms==1.7.2
 django-extra-views==0.6.4  # via django-oscar
 django-filter==1.0.4
@@ -44,7 +44,7 @@ django-phonenumber-field==1.3.0  # via django-oscar
 django-rest-swagger==2.2.0
 django-solo==1.1.3
 django-tables2==1.21.2    # via django-oscar
-django-threadlocals==0.8
+django-threadlocals==0.10
 django-treebeard==4.3     # via django-oscar
 django-waffle==0.14.0
 django-webtest==1.9.2
@@ -65,14 +65,14 @@ edx-opaque-keys==0.4.4
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography
 factory-boy==2.8.1
-faker==1.0.1              # via factory-boy
+faker==1.0.2              # via factory-boy
 freezegun==0.3.7
 funcsigs==1.0.2           # via mock
 future==0.17.1            # via pyjwkest
 gevent==1.0.2
 greenlet==0.4.15          # via gevent
 httpretty==0.8.14
-idna==2.8                 # via cryptography, requests
+idna==2.8                 # via requests
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography, faker
 isodate==0.6.0            # via zeep
@@ -86,42 +86,42 @@ lazy-object-proxy==1.3.1  # via astroid
 libsass==0.9.2
 lxml==3.8.0
 markdown==2.6.9
-markupsafe==1.1.0         # via jinja2
+markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 mock-django==0.6.9
 mock==1.3.0
 ndg-httpsclient==0.5.1
-newrelic==4.8.0.110       # via edx-django-utils
+newrelic==4.14.0.115      # via edx-django-utils
 nose-ignore-docstring==0.2
 nose==1.3.7               # via django-nose
-oauthlib==2.1.0           # via requests-oauthlib, social-auth-core
+oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 path.py==7.2
 paypalrestsdk==1.13.1
-pbr==5.1.1                # via mock, stevedore
+pbr==5.1.3                # via mock, stevedore
 pep8==1.6.2
-phonenumberslite==8.10.2  # via django-phonenumber-field
-pillow==5.4.0             # via django-oscar
+phonenumberslite==8.10.6  # via django-phonenumber-field
+pillow==5.4.1             # via django-oscar
 premailer==2.9.2
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 purl==1.4                 # via django-oscar
 pyasn1==0.4.5             # via ndg-httpsclient
 pycountry==17.1.8
 pycparser==2.19           # via cffi
-pycryptodomex==3.7.2      # via pyjwkest
+pycryptodomex==3.7.3      # via pyjwkest
 pygments==2.3.1
 pyjwkest==1.3.2           # via edx-drf-extensions, social-auth-core
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint==1.6.4
 pymongo==3.7.2            # via edx-opaque-keys
-pyopenssl==18.0.0         # via ndg-httpsclient, paypalrestsdk
-python-dateutil==2.7.5
+pyopenssl==19.0.0         # via ndg-httpsclient, paypalrestsdk
+python-dateutil==2.8.0
 python-openid==2.2.5      # via social-auth-core
 pytz==2016.10
 pyyaml==3.13              # via edx-django-release-util
 rcssmin==1.0.6            # via django-compressor
-requests-oauthlib==1.0.0  # via social-auth-core
-requests-toolbelt==0.8.0  # via zeep
+requests-oauthlib==1.2.0  # via social-auth-core
+requests-toolbelt==0.9.1  # via zeep
 requests==2.21.0
 responses==0.5.1
 rest-condition==1.0.3     # via edx-drf-extensions
@@ -135,8 +135,8 @@ slumber==0.7.1            # via edx-rest-api-client
 social-auth-app-django==1.2.0  # via edx-auth-backends
 social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django
 sorl-thumbnail==12.5.0    # via django-oscar
-soupsieve==1.6.1          # via beautifulsoup4
-stevedore==1.30.0         # via edx-opaque-keys
+soupsieve==1.8            # via beautifulsoup4
+stevedore==1.30.1         # via edx-opaque-keys
 stripe==1.70.0
 testfixtures==4.5.0
 text-unidecode==1.2       # via faker
@@ -145,8 +145,8 @@ unicodecsv==0.14.1
 unidecode==0.4.21         # via django-oscar
 uritemplate==3.0.0        # via coreapi
 urllib3==1.24.1           # via requests
-waitress==1.1.0           # via webtest
-webob==1.8.4              # via webtest
-webtest==2.0.32           # via django-webtest
-wrapt==1.10.11            # via astroid
+waitress==1.2.1           # via webtest
+webob==1.8.5              # via webtest
+webtest==2.0.33           # via django-webtest
+wrapt==1.11.1             # via astroid
 zeep==2.1.1


### PR DESCRIPTION
Running _make upgrade_ without unpinning anything results in enough changes that I thought it might be good to make a PR with just those changes, before unpinning (or upgrading the pin on) _django-oscar_.

Upgrading _django-oscar_ will follow in a later PR.

Edit:
@cpennington pointed out that _oauthlib_ gets a major version bump in this PR (from 2.1.0 to 3.0.1). The release notes for 3.0.0 mention some breaking changes:

```
OAuth2.0 Provider - API/Breaking Changes

Add "request" to confirm_redirect_uri #504
confirm_redirect_uri/get_default_redirect_uri has a bit changed #445
invalid_client is now a FatalError #606
Changed errors status code from 401 to 400:
invalid_grant: #264
invalid_scope: #620
access_denied/unauthorized_client/consent_required/login_required #623
401 must have WWW-Authenticate HTTP Header set. #623
```
https://github.com/oauthlib/oauthlib/releases 

_pyopenssl_ also gets a major version bump (from 18.0.0 to 19.0.0). Its breaking changes are:

```
Backward-incompatible changes:
X509Store.add_cert no longer raises an error if you add a duplicate cert. #787
```
https://pyopenssl.org/en/stable/changelog.html
