### PR TITLE
Removed gevent and updated analytics-python

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -6,6 +6,7 @@ import logging
 
 import six  # pylint: disable=ungrouped-imports
 import waffle
+from analytics import Client as SegmentClient
 from dateutil.parser import parse
 from django.conf import settings
 from django.contrib.auth.models import AbstractUser
@@ -25,7 +26,6 @@ from simple_history.models import HistoricalRecords
 from six.moves.urllib.parse import urljoin, urlsplit
 from slumber.exceptions import HttpNotFoundError, SlumberBaseException
 
-from analytics import Client as SegmentClient
 from ecommerce.core.constants import ALL_ACCESS_CONTEXT, ALLOW_MISSING_LMS_USER_ID
 from ecommerce.core.exceptions import MissingLmsUserIdException
 from ecommerce.core.utils import log_message_and_raise_validation_error

--- a/ecommerce/extensions/analytics/tests/test_utils.py
+++ b/ecommerce/extensions/analytics/tests/test_utils.py
@@ -4,10 +4,10 @@ import json
 
 import ddt
 import mock
+from analytics import Client
 from django.contrib.auth.models import AnonymousUser
 from django.test.client import RequestFactory
 
-from analytics import Client
 from ecommerce.core.models import User  # pylint: disable=unused-import
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.analytics.utils import (

--- a/ecommerce/extensions/analytics/utils.py
+++ b/ecommerce/extensions/analytics/utils.py
@@ -4,6 +4,7 @@ import json
 import logging
 from functools import wraps
 
+from django.db import transaction
 from six.moves.urllib.parse import urlunsplit  # pylint: disable=import-error
 
 from ecommerce.courses.utils import mode_for_product
@@ -171,7 +172,9 @@ def track_segment_event(site, user, event, properties):
             'url': page,
         }
     }
-    return site.siteconfiguration.segment_client.track(user_tracking_id, event, properties, context=context)
+    return transaction.on_commit(
+        lambda: site.siteconfiguration.segment_client.track(user_tracking_id, event, properties,
+                                                            context=context))
 
 
 def translate_basket_line_for_segment(line):

--- a/ecommerce/extensions/basket/tests/test_models.py
+++ b/ecommerce/extensions/basket/tests/test_models.py
@@ -4,10 +4,10 @@ import itertools
 
 import mock
 import six
+from analytics import Client
 from edx_django_utils.cache import DEFAULT_REQUEST_CACHE
 from oscar.core.loading import get_class, get_model
 
-from analytics import Client
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.analytics.utils import parse_tracking_context, translate_basket_line_for_segment
 from ecommerce.extensions.api.v2.tests.views.mixins import CatalogMixin
@@ -16,13 +16,13 @@ from ecommerce.extensions.basket.models import Basket
 from ecommerce.extensions.basket.tests.mixins import BasketMixin
 from ecommerce.extensions.test.factories import create_basket
 from ecommerce.tests.factories import SiteConfigurationFactory, UserFactory
-from ecommerce.tests.testcases import TestCase
+from ecommerce.tests.testcases import TransactionTestCase
 
 Basket = get_model('basket', 'Basket')
 OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
 
 
-class BasketTests(CatalogMixin, BasketMixin, TestCase):
+class BasketTests(CatalogMixin, BasketMixin, TransactionTestCase):
     def assert_basket_state(self, basket, status, user, site):
         """ Verify the given basket's properties. """
         self.assertEqual(basket.status, status)

