### PR TITLE
Added tox to run unit tests under Python 2.7 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: python
-python:
-  - "2.7"
 
 branches:
   only:
@@ -26,11 +24,10 @@ before_install:
 
 matrix:
   include:
-    - env: TESTNAME=quality-and-js
-
+    - python: 2.7
+      env: TESTNAME=quality-and-js
       install:
         - docker exec -t ecommerce_testing bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/ && make requirements'
-
       script:
         - docker exec -t ecommerce_testing bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/docs && make html'
         - docker exec -t ecommerce_testing bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/ && DJANGO_SETTINGS_MODULE=ecommerce.settings.test make check_translations_up_to_date'
@@ -42,19 +39,26 @@ matrix:
         - docker exec -t ecommerce_testing bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/ && DJANGO_SETTINGS_MODULE=ecommerce.settings.test make run_pylint'
         - docker exec -t ecommerce_testing bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/ && DJANGO_SETTINGS_MODULE=ecommerce.settings.test xvfb-run make validate_js'
 
-
-    - env: TESTNAME=test-python
-
+    - python: 2.7
+      env: TESTNAME=test-python
       install:
         - docker exec -t ecommerce_testing bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/ && make requirements'
-
       script:
         - docker exec -t ecommerce_testing bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/docs && make html'
         - docker exec -t ecommerce_testing bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/ && DJANGO_SETTINGS_MODULE=ecommerce.settings.test make clean_static'
         - docker exec -t ecommerce_testing bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/ && DJANGO_SETTINGS_MODULE=ecommerce.settings.test make static'
         - docker exec -t ecommerce_testing bash -c 'source /edx/app/ecommerce/ecommerce_env && cd /edx/app/ecommerce/ecommerce/ && DJANGO_SETTINGS_MODULE=ecommerce.settings.test TRAVIS=1 xvfb-run make validate_python'
-
       after_success:
         - pip install -U codecov
         - docker exec ecommerce_testing /edx/app/ecommerce/ecommerce/.travis/run_coverage.sh
         - codecov
+    
+    - python: 3.6
+      env: TESTNAME=test-python-3.6 TOXENV=py36
+      install:
+        - pip install tox==3.12.1
+      script:
+        - tox
+  allow_failures:
+    - env: TESTNAME=test-python-3.6 TOXENV=py36
+

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -159,6 +159,7 @@ stevedore==1.30.1         # via edx-opaque-keys
 stripe==1.70.0
 testfixtures==4.5.0
 text-unidecode==1.2       # via faker
+tox==3.12.1
 transifex-client==0.12.2
 typing==3.6.6             # via django-extensions
 unicodecsv==0.14.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+skipsdist=True
+envlist = {py27,py36}-master
+
+[testenv]
+setenv =
+    PYTHONPATH = {toxinidir}
+whitelist_externals =
+    make
+commands = make requirements
+           make validate


### PR DESCRIPTION
This is the first step in the migration of e-commerce to python 3.6. I have added tox that will make unit tests run under Python 2.7 and 3.6. This PR contains tox configurations only.