### PR TITLE
ARCH-857: mock add/remove voucher

### DIFF
--- a/ecommerce/extensions/basket/tests/test_views.py
+++ b/ecommerce/extensions/basket/tests/test_views.py
@@ -61,7 +61,6 @@ StockRecord = get_model('partner', 'StockRecord')
 Voucher = get_model('voucher', 'Voucher')
 VoucherAddView = get_class('basket.views', 'VoucherAddView')
 VoucherApplication = get_model('voucher', 'VoucherApplication')
-VoucherRemoveView = get_class('basket.views', 'VoucherRemoveView')
 
 COUPON_CODE = 'COUPONTEST'
 BUNDLE = 'bundle_identifier'
@@ -1016,19 +1015,3 @@ class VoucherAddViewTests(LmsApiMockMixin, TestCase):
         __, product = prepare_voucher(code=COUPON_CODE)
         self.basket.add_product(product)
         self.assert_form_valid_message("Coupon code '{code}' added to basket.".format(code=COUPON_CODE))
-
-
-class VoucherRemoveViewTests(TestCase):
-    def test_post_with_missing_voucher(self):
-        """ If the voucher is missing, verify the view queues a message and redirects. """
-        pk = '12345'
-        view = VoucherRemoveView.as_view()
-        request = RequestFactory().post('/')
-        request.basket.save()
-        response = view(request, pk=pk)
-
-        self.assertEqual(response.status_code, 302)
-
-        actual = list(get_messages(request))[-1].message
-        expected = "No voucher found with id '{}'".format(pk)
-        self.assertEqual(actual, expected)

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -13,6 +13,7 @@ from django.shortcuts import redirect, render
 from django.utils.html import escape
 from django.utils.translation import ugettext as _
 from opaque_keys.edx.keys import CourseKey
+
 from oscar.apps.basket.views import VoucherAddView as BaseVoucherAddView
 from oscar.apps.basket.views import *  # pylint: disable=wildcard-import, unused-wildcard-import
 from oscar.core.prices import Price
