### PR TITLE
Fix enterprise coupons tab pagination.

### DIFF
--- a/ecommerce/extensions/api/pagination.py
+++ b/ecommerce/extensions/api/pagination.py
@@ -1,9 +1,14 @@
-from rest_framework import pagination
+from edx_rest_framework_extensions.paginators import DefaultPagination
+from rest_framework_datatables.pagination import DatatablesPageNumberPagination
 
 
-class PageNumberPagination(pagination.PageNumberPagination):
+class PageNumberPagination(DatatablesPageNumberPagination):
     page_size_query_param = 'page_size'
 
     # NOTE (CCB): This is a hack, necessary until the frontend
     # can properly follow our paginated lists.
     max_page_size = 10000
+
+
+class DatatablesDefaultPagination(DefaultPagination, PageNumberPagination):
+    pass

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -6,7 +6,6 @@ import waffle
 from django.core.exceptions import ValidationError
 from django.shortcuts import get_object_or_404
 from edx_rbac.decorators import permission_required
-from edx_rest_framework_extensions.paginators import DefaultPagination
 from oscar.core.loading import get_model
 from rest_framework import generics, serializers, status
 from rest_framework.decorators import detail_route, list_route
@@ -17,6 +16,7 @@ from ecommerce.core.constants import COUPON_PRODUCT_CLASS_NAME
 from ecommerce.core.utils import log_message_and_raise_validation_error
 from ecommerce.enterprise.constants import ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH
 from ecommerce.enterprise.utils import get_enterprise_customers
+from ecommerce.extensions.api.pagination import DatatablesDefaultPagination
 from ecommerce.extensions.api.permissions import HasDataAPIDjangoGroupAccess
 from ecommerce.extensions.api.serializers import (
     CouponCodeAssignmentSerializer,
@@ -73,7 +73,7 @@ class EnterpriseCustomerViewSet(generics.GenericAPIView):
 
 class EnterpriseCouponViewSet(CouponViewSet):
     """ Coupon resource. """
-    pagination_class = DefaultPagination
+    pagination_class = DatatablesDefaultPagination
 
     def get_queryset(self):
         filter_kwargs = {

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -479,7 +479,7 @@ REST_FRAMEWORK = {
         'ecommerce.extensions.api.authentication.BearerAuthentication',
         'rest_framework.authentication.SessionAuthentication',
     ),
-    'DEFAULT_PAGINATION_CLASS': 'rest_framework_datatables.pagination.DatatablesPageNumberPagination',
+    'DEFAULT_PAGINATION_CLASS': 'ecommerce.extensions.api.pagination.PageNumberPagination',
     'PAGE_SIZE': 20,
     'DEFAULT_THROTTLE_CLASSES': (
         'rest_framework.throttling.UserRateThrottle',


### PR DESCRIPTION
Before we were using custom DefaultPagination class from `edx-drf-extensions` which wasn't allowing datatables pagination to work correctly, created a custom pagination class by inheriting `DefaultPagination` and `DatatablesPageNumberPagination`.