### PR TITLE
Updated Python requirements

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,8 +3,9 @@
 #  edX Fork of Segment's python-analytics 1.2.8 using gevent for queueing
 #
 #############################
--e git+https://github.com/edx/analytics-python.git@1.2.11#egg=analytics-python==1.2.11
+-e 'git+https://github.com/edx/analytics-python.git@1.2.11#egg=analytics-python==1.2.11 ; python_version == "2.7"'
 
+analytics-python ; python_version >= "3"
 coreapi
 django<2.0
 django-compressor==2.2
@@ -33,7 +34,7 @@ edx-ecommerce-worker
 edx-opaque-keys
 edx-rbac
 edx-rest-api-client
-gevent==1.0.2
+gevent==1.0.2 ; python_version == "2.7"
 jsonfield==1.0.3
 libsass==0.9.2
 markdown==2.6.9

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,9 @@
 #
 #    make upgrade
 #
--e git+https://github.com/edx/analytics-python.git@1.2.11#egg=analytics-python==1.2.11
+-e 'git+https://github.com/edx/analytics-python.git@1.2.11#egg=analytics-python==1.2.11 ; python_version == "2.7"'
+
+analytics-python==1.2.9 ; python_version >= "3"
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via zeep
@@ -64,7 +66,7 @@ factory-boy==2.12.0       # via django-oscar
 faker==2.0.0              # via factory-boy
 funcsigs==1.0.2           # via mock
 future==0.17.1            # via pyjwkest
-gevent==1.0.2
+gevent==1.0.2 ; python_version == "2.7"
 greenlet==0.4.15          # via gevent
 idna==2.8                 # via requests
 ipaddress==1.0.22         # via cryptography, faker
@@ -102,6 +104,7 @@ pymongo==3.8.0            # via edx-opaque-keys
 pyopenssl==19.0.0         # via ndg-httpsclient, paypalrestsdk
 python-dateutil==2.8.0
 python-openid==2.2.5 ; python_version == "2.7"
+python3-openid==3.1.0 ; python_version >= "3"
 pytz==2016.10
 pyyaml==5.1.1             # via edx-django-release-util
 rcssmin==1.0.6            # via django-compressor

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,9 +4,10 @@
 #
 #    make upgrade
 #
--e git+https://github.com/edx/analytics-python.git@1.2.11#egg=analytics-python==1.2.11
+-e 'git+https://github.com/edx/analytics-python.git@1.2.11#egg=analytics-python==1.2.11 ; python_version == "2.7"'
 alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via kombu
+analytics-python==1.2.9 ; python_version >= "3"
 anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via zeep
 asn1crypto==0.24.0        # via cryptography
@@ -82,8 +83,8 @@ filelock==3.0.12          # via tox
 freezegun==0.3.12
 funcsigs==1.0.2           # via mock
 future==0.17.1            # via pyjwkest
-futures==3.3.0            # via isort
-gevent==1.0.2
+futures==3.2.0 ; python_version == "2.7"
+gevent==1.0.2 ; python_version == "2.7"
 greenlet==0.4.15          # via gevent
 httpretty==0.9.6
 idna==2.8                 # via requests
@@ -140,9 +141,10 @@ pylint==1.9.5
 pymongo==3.8.0            # via edx-opaque-keys
 pyopenssl==19.0.0         # via ndg-httpsclient, paypalrestsdk
 pyparsing==2.4.0          # via packaging
-pysqlite==2.8.3
+pysqlite==2.8.3 ; python_version == "2.7"
 python-dateutil==2.8.0
 python-openid==2.2.5 ; python_version == "2.7"
+python3-openid==3.1.0 ; python_version >= "3"
 python-slugify==1.2.6     # via transifex-client
 pytz==2016.10
 pyyaml==5.1.1             # via edx-django-release-util, edx-i18n-tools

--- a/requirements/production.in
+++ b/requirements/production.in
@@ -5,7 +5,7 @@ django-ses==0.8.2
 
 # Later versions of gevent wrap Python's __import__ in a way that breaks Oscar imports.
 # For more, see https://github.com/edx/ecommerce/pull/920.
