### PR TITLE
ARCH-603: use lms_user_id from social-auth for analytics (part 2)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -47,7 +47,7 @@ djangorestframework-csv==2.1.0
 djangorestframework-jwt==1.11.0
 djangorestframework==3.6.4
 drf-extensions==0.3.1
-edx-auth-backends==1.2.2
+edx-auth-backends==2.0.0
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==1.0.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -60,7 +60,7 @@ djangorestframework-jwt==1.11.0
 djangorestframework==3.6.4
 docutils==0.14            # via sphinx
 drf-extensions==0.3.1
-edx-auth-backends==1.2.2
+edx-auth-backends==2.0.0
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==1.0.3

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -49,7 +49,7 @@ djangorestframework-csv==2.1.0
 djangorestframework-jwt==1.11.0
 djangorestframework==3.6.4
 drf-extensions==0.3.1
-edx-auth-backends==1.2.2
+edx-auth-backends==2.0.0
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==1.0.3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -57,7 +57,7 @@ djangorestframework-csv==2.1.0
 djangorestframework-jwt==1.11.0
 djangorestframework==3.6.4
 drf-extensions==0.3.1
-edx-auth-backends==1.2.2
+edx-auth-backends==2.0.0
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==1.0.3


### PR DESCRIPTION
This is part 2 of a 2 part change to get the user_id from social-auth
during the oAuth2+SSO flow to the database, and available to ecommerce
for use with analytics.

Part 2 simply has the upgrade to auth-backends 2.0.0. This version of
auth-backends will actually store the user_id in the social-auth table,
making it available to the code from (part 1 #2191) that reads this
user_id and makes it available to the analytics code.

Before merging, this upgrade has two prerequisites:
- [x] A fix to LMS that enables the scope user_id to work at all.
- [ ] Configuring the oauth application for ecommerce-sso to have access
to the user_id scope.

ARCH-603