### PR TITLE
WL-1911 Add better logging to the enterprise condition so we can better understand the errors.

### DIFF
--- a/ecommerce/enterprise/api.py
+++ b/ecommerce/enterprise/api.py
@@ -195,20 +195,9 @@ def catalog_contains_course_runs(site, course_run_ids, enterprise_customer_uuid,
 
     api = site.siteconfiguration.enterprise_api_client
     endpoint = getattr(api, api_resource_name)(api_resource_id)
-    try:
-        contains_content = endpoint.contains_content_items.get(**query_params)['contains_content_items']
+    contains_content = endpoint.contains_content_items.get(**query_params)['contains_content_items']
+    TieredCache.set_all_tiers(cache_key, contains_content, settings.ENTERPRISE_API_CACHE_TIMEOUT)
 
-        TieredCache.set_all_tiers(cache_key, contains_content, settings.ENTERPRISE_API_CACHE_TIMEOUT)
-    except (ConnectionError, KeyError, SlumberHttpBaseException, Timeout):
-        logger.exception(
-            'Failed to check if course_runs [%s] exist in '
-            'EnterpriseCustomerCatalog [%s]'
-            'for EnterpriseCustomer [%s].',
-            course_run_ids,
-            enterprise_customer_catalog_uuid,
-            enterprise_customer_uuid,
-        )
-        contains_content = False
     return contains_content
 
 

--- a/ecommerce/enterprise/tests/test_api.py
+++ b/ecommerce/enterprise/tests/test_api.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from edx_django_utils.cache import TieredCache
 from mock import patch
 from oscar.core.loading import get_model
+from requests.exceptions import ConnectionError
 
 from ecommerce.core.tests import toggle_switch
 from ecommerce.core.utils import get_cache_key
@@ -180,7 +181,8 @@ class EnterpriseAPITests(EnterpriseServiceMockMixin, DiscoveryTestMixin, TestCas
             raise_exception=True,
         )
 
-        self._assert_contains_course_runs(False, [self.course_run.id], 'fake-uuid', 'fake-uuid')
+        with self.assertRaises(ConnectionError):
+            self._assert_contains_course_runs(False, [self.course_run.id], 'fake-uuid', 'fake-uuid')
 
     @ddt.data(
         ('cf246b88-d5f6-4908-a522-fc307e0b0c59',

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -121,7 +121,7 @@ pycountry==17.1.8
 pycparser==2.19           # via cffi
 pycryptodomex==3.8.1      # via pyjwkest
 pygments==2.3.1
-pyinotify==0.9.6
+# pyinotify==0.9.6
 pyjwkest==1.3.2           # via edx-drf-extensions, social-auth-core
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint==1.6.4


### PR DESCRIPTION
Based on my investigations, I suspect that there are a variety of failures, and they are likely coming from this particular code block where we evaluate if a code is applicable to the basket.

However, the information in the logs hasn't been sufficient or consistent between different types of failures. This PR introduces some consistency on what data is logged for the errors impacting enterprise codes and amplifies the exception logging from api calls which was lacking when I looked in splunk.