### PR TITLE
replace calls to the enterprise user endpoint with JWT role check

### DIFF
--- a/ecommerce/enterprise/conditions.py
+++ b/ecommerce/enterprise/conditions.py
@@ -77,6 +77,7 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
             course_run_ids.append(course.id)
 
         courses_in_basket = ','.join(course_run_ids)
+        learner_enterprise_customer_id = None
         try:
             learner_enterprise_customer_id = get_enterprise_id_for_user(basket.site, basket.owner)
         except (ConnectionError, KeyError, SlumberHttpBaseException, Timeout) as exc:

--- a/ecommerce/enterprise/tests/test_conditions.py
+++ b/ecommerce/enterprise/tests/test_conditions.py
@@ -149,11 +149,16 @@ class EnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, DiscoveryTest
         )
         self.assertFalse(self.condition.is_satisfied(offer, basket))
 
-    def setup_enterprise_coupon_data(self, mock_learner_api=True, use_new_enterprise=False):
+    def setup_enterprise_coupon_data(
+            self,
+            mock_learner_api=True,
+            use_new_enterprise=False,
+            offer_type=ConditionalOffer.VOUCHER
+    ):
         offer = factories.EnterpriseOfferFactory(
             partner=self.partner,
             condition=self.condition,
-            offer_type=ConditionalOffer.VOUCHER
+            offer_type=offer_type
         )
         basket = BasketFactory(site=self.site, owner=self.user)
         basket.add_product(self.course_run.seat_products[0])
@@ -193,6 +198,12 @@ class EnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, DiscoveryTest
         """ Ensure the condition returns true for a coupon with an enterprise conditional offer. """
         offer, basket = self.setup_enterprise_coupon_data(mock_learner_api=False)
         self.assertTrue(self.condition.is_satisfied(offer, basket))
+
+    @httpretty.activate
+    def test_is_satisfied_with_get_enterprise_id_for_user_exception(self):
+        """ Ensure the condition returns False when IndexError exception occurs in `get_enterprise_id_for_user`. """
+        offer, basket = self.setup_enterprise_coupon_data(mock_learner_api=False, offer_type=ConditionalOffer.SITE)
+        self.assertFalse(self.condition.is_satisfied(offer, basket))
 
     @httpretty.activate
     def test_is_satisfied_no_course_product_for_voucher_offer(self):

--- a/ecommerce/enterprise/tests/test_conditions.py
+++ b/ecommerce/enterprise/tests/test_conditions.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 import ddt
 import httpretty
 import mock
+from django.test import RequestFactory
 from oscar.core.loading import get_model
 from oscar.test.factories import BasketFactory
 from six.moves import range, zip
@@ -42,6 +43,13 @@ class EnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, DiscoveryTest
         self.test_product = ProductFactory(stockrecords__price_excl_tax=10, categories=[])
         self.course_run = CourseFactory(partner=self.partner)
         self.course_run.create_or_update_seat('verified', True, Decimal(100))
+
+        request = RequestFactory()
+        request.COOKIES = {}
+        mock_crum_get_current_request = mock.patch('ecommerce.enterprise.utils.crum.get_current_request')
+        self.mock_crum_get_current_request = mock_crum_get_current_request.start()
+        self.mock_crum_get_current_request.return_value = request
+        self.addCleanup(mock_crum_get_current_request.stop)
 
     def test_name(self):
         """ The name should contain the EnterpriseCustomer's name. """

--- a/ecommerce/enterprise/tests/test_utils.py
+++ b/ecommerce/enterprise/tests/test_utils.py
@@ -284,13 +284,14 @@ class EnterpriseUtilsTests(EnterpriseServiceMockMixin, TestCase):
     def test_get_enterprise_id_for_user_no_uuid_in_response(self, mock_get_jwt_uuid, mock_fetch):
         """
         Verify if learner data fetch is successful but does not include uuid field,
-        None is returned
+        IndexError is raised
         """
         mock_get_jwt_uuid.return_value = None
         mock_fetch.return_value = {
             'results': []
         }
