### PR TITLE
Revert "Use order number instead of session ID for Cybersource device_fingerprint_id when using JWT auth."

### DIFF
--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -119,8 +119,7 @@ class CybersourceSubmitView(BasePaymentSubmitView):
             'payment_method': 'card',
             'unsigned_field_names': ','.join(Cybersource.PCI_FIELDS),
             'bill_to_email': user.email,
-            # Fall back to order number when there is no session key (JWT auth)
-            'device_fingerprint_id': request.session.session_key or basket.order_number,
+            'device_fingerprint_id': request.session.session_key,
         }
 
         for source, destination in six.iteritems(self.FIELD_MAPPINGS):


### PR DESCRIPTION
Reverts edx/ecommerce#2457