### PR TITLE
ARCH-603: (part 1) update lms_user_id via social-auth for analytics

### DIFF
--- a/ecommerce/core/tests/test_models.py
+++ b/ecommerce/core/tests/test_models.py
@@ -41,7 +41,7 @@ def _make_site_config(payment_processors_str, site_id=1):
 
 @ddt.ddt
 class UserTests(DiscoveryTestMixin, LmsApiMockMixin, TestCase):
-    TEST_CONTEXT = {'foo': 'bar', 'baz': None}
+    TEST_CONTEXT = {'foo': 'bar', 'baz': None, 'lms_user_id': 'test-context-user-id'}
 
     def setUp(self):
         super(UserTests, self).setUp()
@@ -60,6 +60,26 @@ class UserTests(DiscoveryTestMixin, LmsApiMockMixin, TestCase):
 
         self.create_access_token(user)
         self.assertEqual(user.access_token, self.access_token)
+
+    def test_lms_user_id_from_social_auth(self):
+        """ Ensures the lms_user_id can be pulled from the tracking context. """
+        user = self.create_user()
+        self.assertIsNone(user.lms_user_id)
+
+        self.set_user_id_in_social_auth(user, 'test-social-auth-user-id')
+
+        self.assertEqual(user.lms_user_id, 'test-social-auth-user-id')
+
+    def test_lms_user_id_from_tracking_context(self):
+        """ Ensures the lms_user_id can be pulled from the tracking context. """
+        user = self.create_user()
+        self.assertIsNone(user.lms_user_id)
+
+        user.tracking_context = self.TEST_CONTEXT
+        user.save()
+
+        same_user = User.objects.get(id=user.id)
+        self.assertEqual(same_user.lms_user_id, self.TEST_CONTEXT['lms_user_id'])
 
     def test_tracking_context(self):
         """ Ensures that the tracking_context dictionary is written / read

--- a/ecommerce/extensions/analytics/utils.py
+++ b/ecommerce/extensions/analytics/utils.py
@@ -11,7 +11,11 @@ ECOM_TRACKING_ID_FMT = 'ecommerce-{}'
 
 
 def parse_tracking_context(user):
-    """Extract user ID, client ID, and IP address from a user's tracking context.
+    """
+    Extract user ID, client ID, and IP address from a user's tracking context.
+
+    Note: The tracking context may not exist, so user ID has backups so it will
+    always have a value.
 
     Arguments:
         user (User): An instance of the User model.
@@ -19,16 +23,14 @@ def parse_tracking_context(user):
     Returns:
         Tuple of strings: user_tracking_id, ga_client_id, lms_ip
     """
-    tracking_context = user.tracking_context or {}
-
-    user_tracking_id = tracking_context.get('lms_user_id')
+    user_tracking_id = user.lms_user_id
     if user_tracking_id is None:
-        # Even if we cannot extract a good platform user ID from the context, we can still track the
-        # event with an arbitrary local user ID. However, we need to disambiguate the ID we choose
-        # since there's no guarantee it won't collide with a platform user ID that may be tracked
-        # at some point.
+        # If we still don't have the lms user ID, we will use the local user ID. However, we need
+        # to disambiguate the ID we choose since there's no guarantee it won't collide with the
+        # lms user ID that may be tracked at some point.
         user_tracking_id = ECOM_TRACKING_ID_FMT.format(user.id)
 
+    tracking_context = user.tracking_context or {}
     lms_ip = tracking_context.get('lms_ip')
     ga_client_id = tracking_context.get('ga_client_id')
 

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -219,7 +219,6 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.contrib.sites.middleware.CurrentSiteMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
     'waffle.middleware.WaffleMiddleware',
     # NOTE: The overridden BasketMiddleware relies on request.site. This middleware
     # MUST appear AFTER CurrentSiteMiddleware.

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -45,6 +45,7 @@ CONTENT_TYPE = 'application/json'
 class UserMixin(object):
     """Provides utility methods for creating and authenticating users in test cases."""
     access_token = 'test-access-token'
+    user_id = 'test-user-id'
     password = 'test'
 
     def create_user(self, **kwargs):
@@ -62,6 +63,15 @@ class UserMixin(object):
         """
         access_token = access_token or self.access_token
         UserSocialAuth.objects.create(user=user, extra_data={'access_token': access_token})
+
+    def set_user_id_in_social_auth(self, user, user_id=None):
+        """
+        Sets the user_id in social auth for the specified user.
+
+        If no user_id value is supplied, the default (self.user_id) will be used.
+        """
+        user_id = user_id or self.user_id
+        UserSocialAuth.objects.create(user=user, extra_data={'user_id': user_id})
 
     def generate_jwt_token_header(self, user, secret=None):
         """Generate a valid JWT token header for authenticated requests."""


### PR DESCRIPTION
When social-auth makes user_id available to ecommerce, uses this as the backup lms_user_id for later analytics calls.

This is part 1 of a two part change.  This code will use the user_id from social-auth when it is available, but it won't yet be available in part 1.  It will start writing some NewRelic metrics that can be tested.

Part 2 will require the auth-backends upgrade to actually make the user_id available via social-auth.  But this upgrade requires the following:
- Ensure edx-platform change https://github.com/edx/edx-platform/pull/20057 is in Production.
- Add application access in django admin for ecommerce-sso that includes `user_id` scope.
- Ensure this upgrades to 2.0.0 to auth-backends.

ARCH-603