-        assert get_enterprise_id_for_user('some-site', self.learner) is None
+        with self.assertRaises(IndexError):
+            get_enterprise_id_for_user('some-site', self.learner)
 
     def test_get_enterprise_customer_catalogs(self):
         """

--- a/ecommerce/enterprise/tests/test_utils.py
+++ b/ecommerce/enterprise/tests/test_utils.py
@@ -271,13 +271,13 @@ class EnterpriseUtilsTests(EnterpriseServiceMockMixin, TestCase):
     @patch('ecommerce.enterprise.utils.get_enterprise_id_for_current_request_user_from_jwt')
     def test_get_enterprise_id_for_user_fetch_errors(self, mock_get_jwt_uuid, mock_fetch):
         """
-        Verify if that learner data fetch errors, get_enterprise_id_for_user
-        returns None
+        Verify if that learner data fetch errors, get_enterprise_id_for_user raises expected exception
         """
         mock_get_jwt_uuid.return_value = None
         mock_fetch.side_effect = [KeyError]
 
-        assert get_enterprise_id_for_user('some-site', self.learner) is None
+        with self.assertRaises(KeyError):
+            get_enterprise_id_for_user('some-site', self.learner)
 
     @patch('ecommerce.enterprise.utils.fetch_enterprise_learner_data')
     @patch('ecommerce.enterprise.utils.get_enterprise_id_for_current_request_user_from_jwt')

--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -601,7 +601,7 @@ def get_enterprise_id_for_user(site, user):
     except (ConnectionError, KeyError, SlumberHttpBaseException, Timeout) as exc:
         logging.exception('Unable to retrieve enterprise learner data for the user!'
                           'User: %s, Exception: %s', user, exc)
-        return None
+        raise
 
     try:
         return enterprise_learner_response['results'][0]['enterprise_customer']['uuid']

--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -603,9 +603,4 @@ def get_enterprise_id_for_user(site, user):
                           'User: %s, Exception: %s', user, exc)
         raise
 
-    try:
-        return enterprise_learner_response['results'][0]['enterprise_customer']['uuid']
-    except IndexError:
-        pass
-
-    return None
+    return enterprise_learner_response['results'][0]['enterprise_customer']['uuid']

--- a/ecommerce/extensions/offer/applicator.py
+++ b/ecommerce/extensions/offer/applicator.py
@@ -98,7 +98,7 @@ class CustomApplicator(Applicator):
 
         try:
             enterprise_id = get_enterprise_id_for_user(site, user)
-        except (ConnectionError, KeyError, SlumberHttpBaseException, Timeout) as exc:
+        except (ConnectionError, KeyError, IndexError, SlumberHttpBaseException, Timeout) as exc:
             logger.exception('[CustomApplicator] Unable to get enterprise offers because '
                              'we failed to retrieve enterprise learner data for the user. '
                              'User: %s, Message: %s', user.username, exc)

--- a/ecommerce/extensions/offer/tests/test_applicator.py
+++ b/ecommerce/extensions/offer/tests/test_applicator.py
@@ -171,3 +171,14 @@ class CustomApplicatorTests(TestCase):
             assert not enterprise_offers
         else:
             assert enterprise_offers.count() == num_expected_offers
+
+    def test_get_enterprise_offers_with_exception(self):
+        """ Verify get_enterprise_offers returns [] on exception inside `get_enterprise_id_for_user`"""
+        with mock.patch('ecommerce.extensions.offer.applicator.get_enterprise_id_for_user') as mock_ent_id:
+            mock_ent_id.side_effect = IndexError
+            enterprise_offers = self.applicator.get_enterprise_offers(
+                'some-site',
+                self.user
+            )
+
+            assert enterprise_offers == []


### PR DESCRIPTION
**Description:** Now that a learners linked enterprise customer is present in the JWT, we should take advantage of it and reduce our api calls back to the enterprise user endpoint. This PR first try to find the enterprise customer uuid in the JWT and then calls the enterprise learners endpoint if desired information is not present in JWT.

**JIRA:** [ENT-1968](https://openedx.atlassian.net/browse/ENT-1968)