### PR TITLE
make enterprise catalog field a dropdown

### DIFF
--- a/ecommerce/enterprise/tests/mixins.py
+++ b/ecommerce/enterprise/tests/mixins.py
@@ -666,3 +666,37 @@ class EnterpriseServiceMockMixin(object):
             body=body,
             content_type='application/json'
         )
+
+    def mock_enterprise_catalog_api(self, enterprise_customer_uuid, raise_exception=None):
+        """
+        Helper function to register the enterprise catalog API endpoint.
+        """
+        enterprise_catalog_api_response = {
+            'count': 10,
+            'num_pages': 3,
+            'current_page': 2,
+            'results': [
+                {
+                    'enterprise_customer': '6ae013d4-c5c4-474d-8da9-0e559b2448e2',
+                    'uuid': '869d26dd-2c44-487b-9b6a-24eee973f9a4',
+                    'title': 'batman_catalog'
+                },
+                {
+                    'enterprise_customer': '6ae013d4-c5c4-474d-8da9-0e559b2448e2',
+                    'uuid': '1a61de70-f8e8-4e8c-a76e-01783a930ae6',
+                    'title': 'new catalog'
+                }
+            ],
+            'next': "{}?enterprise_customer={}&page=3".format(self.ENTERPRISE_CATALOG_URL, enterprise_customer_uuid),
+            'previous': "{}?enterprise_customer={}".format(self.ENTERPRISE_CATALOG_URL, enterprise_customer_uuid),
+            'start': 0,
+        }
+
+        self.mock_access_token_response()
+        body = raise_timeout if raise_exception else json.dumps(enterprise_catalog_api_response)
+        httpretty.register_uri(
+            method=httpretty.GET,
+            uri='{}'.format(self.ENTERPRISE_CATALOG_URL),
+            body=body,
+            content_type='application/json'
+        )

