### PR TITLE
Updated Python requirements

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -33,7 +33,8 @@ edx-ecommerce-worker
 edx-opaque-keys
 edx-rbac
 edx-rest-api-client
-gevent==1.0.2
+futures ; python_version == "2.7"
+gevent
 jsonfield==1.0.3
 libsass==0.9.2
 markdown==2.6.9

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -64,7 +64,8 @@ factory-boy==2.12.0       # via django-oscar
 faker==1.0.7              # via factory-boy
 funcsigs==1.0.2           # via mock
 future==0.17.1            # via pyjwkest
-gevent==1.0.2
+futures==3.2.0 ; python_version == "2.7"
+gevent==1.4.0
 greenlet==0.4.15          # via gevent
 idna==2.8                 # via requests
 ipaddress==1.0.22         # via cryptography, faker

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -82,8 +82,8 @@ filelock==3.0.12          # via tox
 freezegun==0.3.12
 funcsigs==1.0.2           # via mock
 future==0.17.1            # via pyjwkest
-futures==3.2.0            # via isort
-gevent==1.0.2
+futures==3.2.0 ; python_version == "2.7"
+gevent==1.4.0
 greenlet==0.4.15          # via gevent
 httpretty==0.9.6
 idna==2.8                 # via requests

--- a/requirements/production.in
+++ b/requirements/production.in
@@ -5,7 +5,7 @@ django-ses==0.8.2
 
 # Later versions of gevent wrap Python's __import__ in a way that breaks Oscar imports.
 # For more, see https://github.com/edx/ecommerce/pull/920.
-gevent==1.0.2
+gevent
 
 gunicorn==19.7.1
 newrelic<5

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -66,7 +66,8 @@ factory-boy==2.12.0       # via django-oscar
 faker==1.0.7              # via factory-boy
 funcsigs==1.0.2           # via mock
 future==0.17.1            # via pyjwkest
-gevent==1.0.2
+futures==3.2.0 ; python_version == "2.7"
+gevent==1.4.0
 greenlet==0.4.15          # via gevent
 gunicorn==19.7.1
 idna==2.8                 # via requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -77,8 +77,8 @@ filelock==3.0.12          # via tox
 freezegun==0.3.12
 funcsigs==1.0.2           # via mock
 future==0.17.1            # via pyjwkest
-futures==3.2.0            # via isort
-gevent==1.0.2
+futures==3.2.0 ; python_version == "2.7"
+gevent==1.4.0
 greenlet==0.4.15          # via gevent
 httpretty==0.9.6
 idna==2.8                 # via requests
@@ -133,6 +133,7 @@ pyopenssl==19.0.0         # via ndg-httpsclient, paypalrestsdk
 pyparsing==2.4.0          # via packaging
 python-dateutil==2.8.0
 python-openid==2.2.5 ; python_version == "2.7"
+python3-openid==3.1.0 ; python_version >= "3"
 pytz==2016.10
 pyyaml==5.1.1             # via edx-django-release-util
 rcssmin==1.0.6            # via django-compressor


### PR DESCRIPTION
`gevent` library's version updated from 1.0.2 to 1.4.0 as it was not supporting python3.6 syntax. Also, restricted `futures` to `python_version == "2.7"`