### PR TITLE
Replace edx_rbac.utils.get_decoded_jwt_from_request with edx_rest_framework_extensions.auth.jwt.cookies.get_decoded_jwt

### DIFF
--- a/ecommerce/enterprise/rules.py
+++ b/ecommerce/enterprise/rules.py
@@ -3,13 +3,11 @@ Django rules for enterprise
 """
 from __future__ import absolute_import
 
+import crum
 import rules
-from edx_rbac.utils import (
-    get_decoded_jwt_from_request,
-    get_request_or_stub,
-    request_user_has_implicit_access_via_jwt,
-    user_has_access_via_database
-)
+from edx_rbac.utils import request_user_has_implicit_access_via_jwt, user_has_access_via_database
+from edx_rest_framework_extensions.auth.jwt.authentication import get_decoded_jwt_from_auth
+from edx_rest_framework_extensions.auth.jwt.cookies import get_decoded_jwt
 
 from ecommerce.core.constants import ENTERPRISE_COUPON_ADMIN_ROLE
 from ecommerce.core.models import EcommerceFeatureRoleAssignment
@@ -22,8 +20,8 @@ def request_user_has_implicit_access(user, context):  # pylint: disable=unused-a
      Returns:
         boolean: whether the request user has access or not
     """
-    request = get_request_or_stub()
-    decoded_jwt = get_decoded_jwt_from_request(request)
+    request = crum.get_current_request()
+    decoded_jwt = get_decoded_jwt(request) or get_decoded_jwt_from_auth(request)
     if not context:
         return False
     return request_user_has_implicit_access_via_jwt(decoded_jwt, ENTERPRISE_COUPON_ADMIN_ROLE, context)

--- a/ecommerce/extensions/api/v2/tests/views/test_baskets.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_baskets.py
@@ -13,6 +13,7 @@ import mock
 from django.contrib.auth import get_user_model
 from django.test import override_settings
 from django.urls import reverse
+from edx_rest_framework_extensions.auth.jwt.cookies import jwt_cookie_name
 from oscar.core.loading import get_model
 from oscar.test import factories
 from oscar.test.factories import BasketFactory
@@ -232,6 +233,9 @@ class BasketCreateViewTests(BasketCreationMixin, ThrottlingMixin, TransactionTes
 
     def test_jwt_authentication(self):
         """Test that requests made without a valid JWT fail."""
+        # Remove jwt cookie
+        self.client.cookies[jwt_cookie_name()] = {}
+
         # Verify that the basket creation endpoint requires JWT authentication
         response = self.create_basket(skus=[self.PAID_SKU], auth=False)
         self.assertEqual(response.status_code, 401)

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -22,7 +22,7 @@ from oscar.test.utils import RequestFactory
 from social_django.models import UserSocialAuth
 from threadlocals.threadlocals import set_thread_variable
 
-from ecommerce.core.constants import SYSTEM_ENTERPRISE_ADMIN_ROLE
+from ecommerce.core.constants import ALL_ACCESS_CONTEXT, SYSTEM_ENTERPRISE_ADMIN_ROLE, SYSTEM_ENTERPRISE_OPERATOR_ROLE
 from ecommerce.core.url_utils import get_lms_url
 from ecommerce.courses.models import Course
 from ecommerce.courses.utils import mode_for_product
@@ -153,6 +153,7 @@ class BasketCreationMixin(UserMixin, JwtMixin):
             stockrecords__partner_sku=self.FREE_SKU,
             stockrecords__price_excl_tax=Decimal('0.00'),
         )
+        self.set_jwt_cookie(SYSTEM_ENTERPRISE_OPERATOR_ROLE, ALL_ACCESS_CONTEXT)
 
     def create_basket(self, skus=None, checkout=None, payment_processor_name=None, auth=True, token=None):
         """Issue a POST request to the basket creation endpoint."""

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -27,11 +27,11 @@ drf-extensions==0.3.1
 edx-auth-backends
 edx-django-release-util
 edx-django-utils
-edx-drf-extensions==2.2.0
+edx-drf-extensions
 edx-django-sites-extensions
 edx-ecommerce-worker
 edx-opaque-keys
-edx-rbac==0.2.0
+edx-rbac
 edx-rest-api-client
 gevent==1.0.2
 jsonfield==1.0.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -54,10 +54,11 @@ edx-auth-backends==2.0.1
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==1.0.3
-edx-drf-extensions==2.2.0
+edx-drf-extensions==2.3.0
 edx-ecommerce-worker==0.7.2
 edx-opaque-keys==1.0.0
-edx-rbac==0.2.0
+edx-opaque-keys==1.0.0
+edx-rbac==1.0.1
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography
 factory-boy==2.12.0       # via django-oscar

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -67,11 +67,11 @@ edx-auth-backends==2.0.1
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==1.0.3
-edx-drf-extensions==2.2.0
+edx-drf-extensions==2.3.0
 edx-ecommerce-worker==0.7.2
 edx-i18n-tools==0.4.8
 edx-opaque-keys==1.0.0
-edx-rbac==0.2.0
+edx-rbac==1.0.1
 edx-rest-api-client==1.9.2
 edx-sphinx-theme==1.0.2
 enum34==1.1.6             # via cryptography

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -56,10 +56,10 @@ edx-auth-backends==2.0.1
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==1.0.3
-edx-drf-extensions==2.2.0
+edx-drf-extensions==2.3.0
 edx-ecommerce-worker==0.7.2
 edx-opaque-keys==1.0.0
-edx-rbac==0.2.0
+edx-rbac==1.0.1
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography
 factory-boy==2.12.0       # via django-oscar

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -64,10 +64,10 @@ edx-auth-backends==2.0.1
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==1.0.3
-edx-drf-extensions==2.2.0
+edx-drf-extensions==2.3.0
 edx-ecommerce-worker==0.7.2
 edx-opaque-keys==1.0.0
-edx-rbac==0.2.0
+edx-rbac==1.0.1
 edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography
 factory-boy==2.8.1


### PR DESCRIPTION
**Description:** 
This PR removes the usages of `get_decoded_jwt_from_request` from rbac in favor of `get_decoded_jwt` and `get_decoded_jwt_from_auth ` from edx-drf-extensions. It also adds `get_request_or_stub` and updates the usages.