### PR TITLE
ENT-1987: Added catalog preview link in enterprise coupon screen

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -7,12 +7,14 @@ from decimal import Decimal
 
 import waffle
 from dateutil.parser import parse
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.db.models import Q
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 from oscar.core.loading import get_class, get_model
+from path import Path
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 from rest_framework.settings import api_settings
@@ -957,6 +959,7 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
     seats = serializers.SerializerMethodField()
     start_date = serializers.SerializerMethodField()
     voucher_type = serializers.SerializerMethodField()
+    enterprise_catalog_url_template = serializers.SerializerMethodField()
 
     def get_benefit_type(self, obj):
         return retrieve_benefit(obj).type or getattr(retrieve_benefit(obj).proxy(), 'benefit_class_type', None)
@@ -1092,6 +1095,9 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
     def get_voucher_type(self, obj):
         return retrieve_voucher_usage(obj)
 
+    def get_enterprise_catalog_url_template(self, obj):  # pylint: disable=unused-argument
+        return Path(settings.ENTERPRISE_API_URL) / "enterprise_catalogs/"
+
     class Meta(object):
         model = Product
         fields = (
@@ -1099,7 +1105,8 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
             'client', 'code', 'code_status', 'coupon_type', 'course_seat_types',
             'email_domains', 'end_date', 'enterprise_customer', 'enterprise_customer_catalog',
             'id', 'last_edited', 'max_uses', 'note', 'notify_email', 'num_uses', 'payment_information',
-            'program_uuid', 'price', 'quantity', 'seats', 'start_date', 'title', 'voucher_type'
+            'program_uuid', 'price', 'quantity', 'seats', 'start_date', 'title', 'voucher_type',
+            'enterprise_catalog_url_template'
         )
 
 

--- a/ecommerce/static/js/test/specs/views/enterprise_coupon_detail_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/enterprise_coupon_detail_view_spec.js
@@ -46,7 +46,9 @@ define([
                 expect(view.$('.enterprise-customer > .value').text()).toEqual(
                     model.get('enterprise_customer')
                 );
-                expect(view.$('.enterprise-customer-catalog > .value').text()).toEqual(
+                expect(
+                    view.$('.enterprise-customer-catalog > .value > .enterprise-catalog-details-link').text()
+                ).toEqual(
                     model.get('enterprise_customer_catalog')
                 );
                 expect(view.$('.start-date-info > .value').text()).toEqual(

--- a/ecommerce/static/js/views/coupon_detail_view.js
+++ b/ecommerce/static/js/views/coupon_detail_view.js
@@ -26,7 +26,8 @@ define([
             className: 'coupon-detail-view',
 
             events: {
-                'click .voucher-report-button': 'downloadCouponReport'
+                'click .voucher-report-button': 'downloadCouponReport',
+                'click .external-link': 'routeToLink'
             },
 
             template: _.template(CouponDetailTemplate),
@@ -111,6 +112,16 @@ define([
                     return gettext('Can be used once by multiple customers');
                 }
                 return '';
+            },
+
+            /**
+             * Open external links in a new tab.
+             * Works only for anchor elements that contain 'external-link' class.
+             */
+            routeToLink: function(e) {
+                e.preventDefault();
+                e.stopPropagation();
+                window.open(e.currentTarget.href);
             },
 
             render: function() {

--- a/ecommerce/static/js/views/enterprise_coupon_form_view.js
+++ b/ecommerce/static/js/views/enterprise_coupon_form_view.js
@@ -67,7 +67,11 @@ define([
                     }
                 },
                 'input[name=enterprise_customer_catalog]': {
-                    observe: 'enterprise_customer_catalog'
+                    observe: 'enterprise_customer_catalog',
+                    update: function($el, val) {
+                        $el.val(val);
+                        this.updateEnterpriseCatalogDetailsLink();
+                    }
                 },
                 'input[name=notify_email]': {
                     observe: 'notify_email',
@@ -84,7 +88,22 @@ define([
                 'change [name=invoice_type]': 'toggleInvoiceFields',
                 'change [name=tax_deduction]': 'toggleTaxDeductedSourceField',
                 'click .external-link': 'routeToLink',
-                'click #cancel-button': 'cancelButtonClicked'
+                'click #cancel-button': 'cancelButtonClicked',
+                'change input[name=enterprise_customer_catalog]': 'updateEnterpriseCatalogDetailsLink'
+            },
+
+            updateEnterpriseCatalogDetailsLink: function() {
+                var enterpriseCoupon = this.$('[name=enterprise_customer_catalog]').val();
+                var enterpriseAPIURL = this.model.get('enterprise_catalog_url_template');
+                if (enterpriseCoupon && enterpriseAPIURL) {
+                    this.$(
+                        '#enterprise-catalog-details'
+                    ).attr('href', enterpriseAPIURL + enterpriseCoupon).addClass('external-link').removeClass('hidden');
+                } else {
+                    this.$(
+                        '#enterprise-catalog-details'
+                    ).removeAttr('href').removeClass('external-link').addClass('hidden');
+                }
             },
 
             getEditableAttributes: function() {

--- a/ecommerce/static/templates/enterprise_coupon_detail.html
+++ b/ecommerce/static/templates/enterprise_coupon_detail.html
@@ -31,7 +31,9 @@
         </div>
         <div class="info-item grid-item enterprise-customer-catalog">
             <div class="heading"><%= gettext('Enterprise Customer Catalog') %></div>
-            <div class="value"><%= coupon.enterprise_customer_catalog %></div><br />
+            <div class="value">
+              <a class="external-link enterprise-catalog-details-link" href="<%= coupon.enterprise_catalog_url_template %><%= coupon.enterprise_customer_catalog %>" aria-label="View enterprise catalog details."><%= coupon.enterprise_customer_catalog %></a>
+            </div><br />
         </div>
         <div class="info-item grid-item category">
             <div class="heading"><%= gettext('Category') %></div>

--- a/ecommerce/static/templates/enterprise_coupon_form.html
+++ b/ecommerce/static/templates/enterprise_coupon_form.html
@@ -160,6 +160,7 @@
         <div class="form-group enterprise-customer-catalog">
             <label for="enterprise-customer-catalog"><%= gettext('Enterprise Customer Catalog') %></label>
             <input id="enterprise-customer-catalog" type="text" class="form-control" name="enterprise_customer_catalog">
+            <a id="enterprise-catalog-details" aria-label="View enterprise catalog details.">Enterprise Catalog Details</a>
             <p class="help-block"></p>
         </div>
         <div class="form-group email-domains">


### PR DESCRIPTION
**Description:**
Now that enterprise catalogs are required for enterprise coupons, we can make it easier to see the courses associated with that coupon.

**Acceptance Criteria:**
Add a link below the enterprise catalog field when a catalog is filled in. This link should open in a new tab and show the JSON results of the catalog.