### PR TITLE
ARCH-603: clean-up lms_user_id code

### DIFF
--- a/ecommerce/core/tests/test_models.py
+++ b/ecommerce/core/tests/test_models.py
@@ -67,7 +67,6 @@ class UserTests(DiscoveryTestMixin, LmsApiMockMixin, TestCase):
         self.assertIsNone(user.lms_user_id)
 
         self.set_user_id_in_social_auth(user, 'test-social-auth-user-id')
-
         self.assertEqual(user.lms_user_id, 'test-social-auth-user-id')
 
     def test_lms_user_id_from_tracking_context(self):

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -71,7 +71,7 @@ class UserMixin(object):
         If no user_id value is supplied, the default (self.user_id) will be used.
         """
         user_id = user_id or self.user_id
-        UserSocialAuth.objects.create(user=user, extra_data={'user_id': user_id})
+        UserSocialAuth.objects.update_or_create(user=user, extra_data={'user_id': user_id})
 
     def generate_jwt_token_header(self, user, secret=None):
         """Generate a valid JWT token header for authenticated requests."""


### PR DESCRIPTION
- sets custom metric and returns as soon as an lms_user_id found.
- rename custom metric 'ecommerce_user_id' to
  'ecommerce_user_missing_lms_user_id'.

ARCH-603