### PR TITLE
skip improperly configured offer

### DIFF
--- a/ecommerce/extensions/offer/models.py
+++ b/ecommerce/extensions/offer/models.py
@@ -5,6 +5,7 @@ import re
 
 import six
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django_extensions.db.models import TimeStampedModel
@@ -305,8 +306,11 @@ class ConditionalOffer(AbstractConditionalOffer):
 
             return is_satisfied
 
-        return super(ConditionalOffer, self).is_condition_satisfied(basket)  # pylint: disable=bad-super-call
-
+        try:
+            return super(ConditionalOffer, self).is_condition_satisfied(basket)  # pylint: disable=bad-super-call
+        except ImproperlyConfigured as err:
+            logger.error('Improperly configured ConditionalOffer, id=%s. %s', self.id, err.message)
+            return False
 
 def validate_credit_seat_type(course_seat_types):
     if not isinstance(course_seat_types, six.string_types):


### PR DESCRIPTION
### Background:

Note: I initially saw the following errors (like @albemarle):
```
ImproperlyConfigured: Error importing module ecommerce.extensions.offer.dynamic_conditional_offer: cannot import name DYNAMIC_DISCOUNT_FLAG
```
Running `make clean` in the ecommerce container changed this error to:
```
ImproperlyConfigured: Error importing module ecommerce.extensions.offer.dynamic_conditional_offer: No module named dynamic_conditional_offer
```
I couldn't find `dynamic_conditional_offer` anywhere, but it turned out I have the following in my db:
```
mysql> select id, name, offer_type from offer_conditionaloffer where id=82;
+----+---------------------------+------------+
| id | name                      | offer_type |
+----+---------------------------+------------+
| 82 | dynamic_conditional_offer | Site       |
+----+---------------------------+------------+
1 row in set (0.00 sec)
```

### Solution:

I'm not sure if we would want something like this in Production, and how noisy the logging would be, but it might be better than just having things die.  Without this change, I could not load the basket at all.

My branch will output the following error in place of blowing up:
```
2019-07-25 22:11:48,293 ERROR 2114 [ecommerce.extensions.offer.models] /edx/app/ecommerce/ecommerce/ecommerce/extensions/offer/models.py:312 - Improperly configured ConditionalOffer, id=82. Error importing module ecommerce.extensions.offer.dynamic_conditional_offer: No module named dynamic_conditional_offer
```

Also, I don't know the cleanest way to remove this offer.  The Oscar Dashboard (e.g. http://localhost:18130/dashboard/offers/) also blows up.  Do we just delete the record?  Where/how was it added?

In any case, @albemarle, if you take down my branch things will work for you locally.  You may also need to run `make clean` in ecommerce-shell as noted above.
