### PR TITLE
DO NOT MERGE: Enable Browser Back Button On Receipt Page

### DIFF
--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -51,10 +51,17 @@ ENTERPRISE_CUSTOMER = 'cf246b88-d5f6-4908-a522-fc307e0b0c59'
 ENTERPRISE_CUSTOMER_CATALOG = 'abc18838-adcb-41d5-abec-b28be5bfcc13'
 
 
-def format_url(base='', path='', params=None):
-    if params:
-        return '{base}{path}?{params}'.format(base=base, path=path, params=six.moves.urllib.parse.urlencode(params))
-    return '{base}{path}'.format(base=base, path=path)
+def format_url(base='', path='', params=None, disable_button=False):
+    params = six.moves.urllib.parse.urlencode(params)
+    url = '{base}{path}{params}'.format(
+        base=base,
+        path=path,
+        params='?{params}'.format(params=params) if params else ''
+    )
+    if disable_button:
+        url = url + '&back_button=disable' if params else '?back_button=disable'
+
+    return url
 
 
 class CouponAppViewTests(TestCase):
@@ -366,7 +373,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
 
         order = Order.objects.first()
         receipt_page_url = get_receipt_page_url(self.site.siteconfiguration)
-        expected_url = format_url(base=receipt_page_url, params={'order_number': order.number})
+        expected_url = format_url(base=receipt_page_url, params={'order_number': order.number}, disable_button=True)
 
         self.assertRedirects(response, expected_url, status_code=302, fetch_redirect_response=False)
 

--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -52,16 +52,11 @@ ENTERPRISE_CUSTOMER_CATALOG = 'abc18838-adcb-41d5-abec-b28be5bfcc13'
 
 
 def format_url(base='', path='', params=None, disable_button=False):
-    params = six.moves.urllib.parse.urlencode(params)
-    url = '{base}{path}{params}'.format(
-        base=base,
-        path=path,
-        params='?{params}'.format(params=params) if params else ''
-    )
-    if disable_button:
-        url = url + '&back_button=disable' if params else '?back_button=disable'
-
-    return url
+    if params:
+        if disable_button:
+            params['back_button'] = 'disable'
+        return '{base}{path}?{params}'.format(base=base, path=path, params=six.moves.urllib.parse.urlencode(params))
+    return '{base}{path}'.format(base=base, path=path)
 
 
 class CouponAppViewTests(TestCase):

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -256,7 +256,7 @@ class CouponRedeemView(EdxOrderPlacementMixin, View):
         if basket.total_excl_tax == 0:
             try:
                 order = self.place_free_order(basket)
-                return HttpResponseRedirect(get_receipt_page_url(site_configuration, order.number))
+                return HttpResponseRedirect(get_receipt_page_url(site_configuration, order.number, disable_button=True))
             except:  # pylint: disable=bare-except
                 logger.exception('Failed to create a free order for basket [%d]', basket.id)
                 return HttpResponseRedirect(reverse('checkout:error'))

--- a/ecommerce/extensions/checkout/tests/test_views.py
+++ b/ecommerce/extensions/checkout/tests/test_views.py
@@ -106,7 +106,8 @@ class FreeCheckoutViewTests(EnterpriseServiceMockMixin, TestCase):
         order = Order.objects.first()
         expected_url = get_receipt_page_url(
             order_number=order.number,
-            site_configuration=order.site.siteconfiguration
+            site_configuration=order.site.siteconfiguration,
+            disable_button=True
         )
         self.assertRedirects(response, expected_url, fetch_redirect_response=False)
 

--- a/ecommerce/extensions/checkout/utils.py
+++ b/ecommerce/extensions/checkout/utils.py
@@ -31,13 +31,14 @@ def get_credit_provider_details(credit_provider_id, site_configuration):
         return None
 
 
