### PR TITLE
Remove duplicate code for initializing API clients.

### DIFF
--- a/ecommerce/courses/views.py
+++ b/ecommerce/courses/views.py
@@ -8,11 +8,9 @@ from django.core.management import call_command
 from django.http import Http404, HttpResponse
 from django.views.generic import TemplateView, View
 from edx_django_utils.cache import TieredCache
-from edx_rest_api_client.client import EdxRestApiClient
 from requests import Timeout
 from slumber.exceptions import SlumberBaseException
 
-from ecommerce.core.url_utils import get_lms_url
 from ecommerce.core.views import StaffOnlyMixin
 from ecommerce.extensions.partner.shortcuts import get_partner_for_site
 
@@ -47,10 +45,7 @@ class CourseAppView(StaffOnlyMixin, TemplateView):
             return credit_providers_cache_response.value
 
         try:
-            credit_api = EdxRestApiClient(
-                get_lms_url('/api/credit/v1/'),
-                oauth_access_token=self.request.user.access_token
-            )
+            credit_api = self.request.site.siteconfiguration.credit_api_client
             credit_providers = credit_api.providers.get()
             credit_providers.sort(key=lambda provider: provider['display_name'])
 

--- a/ecommerce/credit/tests/test_views.py
+++ b/ecommerce/credit/tests/test_views.py
@@ -152,6 +152,7 @@ class CheckoutPageTest(DiscoveryTestMixin, TestCase, JwtMixin):
     @httpretty.activate
     def test_get_without_deadline(self):
         """ Verify an error is shown if the user is not eligible for credit. """
+        self.mock_access_token_response()
         self._mock_eligibility_api(body=[])
         self._assert_error_without_deadline()
 
@@ -160,6 +161,7 @@ class CheckoutPageTest(DiscoveryTestMixin, TestCase, JwtMixin):
         """ Verify an error is shown if the Credit API returns an empty list of
         providers.
         """
+        self.mock_access_token_response()
         self._mock_eligibility_api(body=self.eligibilities)
 
         # Create the credit seat
@@ -174,6 +176,7 @@ class CheckoutPageTest(DiscoveryTestMixin, TestCase, JwtMixin):
         """ Verify an error is shown if an exception is raised when requesting
         eligibility information from the Credit API.
         """
+        self.mock_access_token_response()
         self._mock_eligibility_api(body=[], status=500)
         self._assert_error_without_deadline()
 
@@ -187,6 +190,7 @@ class CheckoutPageTest(DiscoveryTestMixin, TestCase, JwtMixin):
         self.course.create_or_update_seat(
             'credit', True, self.price, self.provider, credit_hours=self.credit_hours
         )
+        self.mock_access_token_response()
         self._mock_eligibility_api(body=self.eligibilities)
         self._mock_providers_api(body=[], status=500)
         self._assert_error_without_providers()
@@ -201,6 +205,7 @@ class CheckoutPageTest(DiscoveryTestMixin, TestCase, JwtMixin):
             'credit', True, self.price, self.provider, credit_hours=self.credit_hours
         )
 
+        self.mock_access_token_response()
         self._mock_eligibility_api(body=self.eligibilities)
         self._mock_providers_api(body=self.provider_data)
 
@@ -219,6 +224,7 @@ class CheckoutPageTest(DiscoveryTestMixin, TestCase, JwtMixin):
         # Create the audit seat
         self.course.create_or_update_seat('', False, 0)
 
+        self.mock_access_token_response()
         self._mock_eligibility_api(body=self.eligibilities)
         self._mock_providers_api(body=self.provider_data)
 
@@ -231,6 +237,7 @@ class CheckoutPageTest(DiscoveryTestMixin, TestCase, JwtMixin):
         self.course.create_or_update_seat(
             'credit', True, self.price, self.provider, credit_hours=self.credit_hours, expires=expires
         )
+        self.mock_access_token_response()
         self._mock_eligibility_api(body=self.eligibilities)
 
         response = self.client.get(self.path)
@@ -256,6 +263,7 @@ class CheckoutPageTest(DiscoveryTestMixin, TestCase, JwtMixin):
         )
         new_range = RangeFactory(products=[seat, ])
         prepare_voucher(code=code, _range=new_range, benefit_value=100, benefit_type=benefit_type)
+        self.mock_access_token_response()
         self._mock_eligibility_api(body=self.eligibilities)
         self._mock_providers_api(body=self.provider_data)
 

--- a/ecommerce/credit/views.py
+++ b/ecommerce/credit/views.py
@@ -6,14 +6,11 @@ from dateutil.parser import parse
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
-from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import TemplateView
-from edx_rest_api_client.client import EdxRestApiClient
 from oscar.core.loading import get_model
 from slumber.exceptions import SlumberHttpBaseException
 
-from ecommerce.core.url_utils import get_lms_url
 from ecommerce.courses.models import Course
 from ecommerce.extensions.analytics.utils import prepare_analytics_data
 from ecommerce.extensions.offer.utils import format_benefit_value
