### PR TITLE
Add *.bak for gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ docs/_build
 
 # emacs
 *~
+
+### Unknown artifacts
+*.bak


### PR DESCRIPTION
While running `python-modernize`, its generate .bak file.
So, I guess we need to ignore `*.bak` in git

@edx/ecommerce