### PR TITLE
REVMI-196 Save lms_user_id to db

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -480,11 +480,6 @@ class SiteConfiguration(models.Model):
         return EdxRestApiClient(self.build_lms_url('/api/entitlements/v1/'), jwt=self.access_token)
 
 
-# NOTE: Adding django-simple-history tracking for this model would conflict with the migration
-# "0006_add_service_user" which updates rows in this model.  Adding history to this model was slated
-# in DE-1424, but we ran into this migrations issue and instead punted it.
-#
-# I created a ticket to revisit history for this model: https://openedx.atlassian.net/browse/DE-1481
 class User(AbstractUser):
     """
     Custom user model for use with python-social-auth via edx-auth-backends.

--- a/ecommerce/extensions/analytics/middleware.py
+++ b/ecommerce/extensions/analytics/middleware.py
@@ -1,23 +1,58 @@
 """
-Middleware for analytics app to parse GA cookie.
+Middleware for analytics app to parse Google Analytics (GA) cookie and the lms_user_id.
 """
-
+import logging
 from ecommerce.extensions.analytics.utils import get_google_analytics_client_id
+
+logger = logging.getLogger(__name__)
 
 
 class TrackingMiddleware(object):
     """
-    Middleware that parse `_ga` cookie and save/update in user tracking context.
+    Middleware that parse `_ga` cookie for the user tracking context to obtain the GA client id, extracts the
+    lms_user_id, and updates the user if necessary.
     """
 
     def process_request(self, request):
         user = request.user
         if user.is_authenticated():
+            save_user = False
             tracking_context = user.tracking_context or {}
+
+            # Check for the GA client id
             old_client_id = tracking_context.get('ga_client_id')
             ga_client_id = get_google_analytics_client_id(request)
-
             if ga_client_id and ga_client_id != old_client_id:
                 tracking_context['ga_client_id'] = ga_client_id
                 user.tracking_context = tracking_context
+                save_user = True
+
+            if not user.lms_user_id:
+                # Check for the lms_user_id in social auth
+                lms_user_id_social_auth = self._get_lms_user_id_from_social_auth(user)
+                if lms_user_id_social_auth:
+                    user.lms_user_id = lms_user_id_social_auth
+                    save_user = True
+                    logger.info(u'Saving lms_user_id from social auth for user %s', user.id)
+                else:
+                    # Check for the lms_user_id in the tracking context
+                    lms_user_id_tracking_context = tracking_context.get('lms_user_id')
+                    if lms_user_id_tracking_context:
+                        user.lms_user_id = lms_user_id_tracking_context
+                        save_user = True
+                        logger.info(u'Saving lms_user_id from tracking context for user %s', user.id)
+
+            if save_user:
                 user.save()
+
+    def _get_lms_user_id_from_social_auth(self, user):
+        """
+        Return LMS user_id passed through social auth, if found.
+        Returns None if not found.
+        """
+        lms_user_id_social_auth = None
+        try:
+            lms_user_id_social_auth = user.social_auth.first().extra_data[u'user_id']  # pylint: disable=no-member
+        except Exception:  # pylint: disable=broad-except
+            pass
+        return lms_user_id_social_auth

--- a/ecommerce/extensions/analytics/middleware.py
+++ b/ecommerce/extensions/analytics/middleware.py
@@ -40,7 +40,7 @@ class TrackingMiddleware(object):
                     save_user = True
                     logger.info(u'Saving lms_user_id from social auth for user %s', user.id)
                 else:
-                    # TODO: This will be removed in REVMI-258
+                    # TODO: Remove this once we can successfully get the id from social auth and the db. See REVMI-258
                     # Check for the lms_user_id in the tracking context
                     lms_user_id_tracking_context = tracking_context.get('lms_user_id')
                     if lms_user_id_tracking_context:

--- a/ecommerce/extensions/analytics/middleware.py
+++ b/ecommerce/extensions/analytics/middleware.py
@@ -1,5 +1,5 @@
 """
-Middleware for analytics app to parse Google Analytics (GA) cookie and the lms_user_id.
+Middleware for analytics app to parse the Google Analytics (GA) cookie and the lms_user_id.
 """
 import logging
 from ecommerce.extensions.analytics.utils import get_google_analytics_client_id
@@ -9,8 +9,10 @@ logger = logging.getLogger(__name__)
 
 class TrackingMiddleware(object):
     """