-gevent==1.0.2
+gevent==1.0.2 ; python_version == "2.7"
 
 gunicorn==19.7.1
 newrelic<5

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,8 +4,9 @@
 #
 #    make upgrade
 #
--e git+https://github.com/edx/analytics-python.git@1.2.11#egg=analytics-python==1.2.11
+-e 'git+https://github.com/edx/analytics-python.git@1.2.11#egg=analytics-python==1.2.11 ; python_version == "2.7"'
 amqp==1.4.9               # via kombu
+analytics-python==1.2.9 ; python_version >= "3"
 anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via zeep
 asn1crypto==0.24.0        # via cryptography
@@ -66,7 +67,7 @@ factory-boy==2.12.0       # via django-oscar
 faker==2.0.0              # via factory-boy
 funcsigs==1.0.2           # via mock
 future==0.17.1            # via pyjwkest
-gevent==1.0.2
+gevent==1.0.2 ; python_version == "2.7"
 greenlet==0.4.15          # via gevent
 gunicorn==19.7.1
 idna==2.8                 # via requests
@@ -107,6 +108,7 @@ pyopenssl==19.0.0         # via ndg-httpsclient, paypalrestsdk
 python-dateutil==2.8.0
 python-memcached==1.58
 python-openid==2.2.5 ; python_version == "2.7"
+python3-openid==3.1.0 ; python_version >= "3"
 pytz==2016.10
 pyyaml==5.1.1
 rcssmin==1.0.6            # via django-compressor

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -7,6 +7,7 @@ django-nose
 django-webtest
 factory-boy
 freezegun
+futures ; python_version == "2.7"
 httpretty
 isort
 lxml
@@ -15,7 +16,7 @@ mock-django
 nose-ignore-docstring
 pycodestyle
 pylint
-pysqlite                  # DB-API 2.0 interface for SQLite 3.x (used as the relational database for most tests)
+pysqlite ; python_version == "2.7"                 # DB-API 2.0 interface for SQLite 3.x (used as the relational database for most tests)
 responses
 selenium
 testfixtures                # Provides a LogCapture utility used by several tests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,8 +4,9 @@
 #
 #    make upgrade
 #
--e git+https://github.com/edx/analytics-python.git@1.2.11#egg=analytics-python==1.2.11
+-e 'git+https://github.com/edx/analytics-python.git@1.2.11#egg=analytics-python==1.2.11 ; python_version == "2.7"'
 amqp==1.4.9               # via kombu
+analytics-python==1.2.9 ; python_version >= "3"
 anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via zeep
 asn1crypto==0.24.0        # via cryptography
@@ -77,8 +78,8 @@ filelock==3.0.12          # via tox
 freezegun==0.3.12
 funcsigs==1.0.2           # via mock
 future==0.17.1            # via pyjwkest
-futures==3.3.0            # via isort
-gevent==1.0.2
+futures==3.2.0 ; python_version == "2.7"
+gevent==1.0.2 ; python_version == "2.7"
 greenlet==0.4.15          # via gevent
 httpretty==0.9.6
 idna==2.8                 # via requests
@@ -131,9 +132,10 @@ pylint==1.9.5
 pymongo==3.8.0            # via edx-opaque-keys
 pyopenssl==19.0.0         # via ndg-httpsclient, paypalrestsdk
 pyparsing==2.4.0          # via packaging
-pysqlite==2.8.3
+pysqlite==2.8.3 ; python_version == "2.7"
 python-dateutil==2.8.0
 python-openid==2.2.5 ; python_version == "2.7"
+python3-openid==3.1.0 ; python_version >= "3"
 pytz==2016.10
 pyyaml==5.1.1             # via edx-django-release-util
 rcssmin==1.0.6            # via django-compressor


### PR DESCRIPTION
- restricted `gevent` library to py27 as it is not compatible py36
- restricted futures to python_version == "2.7"
- using upstream version of `analytics-python==1.2.9` under py36. Previously, we were using our forked repo and it had dependency on `gevent`. Restricted forked version to py27 