### PR TITLE
remove unnecessary slots_available_for_assignment util call

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -835,10 +835,14 @@ class EnterpriseCouponOverviewListSerializer(serializers.ModelSerializer):
         """
         Return number of available assignments.
         """
+        all_slots_available = []
         vouchers = coupon.attr.coupon_vouchers.vouchers.all()
-        return sum([
-            voucher.slots_available_for_assignment for voucher in vouchers if voucher.slots_available_for_assignment > 0
-        ])
+        for voucher in vouchers:
+            voucher_slots_available = voucher.slots_available_for_assignment
+            if voucher_slots_available > 0:
+                all_slots_available.append(voucher_slots_available)
+
+        return sum(all_slots_available)
 
     def get_errors(self, coupon):
         """


### PR DESCRIPTION
**Description:** `slots_available_for_assignment` was called twice in a loop making unnecessary calls to db. Refactored the code to call it once to reduce calls to db.

**Stats:**

Tested the overview endpoint on devstack with 10 coupons belong to single enterprise.

Before removal of second call to `slots_available_for_assignment`
- 746 queries in 660.58ms
- 744 queries in 637.53ms
- 744 queries in 644.29ms

After removal of second call to `slots_available_for_assignment`
- 442 queries in 360.42ms
- 442 queries in 385.01ms
- 442 queries in 330.67ms