### PR TITLE
TE-2337: WIP: run e2e tests against firefox container

### DIFF
--- a/docs/test_ecommerce.rst
+++ b/docs/test_ecommerce.rst
@@ -150,6 +150,8 @@ the following procedures.
    :depth: 1
    :local:
 
+.. warning::: This is very out of date.  It should mention renaming /e2e/.env.devstack, and running ``make e2e``.  There is no more ``make accept`` as detailed below.
+
 Configure the LMS
 *****************
 

--- a/e2e/.env.devstack
+++ b/e2e/.env.devstack
@@ -1,4 +1,4 @@
-# Use thse environment variables to run e2e tests for devstack.
+# Use these environment variables to run e2e tests for devstack.
 # NOTE: This file must be renamed to .env in order for the values to be used.
 
 BASIC_AUTH_USERNAME=

--- a/e2e/pytest.ini
+++ b/e2e/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-addopts = --driver=Chrome
+addopts = --driver Remote --host edx.devstack.firefox --port 4444 --capability browserName firefox
 # Each test must complete in less than 60 seconds
 timeout = 60


### PR DESCRIPTION
FYI: This is a starter PR for discussion.  It does not actually fix the e2e tests yet.

This currently gives the following error when trying to use the browser:
```
WebDriverException: Message: First match w3c capabilities is zero length
```
The following old ticket with the same error may or may not be related: https://openedx.atlassian.net/browse/TE-2337