### PR TITLE
ENT-1853 Part 1: Populate enterprise id in a product attribute for the coupon

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -527,6 +527,7 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         self.assertEqual(response_data['id'], self.coupon.id)
         self.assertEqual(response_data['enterprise_customer'], enterprise_customer_id)
         new_coupon = Product.objects.get(id=self.coupon.id)
+        self.assertEqual(new_coupon.attr.enterprise_customer_uuid, enterprise_customer_id)
         self._check_enterprise_fields(new_coupon, enterprise_customer_id, enterprise_catalog_id, enterprise_name)
 
     def test_update_enterprise_offers_switch_off_duplicate_condition(self):
@@ -565,6 +566,7 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         self.assertEqual(response_data['id'], self.coupon.id)
         self.assertEqual(response_data['enterprise_customer'], enterprise_customer_id)
         new_coupon = Product.objects.get(id=self.coupon.id)
+        self.assertEqual(new_coupon.attr.enterprise_customer_uuid, enterprise_customer_id)
         self._check_enterprise_fields(new_coupon, enterprise_customer_id, enterprise_catalog_id, enterprise_name)
 
     def test_create_enterprise_offers_switch_on(self):
@@ -590,6 +592,7 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             }
         )
         new_coupon = Product.objects.get(id=self.coupon.id)
+        self.assertEqual(new_coupon.attr.enterprise_customer_uuid, enterprise_customer_id)
         self._check_enterprise_fields(new_coupon, enterprise_customer_id, enterprise_catalog_id, 'test enterprise')
 
     def test_update_enterprise_offers_enterprise_coupon_switch_on(self):