--- a/ecommerce/extensions/api/v2/urls.py
+++ b/ecommerce/extensions/api/v2/urls.py
@@ -87,6 +87,11 @@ SDN_URLS = [
 
 ENTERPRISE_URLS = [
     url(r'^customers$', enterprise_views.EnterpriseCustomerViewSet.as_view(), name='enterprise_customers'),
+    url(
+        r'^customer_catalogs$',
+        enterprise_views.EnterpriseCustomerCatalogsViewSet.as_view({'get': 'get'}),
+        name='enterprise_customer_catalogs'
+    ),
 ]
 
 ASSIGNMENT_EMAIL_URLS = [

--- a/ecommerce/static/js/apps/enterprise_coupon_admin_app.js
+++ b/ecommerce/static/js/apps/enterprise_coupon_admin_app.js
@@ -2,6 +2,7 @@ require([
     'backbone',
     'collections/category_collection',
     'collections/enterprise_customer_collection',
+    'collections/enterprise_customer_catalogs_collection',
     'ecommerce',
     'routers/enterprise_coupon_router',
     'utils/navigate'
@@ -9,6 +10,7 @@ require([
     function(Backbone,
               CategoryCollection,
               EnterpriseCustomerCollection,
+              EnterpriseCustomerCatalogsCollection,
               ecommerce,
               CouponRouter,
               navigate) {
@@ -32,6 +34,7 @@ require([
             ecommerce.coupons.categories.url = '/api/v2/coupons/categories/';
 
             ecommerce.coupons.enterprise_customers = new EnterpriseCustomerCollection();
+            ecommerce.coupons.enterprise_customer_catalogs = new EnterpriseCustomerCatalogsCollection();
 
             $.when(
                 ecommerce.coupons.categories.fetch(),

--- a/ecommerce/static/js/collections/enterprise_customer_catalogs_collection.js
+++ b/ecommerce/static/js/collections/enterprise_customer_catalogs_collection.js
@@ -1,0 +1,14 @@
+/* istanbul ignore next */
+define([
+    'collections/paginated_collection',
+    'models/enterprise_customer_catalogs_model'
+],
+    function(PaginatedCollection, EnterpriseCustomerCatalogs) {
+        'use strict';
+
+        return PaginatedCollection.extend({
+            model: EnterpriseCustomerCatalogs,
+            url: '/api/v2/enterprise/customer_catalogs'
+        });
+    }
+);

--- a/ecommerce/static/js/collections/paginated_collection.js
+++ b/ecommerce/static/js/collections/paginated_collection.js
@@ -8,8 +8,7 @@ define([
             parse: function(response) {
                 // Continue retrieving the remaining data
                 if (response.next) {
-                    this.url = response.next;
-                    this.fetch({remove: false});
+                    this.fetch({remove: false, url: response.next});
                 }
                 return response.results;
             }

--- a/ecommerce/static/js/models/enterprise_customer_catalogs_model.js
+++ b/ecommerce/static/js/models/enterprise_customer_catalogs_model.js
@@ -1,0 +1,13 @@
+/* istanbul ignore next */
+define([
+    'backbone',
+    'backbone.relational'
+],
+    function(Backbone) {
+        'use strict';
+
+        return Backbone.RelationalModel.extend({
+            urlRoot: '/api/v2/enterprise/customer_catalogs'
+        });
+    }
+);

--- a/ecommerce/static/js/test/mock_data/enterprise_customer_catalogs.js
+++ b/ecommerce/static/js/test/mock_data/enterprise_customer_catalogs.js
@@ -1,0 +1,25 @@
+define([], function() {
+    'use strict';
+
+    var customerCatalogs = {
+        next: null,
+        results: [
+            {
+                enterprise_customer: '349bef52-c0fb-4901-a5b5-26e9b70a4102',
+                uuid: '869d26dd-2c44-487b-9b6a-24eee973f9a4',
+                title: 'Battlestar Galactica'
+            },
+            {
+                enterprise_customer: '349bef52-c0fb-4901-a5b5-26e9b70a4102',
+                uuid: '1a61de70-f8e8-4e8c-a76e-01783a930ae6',
+                title: 'Starship Enterprise'
+            },
+            {
+                enterprise_customer: '349bef52-c0fb-4901-a5b5-26e9b70a4102',
+                uuid: 'f9098aab-1842-45c8-81a2-0e53d8e7609a',
+                title: 'Millenium Falcon'
+            }
+        ]
+    };
+    return customerCatalogs;
+});

--- a/ecommerce/static/js/test/specs/collections/catalog_collection_spec.js
+++ b/ecommerce/static/js/test/specs/collections/catalog_collection_spec.js
@@ -20,8 +20,9 @@ define([
                     response.next = '/api/v2/catalogs/course_catalogs/?page=2';
 
                     collection.parse(response);
-                    expect(collection.url).toEqual(response.next);
-                    expect(collection.fetch).toHaveBeenCalledWith({remove: false});
+                    expect(collection.fetch).toHaveBeenCalledWith(
+                        {remove: false, url: '/api/v2/catalogs/course_catalogs/?page=2'}
+                    );
                 });
             });
         });

--- a/ecommerce/static/js/test/specs/collections/course_collection_spec.js
+++ b/ecommerce/static/js/test/specs/collections/course_collection_spec.js
@@ -37,8 +37,7 @@ define([
                     response.next = '/api/v2/courses/?page=2';
 
                     collection.parse(response);
-                    expect(collection.url).toEqual(response.next);
-                    expect(collection.fetch).toHaveBeenCalledWith({remove: false});
+                    expect(collection.fetch).toHaveBeenCalledWith({remove: false, url: '/api/v2/courses/?page=2'});
                 });
             });
         });

--- a/ecommerce/static/templates/enterprise_coupon_form.html
+++ b/ecommerce/static/templates/enterprise_coupon_form.html
@@ -159,7 +159,7 @@
         </div>
         <div class="form-group enterprise-customer-catalog">
             <label for="enterprise-customer-catalog"><%= gettext('Enterprise Customer Catalog') %></label>
-            <input id="enterprise-customer-catalog" type="text" class="form-control" name="enterprise_customer_catalog">
+            <select id="enterprise-customer-catalog" class="form-control" name="enterprise_customer_catalog" disabled></select>
             <a id="enterprise-catalog-details" aria-label="View enterprise catalog details.">Enterprise Catalog Details</a>
             <p class="help-block"></p>
         </div>


### PR DESCRIPTION
**Description:** This converts the `Enterprise Customer Catalog` field on Enterprise Create/Edit screen to a dropdown. Contents of the dropdown will be names of all the catalogs belong to the enterprise customer selected in the `Enterprise Customer` field.  

**JIRA:** [ENT-1986](https://openedx.atlassian.net/browse/ENT-1986)

**Testing:** PR changes are deployed to sandbox.

**Credentials:**
username: edx 
password: edx

1. Login to https://ecommerce-mammar.sandbox.edx.org/admin with the above credentials
2. Then go to https://ecommerce-mammar.sandbox.edx.org/enterprise/coupons/new/
3. Creating/Editing an Enterprise Coupon should work