-    Middleware that parse `_ga` cookie for the user tracking context to obtain the GA client id, extracts the
-    lms_user_id, and updates the user if necessary.
+    Middleware that:
+    1) parses the `_ga` cookie to find the GA client id and adds this to the user's tracking_context
+    2) extracts the lms_user_id
+    and updates the user if necessary.
     """
 
     def process_request(self, request):

--- a/ecommerce/extensions/analytics/tests/test_middleware.py
+++ b/ecommerce/extensions/analytics/tests/test_middleware.py
@@ -1,26 +1,33 @@
 from django.test.client import RequestFactory
 
+from ecommerce.core.models import User
 from ecommerce.extensions.analytics import middleware
 from ecommerce.tests.testcases import TestCase
+from social_django.models import UserSocialAuth
 
 
 class TrackingMiddlewareTests(TestCase):
     """ Test for TrackingMiddleware. """
+    TEST_CONTEXT = {'foo': 'bar', 'baz': None, 'lms_user_id': 12345}
+
     def setUp(self):
         super(TrackingMiddlewareTests, self).setUp()
         self.middleware = middleware.TrackingMiddleware()
         self.request_factory = RequestFactory()
         self.user = self.create_user()
 
+    def _process_request(self, user):
+        request = self.request_factory.get('/')
+        request.user = user
+        self.middleware.process_request(request)
+
     def _assert_ga_client_id(self, ga_client_id):
         self.request_factory.cookies['_ga'] = 'GA1.2.{}'.format(ga_client_id)
-        request = self.request_factory.get('/')
-        request.user = self.user
-        self.middleware.process_request(request)
+        self._process_request(self.user)
         expected_client_id = self.user.tracking_context.get('ga_client_id')
         self.assertEqual(ga_client_id, expected_client_id)
 
-    def test_process_request(self):
+    def test_save_ga_client_id(self):
         """ Test that middleware save/update GA client id in user tracking context. """
         self.assertIsNone(self.user.tracking_context)
         self._assert_ga_client_id('test-client-id')
@@ -28,3 +35,50 @@ class TrackingMiddlewareTests(TestCase):
         updated_client_id = 'updated-client-id'
         self.assertNotEqual(updated_client_id, self.user.tracking_context.get('ga_client_id'))
         self._assert_ga_client_id(updated_client_id)
+
+    def test_social_auth_lms_user_id_(self):
+        """ Test that middleware saves the lms_use_id from the social auth. """
+        user = self.create_user()
+        user.tracking_context = self.TEST_CONTEXT
+        user.save()
+
+        lms_user_id = 67890
+        UserSocialAuth.objects.create(user=user, extra_data={'user_id': lms_user_id})
+
+        same_user = User.objects.get(id=user.id)
+        self.assertIsNone(same_user.lms_user_id)
+
+        self._process_request(same_user)
+        same_user = User.objects.get(id=user.id)
+        self.assertEqual(same_user.lms_user_id, lms_user_id)
+
+    def test_tracking_context_lms_user_id_(self):
+        """ Test that middleware saves the lms_use_id from the tracking_context. """
+        user = self.create_user()
+        user.tracking_context = self.TEST_CONTEXT
+        user.save()
+
+        same_user = User.objects.get(id=user.id)
+        self.assertIsNone(same_user.lms_user_id)
+
+        self._process_request(same_user)
+        same_user = User.objects.get(id=user.id)
+        self.assertEqual(same_user.lms_user_id, self.TEST_CONTEXT['lms_user_id'])
+
+    def test_does_not_overwrite_lms_user_id(self):
+        """ Test that middleware does not overwrite an existing lms_user_id. """
+        initial_lms_user_id = 18
+        user = self.create_user()
+        user.tracking_context = self.TEST_CONTEXT
+        user.lms_user_id = initial_lms_user_id
+        user.save()
+
+        lms_user_id = 10293
+        UserSocialAuth.objects.create(user=user, extra_data={'user_id': lms_user_id})
+
+        same_user = User.objects.get(id=user.id)
+        self.assertEqual(initial_lms_user_id, same_user.lms_user_id, )
+
+        self._process_request(same_user)
+        same_user = User.objects.get(id=user.id)
+        self.assertEqual(initial_lms_user_id, same_user.lms_user_id)

--- a/ecommerce/extensions/analytics/tests/test_middleware.py
+++ b/ecommerce/extensions/analytics/tests/test_middleware.py
@@ -1,9 +1,9 @@
 from django.test.client import RequestFactory
+from social_django.models import UserSocialAuth
 
 from ecommerce.core.models import User
 from ecommerce.extensions.analytics import middleware
 from ecommerce.tests.testcases import TestCase
-from social_django.models import UserSocialAuth
 
 
 class TrackingMiddlewareTests(TestCase):

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -601,6 +601,7 @@ EDX_DRF_EXTENSIONS = {
         'email': 'email',
         'full_name': 'full_name',
         'tracking_context': 'tracking_context',
+        'user_id': 'lms_user_id',
     },
 }
 


### PR DESCRIPTION
Update the existing middleware, which is already updating the user, to also save the _lms_user_id_. Also update the _JWT_PAYLOAD_USER_ATTRIBUTE_MAPPING_ to start saving the _lms_user_id_, if it is present in the JWT.

A future PR start reading the _lms_user_id_ from this column.

Note: I removed the comment in _models.py_ because that ticket has been closed.