### PR TITLE
REVMI-282 Add UserFactory with default LMS user id

### DIFF
--- a/ecommerce/core/management/commands/tests/factories.py
+++ b/ecommerce/core/management/commands/tests/factories.py
@@ -15,6 +15,7 @@ class PaymentEventFactory(factory.DjangoModelFactory):
 class SuperUserFactory(factory.DjangoModelFactory):
     id = FuzzyInteger(1000, 9999)
     is_superuser = True
+    lms_user_id = 56765
 
     class Meta(object):
         model = get_model('core', 'User')

--- a/ecommerce/core/management/commands/tests/test_deactivate_superusers.py
+++ b/ecommerce/core/management/commands/tests/test_deactivate_superusers.py
@@ -48,3 +48,11 @@ class DeactivateSuperUsersTest(TestCase):
         with mock.patch(self.LOGGER) as patched_log:
             call_command(self.command)
             patched_log.warn.assert_called_once_with('No superusers found, falling back.')
+
+    def test_superuser_factory_lms_user_id(self):
+        """
+        Test that the SuperUserFactory creates users with an LMS user id.
+        """
+        user = User.objects.filter(is_superuser=True).first()
+        self.assertIsNotNone(user.lms_user_id)
+        self.assertEqual(SuperUserFactory.lms_user_id, user.lms_user_id)

--- a/ecommerce/core/management/commands/tests/test_sync_hubspot.py
+++ b/ecommerce/core/management/commands/tests/test_sync_hubspot.py
@@ -11,12 +11,11 @@ from django.core.management.base import CommandError
 from django.test import TestCase
 from factory.django import get_model
 from mock import patch
-from oscar.test.factories import UserFactory
 from slumber.exceptions import HttpClientError
 
 from ecommerce.core.management.commands.sync_hubspot import Command as sync_command
 from ecommerce.extensions.test.factories import create_basket, create_order
-from ecommerce.tests.factories import SiteConfigurationFactory
+from ecommerce.tests.factories import SiteConfigurationFactory, UserFactory
 
 SiteConfiguration = get_model('core', 'SiteConfiguration')
 Basket = get_model('basket', 'Basket')

--- a/ecommerce/core/tests/test_admin.py
+++ b/ecommerce/core/tests/test_admin.py
@@ -2,10 +2,10 @@ from __future__ import absolute_import
 
 from django.contrib import messages
 from django.urls import reverse
-from oscar.test.factories import UserFactory
 
 from ecommerce.core.constants import USER_LIST_VIEW_SWITCH
 from ecommerce.core.tests import toggle_switch
+from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.testcases import TestCase
 
 
@@ -36,3 +36,10 @@ class UserAdminTests(TestCase):
         message = list(response.context['messages'])[0]
         self.assertEqual(message.level, messages.WARNING)
         self.assertEqual(message.message, msg)
+
+    def test_user_factory_lms_user_id(self):
+        """
+        Test that the UserFactory creates users with an LMS user id.
+        """
+        self.assertIsNotNone(self.user.lms_user_id)
+        self.assertEqual(UserFactory.lms_user_id, self.user.lms_user_id)

--- a/ecommerce/coupons/tests/mixins.py
+++ b/ecommerce/coupons/tests/mixins.py
@@ -15,7 +15,7 @@ from ecommerce.core.models import BusinessClient
 from ecommerce.extensions.api.v2.views.coupons import CouponViewSet
 from ecommerce.extensions.basket.utils import prepare_basket
 from ecommerce.extensions.catalogue.utils import create_coupon_product
-from ecommerce.tests.factories import PartnerFactory
+from ecommerce.tests.factories import PartnerFactory, UserFactory
 from ecommerce.tests.mixins import Applicator, Benefit, Catalog, ProductClass, SiteMixin, Voucher
 
 
@@ -504,7 +504,7 @@ class CouponMixin(SiteMixin):
 
         request = RequestFactory()
         request.site = self.site
-        request.user = factories.UserFactory()
+        request.user = UserFactory()
         request.COOKIES = {}
         request.GET = {}
 

--- a/ecommerce/enterprise/tests/test_conditions.py
+++ b/ecommerce/enterprise/tests/test_conditions.py
@@ -23,7 +23,7 @@ from ecommerce.extensions.offer.constants import (
     OFFER_REDEEMED
 )
 from ecommerce.extensions.test import factories
-from ecommerce.tests.factories import ProductFactory, SiteConfigurationFactory
+from ecommerce.tests.factories import ProductFactory, SiteConfigurationFactory, UserFactory
 from ecommerce.tests.testcases import TestCase
 
 ConditionalOffer = get_model('offer', 'ConditionalOffer')
@@ -37,7 +37,7 @@ LOGGER_NAME = 'ecommerce.programs.conditions'
 class EnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, DiscoveryTestMixin, TestCase):
     def setUp(self):
         super(EnterpriseCustomerConditionTests, self).setUp()
-        self.user = factories.UserFactory()
+        self.user = UserFactory()
         self.condition = factories.EnterpriseCustomerConditionFactory()
         self.test_product = ProductFactory(stockrecords__price_excl_tax=10, categories=[])
         self.course_run = CourseFactory(partner=self.partner)
@@ -347,7 +347,7 @@ class AssignableEnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, Cou
             expected_condition_result = assignment.get('result', expected_condition_result)
 
             voucher = Voucher.objects.get(usage=voucher_type, code=code)
-            basket = BasketFactory(site=self.site, owner=factories.UserFactory(email=email))
+            basket = BasketFactory(site=self.site, owner=UserFactory(email=email))
             basket.vouchers.add(voucher)
 
             is_condition_satisfied = self.condition.is_satisfied(voucher.enterprise_offer, basket)
@@ -381,7 +381,7 @@ class AssignableEnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, Cou
         voucher = factories.VoucherFactory(usage=Voucher.SINGLE_USE, num_orders=num_orders)
         enterprise_offer = factories.EnterpriseOfferFactory(max_global_applications=None)
         voucher.offers.add(enterprise_offer)
