### PR TITLE
Remove enterprise related fields from old coupon tool UI

### DIFF
--- a/ecommerce/static/js/models/coupon_model.js
+++ b/ecommerce/static/js/models/coupon_model.js
@@ -183,15 +183,6 @@ define([
                     }
                     return undefined;
                 },
-                enterprise_customer: function(val) {
-                    if ((_.isEmpty(val) || _.isEmpty(val.id)) &&
-                        !_.isEmpty(this.get('enterprise_customer_catalog'))) {
-                        return gettext('Enterprise Customer must be set if Enterprise Customer Catalog is set');
-                    }
-
-                    return undefined;
-                },
-                enterprise_customer_catalog: {required: false},
                 program_uuid: {
                     msg: gettext('A valid Program UUID is required.'),
                     required: function() {

--- a/ecommerce/static/js/test/specs/models/coupon_model_spec.js
+++ b/ecommerce/static/js/test/specs/models/coupon_model_spec.js
@@ -202,13 +202,6 @@ define([
                     model.validate();
                     expect(model.isValid()).toBeTruthy();
                 });
-
-                it('should validate enterprise customer is set if enterprise customer catalog is set', function() {
-                    model.set('enterprise_customer_catalog', 'fake_uuid');
-                    model.set('enterprise_customer', '');
-                    model.validate();
-                    expect(model.isValid()).toBeFalsy();
-                });
             });
 
             describe('test model methods', function() {

--- a/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/coupon_form_view_spec.js
@@ -200,50 +200,21 @@ define([
             });
 
             describe('enterprise customers', function() {
-                it('enterprise customer dropdown should be hidden when a catalog is selected', function() {
-                    view.$('#single-course').prop('checked', true).trigger('change');
-                    expect(SpecUtils.formGroup(view, '[name=enterprise_customer]')).not.toHaveHiddenClass();
-
-                    view.$('#catalog').prop('checked', true).trigger('change');
-                    expect(SpecUtils.formGroup(view, '[name=enterprise_customer]')).toHaveHiddenClass();
-
-                    view.$('#multiple-courses').prop('checked', true).trigger('change');
-                    expect(SpecUtils.formGroup(view, '[name=enterprise_customer]')).not.toHaveHiddenClass();
+                it('enterprise customer field should not be shown on create coupon', function() {
+                    _.each(['#single-course', '#multiple-courses', '#catalog'], function(catalogType) {
+                        view.$(catalogType).prop('checked', true).trigger('change');
+                        expect(SpecUtils.formGroup(view, '[name=enterprise_customer]').length).toBe(0);
+                    });
                 });
 
-                it('enterprise customer is setting properly', function() {
-                    view.$('#single-course').prop('checked', true).trigger('change');
+                it('enterprise customer field shown on edit coupon only if customer is set', function() {
+                    model = new Coupon({enterprise_customer: MockCustomers[0]});
+                    view = new CouponFormView({editing: true, model: model}).render();
 
-                    view.$('[name=enterprise_customer]').val('29c466f1583b47279265d0a1fd7012a3').trigger('change');
-                    expect(view.$('select[name=enterprise_customer] option:selected').text()).toEqual(
-                        MockCustomers[0].name
-                    );
-                    expect(view.$('[name=enterprise_customer]').val()).toEqual('29c466f1583b47279265d0a1fd7012a3');
-
-                    view.$('[name=enterprise_customer]').val('e7d4a3c6f510405d968e28e098ddb543').trigger('change');
-                    expect(view.$('select[name=enterprise_customer] option:selected').text()).toEqual(
-                        MockCustomers[1].name
-                    );
-                    expect(view.$('[name=enterprise_customer]').val()).toEqual('e7d4a3c6f510405d968e28e098ddb543');
-
-                    view.$('[name=enterprise_customer]').val('42a30ade47834489a607cd0f52ba13cf').trigger('change');
-                    expect(view.$('select[name=enterprise_customer] option:selected').text()).toEqual(
-                        MockCustomers[2].name
-                    );
-                    expect(view.$('[name=enterprise_customer]').val()).toEqual('42a30ade47834489a607cd0f52ba13cf');
-                });
-            });
-
-            describe('enterprise customer catalogs', function() {
-                it('enterprise customer catalog field should be hidden when a catalog is selected', function() {
-                    view.$('#single-course').prop('checked', true).trigger('change');
-                    expect(SpecUtils.formGroup(view, '[name=enterprise_customer_catalog]')).not.toHaveHiddenClass();
-
-                    view.$('#catalog').prop('checked', true).trigger('change');
-                    expect(SpecUtils.formGroup(view, '[name=enterprise_customer_catalog]')).toHaveHiddenClass();
-
-                    view.$('#multiple-courses').prop('checked', true).trigger('change');
-                    expect(SpecUtils.formGroup(view, '[name=enterprise_customer_catalog]')).not.toHaveHiddenClass();
+                    _.each(['#single-course', '#multiple-courses'], function(catalogType) {
+                        view.$(catalogType).prop('checked', true).trigger('change');
+                        expect(view.$('[name=enterprise_customer]').val()).toEqual(MockCustomers[0].id);
+                    });
                 });
             });
 

--- a/ecommerce/static/js/views/coupon_form_view.js
+++ b/ecommerce/static/js/views/coupon_form_view.js
@@ -250,31 +250,11 @@ define([
                         };
                     }
                 },
-                'select[name=enterprise_customer]': {
+                'input[name=enterprise_customer]': {
                     observe: 'enterprise_customer',
-                    selectOptions: {
-                        collection: function() {
-                            return ecommerce.coupons.enterprise_customers;
-                        },
-                        defaultOption: {id: '', name: ''},
-                        labelPath: 'name',
-                        valuePath: 'id'
-                    },
-                    setOptions: {
-                        validate: true
-                    },
                     onGet: function(val) {
                         return _.isUndefined(val) || _.isNull(val) ? '' : val.id;
-                    },
-                    onSet: function(val) {
-                        return {
-                            id: val,
-                            name: $('select[name=enterprise_customer] option:selected').text()
-                        };
                     }
-                },
-                'input[name=enterprise_customer_catalog]': {
-                    observe: 'enterprise_customer_catalog'
                 },
                 'input[name=program_uuid]': {
                     observe: 'program_uuid'
@@ -311,8 +291,6 @@ define([
                     'course_seat_types',
                     'course_catalog',
                     'end_date',
-                    'enterprise_customer',
-                    'enterprise_customer_catalog',
                     'invoice_discount_type',
                     'invoice_discount_value',
                     'invoice_number',
@@ -502,11 +480,9 @@ define([
 
             toggleEnterpriseRelatedFields: function(hide) {
                 this.formGroup('[name=enterprise_customer]').toggleClass(this.hiddenClass, hide);
-                this.formGroup('[name=enterprise_customer_catalog]').toggleClass(this.hiddenClass, hide);
 
                 if (hide) {
                     this.model.unset('enterprise_customer');
-                    this.model.unset('enterprise_customer_catalog');
                 }
             },
 
@@ -748,9 +724,13 @@ define([
             render: function() {
                 // Render the parent form/template
                 var catalogId = '';
-                var customerId = '';
+                var enterpriseCustomer = this.model.get('enterprise_customer');
 
-                this.$el.html(this.template(this.model.attributes));
+                this.$el.html(
+                    this.template(
+                        _.extend({}, this.model.attributes, {editing: this.editing})
+                    )
+                );
                 this.stickit();
 
                 this.toggleCatalogTypeField();
@@ -771,10 +751,11 @@ define([
                         catalogId = this.model.get('course_catalog');
                         this.model.set('course_catalog', ecommerce.coupons.catalogs.get(catalogId));
                     }
-                    if (_.isString(this.model.get('enterprise_customer'))) {
+                    if (_.isString(enterpriseCustomer)) {
                         // API returns a string value for enterprise customer
-                        customerId = this.model.get('enterprise_customer');
-                        this.model.set('enterprise_customer', {id: customerId});
+                        this.model.set('enterprise_customer', {id: enterpriseCustomer});
+                    } else if (_.isUndefined(enterpriseCustomer) || _.isNull(enterpriseCustomer)) {
+                        this.formGroup('#enterprise-customer').remove();
                     }
                     if (this.model.get('program_uuid')) {
                         this.$('.catalog-type input').attr('disabled', true);

--- a/ecommerce/static/templates/coupon_form.html
+++ b/ecommerce/static/templates/coupon_form.html
@@ -213,16 +213,13 @@
             </div>
             <div class="catalog_buttons"></div>
         </div>
-        <div class="form-group enterprise-customer">
-            <label for="enterprise-customer"><%= gettext('Enterprise Customer:') %></label>
-            <select id="enterprise-customer" class="form-control" name="enterprise_customer"></select>
-            <p class="help-block"></p>
-        </div>
-        <div class="form-group enterprise-customer-catalog">
-            <label for="enterprise-customer-catalog"><%= gettext('Enterprise Customer Catalog') %></label>
-            <input id="enterprise-customer-catalog" type="text" class="form-control" name="enterprise_customer_catalog">
-            <p class="help-block"></p>
-        </div>
+        <% if(editing) {%>
+            <div class="form-group enterprise-customer">
+                <label for="enterprise-customer"><%= gettext('Enterprise Customer:') %></label>
+                <input id="enterprise-customer" type="text" class="form-control non-editable" name="enterprise_customer">
+                <p class="help-block"></p>
+            </div>
+        <%}%>
         <div class="form-group program-uuid">
             <label for="program-uuid"><%= gettext('Program UUID') %> *</label>
             <input id="program-uuid" type="text" class="form-control" name="program_uuid">


### PR DESCRIPTION
**Description:** This will remove the enterprise customer and enterprise customer catalog fields from old coupon tool. On coupon create screen, both of the the fields will not be shown. On coupon edit screen, enterprise customer catalog field will not be shown at all and enterprise customer field will visible if there is an enterprise customer attached with the coupon.

**JIRA:** [ENT-1985](https://openedx.atlassian.net/browse/ENT-1985)


**Sandbox Login:** Authentication on sandbox is broken but one can login through django admin. Below are the steps I followed to login on Sandbox

0. Sandbox basic auth credentials
   username: **margaret**
   password: **hamilton**
1. Login to https://ecommerce-mammar.sandbox.edx.org/admin using your superuser credentials
2. After successful login in step 1, Go to https://ecommerce-mammar.sandbox.edx.org/coupons and you should be able to explore the coupons :)

**Testing:** Sandbox is updated with changes in this PR.
- Edit: [Old coupon without enterprise customer doesn't show the enterprise customer field](https://ecommerce-mammar.sandbox.edx.org/coupons/5/edit/)
- Create: [Enterprise Customer Catalog and Enterprise Customer Catalog fields are not shown on old coupon screen](https://ecommerce-mammar.sandbox.edx.org/coupons/new/)