--- a/ecommerce/extensions/checkout/tests/test_mixins.py
+++ b/ecommerce/extensions/checkout/tests/test_mixins.py
@@ -39,7 +39,7 @@ from ecommerce.extensions.test.factories import (
 from ecommerce.invoice.models import Invoice
 from ecommerce.tests.factories import SiteConfigurationFactory, UserFactory
 from ecommerce.tests.mixins import BusinessIntelligenceMixin
-from ecommerce.tests.testcases import TestCase
+from ecommerce.tests.testcases import TransactionTestCase
 
 LOGGER_NAME = 'ecommerce.extensions.analytics.utils'
 Basket = get_model('basket', 'Basket')
@@ -57,7 +57,7 @@ Voucher = get_model('voucher', 'Voucher')
 
 @ddt.ddt
 @mock.patch.object(SegmentClient, 'track')
-class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin, RefundTestMixin, TestCase):
+class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin, RefundTestMixin, TransactionTestCase):
     """
     Tests validating generic behaviors of the EdxOrderPlacementMixin.
     """
@@ -66,6 +66,10 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin,
         super(EdxOrderPlacementMixinTests, self).setUp()
         self.user = UserFactory(lms_user_id=61710)
         self.order = self.create_order(status=ORDER.OPEN)
+
+        # Ensure that the basket attribute type exists for these tests
+        self.basket_attribute_type, _ = BasketAttributeType.objects.get_or_create(
+            name=EMAIL_OPT_IN_ATTRIBUTE)
 
     def test_handle_payment_logging(self, __):
         """
@@ -334,7 +338,7 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin,
         """
         BasketAttribute.objects.get_or_create(
             basket=self.order.basket,
-            attribute_type=BasketAttributeType.objects.get(name=EMAIL_OPT_IN_ATTRIBUTE),
+            attribute_type=self.basket_attribute_type,
             value_text=expected_opt_in,
         )
 

--- a/ecommerce/extensions/refund/tests/test_signals.py
+++ b/ecommerce/extensions/refund/tests/test_signals.py
@@ -7,11 +7,11 @@ from ecommerce.extensions.analytics.utils import ECOM_TRACKING_ID_FMT
 from ecommerce.extensions.refund.api import create_refunds
 from ecommerce.extensions.refund.tests.mixins import RefundTestMixin
 from ecommerce.tests.factories import UserFactory
-from ecommerce.tests.testcases import TestCase
+from ecommerce.tests.testcases import TransactionTestCase
 
 
 @patch.object(SegmentClient, 'track')
-class RefundTrackingTests(RefundTestMixin, TestCase):
+class RefundTrackingTests(RefundTestMixin, TransactionTestCase):
     """Tests verifying the behavior of refund tracking."""
 
     def setUp(self):

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,11 +1,4 @@
-#############################
-#
-#  edX Fork of Segment's python-analytics 1.2.8 using gevent for queueing
-#
-#############################
--e 'git+https://github.com/edx/analytics-python.git@1.2.11#egg=analytics-python==1.2.11 ; python_version == "2.7"'
-
-analytics-python ; python_version >= "3"
+analytics-python
 coreapi
 django<2.0
 django-compressor==2.2
@@ -34,7 +27,6 @@ edx-ecommerce-worker
 edx-opaque-keys
 edx-rbac
 edx-rest-api-client
-gevent==1.0.2 ; python_version == "2.7"
 jsonfield==1.0.3
 libsass==0.9.2
 markdown==2.6.9

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,9 +4,8 @@
 #
 #    make upgrade
 #
--e 'git+https://github.com/edx/analytics-python.git@1.2.11#egg=analytics-python==1.2.11 ; python_version == "2.7"'
 amqp==1.4.9               # via kombu
-analytics-python==1.2.9 ; python_version >= "3"
+analytics-python==1.2.9
 anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via zeep
 asn1crypto==0.24.0        # via cryptography
@@ -65,8 +64,6 @@ factory-boy==2.12.0       # via django-oscar
 faker==2.0.0              # via factory-boy
 funcsigs==1.0.2           # via mock
 future==0.17.1            # via pyjwkest
-gevent==1.0.2 ; python_version == "2.7"
-greenlet==0.4.15          # via gevent
 idna==2.8                 # via requests
 ipaddress==1.0.22         # via cryptography, faker
 isodate==0.6.0            # via zeep

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,10 +4,9 @@
 #
 #    make upgrade
 #
