### PR TITLE
add course key to payment api

### DIFF
--- a/ecommerce/extensions/basket/tests/test_views.py
+++ b/ecommerce/extensions/basket/tests/test_views.py
@@ -474,6 +474,7 @@ class PaymentApiResponseTestMixin(BasketLogicTestMixin):
                     u'certificate_type': certificate_type,
                     u'image_url': image_url,
                     u'sku': line.product.stockrecords.first().partner_sku,
+                    u'course_key': str(getattr(line, 'course_key', '')),
                     u'title': title,
                 } for line in basket.lines.all()
             ]

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -271,6 +271,7 @@ class BasketLogicMixin(object):
                 line_data = {
                     'product_title': product.title,
                     'image_url': None,
+                    'course_key': None,
                     'product_description': product.description
                 }
 
@@ -677,6 +678,7 @@ class PaymentApiLogicMixin(BasketLogicMixin):
     def _add_products(self, response, lines_data):
         response['products'] = [
             {
+                'course_key': str(getattr(line_data, 'course_key', '')),
                 'sku': line_data['sku'],
                 'title': line_data['product_title'],
                 'product_type': line_data['line'].product.get_product_class().name,


### PR DESCRIPTION
https://openedx.atlassian.net/browse/REVEM-379
This ticket is for adding support for the new discount feature to the frontend-app-payment mfe


I need to be able to access the course key in the frontend-app-payment repo to make this call https://courses.edx.org/api/discounts/course/course-v1:HarvardX+SKY101x+3T2018 for the discount feature