-        basket = BasketFactory(site=self.site, owner=factories.UserFactory(email=email))
+        basket = BasketFactory(site=self.site, owner=UserFactory(email=email))
         basket.vouchers.add(voucher)
         factories.OfferAssignmentFactory(
             offer=enterprise_offer,
@@ -409,7 +409,7 @@ class AssignableEnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, Cou
         voucher1.offers.add(enterprise_offers[0])
         voucher2.offers.add(enterprise_offers[1])
 
-        basket = BasketFactory(site=self.site, owner=factories.UserFactory(email='test2@example.com'))
+        basket = BasketFactory(site=self.site, owner=UserFactory(email='test2@example.com'))
         basket.vouchers.add(voucher1)
 
         factories.OfferAssignmentFactory(offer=enterprise_offers[0], code=voucher1.code, user_email='test1@example.com')
@@ -585,7 +585,7 @@ class AssignableEnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, Cou
         factories.OfferAssignmentFactory(offer=enterprise_offer, code=code, user_email='test1@example.com')
         factories.OfferAssignmentFactory(offer=enterprise_offer, code=code, user_email='test2@example.com')
 
-        basket = BasketFactory(site=self.site, owner=factories.UserFactory(email='bob@example.com'))
+        basket = BasketFactory(site=self.site, owner=UserFactory(email='bob@example.com'))
         basket.vouchers.add(voucher)
 
         assert self.condition.is_satisfied(enterprise_offer, basket) is True
@@ -643,7 +643,7 @@ class AssignableEnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, Cou
         voucher = factories.VoucherFactory(usage=Voucher.SINGLE_USE, code='AAA', num_orders=num_orders)
         voucher.offers.add(enterprise_offer)
 
-        basket = BasketFactory(site=self.site, owner=factories.UserFactory(email='wow@example.com'))
+        basket = BasketFactory(site=self.site, owner=UserFactory(email='wow@example.com'))
         basket.vouchers.add(voucher)
 
         assert self.condition.is_satisfied(enterprise_offer, basket) == redemptions_available

--- a/ecommerce/extensions/analytics/tests/test_utils.py
+++ b/ecommerce/extensions/analytics/tests/test_utils.py
@@ -6,7 +6,6 @@ import ddt
 import mock
 from django.contrib.auth.models import AnonymousUser
 from django.test.client import RequestFactory
-from oscar.test import factories
 
 from analytics import Client
 from ecommerce.core.models import User  # pylint: disable=unused-import
@@ -22,6 +21,7 @@ from ecommerce.extensions.analytics.utils import (
 from ecommerce.extensions.basket.tests.mixins import BasketMixin
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
 from ecommerce.extensions.test.factories import create_basket
+from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.testcases import TransactionTestCase
 
 
@@ -124,7 +124,7 @@ class UtilsTest(DiscoveryTestMixin, BasketMixin, TransactionTestCase):
         """ The method should return a dict formatted for Segment. """
         basket = create_basket(empty=True)
         basket.site = self.site
-        basket.owner = factories.UserFactory()
+        basket.owner = UserFactory()
         basket.save()
         course = CourseFactory(partner=self.partner)
         seat = course.create_or_update_seat('verified', True, 100)

--- a/ecommerce/extensions/api/tests/test_handlers.py
+++ b/ecommerce/extensions/api/tests/test_handlers.py
@@ -7,10 +7,10 @@ import jwt
 import mock
 from django.conf import settings
 from django.test import TestCase, override_settings
-from oscar.test.factories import UserFactory
 from waffle.testutils import override_switch
 
 from ecommerce.extensions.api.handlers import jwt_decode_handler
+from ecommerce.tests.factories import UserFactory
 
 
 def generate_jwt_token(payload, signing_key):

--- a/ecommerce/extensions/api/v2/tests/views/test_user_management.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_user_management.py
@@ -5,9 +5,9 @@ import json
 import ddt
 import mock
 from django.urls import reverse
-from oscar.test import factories
 from six.moves import range
 
+from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.testcases import TestCase
 
 JSON_CONTENT_TYPE = 'application/json'
@@ -21,7 +21,7 @@ class UsernameReplacementViewTests(TestCase):
 
     def setUp(self):
         super(UsernameReplacementViewTests, self).setUp()
-        self.service_user = factories.UserFactory(username=self.SERVICE_USERNAME)
+        self.service_user = UserFactory(username=self.SERVICE_USERNAME)
         self.url = reverse("api:v2:user_management:username_replacement")
 
     def build_jwt_headers(self, user):
@@ -52,7 +52,7 @@ class UsernameReplacementViewTests(TestCase):
         self.assertEqual(response.status_code, 401)
 
         # Test non-service worker
-        random_user = factories.UserFactory()
+        random_user = UserFactory()
         response = self.call_api(random_user, data)
         self.assertEqual(response.status_code, 403)
 
@@ -79,7 +79,7 @@ class UsernameReplacementViewTests(TestCase):
         in this service are also treated as a success because no work needs to
         be done changing their username.
         """
-        random_users = [factories.UserFactory() for _ in range(5)]
+        random_users = [UserFactory() for _ in range(5)]
         fake_usernames = ["myname_" + str(x) for x in range(5)]
         existing_users = [{user.username: user.username + '_new'} for user in random_users]
         non_existing_users = [{username: username + '_new'} for username in fake_usernames]

--- a/ecommerce/extensions/basket/tests/mixins.py
+++ b/ecommerce/extensions/basket/tests/mixins.py
@@ -5,6 +5,7 @@ from oscar.test import factories
 
 from ecommerce.core.constants import ENROLLMENT_CODE_PRODUCT_CLASS_NAME
 from ecommerce.courses.tests.factories import CourseFactory
+from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.mixins import SiteMixin
 
 Default = get_class('partner.strategy', 'Default')
@@ -14,7 +15,7 @@ Product = get_model('catalogue', 'Product')
 
 class BasketMixin(SiteMixin):
     def create_basket(self, owner, site, status=Basket.OPEN, empty=False):
-        owner = owner or factories.UserFactory()
+        owner = owner or UserFactory()
         site = site or self.site
         basket = Basket.objects.create(owner=owner, site=site, status=status)
         basket.strategy = Default()

--- a/ecommerce/extensions/basket/tests/test_models.py
+++ b/ecommerce/extensions/basket/tests/test_models.py
@@ -6,7 +6,6 @@ import mock
 import six
 from edx_django_utils.cache import DEFAULT_REQUEST_CACHE
 from oscar.core.loading import get_class, get_model
-from oscar.test import factories
 
 from analytics import Client
 from ecommerce.courses.tests.factories import CourseFactory
@@ -16,7 +15,7 @@ from ecommerce.extensions.basket.constants import TEMPORARY_BASKET_CACHE_KEY
 from ecommerce.extensions.basket.models import Basket
 from ecommerce.extensions.basket.tests.mixins import BasketMixin
 from ecommerce.extensions.test.factories import create_basket
-from ecommerce.tests.factories import SiteConfigurationFactory
+from ecommerce.tests.factories import SiteConfigurationFactory, UserFactory
 from ecommerce.tests.testcases import TestCase
 
 Basket = get_model('basket', 'Basket')
@@ -50,7 +49,7 @@ class BasketTests(CatalogMixin, BasketMixin, TestCase):
 
     def test_get_basket_without_existing_baskets(self):
         """ If the user has no existing baskets, the method should return a new one. """
-        user = factories.UserFactory()
+        user = UserFactory()
         self.assertEqual(user.baskets.count(), 0, 'A new user should not have any associated Baskets.')
 
         basket = Basket.get_basket(user, self.site)
@@ -70,7 +69,7 @@ class BasketTests(CatalogMixin, BasketMixin, TestCase):
 
     def test_get_basket_with_existing_baskets(self):
         """ If the user has existing baskets in editable states, the method should return a single merged basket. """
-        user = factories.UserFactory()
+        user = UserFactory()
 
         # Create baskets in a state that qualifies them for merging
         editable_baskets = []
@@ -113,7 +112,7 @@ class BasketTests(CatalogMixin, BasketMixin, TestCase):
 
     def test_create_basket(self):
         """ Verify the method creates a new basket. """
-        user = factories.UserFactory()
+        user = UserFactory()
         basket = Basket.create_basket(self.site, user)
         self.assertEqual(basket.site, self.site)
         self.assertEqual(basket.owner, user)

--- a/ecommerce/extensions/checkout/tests/test_mixins.py
+++ b/ecommerce/extensions/checkout/tests/test_mixins.py
@@ -8,7 +8,7 @@ import mock
 from django.core import mail
 from django.test import RequestFactory
 from oscar.core.loading import get_class, get_model
-from oscar.test.factories import BasketFactory, ProductFactory, UserFactory
+from oscar.test.factories import BasketFactory, ProductFactory
 from testfixtures import LogCapture
 from waffle.models import Sample
 
@@ -37,7 +37,7 @@ from ecommerce.extensions.test.factories import (
     create_order
 )
 from ecommerce.invoice.models import Invoice
-from ecommerce.tests.factories import SiteConfigurationFactory
+from ecommerce.tests.factories import SiteConfigurationFactory, UserFactory
 from ecommerce.tests.mixins import BusinessIntelligenceMixin
 from ecommerce.tests.testcases import TestCase
 

--- a/ecommerce/extensions/dashboard/orders/tests.py
+++ b/ecommerce/extensions/dashboard/orders/tests.py
@@ -9,7 +9,6 @@ from django.test import override_settings
 from django.urls import reverse
 from nose.plugins.skip import SkipTest
 from oscar.core.loading import get_model
-from oscar.test import factories
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.firefox.webdriver import WebDriver
 from selenium.webdriver.support.wait import WebDriverWait
@@ -20,6 +19,7 @@ from ecommerce.extensions.fulfillment.signals import SHIPPING_EVENT_NAME
 from ecommerce.extensions.fulfillment.status import LINE, ORDER
 from ecommerce.extensions.refund.tests.mixins import RefundTestMixin
 from ecommerce.extensions.test.factories import create_order
+from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.testcases import LiveServerTestCase, TestCase
 
 Order = get_model('order', 'Order')
@@ -65,7 +65,7 @@ class OrderViewBrowserTestBase(LiveServerTestCase):
 
         self.btn_selector = '[data-action=retry-fulfillment]'
         self.password = 'test'
-        self.user = factories.UserFactory(password=self.password, is_superuser=True, is_staff=True)
+        self.user = UserFactory(password=self.password, is_superuser=True, is_staff=True)
 
         self.order = create_order(user=self.user, site=self.site)
         self.order.status = ORDER.FULFILLMENT_ERROR

--- a/ecommerce/extensions/dashboard/refunds/tests/test_acceptance.py
+++ b/ecommerce/extensions/dashboard/refunds/tests/test_acceptance.py
@@ -7,13 +7,13 @@ import ddt
 from django.urls import reverse
 from nose.plugins.skip import SkipTest
 from oscar.core.loading import get_model
-from oscar.test import factories
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.firefox.webdriver import WebDriver
 from selenium.webdriver.support.wait import WebDriverWait
 
 from ecommerce.extensions.refund.status import REFUND
 from ecommerce.extensions.refund.tests.mixins import RefundTestMixin
+from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.testcases import LiveServerTestCase
 
 Refund = get_model('refund', 'Refund')
@@ -48,7 +48,7 @@ class RefundAcceptanceTestMixin(RefundTestMixin):
         self.deny_button_selector = '[data-refund-id="{}"] [data-decision="deny"]'.format(self.refund.id)
 
         self.password = 'test'
-        self.user = factories.UserFactory(password=self.password, is_superuser=True, is_staff=True)
+        self.user = UserFactory(password=self.password, is_superuser=True, is_staff=True)
 
     def _login(self):
         """Log into the service and navigate to the refund list view."""

--- a/ecommerce/extensions/dashboard/tests.py
+++ b/ecommerce/extensions/dashboard/tests.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
 
 from django.urls import reverse
-from oscar.test.factories import OrderFactory, UserFactory
+from oscar.test.factories import OrderFactory
 
+from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.testcases import TestCase
 
 

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -40,6 +40,7 @@ from ecommerce.extensions.test.factories import create_order
 from ecommerce.extensions.voucher.models import OrderLineVouchers
 from ecommerce.extensions.voucher.utils import create_vouchers
 from ecommerce.programs.tests.mixins import ProgramTestMixin
+from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.testcases import TestCase
 
 JSON = 'application/json'
@@ -68,7 +69,7 @@ class EnrollmentFulfillmentModuleTests(ProgramTestMixin, DiscoveryTestMixin, Ful
     def setUp(self):
         super(EnrollmentFulfillmentModuleTests, self).setUp()
 
-        self.user = factories.UserFactory()
+        self.user = UserFactory()
         self.user.tracking_context = {
             'ga_client_id': 'test-client-id', 'lms_user_id': 'test-user-id', 'lms_ip': '127.0.0.1'
         }
@@ -449,7 +450,7 @@ class CouponFulfillmentModuleTest(CouponMixin, FulfillmentTestMixin, TestCase):
     def setUp(self):
         super(CouponFulfillmentModuleTest, self).setUp()
         coupon = self.create_coupon()
-        user = factories.UserFactory()
+        user = UserFactory()
         basket = factories.BasketFactory(owner=user, site=self.site)
         basket.add_product(coupon, 1)
         self.order = create_order(number=1, basket=basket, user=user)
@@ -491,7 +492,7 @@ class DonationsFromCheckoutTestFulfillmentModuleTest(FulfillmentTestMixin, TestC
             product_class=donation_class,
             title='Test product'
         )
-        user = factories.UserFactory()
+        user = UserFactory()
         basket = factories.BasketFactory(owner=user, site=self.site)
         factories.create_stockrecord(donation, num_in_stock=2, price_excl_tax=10)
         basket.add_product(donation, 1)
@@ -529,7 +530,7 @@ class EnrollmentCodeFulfillmentModuleTests(DiscoveryTestMixin, TestCase):
         course = CourseFactory(partner=self.partner)
         course.create_or_update_seat('verified', True, 50, create_enrollment_code=True)
         enrollment_code = Product.objects.get(product_class__name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME)
-        user = factories.UserFactory()
+        user = UserFactory()
         basket = factories.BasketFactory(owner=user, site=self.site)
         basket.add_product(enrollment_code, self.QUANTITY)
         self.order = create_order(number=1, basket=basket, user=user)
@@ -572,7 +573,7 @@ class EntitlementFulfillmentModuleTests(FulfillmentTestMixin, TestCase):
 
     def setUp(self):
         super(EntitlementFulfillmentModuleTests, self).setUp()
-        self.user = factories.UserFactory()
+        self.user = UserFactory()
         self.course_entitlement = create_or_update_course_entitlement(
             'verified', 100, self.partner, '111-222-333-444', 'Course Entitlement')
         basket = factories.BasketFactory(owner=self.user, site=self.site)

--- a/ecommerce/extensions/offer/tests/test_applicator.py
+++ b/ecommerce/extensions/offer/tests/test_applicator.py
@@ -14,6 +14,7 @@ from ecommerce.core.constants import SYSTEM_ENTERPRISE_LEARNER_ROLE
 from ecommerce.extensions.offer.applicator import CustomApplicator
 from ecommerce.extensions.offer.constants import CUSTOM_APPLICATOR_LOG_FLAG
 from ecommerce.extensions.test.factories import ConditionalOfferFactory, ConditionFactory, ProgramOfferFactory
+from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.testcases import TestCase
 
 BasketAttribute = get_model('basket', 'BasketAttribute')
@@ -29,7 +30,7 @@ class CustomApplicatorTests(TestCase):
     def setUp(self):
         self.applicator = CustomApplicator()
         self.basket = factories.create_basket(empty=True)
-        self.user = factories.UserFactory()
+        self.user = UserFactory()
 
     def create_bundle_attribute(self, bundle_id):
         """ Helper to add a bundle attribute to a basket. """

--- a/ecommerce/extensions/offer/tests/test_decorators.py
+++ b/ecommerce/extensions/offer/tests/test_decorators.py
@@ -6,8 +6,8 @@ from waffle.models import Switch
 
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
 from ecommerce.extensions.offer.decorators import check_condition_applicability
-from ecommerce.extensions.test.factories import UserFactory, create_basket
-from ecommerce.tests.factories import SiteConfigurationFactory
+from ecommerce.extensions.test.factories import create_basket
+from ecommerce.tests.factories import SiteConfigurationFactory, UserFactory
 from ecommerce.tests.testcases import TestCase
 
 

--- a/ecommerce/extensions/offer/tests/test_models.py
+++ b/ecommerce/extensions/offer/tests/test_models.py
@@ -15,6 +15,7 @@ from slumber.exceptions import SlumberBaseException
 
 from ecommerce.coupons.tests.mixins import CouponMixin, DiscoveryMockMixin
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
+from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.testcases import TestCase
 
 Catalog = get_model('catalogue', 'Catalog')
@@ -377,7 +378,7 @@ class ConditionalOfferTests(DiscoveryTestMixin, DiscoveryMockMixin, TestCase):
     def test_condition_not_satisfied_for_enterprise(self):
         """Verify a condition is not satisfied."""
         valid_user_email = 'valid@{domain}'.format(domain=self.valid_sub_domain)
-        basket = factories.BasketFactory(site=self.site, owner=factories.UserFactory(email=valid_user_email))
+        basket = factories.BasketFactory(site=self.site, owner=UserFactory(email=valid_user_email))
 
         _range = factories.RangeFactory(
             products=[self.product, ],
@@ -396,7 +397,7 @@ class ConditionalOfferTests(DiscoveryTestMixin, DiscoveryMockMixin, TestCase):
         Verify that a basket satisfies a condition only when all of its products are in its range's catalog queryset.
         """
         valid_user_email = 'valid@{domain}'.format(domain=self.valid_sub_domain)
-        basket = factories.BasketFactory(site=self.site, owner=factories.UserFactory(email=valid_user_email))
+        basket = factories.BasketFactory(site=self.site, owner=UserFactory(email=valid_user_email))
         product = self.create_entitlement_product()
         another_product = self.create_entitlement_product()
 
@@ -426,7 +427,7 @@ class ConditionalOfferTests(DiscoveryTestMixin, DiscoveryMockMixin, TestCase):
         Verify that the condition for a single use coupon is only satisfied by single-product baskets.
         """
         valid_user_email = 'valid@{domain}'.format(domain=self.valid_sub_domain)
-        basket = factories.BasketFactory(site=self.site, owner=factories.UserFactory(email=valid_user_email))
+        basket = factories.BasketFactory(site=self.site, owner=UserFactory(email=valid_user_email))
         product1 = self.create_entitlement_product()
         product2 = self.create_entitlement_product()
 
@@ -533,7 +534,7 @@ class BenefitTests(DiscoveryTestMixin, DiscoveryMockMixin, TestCase):
         )
         self.benefit = factories.BenefitFactory(range=_range)
         self.offer = factories.ConditionalOfferFactory(benefit=self.benefit)
-        self.user = factories.UserFactory()
+        self.user = UserFactory()
 
     def test_range(self):
         with self.assertRaises(ValidationError):

--- a/ecommerce/extensions/order/management/commands/create_fake_orders.py
+++ b/ecommerce/extensions/order/management/commands/create_fake_orders.py
@@ -5,8 +5,9 @@ import logging
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 from oscar.core.loading import get_class, get_model
-from oscar.test.factories import UserFactory
 from six.moves import range
+
+from ecommerce.tests.factories import UserFactory
 
 logger = logging.getLogger(__name__)
 Order = get_model('order', 'Order')

--- a/ecommerce/extensions/order/tests/test_admin.py
+++ b/ecommerce/extensions/order/tests/test_admin.py
@@ -2,10 +2,10 @@ from __future__ import absolute_import
 
 from django.contrib import messages
 from django.urls import reverse
-from oscar.test.factories import UserFactory
 
 from ecommerce.core.tests import toggle_switch
 from ecommerce.extensions.order.constants import ORDER_LIST_VIEW_SWITCH
+from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.testcases import TestCase
 
 

--- a/ecommerce/extensions/payment/tests/mixins.py
+++ b/ecommerce/extensions/payment/tests/mixins.py
@@ -30,6 +30,7 @@ from ecommerce.extensions.payment.exceptions import (
 from ecommerce.extensions.payment.helpers import sign
 from ecommerce.extensions.payment.processors.cybersource import Cybersource
 from ecommerce.extensions.test.factories import create_basket
+from ecommerce.tests.factories import UserFactory
 
 CURRENCY = 'USD'
 Basket = get_model('basket', 'Basket')
@@ -410,7 +411,7 @@ class CybersourceNotificationTestsMixin(CybersourceMixin):
     def setUp(self):
         super(CybersourceNotificationTestsMixin, self).setUp()
 
-        self.user = factories.UserFactory()
+        self.user = UserFactory()
         self.billing_address = self.make_billing_address()
 
         self.basket = create_basket(owner=self.user, site=self.site)

--- a/ecommerce/extensions/payment/tests/processors/mixins.py
+++ b/ecommerce/extensions/payment/tests/processors/mixins.py
@@ -5,14 +5,13 @@ from __future__ import absolute_import, unicode_literals
 import ddt
 from django.conf import settings
 from oscar.core.loading import get_model
-from oscar.test import factories
 
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
 from ecommerce.extensions.payment.tests.mixins import PaymentEventsMixin
 from ecommerce.extensions.refund.tests.mixins import RefundTestMixin
 from ecommerce.extensions.test.factories import create_basket
-from ecommerce.tests.factories import SiteConfigurationFactory
+from ecommerce.tests.factories import SiteConfigurationFactory, UserFactory
 
 Partner = get_model('partner', 'Partner')
 
@@ -36,7 +35,7 @@ class PaymentProcessorTestCaseMixin(RefundTestMixin, DiscoveryTestMixin, Payment
         self.product = self.course.create_or_update_seat(self.CERTIFICATE_TYPE, False, 20)
 
         self.processor = self.processor_class(self.site)  # pylint: disable=not-callable
-        self.basket = create_basket(site=self.site, owner=factories.UserFactory(), empty=True)
+        self.basket = create_basket(site=self.site, owner=UserFactory(), empty=True)
         self.basket.add_product(self.product)
 
     def test_configuration(self):

--- a/ecommerce/extensions/payment/tests/processors/test_cybersource.py
+++ b/ecommerce/extensions/payment/tests/processors/test_cybersource.py
@@ -33,6 +33,7 @@ from ecommerce.extensions.payment.processors.cybersource import Cybersource
 from ecommerce.extensions.payment.tests.mixins import CybersourceMixin
 from ecommerce.extensions.payment.tests.processors.mixins import PaymentProcessorTestCaseMixin
 from ecommerce.extensions.test.factories import create_basket
+from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.testcases import TestCase
 
 BasketAttribute = get_model('basket', 'BasketAttribute')
@@ -148,7 +149,7 @@ class CybersourceTests(CybersourceMixin, PaymentProcessorTestCaseMixin, TestCase
         course = CourseFactory(id='a/b/c/d', name='Course with "quotes"')
         product = course.create_or_update_seat(self.CERTIFICATE_TYPE, False, 20)
 
-        basket = create_basket(owner=factories.UserFactory(), site=self.site, empty=True)
+        basket = create_basket(owner=UserFactory(), site=self.site, empty=True)
         basket.add_product(product)
 
         response = self.processor.get_transaction_parameters(basket)

--- a/ecommerce/extensions/payment/tests/views/test_paypal.py
+++ b/ecommerce/extensions/payment/tests/views/test_paypal.py
@@ -23,6 +23,7 @@ from ecommerce.extensions.payment.tests.mixins import PaymentEventsMixin, Paypal
 from ecommerce.extensions.payment.views.paypal import PaypalPaymentExecutionView
 from ecommerce.extensions.test.factories import create_basket, create_order
 from ecommerce.invoice.models import Invoice
+from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.testcases import TestCase
 
 JSON = 'application/json'
@@ -47,7 +48,7 @@ class PaypalPaymentExecutionViewTests(PaypalMixin, PaymentEventsMixin, TestCase)
     def setUp(self):
         super(PaypalPaymentExecutionViewTests, self).setUp()
 
-        self.basket = create_basket(owner=factories.UserFactory(), site=self.site)
+        self.basket = create_basket(owner=UserFactory(), site=self.site)
         self.basket.freeze()
 
         self.processor = Paypal(self.site)
@@ -136,7 +137,7 @@ class PaypalPaymentExecutionViewTests(PaypalMixin, PaymentEventsMixin, TestCase)
 
         course = CourseFactory(partner=self.partner)
         course.create_or_update_seat('verified', True, 50, create_enrollment_code=True)
-        self.basket = create_basket(owner=factories.UserFactory(), site=self.site)
+        self.basket = create_basket(owner=UserFactory(), site=self.site)
         enrollment_code = Product.objects.get(product_class__name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME)
         factories.create_stockrecord(enrollment_code, num_in_stock=2, price_excl_tax='10.00')
         self.basket.add_product(enrollment_code, quantity=1)

--- a/ecommerce/extensions/refund/tests/factories.py
+++ b/ecommerce/extensions/refund/tests/factories.py
@@ -5,11 +5,10 @@ from decimal import Decimal
 import factory
 from django.conf import settings
 from oscar.core.loading import get_model
-from oscar.test.factories import UserFactory
 
 from ecommerce.extensions.refund.status import REFUND, REFUND_LINE
 from ecommerce.extensions.test.factories import create_order
-from ecommerce.tests.factories import SiteConfigurationFactory
+from ecommerce.tests.factories import SiteConfigurationFactory, UserFactory
 
 Category = get_model("catalogue", "Category")
 Partner = get_model('partner', 'Partner')

--- a/ecommerce/extensions/refund/tests/test_admin.py
+++ b/ecommerce/extensions/refund/tests/test_admin.py
@@ -2,10 +2,10 @@ from __future__ import absolute_import
 
 from django.contrib import messages
 from django.urls import reverse
-from oscar.test.factories import UserFactory
 
 from ecommerce.core.tests import toggle_switch
 from ecommerce.extensions.refund.constants import REFUND_LIST_VIEW_SWITCH
+from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.testcases import TestCase
 
 

--- a/ecommerce/extensions/refund/tests/test_api.py
+++ b/ecommerce/extensions/refund/tests/test_api.py
@@ -3,12 +3,12 @@ from __future__ import absolute_import
 import ddt
 from django.test import override_settings
 from oscar.core.loading import get_model
-from oscar.test.factories import UserFactory
 
 from ecommerce.extensions.fulfillment.status import ORDER
 from ecommerce.extensions.refund.api import create_refunds, find_orders_associated_with_course
 from ecommerce.extensions.refund.tests.factories import RefundLineFactory
 from ecommerce.extensions.refund.tests.mixins import RefundTestMixin
+from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.testcases import TestCase
 
 ProductAttribute = get_model("catalogue", "ProductAttribute")

--- a/ecommerce/extensions/refund/tests/test_models.py
+++ b/ecommerce/extensions/refund/tests/test_models.py
@@ -9,7 +9,6 @@ import six
 from django.conf import settings
 from oscar.apps.payment.exceptions import PaymentError
 from oscar.core.loading import get_class, get_model
-from oscar.test.factories import UserFactory
 from testfixtures import LogCapture
 
 from ecommerce.core.constants import SEAT_PRODUCT_CLASS_NAME
@@ -24,6 +23,7 @@ from ecommerce.extensions.refund.status import REFUND, REFUND_LINE
 from ecommerce.extensions.refund.tests.factories import RefundFactory, RefundLineFactory
 from ecommerce.extensions.refund.tests.mixins import RefundTestMixin
 from ecommerce.extensions.test.factories import create_basket, create_order
+from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.testcases import TestCase
 
 PaymentEventType = get_model('order', 'PaymentEventType')

--- a/ecommerce/extensions/refund/tests/test_signals.py
+++ b/ecommerce/extensions/refund/tests/test_signals.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import
 
 from mock import patch
-from oscar.test.factories import UserFactory
 
 from ecommerce.core.models import SegmentClient
 from ecommerce.extensions.analytics.utils import ECOM_TRACKING_ID_FMT
 from ecommerce.extensions.refund.api import create_refunds
 from ecommerce.extensions.refund.tests.mixins import RefundTestMixin
+from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.testcases import TestCase
 
 

--- a/ecommerce/extensions/test/factories.py
+++ b/ecommerce/extensions/test/factories.py
@@ -14,8 +14,7 @@ from oscar.test.factories import (
     OrderCreator,
     OrderTotalCalculator,
     ProductFactory,
-    RangeFactory,
-    UserFactory
+    RangeFactory
 )
 from oscar.test.factories import VoucherFactory as BaseVoucherFactory
 from oscar.test.factories import create_product, create_stockrecord, get_class, get_model
@@ -30,7 +29,7 @@ from ecommerce.journals.conditions import JournalBundleCondition
 from ecommerce.programs.benefits import AbsoluteDiscountBenefitWithoutRange, PercentageDiscountBenefitWithoutRange
 from ecommerce.programs.conditions import ProgramCourseRunSeatsCondition
 from ecommerce.programs.custom import class_path
-from ecommerce.tests.factories import SiteConfigurationFactory
+from ecommerce.tests.factories import SiteConfigurationFactory, UserFactory
 
 Benefit = get_model('offer', 'Benefit')
 Catalog = get_model('catalogue', 'Catalog')

--- a/ecommerce/extensions/voucher/tests/test_models.py
+++ b/ecommerce/extensions/voucher/tests/test_models.py
@@ -6,12 +6,12 @@ import ddt
 from django.core.exceptions import ValidationError
 from django.utils.timezone import now
 from oscar.core.loading import get_model
-from oscar.test.factories import OrderFactory, OrderLineFactory, UserFactory
+from oscar.test.factories import OrderFactory, OrderLineFactory
 
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.offer.constants import OFFER_ASSIGNED, OFFER_ASSIGNMENT_REVOKED, OFFER_REDEEMED
 from ecommerce.extensions.test import factories
-from ecommerce.tests.factories import PartnerFactory
+from ecommerce.tests.factories import PartnerFactory, UserFactory
 from ecommerce.tests.testcases import TestCase
 
 ConditionalOffer = get_model('offer', 'ConditionalOffer')

--- a/ecommerce/extensions/voucher/tests/test_utils.py
+++ b/ecommerce/extensions/voucher/tests/test_utils.py
@@ -17,7 +17,6 @@ from oscar.test.factories import (
     OrderFactory,
     OrderLineFactory,
     RangeFactory,
-    UserFactory,
     VoucherFactory,
     datetime,
     get_model
@@ -41,6 +40,7 @@ from ecommerce.extensions.voucher.utils import (
     get_voucher_discount_info,
     update_voucher_offer
 )
+from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.mixins import LmsApiMockMixin
 from ecommerce.tests.testcases import TestCase
 

--- a/ecommerce/extensions/voucher/tests/test_views.py
+++ b/ecommerce/extensions/voucher/tests/test_views.py
@@ -5,13 +5,12 @@ from uuid import uuid4
 import httpretty
 from django.test import RequestFactory
 from oscar.core.loading import get_model
-from oscar.test import factories
 
 from ecommerce.coupons.tests.mixins import CouponMixin
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
 from ecommerce.extensions.voucher.views import CouponReportCSVView
-from ecommerce.tests.factories import PartnerFactory
+from ecommerce.tests.factories import PartnerFactory, UserFactory
 from ecommerce.tests.mixins import LmsApiMockMixin
 from ecommerce.tests.testcases import TestCase
 
@@ -52,7 +51,7 @@ class CouponReportCSVViewTest(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, 
         self.coupon3.history.all().update(history_user=self.user)
 
     def request_specific_voucher_report(self, coupon):
-        client = factories.UserFactory()
+        client = UserFactory()
         basket = Basket.get_basket(client, self.site)
         basket.add_product(coupon)
 

--- a/ecommerce/invoice/tests.py
+++ b/ecommerce/invoice/tests.py
@@ -4,6 +4,7 @@ from oscar.test import factories
 
 from ecommerce.extensions.test.factories import create_basket
 from ecommerce.invoice.models import Invoice
+from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.testcases import TestCase
 
 
@@ -11,7 +12,7 @@ class InvoiceTests(TestCase):
     """Test to ensure Invoice objects are created correctly"""
     def setUp(self):
         super(InvoiceTests, self).setUp()
-        self.basket = create_basket(owner=factories.UserFactory(), empty=True)
+        self.basket = create_basket(owner=UserFactory(), empty=True)
         self.basket.order = factories.OrderFactory()
         self.basket.save()
         self.invoice = Invoice.objects.create(order=self.basket.order, state='Paid')

--- a/ecommerce/journals/tests/test_condition.py
+++ b/ecommerce/journals/tests/test_condition.py
@@ -8,6 +8,7 @@ from slumber.exceptions import HttpNotFoundError, SlumberBaseException
 
 from ecommerce.extensions.test import factories
 from ecommerce.journals.tests.mixins import JournalMixin  # pylint: disable=no-name-in-module
+from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.testcases import TestCase
 
 Product = get_model('catalogue', 'Product')
@@ -24,7 +25,7 @@ class JournalBundleConditionTests(TestCase, JournalMixin):
 
         self.condition = factories.JournalConditionFactory()
         self.offer = factories.JournalBundleOfferFactory(partner=self.partner, condition=self.condition)
-        self.basket = BasketFactory(site=self.site, owner=factories.UserFactory())
+        self.basket = BasketFactory(site=self.site, owner=UserFactory())
         self.basket.add_product(
             self.create_product(self.client),
             1

--- a/ecommerce/management/tests/test_utils.py
+++ b/ecommerce/management/tests/test_utils.py
@@ -13,8 +13,9 @@ from ecommerce.extensions.payment.constants import CARD_TYPES
 from ecommerce.extensions.payment.models import PaymentProcessorResponse
 from ecommerce.extensions.payment.processors.cybersource import Cybersource
 from ecommerce.extensions.payment.processors.paypal import Paypal
-from ecommerce.extensions.test.factories import UserFactory, create_basket, prepare_voucher
+from ecommerce.extensions.test.factories import create_basket, prepare_voucher
 from ecommerce.management.utils import FulfillFrozenBaskets, refund_basket_transactions
+from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.testcases import TestCase
 
 Free = get_class('shipping.methods', 'Free')

--- a/ecommerce/programs/tests/test_conditions.py
+++ b/ecommerce/programs/tests/test_conditions.py
@@ -12,7 +12,7 @@ from ecommerce.core.constants import COURSE_ENTITLEMENT_PRODUCT_CLASS_NAME
 from ecommerce.courses.models import Course
 from ecommerce.extensions.test import factories
 from ecommerce.programs.tests.mixins import ProgramTestMixin
-from ecommerce.tests.factories import ProductFactory, SiteConfigurationFactory
+from ecommerce.tests.factories import ProductFactory, SiteConfigurationFactory, UserFactory
 from ecommerce.tests.testcases import TestCase
 
 Product = get_model('catalogue', 'Product')
@@ -39,7 +39,7 @@ class ProgramCourseRunSeatsConditionTests(ProgramTestMixin, TestCase):
         """ The method should return True if the basket contains one course run seat corresponding to each
         course in the program. """
         offer = factories.ProgramOfferFactory(partner=self.partner, condition=self.condition)
-        basket = BasketFactory(site=self.site, owner=factories.UserFactory())
+        basket = BasketFactory(site=self.site, owner=UserFactory())
         program = self.mock_program_detail_endpoint(
             self.condition.program_uuid, self.site_configuration.discovery_api_url
         )
@@ -91,7 +91,7 @@ class ProgramCourseRunSeatsConditionTests(ProgramTestMixin, TestCase):
         """ The condition should be satisfied if one valid course run from each course is in either the
         basket or the user's enrolled courses and the site has enabled partial program offers. """
         offer = factories.ProgramOfferFactory(partner=self.partner, condition=self.condition)
-        basket = BasketFactory(site=self.site, owner=factories.UserFactory())
+        basket = BasketFactory(site=self.site, owner=UserFactory())
         program = self.mock_program_detail_endpoint(
             self.condition.program_uuid, self.site_configuration.discovery_api_url
         )
@@ -139,7 +139,7 @@ class ProgramCourseRunSeatsConditionTests(ProgramTestMixin, TestCase):
     def test_is_satisfied_with_exception_for_programs(self, value):
         """ The method should return False if there is an exception when trying to get program details. """
         offer = factories.ProgramOfferFactory(partner=self.partner, condition=self.condition)
-        basket = BasketFactory(site=self.site, owner=factories.UserFactory())
+        basket = BasketFactory(site=self.site, owner=UserFactory())
         basket.add_product(self.test_product)
 
         with mock.patch('ecommerce.programs.conditions.get_program',
@@ -151,7 +151,7 @@ class ProgramCourseRunSeatsConditionTests(ProgramTestMixin, TestCase):
         """ The method should return True despite having an error at the enrollment check, given 1 course run seat
         corresponding to each course in the program. """
         offer = factories.ProgramOfferFactory(partner=self.partner, condition=self.condition)
-        basket = BasketFactory(site=self.site, owner=factories.UserFactory())
+        basket = BasketFactory(site=self.site, owner=UserFactory())
         program = self.mock_program_detail_endpoint(
             self.condition.program_uuid,
             self.site_configuration.discovery_api_url
@@ -168,7 +168,7 @@ class ProgramCourseRunSeatsConditionTests(ProgramTestMixin, TestCase):
     def test_is_satisfied_free_basket(self):
         """ Ensure the basket returns False if the basket total is zero. """
         offer = factories.ProgramOfferFactory(partner=self.partner, condition=self.condition)
-        basket = BasketFactory(site=self.site, owner=factories.UserFactory())
+        basket = BasketFactory(site=self.site, owner=UserFactory())
         test_product = factories.ProductFactory(stockrecords__price_excl_tax=0,
                                                 stockrecords__partner__short_code='test')
         basket.add_product(test_product)
@@ -177,14 +177,14 @@ class ProgramCourseRunSeatsConditionTests(ProgramTestMixin, TestCase):
     def test_is_satisfied_site_mismatch(self):
         """ Ensure the condition returns False if the offer partner does not match the basket site partner. """
         offer = factories.ProgramOfferFactory(partner=SiteConfigurationFactory().partner, condition=self.condition)
-        basket = BasketFactory(site=self.site, owner=factories.UserFactory())
+        basket = BasketFactory(site=self.site, owner=UserFactory())
         basket.add_product(self.test_product)
         self.assertFalse(self.condition.is_satisfied(offer, basket))
 
     def test_is_satisfied_program_retrieval_failure(self):
         """ The method should return False if no program is retrieved """
         offer = factories.ProgramOfferFactory(partner=self.partner, condition=self.condition)
-        basket = BasketFactory(site=self.site, owner=factories.UserFactory())
+        basket = BasketFactory(site=self.site, owner=UserFactory())
         basket.add_product(self.test_product)
         self.condition.program_uuid = None
         self.assertFalse(self.condition.is_satisfied(offer, basket))
@@ -196,7 +196,7 @@ class ProgramCourseRunSeatsConditionTests(ProgramTestMixin, TestCase):
         basket or the user already has an entitlement for the course and the site has enabled partial program offers.
         """
         offer = factories.ProgramOfferFactory(partner=self.partner, condition=self.condition)
-        basket = BasketFactory(site=self.site, owner=factories.UserFactory())
+        basket = BasketFactory(site=self.site, owner=UserFactory())
         program = self.mock_program_detail_endpoint(
             self.condition.program_uuid, self.site_configuration.discovery_api_url
         )
@@ -249,7 +249,7 @@ class ProgramCourseRunSeatsConditionTests(ProgramTestMixin, TestCase):
         User entitlements should not be retrieved if no course in the program has a course entitlement product
         """
         offer = factories.ProgramOfferFactory(partner=self.partner, condition=self.condition)
-        basket = BasketFactory(site=self.site, owner=factories.UserFactory())
+        basket = BasketFactory(site=self.site, owner=UserFactory())
         program = self.mock_program_detail_endpoint(
             self.condition.program_uuid, self.site_configuration.discovery_api_url, include_entitlements=False
         )
@@ -279,7 +279,7 @@ class ProgramCourseRunSeatsConditionTests(ProgramTestMixin, TestCase):
         """
         LMS resource should be properly cached when enrollments is None.
         """
-        basket = BasketFactory(site=self.site, owner=factories.UserFactory())
+        basket = BasketFactory(site=self.site, owner=UserFactory())
         resource_name = 'test_resource_name'
         mock_endpoint = mock.Mock()
         mock_endpoint.get.return_value = None
@@ -302,7 +302,7 @@ class ProgramCourseRunSeatsConditionTests(ProgramTestMixin, TestCase):
         Is satisfied should return false if program is not active.
         """
         offer = factories.ProgramOfferFactory(partner=self.partner, condition=self.condition)
-        basket = BasketFactory(site=self.site, owner=factories.UserFactory())
+        basket = BasketFactory(site=self.site, owner=UserFactory())
         program = self.mock_program_detail_endpoint(
             self.condition.program_uuid,
             self.site_configuration.discovery_api_url,

--- a/ecommerce/sailthru/tests/test_signals.py
+++ b/ecommerce/sailthru/tests/test_signals.py
@@ -5,7 +5,7 @@ import logging
 
 from mock import patch
 from oscar.core.loading import get_model
-from oscar.test.factories import BasketFactory, UserFactory
+from oscar.test.factories import BasketFactory
 
 from ecommerce.core.tests import toggle_switch
 from ecommerce.coupons.tests.mixins import CouponMixin
@@ -13,6 +13,7 @@ from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
 from ecommerce.extensions.test.factories import create_order
 from ecommerce.sailthru.signals import SAILTHRU_CAMPAIGN, process_basket_addition, process_checkout_complete
+from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.testcases import TestCase
 
 BasketAttributeType = get_model('basket', 'BasketAttributeType')

--- a/ecommerce/tests/factories.py
+++ b/ecommerce/tests/factories.py
@@ -46,3 +46,18 @@ class SiteConfigurationFactory(factory.DjangoModelFactory):
 class StockRecordFactory(OscarStockRecordFactory):
     product = factory.SubFactory(ProductFactory)
     price_currency = 'USD'
+
+
+class UserFactory(factory.DjangoModelFactory):
+    class Meta(object):
+        model = get_model('core', 'User')
+
+    username = factory.Sequence(lambda n: 'ecommerce_test_user %d' % n)
+    email = factory.Sequence(lambda n: 'ecommerce_test_%s@example.com' % n)
+    first_name = 'Ecommerce'
+    last_name = 'User'
+    password = factory.PostGenerationMethodCall('set_password', 'somethingSecure')
+    is_active = True
+    is_superuser = False
+    is_staff = False
+    lms_user_id = 98789

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -29,7 +29,7 @@ from ecommerce.core.url_utils import get_lms_url
 from ecommerce.courses.models import Course
 from ecommerce.courses.utils import mode_for_product
 from ecommerce.extensions.fulfillment.signals import SHIPPING_EVENT_NAME
-from ecommerce.tests.factories import SiteConfigurationFactory
+from ecommerce.tests.factories import SiteConfigurationFactory, UserFactory
 
 Applicator = get_class('offer.applicator', 'Applicator')
 Basket = get_model('basket', 'Basket')
@@ -59,7 +59,7 @@ class UserMixin(object):
         not_provided = object()
         if kwargs.get('username', not_provided) is None:
             kwargs.pop('username')
-        return factories.UserFactory(password=self.password, lms_user_id=lms_user_id, **kwargs)
+        return UserFactory(password=self.password, lms_user_id=lms_user_id, **kwargs)
 
     def create_access_token(self, user, access_token=None):
         """


### PR DESCRIPTION
Switch to using our UserFactory, so that we can add a LMS user id by default.

Most of these changes are just imports; actual changes are in _ecommerce.tests.factories.UserFactory_ and _ecommerce.core.management.commands.tests.factories.SuperUserFactory_

Oscar's UserFactory: https://github.com/django-oscar/django-oscar/blob/master/src/oscar/test/factories/customer.py