### PR TITLE
Add DRF APIView for Cybersource submit.

### DIFF
--- a/ecommerce/extensions/payment/tests/views/test_cybersource.py
+++ b/ecommerce/extensions/payment/tests/views/test_cybersource.py
@@ -182,6 +182,24 @@ class CybersourceSubmitViewTests(CybersourceMixin, TestCase):
         self.assertIn(field, errors)
 
 
+class CybersourceSubmitAPIViewTests(CybersourceSubmitViewTests):
+    path = reverse('cybersource:api_submit')
+
+    def setUp(self):  # pylint: disable=useless-super-delegation
+        super(CybersourceSubmitAPIViewTests, self).setUp()
+
+    def test_login_required(self):
+        """ Verify the view returns 401 for unauthenticated users. """
+        self.client.logout()
+        response = self.client.post(self.path)
+        self.assertEqual(response.status_code, 401)
+
+    @freeze_time('2016-01-01')
+    def test_valid_request(self):
+        """ Verify the view returns the CyberSource parameters if the request is valid. """
+        super(CybersourceSubmitAPIViewTests, self).test_valid_request()
+
+
 @ddt.ddt
 class CybersourceInterstitialViewTests(CybersourceNotificationTestsMixin, TestCase):
     """ Test interstitial view for Cybersource Payments. """

--- a/ecommerce/extensions/payment/urls.py
+++ b/ecommerce/extensions/payment/urls.py
@@ -12,6 +12,7 @@ CYBERSOURCE_URLS = [
     url(r'^apple-pay/', include(CYBERSOURCE_APPLE_PAY_URLS, namespace='apple_pay')),
     url(r'^redirect/$', cybersource.CybersourceInterstitialView.as_view(), name='redirect'),
     url(r'^submit/$', cybersource.CybersourceSubmitView.as_view(), name='submit'),
+    url(r'^api-submit/$', cybersource.CybersourceSubmitAPIView.as_view(), name='api_submit'),
 ]
 
 PAYPAL_URLS = [

--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -152,6 +152,22 @@ class CybersourceSubmitView(BasePaymentSubmitView):
         return response
 
 
+class CybersourceSubmitAPIView(APIView, CybersourceSubmitView):
+    # DRF APIView wrapper which allows clients to use
+    # JWT authentication when making Cybersource submit
+    # requests.
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def post(self, request):
+        logger.info(
+            '%s called for basket [%d]. It is in the [%s] state.',
+            self.__class__.__name__,
+            request.basket.id,
+            request.basket.status
+        )
+        return super(CybersourceSubmitAPIView, self).post(request)
+
+
 class CybersourceNotificationMixin(CyberSourceProcessorMixin, OrderCreationMixin):
     # Disable atomicity for the view. Otherwise, we'd be unable to commit to the database
     # until the request had concluded; Django will refuse to commit when an atomic() block


### PR DESCRIPTION
This wraps the Cybersource submit view in a DRF APIView so that we can use JWT authentication when calling this view.