### PR TITLE
ENT-1853 Part 2: Change querysets for filtering coupons for each admin screen

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -463,7 +463,6 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         basket = Basket.objects.filter(lines__product_id=coupon.id).first()
         invoice = Invoice.objects.get(order__basket=basket)
         self.assertEqual(invoice.business_client.name, enterprise_name)
-        self.assertEqual(str(invoice.business_client.enterprise_customer_uuid), enterprise_customer_id)
 
     def test_list_coupons_with_enterprise_data(self):
         """The list endpoint should filter enterprise coupons depending on the enterprise offers switch."""

--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -306,7 +306,6 @@ class EnterpriseCouponViewSetTest(
         basket = Basket.objects.filter(lines__product_id=coupon.id).first()
         invoice = Invoice.objects.get(order__basket=basket)
         self.assertEqual(invoice.business_client.name, enterprise_name)
-        self.assertEqual(str(invoice.business_client.enterprise_customer_uuid), enterprise_customer_id)
 
     def test_update_ent_offers_switch_off(self):
         Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': True})
@@ -2001,7 +2000,6 @@ class EnterpriseCouponViewSetRbacTests(
         basket = Basket.objects.filter(lines__product_id=coupon.id).first()
         invoice = Invoice.objects.get(order__basket=basket)
         self.assertEqual(invoice.business_client.name, enterprise_name)
-        self.assertEqual(str(invoice.business_client.enterprise_customer_uuid), enterprise_customer_id)
 
     def test_update_ent_offers_switch_off(self):
         Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': True})
@@ -2577,21 +2575,6 @@ class EnterpriseCouponViewSetRbacTests(
             '/api/v2/enterprise/coupons/{}/codes/?code_filter={}'.format(coupon.id, VOUCHER_NOT_ASSIGNED)
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-    def test_implicit_permission_codes_detail_no_invoice(self):
-        """
-        Test that we get access denied when invoice not found
-        """
-        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': True})
-        self.get_response('POST', ENTERPRISE_COUPONS_LINK, self.data)
-        coupon = Product.objects.get(title=self.data['title'])
-        Invoice.objects.all().delete()
-        EcommerceFeatureRoleAssignment.objects.all().delete()
-        response = self.get_response(
-            'GET',
-            '/api/v2/enterprise/coupons/{}/codes/?code_filter={}'.format(coupon.id, VOUCHER_NOT_ASSIGNED)
-        )
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_implicit_permission_incorrect_role(self):
         """

--- a/ecommerce/extensions/api/v2/utils.py
+++ b/ecommerce/extensions/api/v2/utils.py
@@ -6,11 +6,9 @@ from django.core.mail import send_mail
 from oscar.core.loading import get_model
 
 from ecommerce.enterprise.utils import get_enterprise_customer
-from ecommerce.invoice.models import Invoice
 
 logger = logging.getLogger(__name__)
 
-Basket = get_model('basket', 'Basket')
 Product = get_model('catalogue', 'Product')
 
 
@@ -54,8 +52,6 @@ def get_enterprise_from_product(product_id):
     """
     try:
         product = Product.objects.get(pk=product_id)
-        basket = Basket.objects.filter(lines__product_id=product.id).first()
-        invoice = Invoice.objects.get(order__basket=basket)
-        return str(invoice.business_client.enterprise_customer_uuid)
-    except (Product.DoesNotExist, Invoice.DoesNotExist):
+        return product.attr.enterprise_customer_uuid
+    except Product.DoesNotExist:
         return None

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -65,7 +65,7 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
         # in the regular coupon list view
         if waffle.switch_is_active(ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH):
             return product_filter.exclude(
-                coupon_vouchers__vouchers__offers__condition__enterprise_customer_uuid__isnull=False,
+                attributes__code='enterprise_customer_uuid',
             )
 
         return product_filter
@@ -119,7 +119,6 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
                 # Create an order now since payment is handled out of band via an invoice.
                 client, __ = BusinessClient.objects.update_or_create(
                     name=cleaned_voucher_data['enterprise_customer_name'] or request.data.get('client'),
-                    defaults={'enterprise_customer_uuid': cleaned_voucher_data['enterprise_customer']}
                 )
                 invoice_data = self.create_update_data_dict(data=request.data, fields=Invoice.UPDATEABLE_INVOICE_FIELDS)
                 response_data = self.create_order_for_invoice(
@@ -449,7 +448,6 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
         if client_username or enterprise_customer:
             client, __ = BusinessClient.objects.update_or_create(
                 name=enterprise_customer_name or client_username,
-                defaults={'enterprise_customer_uuid': enterprise_customer}
             )
             Invoice.objects.filter(order__basket=baskets.first()).update(business_client=client)
             coupon.attr.enterprise_customer_uuid = enterprise_customer

--- a/ecommerce/extensions/catalogue/utils.py
+++ b/ecommerce/extensions/catalogue/utils.py
@@ -108,7 +108,7 @@ def create_coupon_product(
         logger.exception('Failed to create vouchers for [%s] coupon.', coupon_product.title)
         raise
 
-    attach_vouchers_to_coupon_product(coupon_product, vouchers, note)
+    attach_vouchers_to_coupon_product(coupon_product, vouchers, note, enterprise_id=enterprise_customer)
 
     return coupon_product
 


### PR DESCRIPTION
Depends on https://github.com/edx/ecommerce/pull/2231, has to be released separately.

This PR switchES the query sets filtering coupons for the regular and enterprise coupon screens to use the new enterprise id product attribute instead of a combination of the condition and the business client. The way the querysets are for the two screens are inconsistent with each other in a way that is leading to this bug. Additionally, we'll remove the business client enterprise id updating logic, which is causing the data condition that makes the query inconsistency lead to some coupons not displaying on either screen.