--e 'git+https://github.com/edx/analytics-python.git@1.2.11#egg=analytics-python==1.2.11 ; python_version == "2.7"'
 alabaster==0.7.12         # via sphinx
 amqp==1.4.9               # via kombu
-analytics-python==1.2.9 ; python_version >= "3"
+analytics-python==1.2.9
 anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via zeep
 asn1crypto==0.24.0        # via cryptography
@@ -84,8 +83,6 @@ freezegun==0.3.12
 funcsigs==1.0.2           # via mock
 future==0.17.1            # via pyjwkest
 futures==3.3.0 ; python_version == "2.7"
-gevent==1.0.2 ; python_version == "2.7"
-greenlet==0.4.15          # via gevent
 httpretty==0.9.6
 idna==2.8                 # via requests
 imagesize==1.1.0          # via sphinx

--- a/requirements/production.in
+++ b/requirements/production.in
@@ -2,11 +2,6 @@
 -r base.in
 
 django-ses==0.8.2
-
-# Later versions of gevent wrap Python's __import__ in a way that breaks Oscar imports.
-# For more, see https://github.com/edx/ecommerce/pull/920.
-gevent==1.0.2 ; python_version == "2.7"
-
 gunicorn==19.7.1
 newrelic<5
 python-memcached==1.58

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,9 +4,8 @@
 #
 #    make upgrade
 #
--e 'git+https://github.com/edx/analytics-python.git@1.2.11#egg=analytics-python==1.2.11 ; python_version == "2.7"'
 amqp==1.4.9               # via kombu
-analytics-python==1.2.9 ; python_version >= "3"
+analytics-python==1.2.9
 anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via zeep
 asn1crypto==0.24.0        # via cryptography
@@ -67,8 +66,6 @@ factory-boy==2.12.0       # via django-oscar
 faker==2.0.0              # via factory-boy
 funcsigs==1.0.2           # via mock
 future==0.17.1            # via pyjwkest
-gevent==1.0.2 ; python_version == "2.7"
-greenlet==0.4.15          # via gevent
 gunicorn==19.7.1
 idna==2.8                 # via requests
 ipaddress==1.0.22         # via cryptography, faker

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -16,9 +16,8 @@ mock-django
 nose-ignore-docstring
 pycodestyle
 pylint
-pysqlite ; python_version == "2.7"                 # DB-API 2.0 interface for SQLite 3.x (used as the relational database for most tests)
+pysqlite ; python_version == "2.7"  # DB-API 2.0 interface for SQLite 3.x (used as the relational database for most tests)
 responses
 selenium
 testfixtures                # Provides a LogCapture utility used by several tests
 tox
-

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,9 +4,8 @@
 #
 #    make upgrade
 #
--e 'git+https://github.com/edx/analytics-python.git@1.2.11#egg=analytics-python==1.2.11 ; python_version == "2.7"'
 amqp==1.4.9               # via kombu
-analytics-python==1.2.9 ; python_version >= "3"
+analytics-python==1.2.9
 anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via zeep
 asn1crypto==0.24.0        # via cryptography
@@ -79,8 +78,6 @@ freezegun==0.3.12
 funcsigs==1.0.2           # via mock
 future==0.17.1            # via pyjwkest
 futures==3.3.0 ; python_version == "2.7"
-gevent==1.0.2 ; python_version == "2.7"
-greenlet==0.4.15          # via gevent
 httpretty==0.9.6
 idna==2.8                 # via requests
 importlib-metadata==0.19  # via pluggy, tox


### PR DESCRIPTION
- using upstream version of `analytics-python==1.2.9` under py36. Previously, we were using our forked repo and it had dependency on `gevent`.
- Track segment calls are registered as callback functions in `transaction.on_commit` that should be executed after a transaction is successfully committed