### PR TITLE
Updated Python requirements

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -37,6 +37,7 @@ gevent==1.0.2
 jsonfield==1.0.3
 libsass==0.9.2
 markdown==2.6.9
+mysqlclient<1.5
 ndg-httpsclient
 path.py==7.2
 paypalrestsdk
@@ -44,6 +45,8 @@ premailer==2.9.2
 pycountry==17.1.8
 pygments
 python-dateutil
+python-openid ; python_version == "2.7"
+python3-openid ; python_version >= "3"
 pytz==2016.10
 requests
 rules

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ babel==2.7.0              # via django-oscar, django-phonenumber-field
 billiard==3.3.0.23        # via celery
 cached-property==1.5.1    # via zeep
 celery==3.1.26.post2      # via edx-ecommerce-worker
-certifi==2019.3.9         # via requests
+certifi==2019.6.16        # via requests
 cffi==1.12.3              # via cryptography
 chardet==3.0.4            # via requests
 coreapi==2.3.3
@@ -78,13 +78,14 @@ lxml==4.3.4               # via premailer, zeep
 markdown==2.6.9
 markupsafe==1.1.1         # via jinja2
 mock==2.0.0               # via django-oscar
+mysqlclient==1.4.2.post1
 ndg-httpsclient==0.5.1
 newrelic==4.20.0.120      # via edx-django-utils
 oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 path.py==7.2
 paypalrestsdk==1.13.1
-pbr==5.2.1                # via mock, stevedore
+pbr==5.3.1                # via mock, stevedore
 phonenumberslite==8.10.13  # via django-phonenumber-field
 pillow==6.0.0             # via django-oscar
 premailer==2.9.2
@@ -100,7 +101,8 @@ pyjwt==1.7.1              # via djangorestframework-jwt, edx-auth-backends, edx-
 pymongo==3.8.0            # via edx-opaque-keys
 pyopenssl==19.0.0         # via ndg-httpsclient, paypalrestsdk
 python-dateutil==2.8.0
-python-openid==2.2.5      # via social-auth-core
+python-openid==2.2.5 ; python_version == "2.7"
+python3-openid==3.1.0 ; python_version >= "3"  # via social-auth-core
 pytz==2016.10
 pyyaml==5.1.1             # via edx-django-release-util
 rcssmin==1.0.6            # via django-compressor
@@ -121,7 +123,7 @@ sorl-thumbnail==12.5.0    # via django-oscar
 stevedore==1.30.1         # via edx-opaque-keys
 stripe==1.70.0
 text-unidecode==1.2       # via faker
-typing==3.6.6             # via django-extensions
+typing==3.7.4             # via django-extensions
 unicodecsv==0.14.1
 unidecode==0.4.21         # via django-oscar
 uritemplate==3.0.0        # via coreapi

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,10 +18,11 @@ beautifulsoup4==4.7.1     # via webtest
 billiard==3.3.0.23        # via celery
 cached-property==1.5.1    # via zeep
 celery==3.1.26.post2      # via edx-ecommerce-worker
-certifi==2019.3.9         # via requests
+certifi==2019.6.16        # via requests
 cffi==1.12.3              # via cryptography
 chardet==3.0.4            # via requests
-configparser==3.7.4       # via pylint
+configparser==3.7.4       # via importlib-metadata, pylint
+contextlib2==0.5.5        # via importlib-metadata
 cookies==2.2.1            # via responses
 coreapi==2.3.3
 coreschema==0.0.4         # via coreapi
@@ -77,6 +78,7 @@ edx-sphinx-theme==1.0.2
 enum34==1.1.6             # via cryptography
 factory-boy==2.8.1
 faker==1.0.7              # via factory-boy
+filelock==3.0.12          # via tox
 freezegun==0.3.7
 funcsigs==1.0.2           # via mock
 future==0.17.1            # via pyjwkest
@@ -85,6 +87,7 @@ greenlet==0.4.15          # via gevent
 httpretty==0.8.14
 idna==2.8                 # via requests
 imagesize==1.1.0          # via sphinx
+importlib-metadata==0.18  # via pluggy
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography, faker
 isodate==0.6.0            # via zeep
@@ -102,6 +105,7 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 mock-django==0.6.9
 mock==1.3.0
+mysqlclient==1.4.2.post1
 ndg-httpsclient==0.5.1
 newrelic==4.20.0.120      # via edx-django-utils
 nose-ignore-docstring==0.2
@@ -109,16 +113,19 @@ nose==1.3.7               # via django-nose
 oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 path.py==7.2
+pathlib2==2.3.3           # via importlib-metadata
 paypalrestsdk==1.13.1
-pbr==5.2.1                # via mock, stevedore
+pbr==5.3.1                # via mock, stevedore
 pep8==1.6.2
 phonenumberslite==8.10.13  # via django-phonenumber-field
 pillow==6.0.0             # via django-oscar