-def get_receipt_page_url(site_configuration, order_number=None, override_url=None):
+def get_receipt_page_url(site_configuration, order_number=None, override_url=None, disable_button=False):
     """ Returns the receipt page URL.
 
     Args:
         order_number (str): Order number
         site_configuration (SiteConfiguration): Site Configuration containing the flag for enabling Otto receipt page.
         override_url (str): New receipt page to override the default one.
+        disable_button (bool): To disable the back button from receipt page
 
     Returns:
         str: Receipt page URL.
@@ -48,10 +49,15 @@ def get_receipt_page_url(site_configuration, order_number=None, override_url=Non
         base_url = site_configuration.build_ecommerce_url(reverse('checkout:receipt'))
         params = six.moves.urllib.parse.urlencode({'order_number': order_number}) if order_number else ''
 
-    return '{base_url}{params}'.format(
+    url = '{base_url}{params}'.format(
         base_url=base_url,
         params='?{params}'.format(params=params) if params else ''
     )
+    if disable_button:
+        btn_param = six.moves.urllib.parse.urlencode({'back_button': "disable"})
+        url += ('&' if params else '?') + btn_param
+
+    return url
 
 
 def format_currency(currency, amount, format=None, locale=None):  # pylint: disable=redefined-builtin

--- a/ecommerce/extensions/checkout/utils.py
+++ b/ecommerce/extensions/checkout/utils.py
@@ -46,18 +46,17 @@ def get_receipt_page_url(site_configuration, order_number=None, override_url=Non
     if override_url:
         return override_url
     else:
-        base_url = site_configuration.build_ecommerce_url(reverse('checkout:receipt'))
-        params = six.moves.urllib.parse.urlencode({'order_number': order_number}) if order_number else ''
+        url_params = {'order_number': order_number}
+        if disable_button:
+            url_params['back_button'] = 'disable'
 
-    url = '{base_url}{params}'.format(
+        base_url = site_configuration.build_ecommerce_url(reverse('checkout:receipt'))
+        params = six.moves.urllib.parse.urlencode(url_params) if order_number else ''
+
+    return '{base_url}{params}'.format(
         base_url=base_url,
         params='?{params}'.format(params=params) if params else ''
     )
-    if disable_button:
-        btn_param = six.moves.urllib.parse.urlencode({'back_button': "disable"})
-        url += ('&' if params else '?') + btn_param
-
-    return url
 
 
 def format_currency(currency, amount, format=None, locale=None):  # pylint: disable=redefined-builtin

--- a/ecommerce/extensions/checkout/views.py
+++ b/ecommerce/extensions/checkout/views.py
@@ -74,7 +74,8 @@ class FreeCheckoutView(EdxOrderPlacementMixin, RedirectView):
             else:
                 receipt_path = get_receipt_page_url(
                     order_number=order.number,
-                    site_configuration=order.site.siteconfiguration
+                    site_configuration=order.site.siteconfiguration,
+                    disable_button=True
                 )
                 url = site.siteconfiguration.build_lms_url(receipt_path)
         else:
@@ -179,7 +180,8 @@ class ReceiptResponseView(ThankYouView):
         context.update(self.get_show_verification_banner_context(context))
         context.update({
             'explore_courses_url': get_lms_explore_courses_url(),
-            'has_enrollment_code_product': has_enrollment_code_product
+            'has_enrollment_code_product': has_enrollment_code_product,
+            'back_button': self.request.GET.get('back_button', "")
         })
         return context
 

--- a/ecommerce/extensions/payment/tests/mixins.py
+++ b/ecommerce/extensions/payment/tests/mixins.py
@@ -660,7 +660,8 @@ class CybersourceNotificationTestsMixin(CybersourceMixin):
 
         expected_redirect = get_receipt_page_url(
             self.site.siteconfiguration,
-            order_number=notification.get('req_reference_number')
+            order_number=notification.get('req_reference_number'),
+            disable_button=True
         )
 
         self.assertRedirects(response, expected_redirect, fetch_redirect_response=False)

--- a/ecommerce/extensions/payment/tests/views/test_paypal.py
+++ b/ecommerce/extensions/payment/tests/views/test_paypal.py
@@ -75,7 +75,8 @@ class PaypalPaymentExecutionViewTests(PaypalMixin, PaymentEventsMixin, TestCase)
             response,
             url_redirect or get_receipt_page_url(
                 order_number=self.basket.order_number,
-                site_configuration=self.basket.site.siteconfiguration
+                site_configuration=self.basket.site.siteconfiguration,
+                disable_button=True
             ),
             fetch_redirect_response=False
         )
@@ -120,7 +121,8 @@ class PaypalPaymentExecutionViewTests(PaypalMixin, PaymentEventsMixin, TestCase)
             response,
             get_receipt_page_url(
                 order_number=self.basket.order_number,
-                site_configuration=self.basket.site.siteconfiguration
+                site_configuration=self.basket.site.siteconfiguration,
+                disable_button=True
             ),
             fetch_redirect_response=False
         )
@@ -157,7 +159,8 @@ class PaypalPaymentExecutionViewTests(PaypalMixin, PaymentEventsMixin, TestCase)
             response,
             get_receipt_page_url(
                 order_number=self.basket.order_number,
-                site_configuration=self.basket.site.siteconfiguration
+                site_configuration=self.basket.site.siteconfiguration,
+                disable_button=True
             ),
             fetch_redirect_response=False
         )

--- a/ecommerce/extensions/payment/tests/views/test_stripe.py
+++ b/ecommerce/extensions/payment/tests/views/test_stripe.py
@@ -41,7 +41,7 @@ class StripeSubmitViewTests(PaymentEventsMixin, TestCase):
 
     def assert_successful_order_response(self, response, order_number):
         assert response.status_code == 201
-        receipt_url = get_receipt_page_url(self.site_configuration, order_number)
+        receipt_url = get_receipt_page_url(self.site_configuration, order_number, disable_button=True)
         assert json.loads(response.content) == {'url': receipt_url}
 
     def assert_order_created(self, basket, billing_address, card_type, label):

--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -362,7 +362,8 @@ class CybersourceInterstitialView(CybersourceNotificationMixin, View):
     def redirect_to_receipt_page(self, notification):
         receipt_page_url = get_receipt_page_url(
             self.request.site.siteconfiguration,
-            order_number=notification.get('req_reference_number')
+            order_number=notification.get('req_reference_number'),
+            disable_button=True
         )
 
         return redirect(receipt_page_url)

--- a/ecommerce/extensions/payment/views/paypal.py
+++ b/ecommerce/extensions/payment/views/paypal.py
@@ -91,7 +91,8 @@ class PaypalPaymentExecutionView(EdxOrderPlacementMixin, View):
 
         receipt_url = get_receipt_page_url(
             order_number=basket.order_number,
-            site_configuration=basket.site.siteconfiguration
+            site_configuration=basket.site.siteconfiguration,
+            disable_button=True
         )
 
         try:

--- a/ecommerce/extensions/payment/views/stripe.py
+++ b/ecommerce/extensions/payment/views/stripe.py
@@ -76,6 +76,7 @@ class StripeSubmitView(EdxOrderPlacementMixin, BasePaymentSubmitView):
 
         receipt_url = get_receipt_page_url(
             site_configuration=self.request.site.siteconfiguration,
-            order_number=order_number
+            order_number=order_number,
+            disable_button=True
         )
         return JsonResponse({'url': receipt_url}, status=201)

--- a/ecommerce/static/js/pages/receipt_page.js
+++ b/ecommerce/static/js/pages/receipt_page.js
@@ -51,7 +51,9 @@ define([
                 orderId = $el.data('order-id'),
                 totalAmount = $el.data('total-amount');
 
-            disableBackButton();
+            if ($el.data('back-button') === 'disable') {
+                disableBackButton();
+            }
 
             if (orderId) {
                 trackPurchase(orderId, totalAmount, currency);

--- a/ecommerce/static/js/test/specs/pages/receipt_page_spec.js
+++ b/ecommerce/static/js/test/specs/pages/receipt_page_spec.js
@@ -22,14 +22,23 @@ define([
             });
 
             describe('onReady', function() {
-                it('should disable the back button by manipulating the fragment', function() {
+                it('should not disable the back button if default values are used for data-back-button', function() {
+                    ReceiptPage.onReady();
+
+                    expect(location.hash).toEqual('');
+                });
+
+                it('should disable the back button if value of data-back-button is set', function() {
+                    var receiptPage = document.getElementById('receipt-container');
+                    receiptPage.setAttribute('data-back-button', 'disable');
+
                     ReceiptPage.onReady();
 
                     expect(location.hash).toContain('#');
 
                     history.back();
 
-                    expect(location.hash).toContain('#');
+                    setTimeout(function() { expect(window.alert).toHaveBeenCalled(); }, 3000);
                 });
 
                 it('should trigger track purchase', function() {

--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -26,7 +26,8 @@
        class="receipt container content-container"
        data-currency="{{ order.currency }}"
        data-order-id="{{ order.number }}"
-       data-total-amount="{{ order.total_incl_tax | unlocalize }}">
+       data-total-amount="{{ order.total_incl_tax | unlocalize }}"
+       data-back-button="{{ back_button | default:'' }}">
       <h2 class="thank-you">{% trans "Thank you for your order!" %}</h2>
 
       <div class="list-info">


### PR DESCRIPTION
#### Steps to reproduce current behavior:
* Go to https://ecommerce.edx.org/checkout/receipt/?order_number=EDX-29479306#jwudxzwa
* Press back button
* You will get a pop-up saying "Caution! Using the back button on this page may cause you to be charged again."

#### Expected Behavior:
* If a user is viewing order receipt from order history or from an email with enrollment code order information., don't disable the back button. 
* Disable only if the user has landed on receipt page after completing a payment, in which case user might be charged again if he goes back.

[PROD-376](https://openedx.atlassian.net/browse/PROD-376)