### PR TITLE
REVMI-286 Get most recent access token

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -497,8 +497,17 @@ class User(AbstractUser):
 
     @property
     def access_token(self):
+        """
+        Returns the access token from the extra data in the user's social auth.
+
+        Note that a single user_id can be associated with multiple provider/uid combinations. For example:
+            provider    uid             user_id
+            edx-oidc    person          123
+            edx-oauth2  person          123
+            edx-oauth2  person@edx.org  123
+        """
         try:
-            return self.social_auth.first().extra_data[u'access_token']  # pylint: disable=no-member
+            return self.social_auth.order_by('-id').first().extra_data[u'access_token']  # pylint: disable=no-member
         except Exception:  # pylint: disable=broad-except
             return None
 


### PR DESCRIPTION
Get the most recently saved access token and LMS user id.

Background: when we initially added code to get the user_id from the user's social auth, we only checked in the first (oldest) social auth row. This had a high rate of misses. When we switched to looping over all of the social auth rows for a user, the rate of misses plummeted.

Since the access token code also only checked the first (oldest) row, it seemed like a good idea to update it to account for users can having multiple social auth db rows (see REVMI-285 for queries I ran while looking into this).