### PR TITLE
ENT-1838 Filter out enterprise site offers that don't match a user's enterprise

### DIFF
--- a/ecommerce/core/constants.py
+++ b/ecommerce/core/constants.py
@@ -34,6 +34,7 @@ DEFAULT_CATALOG_PAGE_SIZE = 100
 ENTERPRISE_COUPON_ADMIN_ROLE = 'enterprise_coupon_admin'
 
 SYSTEM_ENTERPRISE_ADMIN_ROLE = 'enterprise_admin'
+SYSTEM_ENTERPRISE_LEARNER_ROLE = 'enterprise_learner'
 SYSTEM_ENTERPRISE_OPERATOR_ROLE = 'enterprise_openedx_operator'
 
 # Context to give access to all resources

--- a/ecommerce/enterprise/conditions.py
+++ b/ecommerce/enterprise/conditions.py
@@ -71,14 +71,13 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
             if not course:
                 # Basket contains products not related to a course_run.
                 logger.warning('Unable to apply enterprise offer because '
-                               'the Basket (#%s) contains a product (#%s) not related to a course_run. '
-                               'Offer: %s, Enterprise: %s, Catalog: %s, User: %s',
-                               basket.id,
-                               line.product.id,
+                               'the Basket contains a product not related to a course_run. '
+                               'Offer: %s, Enterprise: %s, Catalog: %s, User: %s, Product ID: %s',
                                offer.id,
                                enterprise_customer,
                                enterprise_catalog,
-                               username)
+                               username,
+                               line.product.id)
                 return False
 
             course_run_ids.append(course.id)
@@ -237,5 +236,13 @@ class AssignableEnterpriseCustomerCondition(EnterpriseCustomerCondition):
         # basket owner can redeem the voucher if free slots are avialable
         if voucher.slots_available_for_assignment:
             return True
+
+        logger.warning('Unable to apply enterprise offer because '
+                       'the voucher has not been assigned to this user and their are no remaining available uses. '
+                       'Offer: %s, Enterprise: %s, Catalog: %s, User: %s',
+                       offer.id,
+                       self.enterprise_customer_uuid,
+                       self.enterprise_customer_catalog_uuid,
+                       basket.owner.username)
 
         return False

--- a/ecommerce/enterprise/tests/test_utils.py
+++ b/ecommerce/enterprise/tests/test_utils.py
@@ -10,6 +10,7 @@ from edx_django_utils.cache import TieredCache
 from mock import patch
 from oscar.test.factories import VoucherFactory
 
