### PR TITLE
Add polyfill for Number.inInteger()

### DIFF
--- a/ecommerce/static/js/pages/basket_page.js
+++ b/ecommerce/static/js/pages/basket_page.js
@@ -132,6 +132,15 @@ define([
 
                 cardType = CreditCardUtils.getCreditCardType(cardNumber);
 
+
+                // Number.isInteger() is not compatible with IE11, so polyfill is required. Polyfill taken from:
+                // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger
+                Number.isInteger = Number.isInteger || function(value) {
+                    return typeof value === 'number' &&
+                        isFinite(value) &&
+                        Math.floor(value) === value;
+                };
+
                 if (!CreditCardUtils.isValidCardNumber(cardNumber)) {
                     BasketPage.appendCardValidationErrorMsg(event, $number, gettext('Invalid card number'));
                 } else if (_.isUndefined(cardType) || !BasketPage.isCardTypeSupported(cardType.name)) {


### PR DESCRIPTION
Number.isInteger() is used in the validation step on basket page. isInteger() is not supported in IE11. To the end user, this results in the validation error not being shown when a non-number is entered in the CVN or expiry fields but the form not being submitted which is quite confusing. 

##### Notes:
* Added a polyfill for isInteger()

[LEARNER-6821](https://openedx.atlassian.net/browse/LEARNER-6821)