### PR TITLE
WL-1924 | Enterprise Coupon showing incorrect benefit type

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -35,6 +35,7 @@ from ecommerce.extensions.offer.constants import (
     OFFER_REDEEMED
 )
 from ecommerce.extensions.offer.utils import (
+    get_benefit_type,
     send_assigned_offer_email,
     send_assigned_offer_reminder_email,
     send_revoked_offer_email
@@ -642,10 +643,14 @@ class CatalogSerializer(serializers.ModelSerializer):
 
 class BenefitSerializer(serializers.ModelSerializer):
     value = serializers.IntegerField()
+    type = serializers.SerializerMethodField()
 
     class Meta(object):
         model = Benefit
         fields = ('type', 'value')
+
+    def get_type(self, benefit):
+        return get_benefit_type(benefit)
 
 
 class VoucherSerializer(serializers.ModelSerializer):

--- a/ecommerce/extensions/api/v2/tests/views/test_vouchers.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_vouchers.py
@@ -25,6 +25,7 @@ from ecommerce.enterprise.constants import ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH
 from ecommerce.extensions.api import serializers
 from ecommerce.extensions.api.v2.views.vouchers import VoucherViewSet
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
+from ecommerce.extensions.offer.utils import get_benefit_type
 from ecommerce.extensions.partner.strategy import DefaultStrategy
 from ecommerce.extensions.test.factories import (
     ConditionalOfferFactory,
@@ -415,7 +416,7 @@ class VoucherViewOffersEndpointTests(DiscoveryMockMixin, CouponMixin, DiscoveryT
         self.assertEqual(len(offers), 1)
         self.assertDictEqual(first_offer, {
             'benefit': {
-                'type': benefit.type,
+                'type': get_benefit_type(benefit),
                 'value': benefit.value
             },
             'contains_verified': True,
@@ -448,7 +449,7 @@ class VoucherViewOffersEndpointTests(DiscoveryMockMixin, CouponMixin, DiscoveryT
         self.assertEqual(len(offers), 1)
         self.assertDictEqual(first_offer, {
             'benefit': {
-                'type': benefit.type,
+                'type': get_benefit_type(benefit),
                 'value': benefit.value
             },
             'contains_verified': True,
@@ -488,7 +489,7 @@ class VoucherViewOffersEndpointTests(DiscoveryMockMixin, CouponMixin, DiscoveryT
         self.assertEqual(len(offers), 1)
         self.assertDictEqual(first_offer, {
             'benefit': {
-                'type': benefit.type,
+                'type': get_benefit_type(benefit),
                 'value': benefit.value
             },
             'contains_verified': True,
@@ -526,7 +527,7 @@ class VoucherViewOffersEndpointTests(DiscoveryMockMixin, CouponMixin, DiscoveryT
         self.assertEqual(len(offers), 1)
         self.assertDictEqual(first_offer, {
             'benefit': {
-                'type': benefit.type,
+                'type': get_benefit_type(benefit),
                 'value': benefit.value
             },
             'contains_verified': True,
@@ -585,7 +586,7 @@ class VoucherViewOffersEndpointTests(DiscoveryMockMixin, CouponMixin, DiscoveryT
         self.assertEqual(len(offers), 1)
         self.assertDictEqual(first_offer, {
             'benefit': {
-                'type': benefit.type,
+                'type': get_benefit_type(benefit),
                 'value': benefit.value
             },
             'contains_verified': True,
@@ -628,7 +629,7 @@ class VoucherViewOffersEndpointTests(DiscoveryMockMixin, CouponMixin, DiscoveryT
 
         self.assertDictEqual(offer, {
             'benefit': {
-                'type': benefit.type,
+                'type': get_benefit_type(benefit),
                 'value': benefit.value
             },
             'contains_verified': True,
@@ -702,7 +703,7 @@ class VoucherViewOffersEndpointTests(DiscoveryMockMixin, CouponMixin, DiscoveryT
             response.data['results'],
             [{
                 'benefit': {
-                    'type': benefit.type,
+                    'type': get_benefit_type(benefit),
                     'value': benefit.value
                 },
                 'contains_verified': True,

--- a/ecommerce/extensions/offer/templatetags/offer_tags.py
+++ b/ecommerce/extensions/offer/templatetags/offer_tags.py
@@ -1,6 +1,6 @@
 from django import template
 
-from ecommerce.extensions.offer.utils import format_benefit_value
+from ecommerce.extensions.offer.utils import format_benefit_value, get_benefit_type
 
 register = template.Library()
 
@@ -25,9 +25,4 @@ def benefit_discount(benefit):
 
 @register.filter(name='benefit_type')
 def benefit_type(benefit):
-    _type = benefit.type
-
-    if not _type:
-        _type = getattr(benefit.proxy(), 'benefit_class_type', None)
-
-    return _type
+    return get_benefit_type(benefit)

--- a/ecommerce/extensions/offer/tests/test_templatetags.py
+++ b/ecommerce/extensions/offer/tests/test_templatetags.py
@@ -12,7 +12,7 @@ from ecommerce.tests.testcases import TestCase
 Benefit = get_model('offer', 'Benefit')
 
 
-@ddt.data
+@ddt.ddt
 class OfferTests(TestCase):
     def test_benefit_discount(self):
         benefit = BenefitFactory(type=Benefit.PERCENTAGE, value=35.00)
@@ -25,7 +25,6 @@ class OfferTests(TestCase):
     @ddt.data(
         ({'type': Benefit.PERCENTAGE}, Benefit.PERCENTAGE),
         ({'type': Benefit.FIXED}, Benefit.FIXED),
-        ({'type': ''}, None),
         ({'type': '', 'proxy_class': class_path(PercentageDiscountBenefitWithoutRange)}, Benefit.PERCENTAGE),
         ({'type': '', 'proxy_class': class_path(AbsoluteDiscountBenefitWithoutRange)}, Benefit.FIXED),
         ({'type': '', 'proxy_class': class_path(EnterprisePercentageDiscountBenefit)}, Benefit.PERCENTAGE),

--- a/ecommerce/extensions/offer/utils.py
+++ b/ecommerce/extensions/offer/utils.py
@@ -51,6 +51,16 @@ def get_discount_value(discount_percentage, product_price):
     return discount_percentage * product_price / 100.0
 
 
+def get_benefit_type(benefit):
+    """ Returns type of benefit using 'type' or 'proxy_class' attributes of Benefit object"""
+    _type = benefit.type
+
+    if not _type:
+        _type = getattr(benefit.proxy(), 'benefit_class_type', None)
+
+    return _type
+
+
 def format_benefit_value(benefit):
     """
     Format benefit value for display based on the benefit type
@@ -62,7 +72,7 @@ def format_benefit_value(benefit):
         benefit_value (str): String value containing formatted benefit value and type.
     """
     benefit_value = _remove_exponent_and_trailing_zeros(Decimal(str(benefit.value)))
-    benefit_type = benefit.type or getattr(benefit.proxy(), 'benefit_class_type', None)
+    benefit_type = get_benefit_type(benefit)
 
     if benefit_type == Benefit.PERCENTAGE:
         benefit_value = _('{benefit_value}%'.format(benefit_value=benefit_value))

--- a/ecommerce/extensions/voucher/utils.py
+++ b/ecommerce/extensions/voucher/utils.py
@@ -26,7 +26,7 @@ from ecommerce.enterprise.utils import get_enterprise_customer
 from ecommerce.extensions.api import exceptions
 from ecommerce.extensions.offer.constants import OFFER_MAX_USES_DEFAULT
 from ecommerce.extensions.offer.models import OFFER_PRIORITY_VOUCHER
-from ecommerce.extensions.offer.utils import get_discount_percentage, get_discount_value
+from ecommerce.extensions.offer.utils import get_benefit_type, get_discount_percentage, get_discount_value
 from ecommerce.invoice.models import Invoice
 from ecommerce.programs.conditions import ProgramCourseRunSeatsCondition
 from ecommerce.programs.constants import BENEFIT_MAP
@@ -156,7 +156,7 @@ def _get_info_for_coupon_report(coupon, voucher):
         discount_data = get_voucher_discount_info(benefit, seat_stockrecord.price_excl_tax)
         coupon_type, discount_percentage, discount_amount = _get_discount_info(discount_data)
     else:
-        benefit_type = benefit.type or getattr(benefit.proxy(), 'benefit_class_type', None)
+        benefit_type = get_benefit_type(benefit)
 
         if benefit_type == Benefit.PERCENTAGE:
             coupon_type = _('Discount') if benefit.value < 100 else _('Enrollment')
@@ -864,9 +864,7 @@ def update_voucher_with_enterprise_offer(offer, benefit_value, enterprise_custom
     """
     return get_or_create_enterprise_offer(
         benefit_value=benefit_value or offer.benefit.value,
-        benefit_type=benefit_type or offer.benefit.type or getattr(
-            offer.benefit.proxy(), 'benefit_class_type', None
-        ),
+        benefit_type=benefit_type or get_benefit_type(offer.benefit),
         enterprise_customer=enterprise_customer or offer.condition.enterprise_customer_uuid,
         enterprise_customer_catalog=enterprise_catalog or offer.condition.enterprise_customer_catalog_uuid,
         offer_name=offer.name,
@@ -900,9 +898,7 @@ def update_voucher_offer(offer, benefit_value, benefit_type=None, max_uses=None,
     return _get_or_create_offer(
         product_range=offer.benefit.range,
         benefit_value=benefit_value or offer.benefit.value,
-        benefit_type=benefit_type or offer.benefit.type or getattr(
-            offer.benefit.proxy(), 'benefit_class_type', None
-        ),
+        benefit_type=benefit_type or get_benefit_type(offer.benefit),
         offer_name=offer.name,
         max_uses=max_uses,
         email_domains=email_domains,


### PR DESCRIPTION
PR Includes:
Fixed => Enterprise Coupon showing incorrect benefit type on https://ecommerce.edx.org/coupons/offer/?code=xxxxxxxxxxxxxxx
fixed => ecommerce.extensions.offer.tests.test_templatetags.OfferTests
some other refactoring related to benefit type
 