### PR TITLE
Revoke Superuser access on Ecomm

### DIFF
--- a/ecommerce/core/management/commands/deactivate_superusers.py
+++ b/ecommerce/core/management/commands/deactivate_superusers.py
@@ -1,0 +1,23 @@
+"""
+Django management command to unset superusers in ecommerce.
+"""
+import logging
+
+from django.apps import apps
+from django.core.management.base import BaseCommand
+
+User = apps.get_model('core', 'User')
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = 'Revoke superuser access of all users on ecommerce.'
+
+    def handle(self, *args, **options):
+        all_superusers = User.objects.filter(is_superuser=True)
+        superusers_count = all_superusers.count()
+        if not superusers_count:
+            logger.warn('No superusers found, falling back.')
+            return
+        updated_users = all_superusers.update(is_superuser=False)
+        logger.info('Successfully Updated [%s] users', updated_users)

--- a/ecommerce/core/management/commands/tests/factories.py
+++ b/ecommerce/core/management/commands/tests/factories.py
@@ -4,8 +4,15 @@ from oscar.core.loading import get_model
 
 
 class PaymentEventFactory(factory.DjangoModelFactory):
-
     id = FuzzyInteger(1000, 9999)
 
     class Meta(object):
         model = get_model('order', 'PaymentEvent')
+
+
+class SuperUserFactory(factory.DjangoModelFactory):
+    id = FuzzyInteger(1000, 9999)
+    is_superuser = True
+
+    class Meta(object):
+        model = get_model('core', 'User')

--- a/ecommerce/core/management/commands/tests/test_deactivate_superusers.py
+++ b/ecommerce/core/management/commands/tests/test_deactivate_superusers.py
@@ -1,0 +1,48 @@
+"""
+Tests for Django management command to verify ecommerce transactions.
+"""
+import mock
+from django.apps import apps
+from django.core.management import call_command
+from django.test import TestCase
+
+from ecommerce.core.management.commands.tests.factories import SuperUserFactory
+
+User = apps.get_model('core', 'User')
+
+
+class DeactivateSuperUsersTest(TestCase):
+    command = 'deactivate_superusers'
+    LOGGER = 'ecommerce.core.management.commands.deactivate_superusers.logger'
+
+    def setUp(self):
+        super(DeactivateSuperUsersTest, self).setUp()
+        __ = SuperUserFactory()
+
+    def _assert_superusers(self, expected_count):
+        """Helper method which fetches superusers and verify their expected count"""
+        super_users = User.objects.filter(is_superuser=True)
+        self.assertEqual(super_users.count(), expected_count)
+
+    def test_superuser_unset(self):
+        """
+        Test that deactivate superusers management command successfully marks
+        superusers inactive.
+        """
+        self._assert_superusers(expected_count=1)
+        with mock.patch(self.LOGGER) as patched_log:
+            call_command(self.command)
+            patched_log.info.assert_called_once_with('Successfully Updated [%s] users', 1)
+        self._assert_superusers(expected_count=0)
+
+    def test_no_superuser(self):
+        """
+        Tests that the management command successfully falls back when
+        the system does not has any superusers.
+        """
+        call_command(self.command)
+        self._assert_superusers(expected_count=0)
+
+        with mock.patch(self.LOGGER) as patched_log:
+            call_command(self.command)
+            patched_log.warn.assert_called_once_with('No superusers found, falling back.')


### PR DESCRIPTION
This PR creates a management command that will revoke superuser access on ecomm for all users. 
There was a bug in one of the python packages which set the superuser incorrectly in the ecomm, so in order to correct the data, we would run this management command which would revoke the superuser access.

When superusers login in the system again, it will correctly map their superuser status in the user model.

Related PRs.
https://github.com/edx/auth-backends/pull/61
https://github.com/edx/ecommerce/pull/2244