+pluggy==0.12.0            # via tox
 polib==1.1.0              # via edx-i18n-tools
 premailer==2.9.2
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 ptvsd==3.0
 purl==1.5                 # via django-oscar
+py==1.8.0                 # via tox
 pyasn1==0.4.5             # via ndg-httpsclient
 pycountry==17.1.8
 pycparser==2.19           # via cffi
@@ -131,7 +138,8 @@ pylint==1.6.4
 pymongo==3.8.0            # via edx-opaque-keys
 pyopenssl==19.0.0         # via ndg-httpsclient, paypalrestsdk
 python-dateutil==2.8.0
-python-openid==2.2.5      # via social-auth-core
+python-openid==2.2.5 ; python_version == "2.7"
+python3-openid==3.1.0 ; python_version >= "3"  # via social-auth-core
 pytz==2016.10
 pyyaml==5.1.1             # via edx-django-release-util, edx-i18n-tools
 rcssmin==1.0.6            # via django-compressor
@@ -143,6 +151,7 @@ rest-condition==1.0.3     # via edx-drf-extensions
 rjsmin==1.0.12            # via django-compressor
 rules==2.0.1
 sailthru-client==2.2.3
+scandir==1.10.0           # via pathlib2
 selenium==3.4.3
 semantic-version==2.6.0   # via edx-drf-extensions
 simplejson==3.16.0        # via django-rest-swagger, sailthru-client
@@ -157,17 +166,20 @@ sphinx==1.5.3
 sqlparse==0.3.0           # via django-debug-toolbar
 stevedore==1.30.1         # via edx-opaque-keys
 stripe==1.70.0
-testfixtures==6.9.0
+testfixtures==6.10.0
 text-unidecode==1.2       # via faker
+toml==0.10.0              # via tox
 tox==3.12.1
 transifex-client==0.12.2
-typing==3.6.6             # via django-extensions
+typing==3.7.4             # via django-extensions
 unicodecsv==0.14.1
 unidecode==0.4.21         # via django-oscar
 uritemplate==3.0.0        # via coreapi
 urllib3==1.25.3           # via requests, transifex-client
+virtualenv==16.6.1        # via tox
 waitress==1.3.0           # via webtest
 webob==1.8.5              # via webtest
 webtest==2.0.33           # via django-webtest
-wrapt==1.11.1             # via astroid
+wrapt==1.11.2             # via astroid
 zeep==3.4.0
+zipp==0.5.1               # via importlib-metadata

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.12         # via sphinx
 babel==2.7.0              # via sphinx
-certifi==2019.3.9         # via requests
+certifi==2019.6.16        # via requests
 chardet==3.0.4            # via requests
 docutils==0.14            # via sphinx
 edx-sphinx-theme==1.0.2

--- a/requirements/production.in
+++ b/requirements/production.in
@@ -8,7 +8,6 @@ django-ses==0.8.2
 gevent==1.0.2
 
 gunicorn==19.7.1
-MySQL-python==1.2.5
 newrelic<5
 python-memcached==1.58
 PyYAML

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -15,7 +15,7 @@ billiard==3.3.0.23        # via celery
 boto==2.49.0              # via django-ses
 cached-property==1.5.1    # via zeep
 celery==3.1.26.post2      # via edx-ecommerce-worker
-certifi==2019.3.9         # via requests
+certifi==2019.6.16        # via requests
 cffi==1.12.3              # via cryptography
 chardet==3.0.4            # via requests
 coreapi==2.3.3
@@ -81,7 +81,7 @@ lxml==4.3.4               # via premailer, zeep
 markdown==2.6.9
 markupsafe==1.1.1         # via jinja2
 mock==2.0.0               # via django-oscar
-mysql-python==1.2.5
+mysqlclient==1.4.2.post1
 ndg-httpsclient==0.5.1
 newrelic==4.20.0.120
 nodeenv==1.1.1
@@ -89,7 +89,7 @@ oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 path.py==7.2
 paypalrestsdk==1.13.1
-pbr==5.2.1                # via mock, stevedore
+pbr==5.3.1                # via mock, stevedore
 phonenumberslite==8.10.13  # via django-phonenumber-field
 pillow==6.0.0             # via django-oscar
 premailer==2.9.2
@@ -106,7 +106,8 @@ pymongo==3.8.0            # via edx-opaque-keys
 pyopenssl==19.0.0         # via ndg-httpsclient, paypalrestsdk
 python-dateutil==2.8.0
 python-memcached==1.58
-python-openid==2.2.5      # via social-auth-core
+python-openid==2.2.5 ; python_version == "2.7"
+python3-openid==3.1.0 ; python_version >= "3"  # via social-auth-core
 pytz==2016.10
 pyyaml==5.1.1
 rcssmin==1.0.6            # via django-compressor
@@ -128,7 +129,7 @@ sorl-thumbnail==12.5.0    # via django-oscar
 stevedore==1.30.1         # via edx-opaque-keys
 stripe==1.70.0
 text-unidecode==1.2       # via faker
