### PR TITLE
REVMI-218 Stop importing the models directly

### DIFF
--- a/ecommerce/core/migrations/0006_add_service_user.py
+++ b/ecommerce/core/migrations/0006_add_service_user.py
@@ -2,23 +2,27 @@
 from __future__ import unicode_literals
 
 from django.conf import settings
-from django.contrib.auth import get_user_model
-from django.db import migrations, models
-
-User = get_user_model()
+from django.contrib.auth.hashers import make_password
+from django.db import migrations
 
 
 class Migration(migrations.Migration):
 
     def add_service_user(apps, schema_editor):
+        app_name, _, model_name = settings.AUTH_USER_MODEL.rpartition('.')
+        User = apps.get_model(app_name, model_name)
+
         service_user = User.objects.create(
             username=settings.ECOMMERCE_SERVICE_WORKER_USERNAME,
             is_superuser=True
         )
-        service_user.set_unusable_password()
+        service_user.password = make_password(None)
         service_user.save()
 
     def remove_service_user(apps, schema_editor):
+        app_name, _, model_name = settings.AUTH_USER_MODEL.rpartition('.')
+        User = apps.get_model(app_name, model_name)
+
         User.objects.get(username=settings.ECOMMERCE_SERVICE_WORKER_USERNAME).delete()
 
     dependencies = [

--- a/ecommerce/core/migrations/0009_service_user_privileges.py
+++ b/ecommerce/core/migrations/0009_service_user_privileges.py
@@ -2,17 +2,17 @@
 from __future__ import unicode_literals
 
 from django.conf import settings
-from django.contrib.auth import get_user_model
 from django.contrib.auth.management import create_permissions
-from django.contrib.auth.models import Permission
 from django.db import migrations
-
-User = get_user_model()
 
 
 class Migration(migrations.Migration):
 
     def alter_service_user_privileges(apps, schema_editor):
+        app_name, _, model_name = settings.AUTH_USER_MODEL.rpartition('.')
+        User = apps.get_model(app_name, model_name)
+        Permission = apps.get_model('auth', 'Permission')
+
         # Explicitly create permissions. Permissions are not created until after
         # Django has finished running migrations, meaning that when migrations are
         # run against a fresh database (e.g., while running tests), any which depend
@@ -34,6 +34,10 @@ class Migration(migrations.Migration):
         service_user.save()
 
     def restore_service_user_privileges(apps, schema_editor):
+        app_name, _, model_name = settings.AUTH_USER_MODEL.rpartition('.')
+        User = apps.get_model(app_name, model_name)
+        Permission = apps.get_model('auth', 'Permission')
+
         service_user = User.objects.get(username=settings.ECOMMERCE_SERVICE_WORKER_USERNAME)
 
         change_order_permission = Permission.objects.get(codename='change_order')


### PR DESCRIPTION
Django data migrations should not directly import models, as this prevents historical versions of the models from being used when the migrations are later run. 

Sample code from the django docs:
```
def combine_names(apps, schema_editor):
    # We can't import the Person model directly as it may be a newer
    # version than this migration expects. We use the historical version.
    Person = apps.get_model('yourappname', 'Person')
```
https://docs.djangoproject.com/en/1.11/topics/migrations/#data-migrations

The migrations changed in this PR are causing issues when I try to add a new column to the User table in a new (later) migration.

Related PRs: 
* https://github.com/edx/ecommerce/pull/2258 demonstrates the problem
* https://github.com/edx/ecommerce/pull/2259 test PR that passes all checks after the data migrations were updated as proposed here
