### PR TITLE
refactor: use a less ambiguous name for product type

### DIFF
--- a/ecommerce/extensions/basket/tests/test_views.py
+++ b/ecommerce/extensions/basket/tests/test_views.py
@@ -439,7 +439,7 @@ class PaymentApiViewTests(BasketLogicTestMixin, BasketMixin, DiscoveryMockMixin,
             'summary_price': Decimal(summary_price),
             'order_total': Decimal(order_total),
             'products': [{
-                'type': product_type,
+                'product_type': product_type,
                 'certificate_type': certificate_type,
                 'image_url': image_url,
                 'sku': basket.lines.first().product.stockrecords.first().partner_sku,

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -615,7 +615,7 @@ class PaymentApiLogicMixin(BasketLogicMixin):
             {
                 'sku': line_data['sku'],
                 'title': line_data['product_title'],
-                'type': line_data['line'].product.get_product_class().name,
+                'product_type': line_data['line'].product.get_product_class().name,
                 'image_url': line_data['image_url'],
                 'certificate_type': self._get_certificate_type(line_data['line'].product),
             }


### PR DESCRIPTION
We want to avoid using "type" as it has a very different meaning in the frontend redux/actions, and could cause very confusing bugs in the payment MFE.

(redux actions reserve the use of the "type" key to describe the action type)