### PR TITLE
REVMI-265 Unpin testfixtures and run make_upgrade

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -42,7 +42,7 @@ django-tables2==1.16.0    # via django-oscar
 django-threadlocals==0.10
 django-treebeard==4.3     # via django-oscar
 django-waffle==0.14.0
-django-widget-tweaks==1.4.3  # via django-oscar
+django-widget-tweaks==1.4.5  # via django-oscar
 django==1.11.21
 django_extensions==1.9.9
 djangorestframework-csv==2.1.0
@@ -74,7 +74,7 @@ jinja2==2.10.1            # via coreschema
 jsonfield==1.0.3
 kombu==3.0.37             # via celery
 libsass==0.9.2
-lxml==4.3.3               # via premailer, zeep
+lxml==4.3.4               # via premailer, zeep
 markdown==2.6.9
 markupsafe==1.1.1         # via jinja2
 mock==2.0.0               # via django-oscar

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -54,7 +54,7 @@ django-threadlocals==0.10
 django-treebeard==4.3     # via django-oscar
 django-waffle==0.14.0
 django-webtest==1.9.2
-django-widget-tweaks==1.4.3  # via django-oscar
+django-widget-tweaks==1.4.5  # via django-oscar
 django==1.11.21
 django_extensions==1.9.9
 djangorestframework-csv==2.1.0
@@ -157,7 +157,7 @@ sphinx==1.5.3
 sqlparse==0.3.0           # via django-debug-toolbar
 stevedore==1.30.1         # via edx-opaque-keys
 stripe==1.70.0
-testfixtures==4.5.0
+testfixtures==6.9.0
 text-unidecode==1.2       # via faker
 transifex-client==0.12.2
 typing==3.6.6             # via django-extensions

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -44,7 +44,7 @@ django-tables2==1.16.0    # via django-oscar
 django-threadlocals==0.10
 django-treebeard==4.3     # via django-oscar
 django-waffle==0.14.0
-django-widget-tweaks==1.4.3  # via django-oscar
+django-widget-tweaks==1.4.5  # via django-oscar
 django==1.11.21
 django_extensions==1.9.9
 djangorestframework-csv==2.1.0
@@ -77,7 +77,7 @@ jinja2==2.10.1            # via coreschema
 jsonfield==1.0.3
 kombu==3.0.37             # via celery
 libsass==0.9.2
-lxml==4.3.3               # via premailer, zeep
+lxml==4.3.4               # via premailer, zeep
 markdown==2.6.9
 markupsafe==1.1.1         # via jinja2
 mock==2.0.0               # via django-oscar

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -17,4 +17,4 @@ pep8==1.6.2
 pylint==1.6.4
 responses==0.5.1
 selenium==3.4.3
-testfixtures==4.5.0
+testfixtures                # Provides a LogCapture utility used by several tests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -52,7 +52,7 @@ django-threadlocals==0.10
 django-treebeard==4.3     # via django-oscar
 django-waffle==0.14.0
 django-webtest==1.9.2
-django-widget-tweaks==1.4.3  # via django-oscar
+django-widget-tweaks==1.4.5  # via django-oscar
 django==1.11.21
 django_extensions==1.9.9
 djangorestframework-csv==2.1.0
@@ -145,7 +145,7 @@ sorl-thumbnail==12.5.0    # via django-oscar
 soupsieve==1.9.1          # via beautifulsoup4
 stevedore==1.30.1         # via edx-opaque-keys
 stripe==1.70.0
-testfixtures==4.5.0
+testfixtures==6.9.0
 text-unidecode==1.2       # via faker
 typing==3.6.6             # via django-extensions
 unicodecsv==0.14.1


### PR DESCRIPTION
Upgrade testfixtures so we can use LogCapture newer method check_present, which will allow us to ensure that a log message is present but not require us to declare every expected log message.

* https://github.com/Simplistix/testfixtures/blob/master/CHANGELOG.rst
* https://github.com/jazzband/django-widget-tweaks/blob/master/CHANGES.rst
* https://github.com/lxml/lxml/blob/lxml-4.3.4/CHANGES.txt