--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -288,6 +288,7 @@ class EnterpriseCouponViewSetTest(
         enterprise_customer_id = self.data['enterprise_customer']['id']
         enterprise_name = self.data['enterprise_customer']['name']
         enterprise_catalog_id = self.data['enterprise_customer_catalog']
+        self.assertEqual(coupon.attr.enterprise_customer_uuid, enterprise_customer_id)
         vouchers = coupon.attr.coupon_vouchers.vouchers.all()
         for voucher in vouchers:
             all_offers = voucher.offers.all()
@@ -366,6 +367,7 @@ class EnterpriseCouponViewSetTest(
             'PUT',
             reverse('api:v2:enterprise-coupons-detail', kwargs={'pk': coupon.id}),
             data={
+                'enterprise_customer': self.data['enterprise_customer'],
                 'enterprise_customer_catalog': new_catalog,
                 'benefit_value': 50,
                 'title': 'Updated Enterprise Coupon',
@@ -373,6 +375,7 @@ class EnterpriseCouponViewSetTest(
         )
         updated_coupon = Product.objects.get(title='Updated Enterprise Coupon')
         self.assertEqual(coupon.id, updated_coupon.id)
+        self.assertEqual(updated_coupon.attr.enterprise_customer_uuid, self.data['enterprise_customer']['id'])
         vouchers = updated_coupon.attr.coupon_vouchers.vouchers.all()
         for voucher in vouchers:
             all_offers = voucher.offers.all()

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -452,6 +452,8 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
                 defaults={'enterprise_customer_uuid': enterprise_customer}
             )
             Invoice.objects.filter(order__basket=baskets.first()).update(business_client=client)
+            coupon.attr.enterprise_customer_uuid = enterprise_customer
+            coupon.save()
 
         coupon_price = request_data.get('price')
         if coupon_price:

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -135,7 +135,8 @@ class EnterpriseCouponViewSet(CouponViewSet):
             coupon_product,
             vouchers,
             cleaned_voucher_data['note'],
-            cleaned_voucher_data.get('notify_email')
+            cleaned_voucher_data.get('notify_email'),
+            cleaned_voucher_data['enterprise_customer']
         )
         return coupon_product
 

--- a/ecommerce/extensions/catalogue/management/commands/populate_enterprise_id_product_attribute.py
+++ b/ecommerce/extensions/catalogue/management/commands/populate_enterprise_id_product_attribute.py
@@ -1,0 +1,72 @@
+"""
+This command change priority of conditional offers.
+"""
+from __future__ import unicode_literals
+
+import logging
+
+from django.core.management import BaseCommand
+from oscar.core.loading import get_model
+
+from ecommerce.core.constants import COUPON_PRODUCT_CLASS_NAME
+
+ConditionalOffer = get_model('offer', 'ConditionalOffer')
+Product = get_model('catalogue', 'Product')
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Populate enterprise_id for coupon products.
+
+    Example:
+
+        ./manage.py change_priority_of_offers
+    """
+
+    help = "Populate enterprise_id for coupon products."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--offset',
+            dest='offset',
+            default=0,
+            help='index to start from.',
+            type=int,
+        )
+        parser.add_argument(
+            '--limit',
+            dest='limit',
+            default=100,
+            help='Number of coupons to update.',
+            type=int,
+        )
+
+    def handle(self, *args, **options):
+        limit = options['limit']
+        offset = options['offset']
+
+        try:
+            coupon_products = Product.objects.filter(
+                product_class__name=COUPON_PRODUCT_CLASS_NAME,
+                coupon_vouchers__vouchers__offers__condition__enterprise_customer_uuid__isnull=False,
+            ).distinct().order_by('id')
+
+            count = coupon_products.count()
+            logger.info('Found %d coupon products to update.', count)
+
+            while offset < count:
+                coupon_product_batch = coupon_products[offset:offset + limit]
+                logger.info('Processing batch from index %d to %d', offset, offset + limit)
+                for coupon in coupon_product_batch:
+                    vouchers = coupon.attr.coupon_vouchers.vouchers
+                    enterprise_id = vouchers.first().enterprise_offer.condition.enterprise_customer_uuid
+                    coupon.attr.enterprise_customer_uuid = str(enterprise_id)
+                    coupon.save()
+                    logger.info('Setting enterprise id product attribute for Product %d to value %s',
+                                coupon.id, enterprise_id)
+
+                offset += limit
+
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.exception('Command execution failed while executing batch %d,%d\n%s', offset, limit, exc)

--- a/ecommerce/extensions/catalogue/management/commands/tests/test_populate_enterprise_id_product_attribute.py
+++ b/ecommerce/extensions/catalogue/management/commands/tests/test_populate_enterprise_id_product_attribute.py
@@ -1,0 +1,126 @@
+import uuid
+
+from django.core.management import call_command
+from oscar.core.loading import get_model
+from testfixtures import LogCapture
+
+from ecommerce.coupons.tests.mixins import CouponMixin
+from ecommerce.tests.testcases import TestCase
+
+Product = get_model('catalogue', 'Product')
+LOGGER_NAME = 'ecommerce.extensions.catalogue.management.commands.populate_enterprise_id_product_attribute'
+
+
+class PopulateEnterpriseIDProductAttributeTests(TestCase, CouponMixin):
+    """Tests for populate_enterprise_id_product_attribute management command."""
+
+    def test_no_coupons_found(self):
+        """Test that command logs no offer needs to be changed."""
+        with LogCapture(LOGGER_NAME) as log:
+            call_command('populate_enterprise_id_product_attribute')
+            log.check(
+                (
+                    LOGGER_NAME,
+                    'INFO',
+                    'Found 0 coupon products to update.'
+                )
+            )
+
+    def test_populate_enterprise_id_product_attribute(self):
+        """Test that command populates the enterprise id product attribute."""
+        enterprise_id = str(uuid.uuid4())
+        coupon = self.create_coupon(enterprise_customer=enterprise_id)
+        expected = [
+            (
+                LOGGER_NAME,
+                'INFO',
+                'Found 1 coupon products to update.'
+            ),
+            (
+                LOGGER_NAME,
+                'INFO',
+                'Processing batch from index 0 to 100'
+            ),
+            (
+                LOGGER_NAME,
+                'INFO',
+                'Setting enterprise id product attribute for Product {} to value {}'.format(coupon.id, enterprise_id)
+            ),
+        ]
+
+        with LogCapture(LOGGER_NAME) as log:
+            call_command('populate_enterprise_id_product_attribute')
+            log.check(*expected)
+
+        coupon = Product.objects.get(id=coupon.id)
+        assert coupon.attr.enterprise_customer_uuid == enterprise_id
+
+    def test_populate_enterprise_id_product_attribute_in_batches(self):
+        """Test that command populates enterprise id product attribute in batches."""
+        coupon_count = 10
+        coupon_ids = []
+        enterprise_ids = []
+        log_messages = []
+        for idx in range(coupon_count):
+            enterprise_id = str(uuid.uuid4())
+            coupon = self.create_coupon(title='Test Coupon {}'.format(idx), enterprise_customer=enterprise_id)
+            coupon_ids.append(coupon.id)
+            enterprise_ids.append(enterprise_id)
+            log_messages.append(
+                (
+                    LOGGER_NAME,
+                    'INFO',
+                    'Setting enterprise id product attribute for Product {} to value {}'.format(
+                        coupon.id, enterprise_id)
+                )
+            )
+
+        expected = [
+            (
+                LOGGER_NAME,
+                'INFO',
+                'Found {} coupon products to update.'.format(coupon_count)
+            ),
+            (
+                LOGGER_NAME,
+                'INFO',
+                'Processing batch from index 0 to 5'
+            ),
+        ]
+        expected.extend(log_messages[:5])
+        expected.append(
+            (
+                LOGGER_NAME,
+                'INFO',
+                'Processing batch from index 5 to 10'
+            ),
+        )
+        expected.extend(log_messages[5:])
+
+        with LogCapture(LOGGER_NAME) as log:
+            call_command('populate_enterprise_id_product_attribute', limit=5)
+            log.check(*expected)
+
+        for idx in range(coupon_count):
+            coupon = Product.objects.get(id=coupon_ids[idx])
+            assert coupon.attr.enterprise_customer_uuid == enterprise_ids[idx]
+
+    def test_populate_enterprise_id_product_attribute_with_exception(self):
+        """Test that command with exception."""
+        self.create_coupon(enterprise_customer=str(uuid.uuid4()))
+        expected = [
+            (
+                LOGGER_NAME,
+                'INFO',
+                'Found 1 coupon products to update.'
+            ),
+            (
+                LOGGER_NAME,
+                'ERROR',
+                'Command execution failed while executing batch -1,10\nNegative indexing is not supported.'
+            )
+        ]
+
+        with LogCapture(LOGGER_NAME) as log:
+            call_command('populate_enterprise_id_product_attribute', offset=-1, limit=10)
+            log.check(*expected)

--- a/ecommerce/extensions/catalogue/migrations/0038_coupon_enterprise_id_attribute.py
+++ b/ecommerce/extensions/catalogue/migrations/0038_coupon_enterprise_id_attribute.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from oscar.core.loading import get_model
+
+from ecommerce.core.constants import COUPON_PRODUCT_CLASS_NAME
+
+ProductAttribute = get_model("catalogue", "ProductAttribute")
+ProductClass = get_model("catalogue", "ProductClass")
+
+
+def create_enterprise_id_attribute(apps, schema_editor):
+    """Create coupon enterprise_customer_uuid attribute."""
+    coupon = ProductClass.objects.get(name=COUPON_PRODUCT_CLASS_NAME)
+    ProductAttribute.objects.create(
+        product_class=coupon,
+        name='Enterprise Customer UUID',
+        code='enterprise_customer_uuid',
+        type='text',
+        required=False
+    )
+
+
+def remove_enterprise_id_attribute(apps, schema_editor):
+    """Remove coupon enterprise_customer_uuid attribute."""
+    coupon = ProductClass.objects.get(name=COUPON_PRODUCT_CLASS_NAME)
+    ProductAttribute.objects.get(product_class=coupon, code='enterprise_customer_uuid').delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('catalogue', '0037_add_sec_disc_reward_coupon_category')
+    ]
+    operations = [
+        migrations.RunPython(create_enterprise_id_attribute, remove_enterprise_id_attribute)
+    ]

--- a/ecommerce/extensions/catalogue/utils.py
+++ b/ecommerce/extensions/catalogue/utils.py
@@ -130,13 +130,15 @@ def create_coupon_product_and_stockrecord(title, category, partner, price):
     return coupon_product
 
 
-def attach_vouchers_to_coupon_product(coupon_product, vouchers, note, notify_email=None):
+def attach_vouchers_to_coupon_product(coupon_product, vouchers, note, notify_email=None, enterprise_id=None):
     coupon_vouchers, __ = CouponVouchers.objects.get_or_create(coupon=coupon_product)
     coupon_vouchers.vouchers.add(*vouchers)
     coupon_product.attr.coupon_vouchers = coupon_vouchers
     coupon_product.attr.note = note
     if notify_email:
         coupon_product.attr.notify_email = notify_email
+    if enterprise_id:
+        coupon_product.attr.enterprise_customer_uuid = enterprise_id
     coupon_product.save()
 
 


### PR DESCRIPTION
This PR introduces a new attribute on the Coupon Product for storing enterprise id. It also migrates existing coupon products with enterprise ids to set this attribute, and updates the update and create paths related to enterprise id on coupons to set the attribute.

The next part, which will come in a separate PR, will switch the query sets filtering coupons for the regular and enterprise coupon screens to use this field instead of a combination of the condition and the business client. The way the querysets are for the two screens are inconsistent with each other in a way that is leading to this bug. Additionally, we'll remove the business client enterprise id updating logic, which is causing the data condition that makes the query inconsistency lead to some coupons not displaying on either screen.