-typing==3.6.6             # via django-extensions
+typing==3.7.4             # via django-extensions
 unicodecsv==0.14.1
 unidecode==0.4.21         # via django-oscar
 uritemplate==3.0.0        # via coreapi

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -18,3 +18,4 @@ pylint==1.6.4
 responses==0.5.1
 selenium==3.4.3
 testfixtures                # Provides a LogCapture utility used by several tests
+tox

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -17,10 +17,11 @@ beautifulsoup4==4.7.1     # via webtest
 billiard==3.3.0.23        # via celery
 cached-property==1.5.1    # via zeep
 celery==3.1.26.post2      # via edx-ecommerce-worker
-certifi==2019.3.9         # via requests
+certifi==2019.6.16        # via requests
 cffi==1.12.3              # via cryptography
 chardet==3.0.4            # via requests
-configparser==3.7.4       # via pylint
+configparser==3.7.4       # via importlib-metadata, pylint
+contextlib2==0.5.5        # via importlib-metadata
 cookies==2.2.1            # via responses
 coreapi==2.3.3
 coreschema==0.0.4         # via coreapi
@@ -72,6 +73,7 @@ edx-rest-api-client==1.9.2
 enum34==1.1.6             # via cryptography
 factory-boy==2.8.1
 faker==1.0.7              # via factory-boy
+filelock==3.0.12          # via tox
 freezegun==0.3.7
 funcsigs==1.0.2           # via mock
 future==0.17.1            # via pyjwkest
@@ -79,6 +81,7 @@ gevent==1.0.2
 greenlet==0.4.15          # via gevent
 httpretty==0.8.14
 idna==2.8                 # via requests
+importlib-metadata==0.18  # via pluggy
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via cryptography, faker
 isodate==0.6.0            # via zeep
@@ -96,6 +99,7 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 mock-django==0.6.9
 mock==1.3.0
+mysqlclient==1.4.2.post1
 ndg-httpsclient==0.5.1
 newrelic==4.20.0.120      # via edx-django-utils
 nose-ignore-docstring==0.2
@@ -103,14 +107,17 @@ nose==1.3.7               # via django-nose
 oauthlib==3.0.1           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 path.py==7.2
+pathlib2==2.3.3           # via importlib-metadata
 paypalrestsdk==1.13.1
-pbr==5.2.1                # via mock, stevedore
+pbr==5.3.1                # via mock, stevedore
 pep8==1.6.2
 phonenumberslite==8.10.13  # via django-phonenumber-field
 pillow==6.0.0             # via django-oscar
+pluggy==0.12.0            # via tox
 premailer==2.9.2
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 purl==1.5                 # via django-oscar
+py==1.8.0                 # via tox
 pyasn1==0.4.5             # via ndg-httpsclient
 pycountry==17.1.8
 pycparser==2.19           # via cffi
@@ -122,7 +129,8 @@ pylint==1.6.4
 pymongo==3.8.0            # via edx-opaque-keys
 pyopenssl==19.0.0         # via ndg-httpsclient, paypalrestsdk
 python-dateutil==2.8.0
-python-openid==2.2.5      # via social-auth-core
+python-openid==2.2.5 ; python_version == "2.7"
+python3-openid==3.1.0 ; python_version >= "3"
 pytz==2016.10
 pyyaml==5.1.1             # via edx-django-release-util
 rcssmin==1.0.6            # via django-compressor
@@ -134,6 +142,7 @@ rest-condition==1.0.3     # via edx-drf-extensions
 rjsmin==1.0.12            # via django-compressor
 rules==2.0.1
 sailthru-client==2.2.3
+scandir==1.10.0           # via pathlib2
 selenium==3.4.3
 semantic-version==2.6.0   # via edx-drf-extensions
 simplejson==3.16.0        # via django-rest-swagger, sailthru-client
@@ -145,15 +154,19 @@ sorl-thumbnail==12.5.0    # via django-oscar
 soupsieve==1.9.1          # via beautifulsoup4
 stevedore==1.30.1         # via edx-opaque-keys
 stripe==1.70.0
-testfixtures==6.9.0
+testfixtures==6.10.0
 text-unidecode==1.2       # via faker
-typing==3.6.6             # via django-extensions
+toml==0.10.0              # via tox
+tox==3.12.1
+typing==3.7.4             # via django-extensions
 unicodecsv==0.14.1
 unidecode==0.4.21         # via django-oscar
 uritemplate==3.0.0        # via coreapi
 urllib3==1.25.3           # via requests
+virtualenv==16.6.1        # via tox
 waitress==1.3.0           # via webtest
 webob==1.8.5              # via webtest
 webtest==2.0.33           # via django-webtest
-wrapt==1.11.1             # via astroid
+wrapt==1.11.2             # via astroid
 zeep==3.4.0
+zipp==0.5.1               # via importlib-metadata


### PR DESCRIPTION
`mysql-python` is replaced with `mysqlclient`. It is required for Python 3 support. Ran `make upgrade` command to generate and update dependency versions