### PR TITLE
Adding more thorough logging of VoucherAddView

### DIFF
--- a/ecommerce/enterprise/tests/test_conditions.py
+++ b/ecommerce/enterprise/tests/test_conditions.py
@@ -195,6 +195,15 @@ class EnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, DiscoveryTest
         offer, basket = self.setup_enterprise_coupon_data(mock_learner_api=False)
         self.assertTrue(self.condition.is_satisfied(offer, basket))
 
+    @httpretty.activate
+    def test_is_satisfied_no_course_product_for_voucher_offer(self):
+        """ Ensure the condition returns false if the basket contains a product not associated with a course run. """
+        Switch.objects.update_or_create(name=ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH, defaults={'active': True})
+        offer, basket = self.setup_enterprise_coupon_data()
+        basket.flush()
+        basket.add_product(self.test_product)
+        self.assertFalse(self.condition.is_satisfied(offer, basket))
+
     def test_is_satisfied_empty_basket(self):
         """ Ensure the condition returns False if the basket is empty. """
         offer = factories.EnterpriseOfferFactory(partner=self.partner, condition=self.condition)

--- a/ecommerce/extensions/basket/tests/test_views.py
+++ b/ecommerce/extensions/basket/tests/test_views.py
@@ -763,7 +763,9 @@ class VoucherAddViewTests(LmsApiMockMixin, TestCase):
         self.basket.add_product(product)
         order = factories.OrderFactory()
         VoucherApplication.objects.create(voucher=voucher, user=self.user, order=order)
-        self.assert_form_valid_message("Coupon code '{code}' has already been redeemed.".format(code=COUPON_CODE))
+        self.assert_form_valid_message(
+            "Coupon code '{code}' is not available. This coupon has already been used".format(code=COUPON_CODE)
+        )
 
     def test_voucher_valid_without_site(self):
         """ Verify coupon works when the sites on the coupon and request are the same. """
@@ -796,7 +798,9 @@ class VoucherAddViewTests(LmsApiMockMixin, TestCase):
             attribute_type=BasketAttributeType.objects.get(name=BUNDLE),
             value_text='test_bundle'
         )
-        self.assert_form_valid_message("Coupon code '{code}' is not valid for this basket.".format(code=voucher.code))
+        self.assert_form_valid_message(
+            "Coupon code '{code}' is not valid for this basket for a bundled purchase.".format(code=voucher.code)
+        )
 
     def test_multi_use_voucher_valid_for_bundle(self):
         """ Verify multi use coupon works when voucher is used against a bundle. """

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -448,9 +448,12 @@ class VoucherAddView(BaseVoucherAddView):  # pylint: disable=function-redefined
         Validates and applies voucher on basket.
         """
         self.request.basket.clear_vouchers()
-
+        username = self.request.user and self.request.user.username
         is_valid, message = validate_voucher(voucher, self.request.user, self.request.basket, self.request.site)
         if not is_valid:
+            logger.warning('[Code Redemption Failure] The voucher is not valid for this basket. '
+                           'User: %s, Basket: %s, Code: %s, Message: %s',
+                           username, self.request.basket.id, voucher.code, message)
             messages.error(self.request, message)
             self.request.basket.vouchers.remove(voucher)
             return
@@ -458,6 +461,9 @@ class VoucherAddView(BaseVoucherAddView):  # pylint: disable=function-redefined
         valid, msg = apply_voucher_on_basket_and_check_discount(voucher, self.request, self.request.basket)
 
         if not valid:
+            logger.warning('[Code Redemption Failure] The voucher could not be applied to this basket. '
+                           'User: %s, Basket: %s, Code: %s, Message: %s',
+                           username, self.request.basket.id, voucher.code, msg)
             messages.warning(self.request, msg)
             self.request.basket.vouchers.remove(voucher)
         else:
@@ -465,9 +471,16 @@ class VoucherAddView(BaseVoucherAddView):  # pylint: disable=function-redefined
 
     def form_valid(self, form):
         code = form.cleaned_data['code']
+        username = self.request.user and self.request.user.username
         if self.request.basket.is_empty:
+            logger.warning('[Code Redemption Failure] User attempted to apply a code to an empty basket. '
+                           'User: %s, Basket: %s, Code: %s',
+                           username, self.request.basket.id, code)
             return redirect_to_referrer(self.request, 'basket:summary')
         if self.request.basket.contains_voucher(code):
+            logger.warning('[Code Redemption Failure] User tried to apply a code that is already applied. '
+                           'User: %s, Basket: %s, Code: %s',
+                           username, self.request.basket.id, code)
             messages.error(
                 self.request,
                 _("You have already added coupon code '{code}' to your basket.").format(code=code)

--- a/ecommerce/extensions/voucher/models.py
+++ b/ecommerce/extensions/voucher/models.py
@@ -50,7 +50,7 @@ class Voucher(AbstractVoucher):
             applications = self.applications.filter(voucher=self).exclude(user=user)
             if applications.exists():
                 is_available = False
-                message = _('This voucher is only available to another user')  # pylint: disable=redefined-variable-type
+                message = _('This voucher is assigned to another user.')  # pylint: disable=redefined-variable-type
 
         return is_available, message
 

--- a/ecommerce/extensions/voucher/tests/test_models.py
+++ b/ecommerce/extensions/voucher/tests/test_models.py
@@ -132,7 +132,7 @@ class VoucherTests(TestCase):
         assert (is_available, message) == (True, '')
 
         is_available, message = voucher.is_available_to_user(user2)
-        assert (is_available, message) == (False, 'This voucher is only available to another user')
+        assert (is_available, message) == (False, 'This voucher is assigned to another user.')
 
     def test_slots_available_for_assignment_no_enterprise_offer(self):
         """ Verify that a voucher with no enterprise offer returns none for slots_available_for_assignment. """


### PR DESCRIPTION
This PR adds more robust logging to the user-facing error paths related to users redeeming codes, which occur in VoucherAddView and CouponRedeemView.

Each message is prefixed with `[Code Redemption Failure]` so that they can be easily filtered in splunk. Each message also includes relevant metadata, if available, in a standard order that can also be parsed by a splunk query. These fields are, in order: User, Offer, Product, Basket, Code, Message, Enterprise, Catalog, Courses, Range.