### PR TITLE
Replace save_without_historical_record with skip_history_when_saving

### DIFF
--- a/ecommerce/extensions/catalogue/migrations/0002_auto_20150223_1052.py
+++ b/ecommerce/extensions/catalogue/migrations/0002_auto_20150223_1052.py
@@ -19,6 +19,9 @@ def create_catalog(apps, schema_editor):
     ProductAttribute = apps.get_model("catalogue", "ProductAttribute")
     ProductClass = apps.get_model("catalogue", "ProductClass")
 
+    for klass in (Category, ProductAttribute, ProductClass):
+        klass.skip_history_when_saving = True
+
     # Create a new product class for course seats
     seat = ProductClass(
         track_stock=False,
@@ -76,11 +79,9 @@ def remove_catalog(apps, schema_editor):
     ProductClass = apps.get_model("catalogue", "ProductClass")
     ProductAttribute = apps.get_model("catalogue", "ProductAttribute")
 
-    Category.skip_history_when_saving = True
-    ProductClass.skip_history_when_saving = True
-
-    # Needed for cascading delete
-    ProductAttribute.skip_history_when_saving = True
+    # ProductAttribute is needed for cascading delete
+    for klass in (Category, ProductAttribute, ProductClass):
+        klass.skip_history_when_saving = True
 
     Category.objects.filter(slug='seats').delete()
     ProductClass.objects.filter(name=SEAT_PRODUCT_CLASS_NAME).delete()

--- a/ecommerce/extensions/catalogue/migrations/0006_credit_provider_attr.py
+++ b/ecommerce/extensions/catalogue/migrations/0006_credit_provider_attr.py
@@ -7,7 +7,6 @@ from ecommerce.core.constants import SEAT_PRODUCT_CLASS_NAME
 
 
 def create_credit_provider_attribute(apps, schema_editor):
-
     # Get seat Object
     ProductClass = apps.get_model('catalogue', 'ProductClass')
     seat = ProductClass.objects.get(name=SEAT_PRODUCT_CLASS_NAME)

--- a/ecommerce/extensions/catalogue/migrations/0013_coupon_product_class.py
+++ b/ecommerce/extensions/catalogue/migrations/0013_coupon_product_class.py
@@ -14,13 +14,16 @@ ProductClass = get_model("catalogue", "ProductClass")
 
 def create_product_class(apps, schema_editor):
     """Create a Coupon product class."""
+    for klass in (Category, ProductAttribute, ProductClass):
+        klass.skip_history_when_saving = True
+
     coupon = ProductClass(
         track_stock=False,
         requires_shipping=False,
         name=COUPON_PRODUCT_CLASS_NAME,
         slug=slugify(COUPON_PRODUCT_CLASS_NAME),
     )
-    coupon.save_without_historical_record()
+    coupon.save()
 
     pa = ProductAttribute(
         product_class=coupon,
@@ -29,7 +32,7 @@ def create_product_class(apps, schema_editor):
         type='entity',
         required=False
     )
-    pa.save_without_historical_record()
+    pa.save()
 
     # Create a category for coupons.
     c = Category(
@@ -40,7 +43,7 @@ def create_product_class(apps, schema_editor):
         image='',
         name='Coupons'
     )
-    c.save_without_historical_record()
+    c.save()
 
 
 def remove_product_class(apps, schema_editor):

--- a/ecommerce/extensions/catalogue/migrations/0014_alter_couponvouchers_attribute.py
+++ b/ecommerce/extensions/catalogue/migrations/0014_alter_couponvouchers_attribute.py
@@ -9,16 +9,18 @@ ProductAttribute = get_model("catalogue", "ProductAttribute")
 
 def alter_couponvouchers_attribute(apps, schema_editor):
     """Change the coupon_vouchers product attribute to be required."""
+    ProductAttribute.skip_history_when_saving = True
     coupon_vouchers = ProductAttribute.objects.get(code='coupon_vouchers')
     coupon_vouchers.required = True
-    coupon_vouchers.save_without_historical_record()
+    coupon_vouchers.save()
 
 
 def reverse_migration(apps, schema_editor):
     """Reverse coupon_vouchers product attribute to not be required."""
+    ProductAttribute.skip_history_when_saving = True
     coupon_vouchers = ProductAttribute.objects.get(code='coupon_vouchers')
     coupon_vouchers.required = False
-    coupon_vouchers.save_without_historical_record()
+    coupon_vouchers.save()
 
 
 class Migration(migrations.Migration):

--- a/ecommerce/extensions/catalogue/migrations/0017_enrollment_code_product_class.py
+++ b/ecommerce/extensions/catalogue/migrations/0017_enrollment_code_product_class.py
@@ -14,13 +14,16 @@ ProductClass = get_model('catalogue', 'ProductClass')
 
 def create_enrollment_code_product_class(apps, schema_editor):
     """Create an Enrollment code product class and switch to turn automatic creation on."""
+    for klass in (Category, ProductAttribute, ProductClass):
+        klass.skip_history_when_saving = True
+
     enrollment_code = ProductClass(
         track_stock=False,
         requires_shipping=False,
         name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME,
         slug=slugify(ENROLLMENT_CODE_PRODUCT_CLASS_NAME),
     )
-    enrollment_code.save_without_historical_record()
+    enrollment_code.save()
 
     pa1 = ProductAttribute(
         product_class=enrollment_code,
@@ -29,7 +32,7 @@ def create_enrollment_code_product_class(apps, schema_editor):
         type='text',
         required=True
     )
-    pa1.save_without_historical_record()
+    pa1.save()
 
     pa2 = ProductAttribute(
         product_class=enrollment_code,
@@ -38,7 +41,7 @@ def create_enrollment_code_product_class(apps, schema_editor):
         type='text',
         required=True
     )
-    pa2.save_without_historical_record()
+    pa2.save()
 
 
 def remove_enrollment_code_product_class(apps, schema_editor):

--- a/ecommerce/extensions/catalogue/migrations/0019_enrollment_code_idverifyreq_attribute.py
+++ b/ecommerce/extensions/catalogue/migrations/0019_enrollment_code_idverifyreq_attribute.py
@@ -12,6 +12,7 @@ ProductClass = get_model("catalogue", "ProductClass")
 
 def create_idverifyreq_attribute(apps, schema_editor):
     """Create enrollment code 'id_verification_required' attribute."""
+    ProductAttribute.skip_history_when_saving = True
     enrollment_code_class = ProductClass.objects.get(name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME)
     pa = ProductAttribute(
         product_class=enrollment_code_class,
@@ -20,7 +21,7 @@ def create_idverifyreq_attribute(apps, schema_editor):
         type='boolean',
         required=False
     )
-    pa.save_without_historical_record()
+    pa.save()
 
 
 def remove_idverifyreq_attribute(apps, schema_editor):

--- a/ecommerce/extensions/catalogue/migrations/0024_fix_enrollment_code_slug.py
+++ b/ecommerce/extensions/catalogue/migrations/0024_fix_enrollment_code_slug.py
@@ -12,19 +12,21 @@ RIGHT_SLUG = 'enrollment_code'
 
 def fix_enrollment_code_slug(apps, schema_editor):
     """Update the faulty product class."""
+    ProductClass.skip_history_when_saving = True
     try:
         product_class = ProductClass.objects.get(slug=WRONG_SLUG)
         product_class.slug = RIGHT_SLUG
-        product_class.save_without_historical_record()
+        product_class.save()
     except ProductClass.DoesNotExist:
         pass
 
 
 def revert_migration(apps, schema_editor):
+    ProductClass.skip_history_when_saving = True
     try:
         product_class = ProductClass.objects.get(slug=RIGHT_SLUG)
         product_class.slug = WRONG_SLUG
-        product_class.save_without_historical_record()
+        product_class.save()
     except ProductClass.DoesNotExist:
         pass
 

--- a/ecommerce/extensions/catalogue/migrations/0027_catalogue_entitlement_option.py
+++ b/ecommerce/extensions/catalogue/migrations/0027_catalogue_entitlement_option.py
@@ -9,11 +9,12 @@ Option = get_model('catalogue', 'Option')
 
 def create_entitlement_option(apps, schema_editor):
     """ Create catalogue entitlement option. """
+    Option.skip_history_when_saving = True
     course_entitlement_option = Option()
     course_entitlement_option.name = 'Course Entitlement'
     course_entitlement_option.code = 'course_entitlement'
     course_entitlement_option.type = Option.OPTIONAL
-    course_entitlement_option.save_without_historical_record()
+    course_entitlement_option.save()
 
 
 def remove_entitlement_option(apps, schema_editor):

--- a/ecommerce/extensions/catalogue/migrations/0031_course_entitlement_idverifyreq_attr.py
+++ b/ecommerce/extensions/catalogue/migrations/0031_course_entitlement_idverifyreq_attr.py
@@ -12,6 +12,8 @@ ProductClass = get_model("catalogue", "ProductClass")
 
 def create_idverifyreq_attribute(apps, schema_editor):
     """Create entitlement code 'id_verification_required' attribute."""
+    ProductAttribute.skip_history_when_saving = True
+
     entitlement_code_class = ProductClass.objects.get(name=COURSE_ENTITLEMENT_PRODUCT_CLASS_NAME)
     pa = ProductAttribute(
         product_class=entitlement_code_class,
@@ -20,7 +22,7 @@ def create_idverifyreq_attribute(apps, schema_editor):
         type='boolean',
         required=False
     )
-    pa.save_without_historical_record()
+    pa.save()
 
 
 def remove_idverifyreq_attribute(apps, schema_editor):

--- a/ecommerce/extensions/catalogue/migrations/0032_journal_product_class.py
+++ b/ecommerce/extensions/catalogue/migrations/0032_journal_product_class.py
@@ -17,6 +17,9 @@ JOURNAL_SLUG_NAME = slugify(JOURNAL_PRODUCT_CLASS_NAME)
 
 def create_product_class(apps, schema_editor):
     """ Create a journal product class """
+    for klass in (Category, Product, ProductClass, ProductAttribute):
+        klass.skip_history_when_saving = True
+
     # Create a new product class for journal
     journal = ProductClass(
         track_stock=False,
@@ -24,7 +27,7 @@ def create_product_class(apps, schema_editor):
         name=JOURNAL_PRODUCT_CLASS_NAME,
         slug=JOURNAL_SLUG_NAME
     )
-    journal.save_without_historical_record()
+    journal.save()
 
     # Create product attributes for journal products
     pa1 = ProductAttribute.objects.create(
@@ -34,10 +37,9 @@ def create_product_class(apps, schema_editor):
         type="text",
         required=True
     )
-    pa1.save_without_historical_record()
+    pa1.save()
 
     # Create a category for the journal
-    Category.skip_history_when_saving = True
     Category.add_root(
         description="All journals",
         slug="journals",

--- a/ecommerce/extensions/catalogue/migrations/0036_coupon_notify_email_attribute.py
+++ b/ecommerce/extensions/catalogue/migrations/0036_coupon_notify_email_attribute.py
@@ -12,6 +12,8 @@ ProductClass = get_model("catalogue", "ProductClass")
 
 def create_notify_email_attribute(apps, schema_editor):
     """Create coupon notify_email attribute."""
+    ProductAttribute.skip_history_when_saving = True
+
     coupon = ProductClass.objects.get(name=COUPON_PRODUCT_CLASS_NAME)
     pa = ProductAttribute(
         product_class=coupon,
@@ -20,7 +22,7 @@ def create_notify_email_attribute(apps, schema_editor):
         type='text',
         required=False
     )
-    pa.save_without_historical_record()
+    pa.save()
 
 
 def remove_notify_email_attribute(apps, schema_editor):

--- a/ecommerce/extensions/catalogue/migrations/0038_coupon_enterprise_id_attribute.py
+++ b/ecommerce/extensions/catalogue/migrations/0038_coupon_enterprise_id_attribute.py
@@ -12,6 +12,7 @@ ProductClass = get_model("catalogue", "ProductClass")
 
 def create_enterprise_id_attribute(apps, schema_editor):
     """Create coupon enterprise_customer_uuid attribute."""
+    ProductAttribute.skip_history_when_saving = True
     coupon = ProductClass.objects.get(name=COUPON_PRODUCT_CLASS_NAME)
     pa = ProductAttribute(
         product_class=coupon,
@@ -20,7 +21,7 @@ def create_enterprise_id_attribute(apps, schema_editor):
         type='text',
         required=False
     )
-    pa.save_without_historical_record()
+    pa.save()
 
 
 def remove_enterprise_id_attribute(apps, schema_editor):


### PR DESCRIPTION
In migrations that change data on tables with history enabled save_without_historical_record does not behave as intended. Using skip_history_when_saving does seem to do what we want.