### PR TITLE
Enable back button from receipt page

### DIFF
--- a/ecommerce/static/js/pages/receipt_page.js
+++ b/ecommerce/static/js/pages/receipt_page.js
@@ -51,7 +51,9 @@ define([
                 orderId = $el.data('order-id'),
                 totalAmount = $el.data('total-amount');
 
-            disableBackButton();
+            if (document.referrer.toLowerCase().includes('payment')) {
+                disableBackButton();
+            }
 
             if (orderId) {
                 trackPurchase(orderId, totalAmount, currency);

--- a/ecommerce/static/js/test/specs/pages/receipt_page_spec.js
+++ b/ecommerce/static/js/test/specs/pages/receipt_page_spec.js
@@ -24,7 +24,6 @@ define([
             describe('onReady', function() {
                 it('should disable the back button by manipulating the fragment', function() {
                     spyOnProperty(document, 'referrer', 'get').and.returnValue('payment/cybersource/redirect/');
-                    spyOn(window, 'alert')
 
                     ReceiptPage.onReady();
 
@@ -33,21 +32,16 @@ define([
                     history.back();
 
                     expect(location.hash).toContain('#');
-                    expect(window.alert).toHaveBeenCalledWith('Caution! Using the back button on this page may cause you to be charged again.');
                 });
 
                 it('should not disable the back button if the referrer is not payment page', function() {
+                    history.replaceState(null, null, '');
                     var referrer = 'account/settings';
-                    var currentLocation = location.href;
 
                     spyOnProperty(document, 'referrer', 'get').and.returnValue(referrer);
 
                     ReceiptPage.onReady();
                     expect(location.hash).toEqual('');
-
-                    // It will allow the user to go back since the referrer is not the payment page
-                    history.back();
-                    expect(location.href).not.toEqual(currentLocation);
                 });
 
                 it('should trigger track purchase', function() {

--- a/ecommerce/static/js/test/specs/pages/receipt_page_spec.js
+++ b/ecommerce/static/js/test/specs/pages/receipt_page_spec.js
@@ -23,6 +23,9 @@ define([
 
             describe('onReady', function() {
                 it('should disable the back button by manipulating the fragment', function() {
+                    spyOnProperty(document, 'referrer', 'get').and.returnValue('payment/cybersource/redirect/');
+                    spyOn(window, 'alert')
+
                     ReceiptPage.onReady();
 
                     expect(location.hash).toContain('#');
@@ -30,6 +33,21 @@ define([
                     history.back();
 
                     expect(location.hash).toContain('#');
+                    expect(window.alert).toHaveBeenCalledWith('Caution! Using the back button on this page may cause you to be charged again.');
+                });
+
+                it('should not disable the back button if the referrer is not payment page', function() {
+                    var referrer = 'account/settings';
+                    var currentLocation = location.href;
+
+                    spyOnProperty(document, 'referrer', 'get').and.returnValue(referrer);
+
+                    ReceiptPage.onReady();
+                    expect(location.hash).toEqual('');
+
+                    // It will allow the user to go back since the referrer is not the payment page
+                    history.back();
+                    expect(location.href).not.toEqual(currentLocation);
                 });
 
                 it('should trigger track purchase', function() {


### PR DESCRIPTION
**This is a test PR**
#### Steps to reproduce current behavior:
* Go to https://ecommerce.edx.org/checkout/receipt/?order_number=EDX-29479306#jwudxzwa
* Press back button
* You will get a pop-up saying "Caution! Using the back button on this page may cause you to be charged again."

#### Expected Behavior:
* If a user is viewing order receipt from order history, don't disable the back button. 
* Disable only if the user has landed on receipt page after completing a payment, in which case user might be charged again if he goes back.



[PROD-376](https://openedx.atlassian.net/browse/PROD-376)