### PR TITLE
Payment API: benefit_type and unformatted benefit_value

### DIFF
--- a/ecommerce/extensions/basket/tests/test_views.py
+++ b/ecommerce/extensions/basket/tests/test_views.py
@@ -363,20 +363,18 @@ class BasketLogicTestMixin(object):
             response = self.client.get(url if url else self.path)
         self.assertEqual(response.status_code, status_code)
 
-        if discount_type == Benefit.FIXED:
-            benefit_value = u'${}.00'.format(discount_value)
-            if summary_discounts is None:
+        if summary_discounts is None:
+            if discount_type == Benefit.FIXED:
                 summary_discounts = discount_value
-        else:
-            benefit_value = u'{}%'.format(discount_value)
-            if summary_discounts is None:
+            else:
                 summary_discounts = summary_price * (float(discount_value) / 100)
 
         order_total = round(summary_price - summary_discounts, 2)
 
         if discount_value:
             coupons = [{
-                'benefit_value': benefit_value,
+                'benefit_type': discount_type,
+                'benefit_value': discount_value,
                 'code': u'COUPONTEST',
                 'id': voucher.id,
             }]
@@ -385,7 +383,8 @@ class BasketLogicTestMixin(object):
 
         if offer_provider:
             offers = [{
-                'benefit_value': benefit_value,
+                'benefit_type': discount_type,
+                'benefit_value': discount_value,
                 'provider': offer_provider,
             }]
         else:

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -45,7 +45,12 @@ from ecommerce.extensions.basket.utils import (
     prepare_basket,
     validate_voucher
 )
-from ecommerce.extensions.offer.utils import format_benefit_value, get_redirect_to_email_confirmation_if_required
+from ecommerce.extensions.offer.utils import (
+    format_benefit_value,
+    get_benefit_type,
+    get_quantized_benefit_value,
+    get_redirect_to_email_confirmation_if_required
+)
 from ecommerce.extensions.order.exceptions import AlreadyPlacedOrderException
 from ecommerce.extensions.partner.shortcuts import get_partner_for_site
 from ecommerce.extensions.payment.constants import (
@@ -252,17 +257,15 @@ class BasketLogicMixin(object):
         # Currently only one voucher per basket is supported.
         try:
             applied_voucher = self.request.basket.vouchers.first()
-            total_benefit = (
-                format_benefit_value(applied_voucher.best_offer.benefit)
-                if applied_voucher else None
-            )
+            total_benefit_object = applied_voucher.best_offer.benefit if applied_voucher else None
         # TODO This ValueError handling no longer seems to be required and could probably be removed
         except ValueError:  # pragma: no cover
-            total_benefit = None
+            total_benefit_object = None
 
         num_of_items = self.request.basket.num_items
         return {
-            'total_benefit': total_benefit,
+            'total_benefit_object': total_benefit_object,
+            'total_benefit': format_benefit_value(total_benefit_object) if total_benefit_object else None,
             'free_basket': context['order_total'].incl_tax == 0,
             'line_price': (self.request.basket.total_incl_tax_excl_discounts / num_of_items) if num_of_items > 0 else 0,
         }
@@ -645,7 +648,8 @@ class PaymentApiLogicMixin(BasketLogicMixin):
         response['offers'] = [
             {
                 'provider': offer.condition.enterprise_customer_name,
-                'benefit_value': format_benefit_value(offer.benefit),
+                'benefit_type': get_benefit_type(offer.benefit) if offer.benefit else None,
+                'benefit_value': get_quantized_benefit_value(offer.benefit) if offer.benefit else None,
             }
             for offer in self.request.basket.applied_offers().values()
             if offer.condition.enterprise_customer_name
@@ -653,11 +657,13 @@ class PaymentApiLogicMixin(BasketLogicMixin):
 
     def _add_coupons(self, response, context):
         response['show_coupon_form'] = context['show_voucher_form']
+        benefit = context['total_benefit_object']
         response['coupons'] = [
             {
                 'id': voucher.id,
                 'code': voucher.code,
-                'benefit_value': context['total_benefit'],
+                'benefit_type': get_benefit_type(benefit) if benefit else None,
+                'benefit_value': get_quantized_benefit_value(benefit) if benefit else None,
             }
             for voucher in self.request.basket.vouchers.all()
             if response['show_coupon_form'] and self.request.basket.contains_a_voucher

--- a/ecommerce/extensions/offer/utils.py
+++ b/ecommerce/extensions/offer/utils.py
@@ -64,6 +64,13 @@ def get_benefit_type(benefit):
     return _type
 
 
+def get_quantized_benefit_value(benefit):
+    """
+    Returns the rounded value of the given benefit, without any decimal points.
+    """
+    return _remove_exponent_and_trailing_zeros(Decimal(str(benefit.value)))
+
+
 def format_benefit_value(benefit):
     """
     Format benefit value for display based on the benefit type
@@ -74,7 +81,7 @@ def format_benefit_value(benefit):
     Returns:
         benefit_value (str): String value containing formatted benefit value and type.
     """
-    benefit_value = _remove_exponent_and_trailing_zeros(Decimal(str(benefit.value)))
+    benefit_value = get_quantized_benefit_value(benefit)
     benefit_type = get_benefit_type(benefit)
 
     if benefit_type == Benefit.PERCENTAGE:


### PR DESCRIPTION
Return `benefit_type` and `benefit_value` as separate fields from Payment APIs, in order to enable the frontend code to localize the values correctly.

https://openedx.atlassian.net/browse/ARCH-767