### PR TITLE
Configure jasmine tests for docker devstack.

### DIFF
--- a/.travis/docker-compose-travis.yml
+++ b/.travis/docker-compose-travis.yml
@@ -36,3 +36,5 @@ services:
       DB_PORT: "3306"
       DB_USER: "ecomm001"
       DJANGO_SETTINGS_MODULE: "ecommerce.settings.test"
+      JASMINE_HOSTNAME: "localhost"
+      JASMINE_WEB_DRIVER: "Firefox"

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,10 @@
 // Karma configuration
 // Generated on Tue Jul 21 2015 10:10:16 GMT-0400 (EDT)
 
+var webdriver = require('selenium-webdriver'),
+    JASMINE_WEB_DRIVER = process.env.JASMINE_WEB_DRIVER || 'FirefoxDocker',
+    hostname = process.env.JASMINE_HOSTNAME || 'edx.devstack.ecommerce';
+
 module.exports = function(config) {
     const coveragePath = 'ecommerce/static/js/!(test)/**/*.js';
     var preprocessors = {};
@@ -47,6 +51,7 @@ module.exports = function(config) {
        'karma-coverage-allsources',
        'karma-coverage',
        'karma-spec-reporter',
+       'karma-selenium-webdriver-launcher',
        'karma-sinon'
    ],
 
@@ -70,6 +75,7 @@ module.exports = function(config) {
 
     // web server port
     port: 9876,
+    hostname: hostname,
 
 
     // enable / disable colors in the output (reporters and logs)
@@ -87,7 +93,30 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['Firefox'],
+    browsers: [JASMINE_WEB_DRIVER],
+
+    customLaunchers: {
+        ChromeDocker: {
+            base: 'SeleniumWebdriver',
+            browserName: 'chrome',
+            getDriver: function() {
+                return new webdriver.Builder()
+                    .forBrowser('chrome')
+                    .usingServer('http://edx.devstack.chrome:4444/wd/hub')
+                    .build();
+            }
+        },
+        FirefoxDocker: {
+            base: 'SeleniumWebdriver',
+            browserName: 'firefox',
+            getDriver: function() {
+                return new webdriver.Builder()
+                    .forBrowser('firefox')
+                    .usingServer('http://edx.devstack.firefox:4444/wd/hub')
+                    .build();
+            }
+        }
+    },
 
 
     // Continuous Integration mode

--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
     "karma-jasmine": "1.1.0",
     "karma-jquery": "0.2.2",
     "karma-requirejs": "1.1.0",
+    "karma-selenium-webdriver-launcher": "0.0.4",
     "karma-sinon": "1.0.5",
     "karma-spec-reporter": "0.0.26",
+    "selenium-webdriver": "3.4.0",
     "sinon": "2.3.8"
   }
 }


### PR DESCRIPTION
E-commerce wasn't configured to run jasmine tests locally on docker devstack, added configuration for custom launchers to fix it.

[PROD-455](https://openedx.atlassian.net/browse/PROD-455)