### PR TITLE
ENT-2035 | Adding new endpoint to return data about remaining code redemptions for a user

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import logging
+from collections import OrderedDict
 from datetime import timedelta
 from decimal import Decimal
 
@@ -816,6 +817,27 @@ class CouponListSerializer(serializers.ModelSerializer):
     class Meta(object):
         model = Product
         fields = ('category', 'client', 'code', 'id', 'title', 'date_created')
+
+
+class OfferAssignmentSummarySerializer(serializers.BaseSerializer):  # pylint: disable=abstract-method
+    """
+    Serializer for OfferAssignment endpoint.
+    """
+
+    def to_representation(self, instance):
+        representation = OrderedDict()
+
+        offer_assignment = instance['obj']
+        representation['usage_type'] = get_benefit_type(offer_assignment.offer.benefit)
+        representation['benefit_value'] = offer_assignment.offer.benefit.value
+
+        representation['redemptions_remaining'] = instance['count']
+        representation['code'] = offer_assignment.code
+        representation['catalog'] = offer_assignment.offer.condition.enterprise_customer_catalog_uuid
+        representation['coupon_start_date'] = offer_assignment.offer.vouchers.first().start_datetime
+        representation['coupon_end_date'] = offer_assignment.offer.vouchers.first().end_datetime
+
+        return representation
 
 
 class EnterpriseCouponOverviewListSerializer(serializers.ModelSerializer):

--- a/ecommerce/extensions/api/v2/urls.py
+++ b/ecommerce/extensions/api/v2/urls.py
@@ -132,6 +132,12 @@ router.register(r'catalogs', catalog_views.CatalogViewSet, base_name='catalog') 
               parents_query_lookups=['stockrecords__catalogs'])
 router.register(r'coupons', coupon_views.CouponViewSet, base_name='coupons')
 router.register(r'enterprise/coupons', enterprise_views.EnterpriseCouponViewSet, base_name='enterprise-coupons')
+router.register(
+    r'enterprise/offer_assignment_summary',
+    enterprise_views.OfferAssignmentSummaryViewSet,
+    base_name='enterprise-offer-assignment-summary',
+)
+
 router.register(r'courses', course_views.CourseViewSet, base_name='course') \
     .register(r'products', product_views.ProductViewSet,
               base_name='course-product', parents_query_lookups=['course_id'])


### PR DESCRIPTION
ENT-2035 | Adding new endpoint to return data about remaining code redemptions for a user

Serializing by default happens per object returned by the queryset, so to return a total number of redemptions available (based on offerAssignments) in an API response that contains few results that have been rolled up, we need to do some processing before we get to the serializer (I chose in `get_queryset` on the view).

The view does the work of finding all offerAssignments associated with a given user (via their user_email), as well as "rolling up" the offerAssignments per code.

Another thing maybe worth mentioning that didn't end up in my PR: I tried to do some fancy custom lookups when gather the offerAssignment objects in the view (specifically, annotating the number of offerAssignments per code, but was unable to get the DB to return what I intended). While rolling up the Count of offerAssignments, I looked into using `.distinct('code')` which underlyingly is a `DISTINCT ON`, but that's only available in postgres, which we don't use.