@@ -106,7 +103,8 @@ class Checkout(TemplateView):
             Eligibility deadline date or None if user is not eligible.
         """
         try:
-            eligibilities = self.credit_api_client.eligibility.get(username=user.username, course_key=course_key)
+            credit_api_client = self.request.site.siteconfiguration.credit_api_client
+            eligibilities = credit_api_client.eligibility.get(username=user.username, course_key=course_key)
             if not eligibilities:
                 return None
 
@@ -179,16 +177,8 @@ class Checkout(TemplateView):
         provider_ids = ",".join([seat.attr.credit_provider for seat in credit_seats if seat.attr.credit_provider])
 
         try:
-            return self.credit_api_client.providers.get(provider_ids=provider_ids)
+            credit_api_client = self.request.site.siteconfiguration.credit_api_client
+            return credit_api_client.providers.get(provider_ids=provider_ids)
         except SlumberHttpBaseException:
             logger.exception('An error occurred while retrieving credit provider details.')
             return None
-
-    @cached_property
-    def credit_api_client(self):
-        """ Returns an instance of the Credit API client. """
-
-        return EdxRestApiClient(
-            get_lms_url('api/credit/v1/'),
-            oauth_access_token=self.request.user.access_token
-        )

--- a/ecommerce/extensions/api/v2/views/providers.py
+++ b/ecommerce/extensions/api/v2/views/providers.py
@@ -15,7 +15,6 @@ class ProviderViewSet(APIView):
     def get(self, request):
         credit_provider_id = request.GET.get('credit_provider_id')
         provider_data = get_credit_provider_details(
-            access_token=request.user.access_token,
             credit_provider_id=credit_provider_id,
             site_configuration=request.site.siteconfiguration
         )

--- a/ecommerce/extensions/api/v2/views/vouchers.py
+++ b/ecommerce/extensions/api/v2/views/vouchers.py
@@ -176,10 +176,9 @@ class VoucherViewSet(NonDestroyableModelViewSet):
             course_catalog_data = course_run_metadata[course_id]
             if course_seat_types == 'credit':
                 # Omit credit seats for which the user is not eligible or which the user already bought.
-                if request.user.is_eligible_for_credit(product.course_id):
-                    if Order.objects.filter(user=request.user, lines__product=product).exists():
-                        continue
-                else:
+                if not request.user.is_eligible_for_credit(product.course_id, request.site.siteconfiguration):
+                    continue
+                elif Order.objects.filter(user=request.user, lines__product=product).exists():
                     continue
                 credit_seats = Product.objects.filter(parent=product.parent, attributes__name='credit_provider')
 

--- a/ecommerce/extensions/checkout/signals.py
+++ b/ecommerce/extensions/checkout/signals.py
@@ -108,7 +108,6 @@ def send_course_purchase_email(sender, order=None, **kwargs):  # pylint: disable
                 return
             elif product.is_seat_product:
                 provider_data = get_credit_provider_details(
-                    access_token=order.site.siteconfiguration.access_token,
                     credit_provider_id=credit_provider_id,
                     site_configuration=order.site.siteconfiguration
                 )

--- a/ecommerce/extensions/checkout/tests/test_utils.py
+++ b/ecommerce/extensions/checkout/tests/test_utils.py
@@ -33,6 +33,7 @@ class UtilTests(TestCase):
     @httpretty.activate
     def test_get_credit_provider_details(self):
         """ Check that credit provider details are returned. """
+        self.mock_access_token_response()
         httpretty.register_uri(
             httpretty.GET,
             self.site.siteconfiguration.build_lms_url(self.get_credit_provider_details_url(self.credit_provider_id)),
@@ -40,7 +41,6 @@ class UtilTests(TestCase):
             content_type="application/json"
         )
         provider_data = get_credit_provider_details(
-            self.access_token,
             self.credit_provider_id,
             self.site.siteconfiguration
         )
@@ -55,7 +55,6 @@ class UtilTests(TestCase):
             status=400
         )
         provider_data = get_credit_provider_details(
-            self.access_token,
             self.credit_provider_id,
             self.site.siteconfiguration
         )
@@ -67,7 +66,6 @@ class UtilTests(TestCase):
         with mock.patch.object(requests, 'get', mock.Mock(side_effect=exception)):
             self.assertIsNone(
                 get_credit_provider_details(
-                    self.access_token,
                     self.credit_provider_id,
                     self.site.siteconfiguration
                 )

--- a/ecommerce/extensions/checkout/utils.py
+++ b/ecommerce/extensions/checkout/utils.py
@@ -5,28 +5,23 @@ from babel.numbers import format_currency as default_format_currency
 from django.conf import settings
 from django.urls import reverse
 from django.utils.translation import get_language, to_locale
-from edx_rest_api_client.client import EdxRestApiClient
 from requests.exceptions import ConnectionError, Timeout
 from slumber.exceptions import SlumberHttpBaseException
 
 logger = logging.getLogger(__name__)
 
 
-def get_credit_provider_details(access_token, credit_provider_id, site_configuration):
+def get_credit_provider_details(credit_provider_id, site_configuration):
     """ Returns the credit provider details from LMS.
 
     Args:
-        access_token (str): JWT access token
         credit_provider_id (str): Identifier for the provider
         site_configuration (SiteConfiguration): Ecommerce Site Configuration
 
     Returns: dict
     """
     try:
-        return EdxRestApiClient(
-            site_configuration.build_lms_url('api/credit/v1/'),
-            oauth_access_token=access_token
-        ).providers(credit_provider_id).get()
+        return site_configuration.credit_api_client.providers(credit_provider_id).get()
     except (ConnectionError, SlumberHttpBaseException, Timeout):
         logger.exception('Failed to retrieve credit provider details for provider [%s].', credit_provider_id)
         return None


### PR DESCRIPTION
Use JWT access token initialized clients instead of OAuth access token clients, also remove duplicate code for API client initialization.

Oauth access token calls to LMS returning 401 Unauthenticated response for some users.

LEARNER-7145