### PR TITLE
Adding *.bak to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ private.py
 docs/_build
 *.backup
 *.log
+*.bak
 
 # Visual Studio Code
 .vscode


### PR DESCRIPTION
modernize generates .bak files while running python-modernize command. We need to add this extension in .gitignore as there is no need to commit these files. 