### PR TITLE
install code-annotations

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -102,7 +102,6 @@ pymongo==3.8.0            # via edx-opaque-keys
 pyopenssl==19.0.0         # via ndg-httpsclient, paypalrestsdk
 python-dateutil==2.8.0
 python-openid==2.2.5 ; python_version == "2.7"
-python3-openid==3.1.0 ; python_version >= "3"  # via social-auth-core
 pytz==2016.10
 pyyaml==5.1.1             # via edx-django-release-util
 rcssmin==1.0.6            # via django-compressor

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,6 +21,8 @@ celery==3.1.26.post2      # via edx-ecommerce-worker
 certifi==2019.6.16        # via requests
 cffi==1.12.3              # via cryptography
 chardet==3.0.4            # via requests
+click==7.0                # via code-annotations
+code-annotations==0.3.2
 configparser==3.7.4       # via importlib-metadata, pylint
 contextlib2==0.5.5        # via importlib-metadata
 cookies==2.2.1            # via responses
@@ -94,7 +96,7 @@ isodate==0.6.0            # via zeep
 isort==4.2.5
 itypes==1.1.0             # via coreapi
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.10.1            # via coreschema, diff-cover, jinja2-pluralize, sphinx
+jinja2==2.10.1            # via code-annotations, coreschema, diff-cover, jinja2-pluralize, sphinx
 jsonfield==1.0.3
 kombu==3.0.37             # via celery
 lazy-object-proxy==1.4.1  # via astroid
@@ -139,9 +141,9 @@ pymongo==3.8.0            # via edx-opaque-keys
 pyopenssl==19.0.0         # via ndg-httpsclient, paypalrestsdk
 python-dateutil==2.8.0
 python-openid==2.2.5 ; python_version == "2.7"
-python3-openid==3.1.0 ; python_version >= "3"  # via social-auth-core
+python-slugify==3.0.2     # via code-annotations
 pytz==2016.10
-pyyaml==5.1.1             # via edx-django-release-util, edx-i18n-tools
+pyyaml==5.1.1             # via code-annotations, edx-django-release-util, edx-i18n-tools
 rcssmin==1.0.6            # via django-compressor
 requests-oauthlib==1.2.0  # via social-auth-core
 requests-toolbelt==0.9.1  # via zeep
@@ -164,10 +166,10 @@ sorl-thumbnail==12.5.0    # via django-oscar
 soupsieve==1.9.1          # via beautifulsoup4
 sphinx==1.5.3
 sqlparse==0.3.0           # via django-debug-toolbar
-stevedore==1.30.1         # via edx-opaque-keys
+stevedore==1.30.1         # via code-annotations, edx-opaque-keys
 stripe==1.70.0
 testfixtures==6.10.0
-text-unidecode==1.2       # via faker
+text-unidecode==1.2       # via faker, python-slugify
 toml==0.10.0              # via tox
 tox==3.12.1
 transifex-client==0.12.2
@@ -183,3 +185,6 @@ webtest==2.0.33           # via django-webtest
 wrapt==1.11.2             # via astroid
 zeep==3.4.0
 zipp==0.5.1               # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools==41.0.1        # via tox

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -107,7 +107,6 @@ pyopenssl==19.0.0         # via ndg-httpsclient, paypalrestsdk
 python-dateutil==2.8.0
 python-memcached==1.58
 python-openid==2.2.5 ; python_version == "2.7"
-python3-openid==3.1.0 ; python_version >= "3"  # via social-auth-core
 pytz==2016.10
 pyyaml==5.1.1
 rcssmin==1.0.6            # via django-compressor

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,5 +1,6 @@
 -r base.in
 
+code-annotations
 coverage==4.3.4
 ddt==1.1.1
 diff-cover==0.9.6

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -20,6 +20,8 @@ celery==3.1.26.post2      # via edx-ecommerce-worker
 certifi==2019.6.16        # via requests
 cffi==1.12.3              # via cryptography
 chardet==3.0.4            # via requests
+click==7.0                # via code-annotations
+code-annotations==0.3.2
 configparser==3.7.4       # via importlib-metadata, pylint
 contextlib2==0.5.5        # via importlib-metadata
 cookies==2.2.1            # via responses
@@ -88,7 +90,7 @@ isodate==0.6.0            # via zeep
 isort==4.2.5
 itypes==1.1.0             # via coreapi
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.10.1            # via coreschema, diff-cover, jinja2-pluralize
+jinja2==2.10.1            # via code-annotations, coreschema, diff-cover, jinja2-pluralize
 jsonfield==1.0.3
 kombu==3.0.37             # via celery
 lazy-object-proxy==1.4.1  # via astroid
@@ -130,9 +132,9 @@ pymongo==3.8.0            # via edx-opaque-keys
 pyopenssl==19.0.0         # via ndg-httpsclient, paypalrestsdk
 python-dateutil==2.8.0
 python-openid==2.2.5 ; python_version == "2.7"
-python3-openid==3.1.0 ; python_version >= "3"
+python-slugify==3.0.2     # via code-annotations
 pytz==2016.10
-pyyaml==5.1.1             # via edx-django-release-util
+pyyaml==5.1.1             # via code-annotations, edx-django-release-util
 rcssmin==1.0.6            # via django-compressor
 requests-oauthlib==1.2.0  # via social-auth-core
 requests-toolbelt==0.9.1  # via zeep
@@ -152,10 +154,10 @@ social-auth-app-django==1.2.0  # via edx-auth-backends
 social-auth-core[openidconnect]==1.7.0  # via edx-auth-backends, social-auth-app-django
 sorl-thumbnail==12.5.0    # via django-oscar
 soupsieve==1.9.1          # via beautifulsoup4
-stevedore==1.30.1         # via edx-opaque-keys
+stevedore==1.30.1         # via code-annotations, edx-opaque-keys
 stripe==1.70.0
 testfixtures==6.10.0
-text-unidecode==1.2       # via faker
+text-unidecode==1.2       # via faker, python-slugify
 toml==0.10.0              # via tox
 tox==3.12.1
 typing==3.7.4             # via django-extensions
@@ -170,3 +172,6 @@ webtest==2.0.33           # via django-webtest
 wrapt==1.11.2             # via astroid
 zeep==3.4.0
 zipp==0.5.1               # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools==41.0.1        # via tox


### PR DESCRIPTION
As part of the feature toggle report generator, we need to have code-annotations installed in each IDA that we want to report on. This will be used to gather data on the in-code definitions of feature toggles.