@@ -484,19 +485,22 @@ class PaymentApiView(BasketLogicMixin, APIView):
 
         """
         return {
-            'line_total': context['order_total'].excl_tax + 12,
-            'line_discount': 12,
+            'total_excl_discount': context['order_total'].excl_tax + 12,
+            'total_discount': 12,
             'order_total': context['order_total'].excl_tax,
             'products': [
                 # NOTE: Will add additional level for program and include bundle_id for bundles
                 {
                     'name': 'Introduction to Happiness',
+                    # TODO: A real sample value would be 'verified'.  Not sure what this is called? Certificate type?
+                    # https://github.com/edx/ecommerce/search?q=seat_type+certificate&unscoped_q=seat_type+certificate
                     'seat_type': 'verified-certificate',
                     'img_url': 'https://prod-discovery.edx-cdn.org/media/course/image/21be6203.small.jpg',
                 },
             ],
             'show_voucher_form': True,
             'voucher': {
+                'id': 12345,
                 'code': 'SUMMER20',
                 "benefit": {
                     "type": "Percentage",
@@ -513,7 +517,6 @@ class PaymentApiView(BasketLogicMixin, APIView):
                     'type': 'paypal',
                 }
             ],
-            'sdn_check': True,
         }
 
     def get(self, request):  # pylint: disable=unused-argument
@@ -622,3 +625,56 @@ class VoucherAddView(BaseVoucherAddView):  # pylint: disable=function-redefined
                     )
                 self.apply_voucher_to_basket(voucher)
         return redirect_to_referrer(self.request, 'basket:summary')
+
+
+class AddVoucherApiView(APIView):
+    """
+    Api for adding voucher to a basket.
+
+    POST:
+    Adds voucher to a basket using the voucher's code.
+    {
+        "code": "SUMMER20"
+    }
+    Will return 200 and the relevant basket updates as json if successful.
+    If unsuccessful, will return 406 with the error.
+    """
+    permission_classes = (IsAuthenticated,)
+
+    def post(self, request):  # pylint: disable=unused-argument
+        code = request.data.get('code')
+        # TODO: ARCH-853: Replace mock implementation with real implementation
+        return Response({
+            'voucher': {
+                'id': 12345,
+                'code': code,
+                "benefit": {
+                    "type": "Percentage",
+                    "value": 20
+                },
+            },
+            'total_excl_discount': 112,
+            'total_discount': 12,
+            'order_total': 100,
+        })
+
+
+class RemoveVoucherApiView(APIView):
+    """
+    Api for removing voucher from a basket.
+
+    DELETE:
+    Will return 200 and the relevant basket updates as json if successful.
+    If unsuccessful, will return 406 with the error.
+
+    NOTE: Because this is a backend-for-frontend api, we are ok with returning content for a DELETE api.
+    """
+    permission_classes = (IsAuthenticated,)
+
+    def delete(self, request, voucherid):  # pylint: disable=unused-argument
+        # TODO: ARCH-853: Replace mock implementation with real implementation
+        return Response({
+            'total_excl_discount': 112,
+            'total_discount': 0,
+            'order_total': 112,
+        })

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -14,7 +14,6 @@ from django.utils.html import escape
 from django.utils.translation import ugettext as _
 from opaque_keys.edx.keys import CourseKey
 from oscar.apps.basket.views import VoucherAddView as BaseVoucherAddView
-from oscar.apps.basket.views import VoucherRemoveView as BaseVoucherRemoveView
 from oscar.apps.basket.views import *  # pylint: disable=wildcard-import, unused-wildcard-import
 from oscar.core.prices import Price
 from requests.exceptions import ConnectionError, Timeout
@@ -623,13 +622,3 @@ class VoucherAddView(BaseVoucherAddView):  # pylint: disable=function-redefined
                     )
                 self.apply_voucher_to_basket(voucher)
         return redirect_to_referrer(self.request, 'basket:summary')
-
-
-class VoucherRemoveView(BaseVoucherRemoveView):  # pylint: disable=function-redefined
-    def post(self, request, *args, **kwargs):
-        # TODO Remove this once https://github.com/django-oscar/django-oscar/pull/2241 is merged.
-        # This prevents an issue that arises when the user applies a voucher, opens the basket page in
-        # another window/tab, and attempts to remove the voucher on both screens. Under this scenario the
-        # second attempt to remove the voucher will raise an error.
-        kwargs['pk'] = int(kwargs['pk'])
-        return super(VoucherRemoveView, self).post(request, *args, **kwargs)

--- a/ecommerce/payment_bff/README.rst
+++ b/ecommerce/payment_bff/README.rst
@@ -1,0 +1,6 @@
+Payment Backend-for-Frontend (BFF)
+==================================
+
+This app introduces (backend-for-frontend) APIs for the Payment page microfrontend (MFE).
+
+Not all of the API best practices will be followed, because the API endpoints are optimized to allow the frontend to make fewer API calls.

--- a/ecommerce/payment_bff/urls.py
+++ b/ecommerce/payment_bff/urls.py
@@ -1,14 +1,20 @@
 from django.conf.urls import include, url
 from rest_framework.urlpatterns import format_suffix_patterns
 
-from ecommerce.extensions.basket.views import PaymentApiView
+from ecommerce.extensions.basket.views import AddVoucherApiView, PaymentApiView, RemoveVoucherApiView
 
 PAYMENT_URLS = [
-    url(r'^payment/', PaymentApiView.as_view(), name='payment'),
+    url(r'^$', PaymentApiView.as_view(), name='payment'),
+    url(r'^vouchers/$', AddVoucherApiView.as_view(), name='addvoucher'),
+    url(r'^vouchers/(?P<voucherid>[\d]+)$', RemoveVoucherApiView.as_view(), name='removevoucher'),
+]
+
+PAYMENT_ROOT_URL = [
+    url(r'^payment/', include(PAYMENT_URLS, namespace='payment')),
 ]
 
 urlpatterns = [
-    url(r'^v0/', include(PAYMENT_URLS, namespace='v0')),
+    url(r'^v0/', include(PAYMENT_ROOT_URL, namespace='v0')),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/ecommerce/settings/devstack.py
+++ b/ecommerce/settings/devstack.py
@@ -34,7 +34,8 @@ JWT_AUTH.update({
 
 CORS_ORIGIN_WHITELIST = (
     'http://localhost:1991',
-    'http://localhost:1996'
+    'http://localhost:1996',
+    'http://localhost:1998',
 )
 CORS_ALLOW_HEADERS = corsheaders_default_headers + (
     'use-jwt-cookie',


### PR DESCRIPTION
**POST /payment-bff/v0/payment/vouchers/**
**Params:**
```
{
    "code": "DEMO25"
}
```
**Results:**
```
{
  "total_excl_discount": 112,
  "order_total": 100,
  "voucher": {
    "benefit": {
      "type": "Percentage",
      "value": 20
    },
    "code": "DEMO25",
    "id": 12345
  },
  "total_discount": 12
}
```

**DELETE /payment-bff/v0/payment/vouchers/{voucherid}**
**Results:**
```
{
  "total_excl_discount": 112,
  "order_total": 102,
  "total_discount": 10
}
```
FYI: It is possible to have a discount without a coupon/voucher.  I _don't_ think `total_excl_discount` should change, but better safe than sorry. :)