+from ecommerce.core.constants import SYSTEM_ENTERPRISE_ADMIN_ROLE, SYSTEM_ENTERPRISE_LEARNER_ROLE
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
 from ecommerce.enterprise.utils import (
     enterprise_customer_user_needs_consent,
@@ -17,6 +18,8 @@ from ecommerce.enterprise.utils import (
     get_enterprise_customer,
     get_enterprise_customer_uuid,
     get_enterprise_customers,
+    get_enterprise_id_for_current_request_user_from_jwt,
+    get_enterprise_id_for_user,
     get_or_create_enterprise_customer_user,
     set_enterprise_customer_cookie
 )
@@ -190,3 +193,98 @@ class EnterpriseUtilsTests(EnterpriseServiceMockMixin, TestCase):
 
         cached_response = get_enterprise_catalog(self.site, enterprise_catalog_uuid, 50, 1)
         self.assertEqual(response, cached_response)
+
+    @patch('ecommerce.enterprise.utils.get_decoded_jwt')
+    def test_get_enterprise_id_for_current_request_user_from_jwt_request_has_no_jwt(self, mock_decode_jwt):
+        """
+        Verify get_enterprise_id_for_current_request_user_from_jwt returns None if
+        decoded_jwt is None
+        """
+        mock_decode_jwt.return_value = None
+        assert get_enterprise_id_for_current_request_user_from_jwt() is None
+
+    @patch('ecommerce.enterprise.utils.get_decoded_jwt')
+    def test_get_enterprise_id_for_current_request_user_from_jwt_request_has_jwt(self, mock_decode_jwt):
+        """
+        Verify get_enterprise_id_for_current_request_user_from_jwt returns jwt context
+        for user if request has jwt and user has proper role
+        """
+        mock_decode_jwt.return_value = {
+            'roles': ['{}:some-uuid'.format(SYSTEM_ENTERPRISE_LEARNER_ROLE)]
+        }
+        assert get_enterprise_id_for_current_request_user_from_jwt() == 'some-uuid'
+
+    @patch('ecommerce.enterprise.utils.get_decoded_jwt')
+    def test_get_enterprise_id_for_current_request_user_from_jwt_request_has_jwt_no_context(self, mock_decode_jwt):
+        """
+        Verify get_enterprise_id_for_current_request_user_from_jwt returns None if jwt
+        context is missing
+        """
+        mock_decode_jwt.return_value = {
+            'roles': ['{}'.format(SYSTEM_ENTERPRISE_LEARNER_ROLE)]
+        }
+        assert get_enterprise_id_for_current_request_user_from_jwt() is None
+
+    @patch('ecommerce.enterprise.utils.get_decoded_jwt')
+    def test_get_enterprise_id_for_current_request_user_from_jwt_request_has_jwt_non_learner(self, mock_decode_jwt):
+        """
+        Verify get_enterprise_id_for_current_request_user_from_jwt returns None if
+        user role is incorrect
+        """
+
+        mock_decode_jwt.return_value = {
+            'roles': ['{}:some-uuid'.format(SYSTEM_ENTERPRISE_ADMIN_ROLE)]
+        }
+        assert get_enterprise_id_for_current_request_user_from_jwt() is None
+
+    @patch('ecommerce.enterprise.utils.get_enterprise_id_for_current_request_user_from_jwt')
+    def test_get_enterprise_id_for_user_enterprise_in_jwt(self, mock_get_jwt_uuid):
+        """
+        Verify get_enterprise_id_for_user returns ent id if uuid in jwt context
+        """
+        mock_get_jwt_uuid.return_value = 'my-uuid'
+        assert get_enterprise_id_for_user('some-site', self.learner) == 'my-uuid'
+
+    @patch('ecommerce.enterprise.utils.fetch_enterprise_learner_data')
+    @patch('ecommerce.enterprise.utils.get_enterprise_id_for_current_request_user_from_jwt')
+    def test_get_enterprise_id_for_user_fetch_learner_data_has_uuid(self, mock_get_jwt_uuid, mock_fetch):
+        """
+        Verify get_enterprise_id_for_user returns enterprise id if jwt does not have
+        enterprise uuid, but is able to fetch it via api call
+        """
+        mock_get_jwt_uuid.return_value = None
+        mock_fetch.return_value = {
+            'results': [
+                {
+                    'enterprise_customer': {
+                        'uuid': 'my-uuid'
+                    }
+                }
+            ]
+        }
+        assert get_enterprise_id_for_user('some-site', self.learner) == 'my-uuid'
+
+    @patch('ecommerce.enterprise.utils.fetch_enterprise_learner_data')
+    @patch('ecommerce.enterprise.utils.get_enterprise_id_for_current_request_user_from_jwt')
+    def test_get_enterprise_id_for_user_fetch_errors(self, mock_get_jwt_uuid, mock_fetch):
+        """
+        Verify if that learner data fetch errors, get_enterprise_id_for_user
+        returns None
+        """
+        mock_get_jwt_uuid.return_value = None
+        mock_fetch.side_effect = [KeyError]
+
+        assert get_enterprise_id_for_user('some-site', self.learner) is None
+
+    @patch('ecommerce.enterprise.utils.fetch_enterprise_learner_data')
+    @patch('ecommerce.enterprise.utils.get_enterprise_id_for_current_request_user_from_jwt')
+    def test_get_enterprise_id_for_user_no_uuid_in_response(self, mock_get_jwt_uuid, mock_fetch):
+        """
+        Verify if learner data fetch is successful but does not include uuid field,
+        None is returned
+        """
+        mock_get_jwt_uuid.return_value = None
+        mock_fetch.return_value = {
+            'results': []
+        }
+        assert get_enterprise_id_for_user('some-site', self.learner) is None

--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -7,17 +7,21 @@ import logging
 from collections import OrderedDict
 from urllib import urlencode
 
+import crum
 import waffle
 from django.conf import settings
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 from edx_django_utils.cache import TieredCache
 from edx_rest_api_client.client import EdxRestApiClient
+from edx_rest_framework_extensions.auth.jwt.cookies import get_decoded_jwt
 from oscar.core.loading import get_model
 from requests.exceptions import ConnectionError, Timeout
 from slumber.exceptions import SlumberHttpBaseException
 
+from ecommerce.core.constants import SYSTEM_ENTERPRISE_LEARNER_ROLE
 from ecommerce.core.utils import deprecated_traverse_pagination
+from ecommerce.enterprise.api import fetch_enterprise_learner_data
 from ecommerce.enterprise.exceptions import EnterpriseDoesNotExist
 from ecommerce.extensions.offer.models import OFFER_PRIORITY_ENTERPRISE
 
@@ -444,3 +448,36 @@ def get_enterprise_catalog(site, enterprise_catalog, limit, page):
     TieredCache.set_all_tiers(cache_key, response, settings.CATALOG_RESULTS_CACHE_TIMEOUT)
 
     return response
+
+
+def get_enterprise_id_for_current_request_user_from_jwt():
+    request = crum.get_current_request()
+    decoded_jwt = get_decoded_jwt(request)
+    if decoded_jwt:
+        roles_claim = decoded_jwt.get('roles', [])
+        for role_data in roles_claim:
+            role_in_jwt, __, context_in_jwt = role_data.partition(':')
+            if role_in_jwt == SYSTEM_ENTERPRISE_LEARNER_ROLE and context_in_jwt:
+                return context_in_jwt
+
+    return None
+
+
+def get_enterprise_id_for_user(site, user):
+    enterprise_from_jwt = get_enterprise_id_for_current_request_user_from_jwt()
+    if enterprise_from_jwt:
+        return enterprise_from_jwt
+
+    try:
+        enterprise_learner_response = fetch_enterprise_learner_data(site, user)
+    except (ConnectionError, KeyError, SlumberHttpBaseException, Timeout) as exc:
+        logging.exception('Unable to retrieve enterprise learner data for the user!'
+                          'User: %s, Exception: %s', user, exc)
+        return None
+
+    try:
+        return enterprise_learner_response['results'][0]['enterprise_customer']['uuid']
+    except IndexError:
+        pass
+
+    return None

--- a/ecommerce/extensions/offer/applicator.py
+++ b/ecommerce/extensions/offer/applicator.py
@@ -5,6 +5,7 @@ import waffle
 from oscar.apps.offer.applicator import Applicator
 from oscar.core.loading import get_model
 
+from ecommerce.enterprise.utils import get_enterprise_id_for_user
 from ecommerce.extensions.offer.constants import CUSTOM_APPLICATOR_LOG_FLAG
 
 logger = logging.getLogger(__name__)
@@ -61,12 +62,13 @@ class CustomApplicator(Applicator):
 
         # edX currently does not use user offers or session offers.
         # The default oscar implementations which return [] are here in case edX ever starts using these offers.
+        enterprise_offers = self.get_enterprise_offers(basket.site, user)
         user_offers = self.get_user_offers(user)
         session_offers = self.get_session_offers(request)
 
         return list(
             sorted(
-                chain(session_offers, basket_offers, user_offers, program_offers, site_offers),
+                chain(session_offers, basket_offers, user_offers, program_offers, enterprise_offers, site_offers),
                 key=lambda o: o.priority,
                 reverse=True,
             )
@@ -77,8 +79,27 @@ class CustomApplicator(Applicator):
         Return site offers that are available to baskets without bundle ids.
         """
         ConditionalOffer = get_model('offer', 'ConditionalOffer')
-        qs = ConditionalOffer.active.filter(offer_type=ConditionalOffer.SITE, condition__program_uuid__isnull=True)
+        qs = ConditionalOffer.active.filter(
+            offer_type=ConditionalOffer.SITE,
+            condition__program_uuid__isnull=True,
+            condition__enterprise_customer_uuid__isnull=True,
+        )
         return qs.select_related('condition', 'benefit')
+
+    def get_enterprise_offers(self, site, user):
+        """
+        Return enterprise offers filtered by the user's enterprise, if it exists.
+        """
+        enterprise_id = get_enterprise_id_for_user(site, user)
+        if enterprise_id:
+            ConditionalOffer = get_model('offer', 'ConditionalOffer')
+            offers = ConditionalOffer.active.filter(
+                offer_type=ConditionalOffer.SITE,
+                condition__enterprise_customer_uuid=enterprise_id
+            )
+            return offers.select_related('condition', 'benefit')
+
+        return []
 
     def get_program_offers(self, bundle_attribute):
         """

--- a/ecommerce/extensions/offer/tests/test_applicator.py
+++ b/ecommerce/extensions/offer/tests/test_applicator.py
@@ -1,12 +1,16 @@
+from uuid import uuid4
+
+import ddt
 import mock
 from oscar.core.loading import get_model
 from oscar.test import factories
 from testfixtures import LogCapture
 from waffle.testutils import override_flag
 
+from ecommerce.core.constants import SYSTEM_ENTERPRISE_LEARNER_ROLE
 from ecommerce.extensions.offer.applicator import CustomApplicator
 from ecommerce.extensions.offer.constants import CUSTOM_APPLICATOR_LOG_FLAG
-from ecommerce.extensions.test.factories import ConditionalOfferFactory, ProgramOfferFactory
+from ecommerce.extensions.test.factories import ConditionalOfferFactory, ConditionFactory, ProgramOfferFactory
 from ecommerce.tests.testcases import TestCase
 
 BasketAttribute = get_model('basket', 'BasketAttribute')
@@ -15,6 +19,7 @@ BUNDLE = 'bundle_identifier'
 LOGGER_NAME = 'ecommerce.extensions.offer.applicator'
 
 
+@ddt.ddt
 class CustomApplicatorTests(TestCase):
     """ Tests for the Program Applicator. """
 
@@ -34,7 +39,11 @@ class CustomApplicatorTests(TestCase):
     def assert_correct_offers(self, expected_offers):
         """ Helper to verify applicator returns the expected offers. """
         # No need to pass a request to get_offers since we currently don't support session offers
-        offers = self.applicator.get_offers(self.basket, self.user)
+        with mock.patch('ecommerce.enterprise.utils.get_decoded_jwt') as mock_get_jwt:
+            mock_get_jwt.return_value = {
+                'roles': ['{}:{}'.format(SYSTEM_ENTERPRISE_LEARNER_ROLE, uuid4())]
+            }
+            offers = self.applicator.get_offers(self.basket, self.user)
         self.assertEqual(offers, expected_offers)
 
     def test_get_offers_with_bundle(self):
@@ -97,3 +106,64 @@ class CustomApplicatorTests(TestCase):
             )
 
         self.assertFalse(self.applicator.get_program_offers.called)  # Verify there was no attempt to match off a bundle
+
+    def test_get_site_offers(self):
+        """ Verify get_site_offers returns correct objects based on filter"""
+
+        uuid = uuid4()
+        for _ in range(2):
+            condition = ConditionFactory(
+                program_uuid=None,
+                enterprise_customer_uuid=uuid
+            )
+            ConditionalOfferFactory(condition=condition)
+        for _ in range(3):
+            condition = ConditionFactory(
+                program_uuid=None,
+                enterprise_customer_uuid=None
+            )
+            ConditionalOfferFactory(condition=condition)
+
+        assert self.applicator.get_site_offers().count() == 3
+
+    @ddt.data(
+        (uuid4(), 2),
+        (None, 0),
+    )
+    @ddt.unpack
+    def test_get_enterprise_offers(self, enterprise_id, num_expected_offers):
+        """ Verify get_enterprise_offers returns correct objects based on filter"""
+
+        uuid = enterprise_id or uuid4()
+
+        for _ in range(2):
+            condition = ConditionFactory(
+                program_uuid=None,
+                enterprise_customer_uuid=uuid
+            )
+            ConditionalOfferFactory(condition=condition)
+        for _ in range(3):
+            condition = ConditionFactory(
+                program_uuid=None,
+                enterprise_customer_uuid=None
+            )
+            ConditionalOfferFactory(condition=condition)
+        # Make some condition offers with a uuid other than ours
+        for _ in range(4):
+            condition = ConditionFactory(
+                program_uuid=None,
+                enterprise_customer_uuid=uuid4()
+            )
+            ConditionalOfferFactory(condition=condition)
+
+        with mock.patch('ecommerce.extensions.offer.applicator.get_enterprise_id_for_user') as mock_ent_id:
+            mock_ent_id.return_value = enterprise_id
+            enterprise_offers = self.applicator.get_enterprise_offers(
+                'some-site',
+                self.user
+            )
+
+        if num_expected_offers == 0:
+            assert not enterprise_offers
+        else:
+            assert enterprise_offers.count() == num_expected_offers


### PR DESCRIPTION
This PR changes the CustomApplicator to filter out enterprise site offers when fetching site offers, and grabs them separately by matching on the user's enterprise customer id, if it exists.

Currently we are looping over all of the Enterprise site wide offers which results in us going through redundant logic, and creates noise in the logs. We will cut down on api calls as well with this change.

**Testing Instructions**
This change should have no impact to the user experience beyond possibly faster basket page loads.
As such, the following should be verified:

1. If an enterprise offer is configured for a given enterprise, an enterprise user previously linked to the enterprise should get the offer automatically applied to their basket.
	- Find (or create) a user that is linked to an enterprise.
	- Ensure there is a valid, non-expired enterprise offer for that enterprise: https://ecommerce.stage.edx.org/enterprise/offers
	- Find an enroll-able course in that enterprise’s catalog which has a verified track.
	- Enroll in the verified track for the course.
	- If the enterprise offer is for 100% off, you should bypass the basket page. Otherwise, you should see the offer discount applied in the basket page.

2. If enterprise offer is not configured for a given enterprise, an enterprise user linked to that enterprise should not have any enterprise offers evaluated for them.
	- Find (or create) a user that is linked to an enterprise.
	- Ensure there is either no enterprise offers configured for the given enterprise or, if there is one, ensure it is expired (end date in the past).
	- Find an enroll-able course in that enterprise’s catalog which has a verified track.
	- Enroll in the verified track for the course.
	- The user should end up on basket page with no offer discount applied.

3. If a non-enterprise user purchases a course, they should not have any enterprise offers evaluated for them.
	- Find (or create) a user that is NOT linked to an enterprise.
	- Ensure there is a valid, non-expired enterprise offer for that enterprise: https://ecommerce.stage.edx.org/enterprise/offers
	- Find an enroll-able course in that enterprise’s catalog which has a verified track.
	- Enroll in the verified track for course.
	- The user should end up on basket page with no offer discount applied.

4. If a user (linked or not to an enterprise) attempts to redeem a valid enterprise coupon, they should be able to successfully do so.
	- Find (or create) a user that is NOT linked to an enterprise.
	- Find an enroll-able course in that enterprise’s catalog which has a verified track.
	- Enroll in the verified track for the course.
	- The user should end up on basket page with no offer discount applied.
	- Enter in a valid coupon code for an enterprise. I found this by viewing the Code Management page of edx-portal to get a coupon code for Pied Piper.
	- If the coupon code is for an offer with 100% off, you should bypass the checkout process and be enrolled in the verified track. Otherwise, you should see the offer discount applied in the basket page.

Also, just FYI: Finding courses on stage that will work is kind of a pain. For your convenience, here's the course I was testing with: https://stage.edx.org/course/next-generation-infrastructure-delftx-ngix-1