### PR TITLE
EG-64 Change django-oscar pin to < 1.6 and run make upgrade

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -13,7 +13,7 @@ django-crispy-forms
 django_extensions==1.9.9
 django-filter==1.0.4
 django-libsass==0.5
-django-oscar==1.5.1
+django-oscar==1.5.4
 django-rest-swagger
 django-solo
 django-threadlocals

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -13,7 +13,7 @@ django-crispy-forms
 django_extensions==1.9.9
 django-filter==1.0.4
 django-libsass==0.5
-django-oscar==1.5.4
+django-oscar<1.6                    # 1.6 has backwards incompatible changes
 django-rest-swagger
 django-solo
 django-threadlocals

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,17 +24,17 @@ cssutils==1.0.2           # via premailer
 defusedxml==0.5.0         # via zeep
 django-appconf==1.0.3     # via django-compressor
 django-compressor==2.2
-django-cors-headers==2.4.1
+django-cors-headers==2.5.0
 django-crispy-forms==1.7.2
-django-extra-views==0.6.4  # via django-oscar
+django-extra-views==0.10.0  # via django-oscar
 django-filter==1.0.4
 django-haystack==2.8.1    # via django-oscar
 django-libsass==0.5
-django-oscar==1.5.1
+django-oscar==1.5.4
 django-phonenumber-field==1.3.0  # via django-oscar
 django-rest-swagger==2.2.0
 django-solo==1.1.3
-django-tables2==1.21.2    # via django-oscar
+django-tables2==1.16.0    # via django-oscar
 django-threadlocals==0.10
 django-treebeard==4.3     # via django-oscar
 django-waffle==0.14.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -33,19 +33,19 @@ defusedxml==0.5.0         # via zeep
 diff-cover==0.9.6
 django-appconf==1.0.3     # via django-compressor
 django-compressor==2.2
-django-cors-headers==2.4.1
+django-cors-headers==2.5.0
 django-crispy-forms==1.7.2
 django-debug-toolbar==1.7
-django-extra-views==0.6.4  # via django-oscar
+django-extra-views==0.10.0  # via django-oscar
 django-filter==1.0.4
 django-haystack==2.8.1    # via django-oscar
 django-libsass==0.5
 django-nose==1.4.4
-django-oscar==1.5.1
+django-oscar==1.5.4
 django-phonenumber-field==1.3.0  # via django-oscar
 django-rest-swagger==2.2.0
 django-solo==1.1.3
-django-tables2==1.21.2    # via django-oscar
+django-tables2==1.16.0    # via django-oscar
 django-threadlocals==0.10
 django-treebeard==4.3     # via django-oscar
 django-waffle==0.14.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -25,18 +25,18 @@ cssutils==1.0.2           # via premailer
 defusedxml==0.5.0         # via zeep
 django-appconf==1.0.3     # via django-compressor
 django-compressor==2.2
-django-cors-headers==2.4.1
+django-cors-headers==2.5.0
 django-crispy-forms==1.7.2
-django-extra-views==0.6.4  # via django-oscar
+django-extra-views==0.10.0  # via django-oscar
 django-filter==1.0.4
 django-haystack==2.8.1    # via django-oscar
 django-libsass==0.5
-django-oscar==1.5.1
+django-oscar==1.5.4
 django-phonenumber-field==1.3.0  # via django-oscar
 django-rest-swagger==2.2.0
 django-ses==0.8.2
 django-solo==1.1.3
-django-tables2==1.21.2    # via django-oscar
+django-tables2==1.16.0    # via django-oscar
 django-threadlocals==0.10
 django-treebeard==4.3     # via django-oscar
 django-waffle==0.14.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -32,18 +32,18 @@ defusedxml==0.5.0         # via zeep
 diff-cover==0.9.6
 django-appconf==1.0.3     # via django-compressor
 django-compressor==2.2
-django-cors-headers==2.4.1
+django-cors-headers==2.5.0
 django-crispy-forms==1.7.2
-django-extra-views==0.6.4  # via django-oscar
+django-extra-views==0.10.0  # via django-oscar
 django-filter==1.0.4
 django-haystack==2.8.1    # via django-oscar
 django-libsass==0.5
 django-nose==1.4.4
-django-oscar==1.5.1
+django-oscar==1.5.4
 django-phonenumber-field==1.3.0  # via django-oscar
 django-rest-swagger==2.2.0
 django-solo==1.1.3
-django-tables2==1.21.2    # via django-oscar
+django-tables2==1.16.0    # via django-oscar
 django-threadlocals==0.10
 django-treebeard==4.3     # via django-oscar
 django-waffle==0.14.0


### PR DESCRIPTION
Update django-oscar to the latest 1.5.x version, which is 1.5.4, since 1.6 contains backwards incompatible changes that I'd like to avoid for now.

Note that this seems to downgrade _django-tables2_ from 1.21.2 to 1.16.0.

Oscar release notes:
https://django-oscar.readthedocs.io/en/latest/releases/v1.5.2.html
https://django-oscar.readthedocs.io/en/latest/releases/v1.5.3.html
https://django-oscar.readthedocs.io/en/latest/releases/v1.5.4.html