### PR TITLE
ARCH-1051: enable jwt auth for add to basket and use lms login

### DIFF
--- a/ecommerce/core/authentication.py
+++ b/ecommerce/core/authentication.py
@@ -7,55 +7,41 @@ from django.utils.deprecation import MiddlewareMixin
 from edx_django_utils.cache import RequestCache
 
 from edx_rest_framework_extensions.auth.jwt.middleware import USE_JWT_COOKIE_HEADER
-from rest_framework.permissions import BasePermission
+from rest_framework.permissions import IsAuthenticated
 
 from ecommerce.extensions.payment.constants import (
-    ENABLE_JWT_AUTH_LOGIN_REQUIRED_FLAG_NAME,
+    ENABLE_JWT_AUTH_WITH_LOGIN_REQUIRED_FLAG_NAME,
     ENABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME,
+    ENABLE_LMS_LOGIN_FOR_LOGIN_REQUIRED_FLAG_NAME,
 )
 
 logger = logging.getLogger(__name__)
 
 
 # TODO: Move to edx-drf-extensions
-def jwt_auth_login_required_flag_enabled(request):
-    return waffle.flag_is_active(
-        request,
-        ENABLE_JWT_AUTH_LOGIN_REQUIRED_FLAG_NAME
-    )
-
-
-# TODO: Move to edx-drf-extensions
-class JwtAuthLoginRequiredMiddleware(MiddlewareMixin):
+class JwtAuthWithLoginRequiredMiddleware(MiddlewareMixin):
     """
-    Middleware enables an endpoint with JwtAuthentication to redirect to login for unauthenticated users, rather
-    than returning a 401.
+    Middleware enables DRF JwtAuthentication authentication class for endpoints
+    using the LoginRequired permission class.
+
+    Enables a non-standard use of DRF, because DRF only supports returning
+    a 401 for unauthorized users, but this middleware allows a DRF endpoint
+    to redirect to login.
+
+    This can be used to convert a plan Django view using @login_required into a
+    DRF APIView, which is useful to enable our DRF JwtAuthentication class.
 
     Usage Notes:
     - This middleware must be added before JwtAuthCookieMiddleware.
-    - Requires adding LoginRequired permission to endpoint in place of IsAuthenticated.
+    - Only affects endpoints using the LoginRequired permission class.
 
+    See https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0009-jwt-in-session-cookie.rst
     """
-    _TRIGGER_LOGIN_REDIRECT_CACHE_KEY = 'trigger_login_redirect'
+    _LOGIN_REQUIRED_FOUND_CACHE_KEY = 'login_required_found'
 
-    @classmethod
     def _get_request_cache(cls):
-        cache_namespace = 'JwtAuthLoginRequiredMiddleware'
+        cache_namespace = 'JwtAuthWithLoginRequiredMiddleware'
         return RequestCache(cache_namespace).data
-
-    @classmethod
-    def _was_login_redirect_triggered(cls):
-        return cls._get_request_cache().get(cls._TRIGGER_LOGIN_REDIRECT_CACHE_KEY, False)
-
-    @classmethod
-    def trigger_login_redirect(cls):
-        """
-        Sets a flag to later trigger a redirect to login.
-
-        The LoginRequired permission class uses this to signal that login redirect should occur.
-
-        """
-        cls._get_request_cache()[cls._TRIGGER_LOGIN_REDIRECT_CACHE_KEY] = True
 
     def _includes_base_class(self, iter_classes, base_class):
         """
@@ -65,7 +51,16 @@ class JwtAuthLoginRequiredMiddleware(MiddlewareMixin):
             issubclass(current_class, base_class) for current_class in iter_classes,
         )
 
-    def _is_using_login_required_permission_class(self, view_func):
+    def _is_login_required_found(self):
+        """
+        Returns True if LoginRequired permission was found, and False otherwise.
+        """
+        return self._get_request_cache().get(self._LOGIN_REQUIRED_FOUND_CACHE_KEY, False)
+
+    def _check_and_cache_login_required_found(self, view_func):
+        """
+        Checks for LoginRequired permission and caches the result.
+        """
         # Views as functions store the view's class in the 'view_class' attribute.
         # Viewsets store the view's class in the 'cls' attribute.
         view_class = getattr(
@@ -75,29 +70,38 @@ class JwtAuthLoginRequiredMiddleware(MiddlewareMixin):
         )
 
         view_permission_classes = getattr(view_class, 'permission_classes', tuple())
-        return self._includes_base_class(view_permission_classes, LoginRequired)
+        is_login_required_found = self._includes_base_class(view_permission_classes, LoginRequired)
+        self._get_request_cache()[self._LOGIN_REQUIRED_FOUND_CACHE_KEY] = is_login_required_found
 
     def get_login_url(self, request):  # pylint: disable=unused-argument
         """
         Return None for default login url.
 
-        Can be overridden to provide different urls in different circumstances (i.e. A/B testing)
-
+        Can be overridden for slow-rollout or A/B testing of transition to other login mechanisms.
         """
         return None
+
+    def is_jwt_auth_enabled_with_login_required(self, request, view_func):  # pylint: disable=unused-argument
+        """
+        Returns True if JwtAuthentication is enabled with the LoginRequired permission class.
+
+        Can be overridden for slow roll-out or A/B testing.
+        """
+        return self._is_login_required_found()
 
     def process_view(self, request, view_func, view_args, view_kwargs):  # pylint: disable=unused-argument
         """
         Enables Jwt Authentication for endpoints using the LoginRequired permission class.
-
-        See https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0009-jwt-in-session-cookie.rst
-
         """
-        if jwt_auth_login_required_flag_enabled(request) and self._is_using_login_required_permission_class(view_func):
+        self._check_and_cache_login_required_found(view_func)
+        if self.is_jwt_auth_enabled_with_login_required(request, view_func):
             request.META[USE_JWT_COOKIE_HEADER] = 'true'
 
     def process_response(self, request, response):
-        if self._was_login_redirect_triggered():
+        """
+        Redirects unauthenticated users to login when LoginRequired permission class was used.
+        """
+        if self._is_login_required_found() and not request.user.is_authenticated:
             fake_decorated_function = lambda request: None
             login_url = self.get_login_url(request)
             return login_required(function=fake_decorated_function, login_url=login_url)(request)
@@ -106,29 +110,40 @@ class JwtAuthLoginRequiredMiddleware(MiddlewareMixin):
 
 
 # TODO: Move to edx-drf-extensions
-class LoginRequired(BasePermission):
+class LoginRequired(IsAuthenticated):
     """
-    DRF permission class that replaces IsAuthenticated if the endpoint should
-    redirect to login rather than returning a 401.
+    A non-standard DRF permission class that will login redirect unauthorized users.
 
-    Side-effect:
-        Use of this permission declares that JWT Cookies can be used.
+    It can be used to convert a plan Django view using @login_required into a
+    DRF APIView, which is useful to enable our DRF JwtAuthentication class.
+
+    This permission is non-standard because DRF only supports returning a 401
+    status for unauthorized users.
+
+    Requires JwtAuthWithLoginRequiredMiddleware in order to work.
 
     """
-    def has_permission(self, request, view):
-        if request.user.is_authenticated:
-            return True
-
-        JwtAuthLoginRequiredMiddleware.trigger_login_redirect()
-        return False
+    pass
 
 
-class EcommerceJwtAuthLoginRequiredMiddleware(JwtAuthLoginRequiredMiddleware):
+class EcommerceJwtAuthWithLoginRequiredMiddleware(JwtAuthWithLoginRequiredMiddleware):
     """
-    Overrides JwtAuthLoginRequiredMiddleware to provide a differently login url in
+    Overrides JwtAuthWithLoginRequiredMiddleware to provide a different login url in
     different circumstances.
 
     """
+    def _jwt_auth_login_required_flag_enabled(self, request):
+        return waffle.flag_is_active(
+            request,
+            ENABLE_JWT_AUTH_WITH_LOGIN_REQUIRED_FLAG_NAME
+        )
+
+    def _lms_login_for_login_required_flag_enabled(self, request):
+        return waffle.flag_is_active(
+            request,
+            ENABLE_LMS_LOGIN_FOR_LOGIN_REQUIRED_FLAG_NAME
+        )
+
     def _use_payment_microfrontend(self, request):
         """
         Return whether the current request should use the payment MFE.
@@ -144,13 +159,20 @@ class EcommerceJwtAuthLoginRequiredMiddleware(JwtAuthLoginRequiredMiddleware):
             payment_microfrontend_flag_enabled
         )
 
+    def is_jwt_auth_enabled_with_login_required(self, request, view_func):
+        if self._jwt_auth_login_required_flag_enabled(request):
+            return super(
+                EcommerceJwtAuthWithLoginRequiredMiddleware, self
+            ).is_jwt_auth_enabled_with_login_required(request, view_func)
+
+        return False
+
     def get_login_url(self, request):
         """
         When using the payment mfe, use lms login to get jwt cookies.
         Otherwise, return None to get the default login for the social-auth SSO flow.
         """
-        if jwt_auth_login_required_flag_enabled(request) and self._use_payment_microfrontend(request):
+        if self._lms_login_for_login_required_flag_enabled(request) and self._use_payment_microfrontend(request):
             return request.site.siteconfiguration.build_lms_url('/login')
 
         return None
-

--- a/ecommerce/core/authentication.py
+++ b/ecommerce/core/authentication.py
@@ -1,0 +1,90 @@
+import logging
+
+from django.shortcuts import redirect
+from django.urls import reverse
+from django.utils.deprecation import MiddlewareMixin
+from django.utils.http import urlquote_plus
+from edx_django_utils.cache import RequestCache
+from edx_rest_framework_extensions.auth.jwt.middleware import USE_JWT_COOKIE_HEADER
+from rest_framework.permissions import BasePermission
+
+logger = logging.getLogger(__name__)
+
+
+def _login_redirect_to_lms(request):
+    """
+    This view redirects to the LMS login view. It is used for Django's LOGIN_URL
+    setting, which is where unauthenticated requests to protected endpoints are redirected.
+    """
+    # TODO: Why isn't the next_url appearing?
+    next_url = request.GET.get('next')
+    absolute_next_url = request.build_absolute_uri(next_url)
+    login_url = '/login{params}'.format(
+        params='?next=' + urlquote_plus(absolute_next_url) if next_url else '',
+    )
+    lms_login_url = 'http://localhost:18000' + login_url
+    # TODO: Is this what it should be? It is going to: http://edx.devstack.lms:18000/login?...
+    # lms_login_url = request.site.siteconfiguration.build_lms_url(login_url)
+    return redirect(lms_login_url)
+
+
+class UseJwtCookieMiddleware(MiddlewareMixin):
+    """
+    Enables use of Jwt Cookies when working with microfrontends.
+
+    For example, /basket/add is called before reaching the payment microfrontend (mfe), and we do not want to use
+    the social-auth SSO flow (which is slow), before getting to the payment mfe which will then use Jwt Authentication.
+
+    Notes:
+    - This middleware must be added before JwtAuthCookieMiddleware.
+    - Requires IsAuthenticatedOrLoginRequired permission to work correctly
+
+    """
+    _CACHE_NAMESPACE = 'UseJwtCookieMiddleware'
+    _REDIRECT_ON_FAILURE_CACHE_KEY = 'redirect_on_failure'
+
+    @classmethod
+    def _cache(cls):
+        return RequestCache(cls._CACHE_NAMESPACE).data
+
+    @classmethod
+    def _get_redirect_on_permission_failure(cls):
+        return cls._cache().get(cls._REDIRECT_ON_FAILURE_CACHE_KEY, False)
+
+    @classmethod
+    def set_redirect_on_permission_failure(cls):
+        """
+        Enables coordination with IsAuthenticatedOrLoginRequired permission class to signal when
+        to redirect for permission failures.
+        """
+        cls._cache()[cls._REDIRECT_ON_FAILURE_CACHE_KEY] = True
+
+    def process_request(self, request):
+        # TODO: Maybe flag is needed, because this call currently requires a user, and we don't have one yet.
+        # Problem:
+        # - Can't import use_payment_microfrontend.  Don't want to move it in here yet, because I think there are
+        #   issues with that.
+        #if use_payment_microfrontend(request):
+        if True:
+            request.META[USE_JWT_COOKIE_HEADER] = 'true'
+
+    def process_response(self, request, response):
+        if self._get_redirect_on_permission_failure():
+            # TODO: Need to fix this condition.  See above.
+            #if use_payment_microfrontend(request):
+            if True:
+                return _login_redirect_to_lms(request)
+            else:
+                return reverse('login')
+
+        return response
+
+
+class IsAuthenticatedOrLoginRequired(BasePermission):
+    def has_permission(self, request, view):
+        if request.user.is_authenticated:
+            return True
+
+        # Tell the UseJwtCookieMiddleware to redirect to login
+        UseJwtCookieMiddleware.set_redirect_on_permission_failure()
+        return False

--- a/ecommerce/core/authentication.py
+++ b/ecommerce/core/authentication.py
@@ -1,13 +1,8 @@
 import logging
 
 import waffle
-from django.contrib.auth.decorators import login_required
+from edx_rest_framework_extensions.auth.jwt.middleware import JwtAuthWithLoginRequiredMiddleware
 
-from django.utils.deprecation import MiddlewareMixin
-from edx_django_utils.cache import RequestCache
-
-from edx_rest_framework_extensions.auth.jwt.middleware import USE_JWT_COOKIE_HEADER
-from rest_framework.permissions import IsAuthenticated
 
 from ecommerce.extensions.payment.constants import (
     ENABLE_JWT_AUTH_WITH_LOGIN_REQUIRED_FLAG_NAME,
@@ -16,114 +11,6 @@ from ecommerce.extensions.payment.constants import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-# TODO: Move to edx-drf-extensions
-class JwtAuthWithLoginRequiredMiddleware(MiddlewareMixin):
-    """
-    Middleware enables DRF JwtAuthentication authentication class for endpoints
-    using the LoginRequired permission class.
-
-    Enables a non-standard use of DRF, because DRF only supports returning
-    a 401 for unauthorized users, but this middleware allows a DRF endpoint
-    to redirect to login.
-
-    This can be used to convert a plan Django view using @login_required into a
-    DRF APIView, which is useful to enable our DRF JwtAuthentication class.
-
-    Usage Notes:
-    - This middleware must be added before JwtAuthCookieMiddleware.
-    - Only affects endpoints using the LoginRequired permission class.
-
-    See https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0009-jwt-in-session-cookie.rst
-    """
-    _LOGIN_REQUIRED_FOUND_CACHE_KEY = 'login_required_found'
-
-    def _get_request_cache(cls):
-        cache_namespace = 'JwtAuthWithLoginRequiredMiddleware'
-        return RequestCache(cache_namespace).data
-
-    def _includes_base_class(self, iter_classes, base_class):
-        """
-        Returns whether any class in iter_class is a subclass of the given base_class.
-        """
-        return any(
-            issubclass(current_class, base_class) for current_class in iter_classes,
-        )
-
-    def _is_login_required_found(self):
-        """
-        Returns True if LoginRequired permission was found, and False otherwise.
-        """
-        return self._get_request_cache().get(self._LOGIN_REQUIRED_FOUND_CACHE_KEY, False)
-
-    def _check_and_cache_login_required_found(self, view_func):
-        """
-        Checks for LoginRequired permission and caches the result.
-        """
-        # Views as functions store the view's class in the 'view_class' attribute.
-        # Viewsets store the view's class in the 'cls' attribute.
-        view_class = getattr(
-            view_func,
-            'view_class',
-            getattr(view_func, 'cls', view_func),
-        )
-
-        view_permission_classes = getattr(view_class, 'permission_classes', tuple())
-        is_login_required_found = self._includes_base_class(view_permission_classes, LoginRequired)
-        self._get_request_cache()[self._LOGIN_REQUIRED_FOUND_CACHE_KEY] = is_login_required_found
-
-    def get_login_url(self, request):  # pylint: disable=unused-argument
-        """
-        Return None for default login url.
-
-        Can be overridden for slow-rollout or A/B testing of transition to other login mechanisms.
-        """
-        return None
-
-    def is_jwt_auth_enabled_with_login_required(self, request, view_func):  # pylint: disable=unused-argument
-        """
-        Returns True if JwtAuthentication is enabled with the LoginRequired permission class.
-
-        Can be overridden for slow roll-out or A/B testing.
-        """
-        return self._is_login_required_found()
-
-    def process_view(self, request, view_func, view_args, view_kwargs):  # pylint: disable=unused-argument
-        """
-        Enables Jwt Authentication for endpoints using the LoginRequired permission class.
-        """
-        self._check_and_cache_login_required_found(view_func)
-        if self.is_jwt_auth_enabled_with_login_required(request, view_func):
-            request.META[USE_JWT_COOKIE_HEADER] = 'true'
-
-    def process_response(self, request, response):
-        """
-        Redirects unauthenticated users to login when LoginRequired permission class was used.
-        """
-        if self._is_login_required_found() and not request.user.is_authenticated:
-            fake_decorated_function = lambda request: None
-            login_url = self.get_login_url(request)
-            return login_required(function=fake_decorated_function, login_url=login_url)(request)
-
-        return response
-
-
-# TODO: Move to edx-drf-extensions
-class LoginRequired(IsAuthenticated):
-    """
-    A non-standard DRF permission class that will login redirect unauthorized users.
-
-    It can be used to convert a plan Django view using @login_required into a
-    DRF APIView, which is useful to enable our DRF JwtAuthentication class.
-
-    This permission is non-standard because DRF only supports returning a 401
-    status for unauthorized users.
-
-    Requires JwtAuthWithLoginRequiredMiddleware in order to work.
-
-    """
-    pass
 
 
 class EcommerceJwtAuthWithLoginRequiredMiddleware(JwtAuthWithLoginRequiredMiddleware):

--- a/ecommerce/core/authentication.py
+++ b/ecommerce/core/authentication.py
@@ -1,20 +1,32 @@
 import logging
 
 import waffle
-
 from django.contrib.auth.decorators import login_required
 
 from django.utils.deprecation import MiddlewareMixin
 from edx_django_utils.cache import RequestCache
 
-from ecommerce.extensions.payment.constants import ENABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME
 from edx_rest_framework_extensions.auth.jwt.middleware import USE_JWT_COOKIE_HEADER
 from rest_framework.permissions import BasePermission
+
+from ecommerce.extensions.payment.constants import (
+    ENABLE_JWT_AUTH_LOGIN_REQUIRED_FLAG_NAME,
+    ENABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME,
+)
 
 logger = logging.getLogger(__name__)
 
 
-class JwtAuthWithLoginRequiredMiddleware(MiddlewareMixin):
+# TODO: Move to edx-drf-extensions
+def jwt_auth_login_required_flag_enabled(request):
+    return waffle.flag_is_active(
+        request,
+        ENABLE_JWT_AUTH_LOGIN_REQUIRED_FLAG_NAME
+    )
+
+
+# TODO: Move to edx-drf-extensions
+class JwtAuthLoginRequiredMiddleware(MiddlewareMixin):
     """
     Middleware enables an endpoint with JwtAuthentication to redirect to login for unauthenticated users, rather
     than returning a 401.
@@ -24,24 +36,26 @@ class JwtAuthWithLoginRequiredMiddleware(MiddlewareMixin):
     - Requires adding LoginRequired permission to endpoint in place of IsAuthenticated.
 
     """
-    _ENABLE_LOGIN_REDIRECT_CACHE_KEY = 'enable_login_redirect'
+    _TRIGGER_LOGIN_REDIRECT_CACHE_KEY = 'trigger_login_redirect'
 
     @classmethod
-    def _get_cache(cls):
-        cache_namespace = cls.__name__
+    def _get_request_cache(cls):
+        cache_namespace = 'JwtAuthLoginRequiredMiddleware'
         return RequestCache(cache_namespace).data
 
     @classmethod
-    def _is_login_redirect_enabled(cls):
-        return cls._get_cache().get(cls._ENABLE_LOGIN_REDIRECT_CACHE_KEY, False)
+    def _was_login_redirect_triggered(cls):
+        return cls._get_request_cache().get(cls._TRIGGER_LOGIN_REDIRECT_CACHE_KEY, False)
 
     @classmethod
-    def enable_login_redirect(cls):
+    def trigger_login_redirect(cls):
         """
-        Enables coordination with IsAuthenticatedOrLoginRequired permission class to signal when
-        to redirect for permission failures.
+        Sets a flag to later trigger a redirect to login.
+
+        The LoginRequired permission class uses this to signal that login redirect should occur.
+
         """
-        cls._get_cache()[cls._ENABLE_LOGIN_REDIRECT_CACHE_KEY] = True
+        cls._get_request_cache()[cls._TRIGGER_LOGIN_REDIRECT_CACHE_KEY] = True
 
     def _includes_base_class(self, iter_classes, base_class):
         """
@@ -63,15 +77,6 @@ class JwtAuthWithLoginRequiredMiddleware(MiddlewareMixin):
         view_permission_classes = getattr(view_class, 'permission_classes', tuple())
         return self._includes_base_class(view_permission_classes, LoginRequired)
 
-    def process_view(self, request, view_func, view_args, view_kwargs):  # pylint: disable=unused-argument
-        """
-        Enables Jwt Authentication for endpoints using the LoginRequired permission class.
-
-        See https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0009-jwt-in-session-cookie.rst
-        """
-        if self._is_using_login_required_permission_class(view_func):
-            request.META[USE_JWT_COOKIE_HEADER] = 'true'
-
     def get_login_url(self, request):  # pylint: disable=unused-argument
         """
         Return None for default login url.
@@ -81,52 +86,70 @@ class JwtAuthWithLoginRequiredMiddleware(MiddlewareMixin):
         """
         return None
 
-    @login_required()
+    def process_view(self, request, view_func, view_args, view_kwargs):  # pylint: disable=unused-argument
+        """
+        Enables Jwt Authentication for endpoints using the LoginRequired permission class.
+
+        See https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0009-jwt-in-session-cookie.rst
+
+        """
+        if jwt_auth_login_required_flag_enabled(request) and self._is_using_login_required_permission_class(view_func):
+            request.META[USE_JWT_COOKIE_HEADER] = 'true'
+
     def process_response(self, request, response):
-        if self._is_login_redirect_enabled():
+        if self._was_login_redirect_triggered():
+            fake_decorated_function = lambda request: None
             login_url = self.get_login_url(request)
-            return login_required(login_url=login_url)(request)
+            return login_required(function=fake_decorated_function, login_url=login_url)(request)
 
         return response
 
 
+# TODO: Move to edx-drf-extensions
 class LoginRequired(BasePermission):
     """
     DRF permission class that replaces IsAuthenticated if the endpoint should
     redirect to login rather than returning a 401.
+
+    Side-effect:
+        Use of this permission declares that JWT Cookies can be used.
 
     """
     def has_permission(self, request, view):
         if request.user.is_authenticated:
             return True
 
-        JwtAuthWithLoginRequiredMiddleware.enable_login_redirect()
+        JwtAuthLoginRequiredMiddleware.trigger_login_redirect()
         return False
 
 
-class EcommerceJwtAuthWithLoginRequiredMiddleware(JwtAuthWithLoginRequiredMiddleware):
-    def _use_payment_microfrontend(request):
+class EcommerceJwtAuthLoginRequiredMiddleware(JwtAuthLoginRequiredMiddleware):
+    """
+    Overrides JwtAuthLoginRequiredMiddleware to provide a differently login url in
+    different circumstances.
+
+    """
+    def _use_payment_microfrontend(self, request):
         """
         Return whether the current request should use the payment MFE.
         """
-        if (
-                request.site.siteconfiguration.enable_microfrontend_for_basket_page and
-                request.site.siteconfiguration.payment_microfrontend_url
-        ):
-            payment_microfrontend_flag_enabled = waffle.flag_is_active(
-                request,
-                ENABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME,
-            )
-            return payment_microfrontend_flag_enabled
+        payment_microfrontend_flag_enabled = waffle.flag_is_active(
+            request,
+            ENABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME
+        )
 
-        return False
+        return (
+            request.site.siteconfiguration.enable_microfrontend_for_basket_page and
+            request.site.siteconfiguration.payment_microfrontend_url and
+            payment_microfrontend_flag_enabled
+        )
 
     def get_login_url(self, request):
         """
         When using the payment mfe, use lms login to get jwt cookies.
         Otherwise, return None to get the default login for the social-auth SSO flow.
         """
-        if self._use_payment_microfrontend():
+        if jwt_auth_login_required_flag_enabled(request) and self._use_payment_microfrontend(request):
             return request.site.siteconfiguration.build_lms_url('/login')
 
         return None

--- a/ecommerce/core/authentication.py
+++ b/ecommerce/core/authentication.py
@@ -1,90 +1,133 @@
 import logging
 
-from django.shortcuts import redirect
-from django.urls import reverse
+import waffle
+
+from django.contrib.auth.decorators import login_required
+
 from django.utils.deprecation import MiddlewareMixin
-from django.utils.http import urlquote_plus
 from edx_django_utils.cache import RequestCache
+
+from ecommerce.extensions.payment.constants import ENABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME
 from edx_rest_framework_extensions.auth.jwt.middleware import USE_JWT_COOKIE_HEADER
 from rest_framework.permissions import BasePermission
 
 logger = logging.getLogger(__name__)
 
 
-def _login_redirect_to_lms(request):
+class JwtAuthWithLoginRequiredMiddleware(MiddlewareMixin):
     """
-    This view redirects to the LMS login view. It is used for Django's LOGIN_URL
-    setting, which is where unauthenticated requests to protected endpoints are redirected.
-    """
-    # TODO: Why isn't the next_url appearing?
-    next_url = request.GET.get('next')
-    absolute_next_url = request.build_absolute_uri(next_url)
-    login_url = '/login{params}'.format(
-        params='?next=' + urlquote_plus(absolute_next_url) if next_url else '',
-    )
-    lms_login_url = 'http://localhost:18000' + login_url
-    # TODO: Is this what it should be? It is going to: http://edx.devstack.lms:18000/login?...
-    # lms_login_url = request.site.siteconfiguration.build_lms_url(login_url)
-    return redirect(lms_login_url)
+    Middleware enables an endpoint with JwtAuthentication to redirect to login for unauthenticated users, rather
+    than returning a 401.
 
-
-class UseJwtCookieMiddleware(MiddlewareMixin):
-    """
-    Enables use of Jwt Cookies when working with microfrontends.
-
-    For example, /basket/add is called before reaching the payment microfrontend (mfe), and we do not want to use
-    the social-auth SSO flow (which is slow), before getting to the payment mfe which will then use Jwt Authentication.
-
-    Notes:
+    Usage Notes:
     - This middleware must be added before JwtAuthCookieMiddleware.
-    - Requires IsAuthenticatedOrLoginRequired permission to work correctly
+    - Requires adding LoginRequired permission to endpoint in place of IsAuthenticated.
 
     """
-    _CACHE_NAMESPACE = 'UseJwtCookieMiddleware'
-    _REDIRECT_ON_FAILURE_CACHE_KEY = 'redirect_on_failure'
+    _ENABLE_LOGIN_REDIRECT_CACHE_KEY = 'enable_login_redirect'
 
     @classmethod
-    def _cache(cls):
-        return RequestCache(cls._CACHE_NAMESPACE).data
+    def _get_cache(cls):
+        cache_namespace = cls.__name__
+        return RequestCache(cache_namespace).data
 
     @classmethod
-    def _get_redirect_on_permission_failure(cls):
-        return cls._cache().get(cls._REDIRECT_ON_FAILURE_CACHE_KEY, False)
+    def _is_login_redirect_enabled(cls):
+        return cls._get_cache().get(cls._ENABLE_LOGIN_REDIRECT_CACHE_KEY, False)
 
     @classmethod
-    def set_redirect_on_permission_failure(cls):
+    def enable_login_redirect(cls):
         """
         Enables coordination with IsAuthenticatedOrLoginRequired permission class to signal when
         to redirect for permission failures.
         """
-        cls._cache()[cls._REDIRECT_ON_FAILURE_CACHE_KEY] = True
+        cls._get_cache()[cls._ENABLE_LOGIN_REDIRECT_CACHE_KEY] = True
 
-    def process_request(self, request):
-        # TODO: Maybe flag is needed, because this call currently requires a user, and we don't have one yet.
-        # Problem:
-        # - Can't import use_payment_microfrontend.  Don't want to move it in here yet, because I think there are
-        #   issues with that.
-        #if use_payment_microfrontend(request):
-        if True:
+    def _includes_base_class(self, iter_classes, base_class):
+        """
+        Returns whether any class in iter_class is a subclass of the given base_class.
+        """
+        return any(
+            issubclass(current_class, base_class) for current_class in iter_classes,
+        )
+
+    def _is_using_login_required_permission_class(self, view_func):
+        # Views as functions store the view's class in the 'view_class' attribute.
+        # Viewsets store the view's class in the 'cls' attribute.
+        view_class = getattr(
+            view_func,
+            'view_class',
+            getattr(view_func, 'cls', view_func),
+        )
+
+        view_permission_classes = getattr(view_class, 'permission_classes', tuple())
+        return self._includes_base_class(view_permission_classes, LoginRequired)
+
+    def process_view(self, request, view_func, view_args, view_kwargs):  # pylint: disable=unused-argument
+        """
+        Enables Jwt Authentication for endpoints using the LoginRequired permission class.
+
+        See https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0009-jwt-in-session-cookie.rst
+        """
+        if self._is_using_login_required_permission_class(view_func):
             request.META[USE_JWT_COOKIE_HEADER] = 'true'
 
+    def get_login_url(self, request):  # pylint: disable=unused-argument
+        """
+        Return None for default login url.
+
+        Can be overridden to provide different urls in different circumstances (i.e. A/B testing)
+
+        """
+        return None
+
+    @login_required()
     def process_response(self, request, response):
-        if self._get_redirect_on_permission_failure():
-            # TODO: Need to fix this condition.  See above.
-            #if use_payment_microfrontend(request):
-            if True:
-                return _login_redirect_to_lms(request)
-            else:
-                return reverse('login')
+        if self._is_login_redirect_enabled():
+            login_url = self.get_login_url(request)
+            return login_required(login_url=login_url)(request)
 
         return response
 
 
-class IsAuthenticatedOrLoginRequired(BasePermission):
+class LoginRequired(BasePermission):
+    """
+    DRF permission class that replaces IsAuthenticated if the endpoint should
+    redirect to login rather than returning a 401.
+
+    """
     def has_permission(self, request, view):
         if request.user.is_authenticated:
             return True
 
-        # Tell the UseJwtCookieMiddleware to redirect to login
-        UseJwtCookieMiddleware.set_redirect_on_permission_failure()
+        JwtAuthWithLoginRequiredMiddleware.enable_login_redirect()
         return False
+
+
+class EcommerceJwtAuthWithLoginRequiredMiddleware(JwtAuthWithLoginRequiredMiddleware):
+    def _use_payment_microfrontend(request):
+        """
+        Return whether the current request should use the payment MFE.
+        """
+        if (
+                request.site.siteconfiguration.enable_microfrontend_for_basket_page and
+                request.site.siteconfiguration.payment_microfrontend_url
+        ):
+            payment_microfrontend_flag_enabled = waffle.flag_is_active(
+                request,
+                ENABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME,
+            )
+            return payment_microfrontend_flag_enabled
+
+        return False
+
+    def get_login_url(self, request):
+        """
+        When using the payment mfe, use lms login to get jwt cookies.
+        Otherwise, return None to get the default login for the social-auth SSO flow.
+        """
+        if self._use_payment_microfrontend():
+            return request.site.siteconfiguration.build_lms_url('/login')
+
+        return None
+

--- a/ecommerce/extensions/basket/app.py
+++ b/ecommerce/extensions/basket/app.py
@@ -17,7 +17,7 @@ class BasketApplication(app.BasketApplication):
             url(r'^vouchers/add/$', self.add_voucher_view.as_view(), name='vouchers-add'),
             url(r'^vouchers/(?P<pk>\d+)/remove/$', self.remove_voucher_view.as_view(), name='vouchers-remove'),
             url(r'^saved/$', login_required(self.saved_view.as_view()), name='saved'),
-            url(r'^add/$', login_required(self.basket_add_items_view.as_view()), name='basket-add'),
+            url(r'^add/$', self.basket_add_items_view.as_view(), name='basket-add'),
         ]
         return self.post_process_urls(urls)
 

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -24,7 +24,7 @@ from six.moves import range, zip
 from six.moves.urllib.parse import urlencode
 from slumber.exceptions import SlumberBaseException
 
-from ecommerce.core.authentication import IsAuthenticatedOrLoginRequired
+from ecommerce.core.authentication import LoginRequired
 from ecommerce.core.exceptions import SiteConfigurationError
 from ecommerce.core.url_utils import absolute_redirect, get_lms_course_about_url, get_lms_url
 from ecommerce.courses.utils import get_certificate_type_display_value, get_course_info_from_catalog
@@ -134,7 +134,7 @@ class BasketAddItemsView(APIView):
     View that adds multiple products to a user's basket.
     An additional coupon code can be supplied so the offer is applied to the basket.
     """
-    permission_classes = (IsAuthenticatedOrLoginRequired,)
+    permission_classes = (LoginRequired,)
 
     def get(self, request):
         try:

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -24,6 +24,7 @@ from six.moves import range, zip
 from six.moves.urllib.parse import urlencode
 from slumber.exceptions import SlumberBaseException
 
+from ecommerce.core.authentication import IsAuthenticatedOrLoginRequired
 from ecommerce.core.exceptions import SiteConfigurationError
 from ecommerce.core.url_utils import absolute_redirect, get_lms_course_about_url, get_lms_url
 from ecommerce.courses.utils import get_certificate_type_display_value, get_course_info_from_catalog
@@ -77,7 +78,7 @@ Selector = get_class('partner.strategy', 'Selector')
 
 
 def _get_payment_microfrontend_url_if_configured(request):
-    if _use_payment_microfrontend(request):
+    if use_payment_microfrontend(request):
         return request.site.siteconfiguration.payment_microfrontend_url
     else:
         return None
@@ -91,7 +92,7 @@ def _force_payment_microfrontend_bucket(request):
     return waffle.flag_is_active(request, FORCE_MICROFRONTEND_BUCKET_FLAG_NAME)
 
 
-def _use_payment_microfrontend(request):
+def use_payment_microfrontend(request):
     """
     Return whether the current request should use the payment MFE.
     """
@@ -128,11 +129,13 @@ def _use_payment_microfrontend(request):
         return False
 
 
-class BasketAddItemsView(View):
+class BasketAddItemsView(APIView):
     """
     View that adds multiple products to a user's basket.
     An additional coupon code can be supplied so the offer is applied to the basket.
     """
+    permission_classes = (IsAuthenticatedOrLoginRequired,)
+
     def get(self, request):
         try:
             skus = self._get_skus(request)

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -12,6 +12,7 @@ from django.http import HttpResponseBadRequest, HttpResponseRedirect
 from django.shortcuts import render
 from django.utils.html import escape
 from django.utils.translation import ugettext as _
+from edx_rest_framework_extensions.permissions import LoginRequired
 from opaque_keys.edx.keys import CourseKey
 from oscar.apps.basket.views import VoucherAddView as BaseVoucherAddView
 from oscar.apps.basket.views import *  # pylint: disable=wildcard-import, unused-wildcard-import
@@ -24,7 +25,6 @@ from six.moves import range, zip
 from six.moves.urllib.parse import urlencode
 from slumber.exceptions import SlumberBaseException
 
-from ecommerce.core.authentication import LoginRequired
 from ecommerce.core.exceptions import SiteConfigurationError
 from ecommerce.core.url_utils import absolute_redirect, get_lms_course_about_url, get_lms_url
 from ecommerce.courses.utils import get_certificate_type_display_value, get_course_info_from_catalog

--- a/ecommerce/extensions/payment/constants.py
+++ b/ecommerce/extensions/payment/constants.py
@@ -38,10 +38,23 @@ CYBERSOURCE_CARD_TYPE_MAP = {
 
 CLIENT_SIDE_CHECKOUT_FLAG_NAME = 'enable_client_side_checkout'
 
-# .. toggle_name: enable_jwt_auth_login_required
+# .. toggle_name: enable_lms_login_for_login_required
 # .. toggle_type: waffle_flag
 # .. toggle_default: False
-# .. toggle_description: Supports staged rollout of Jwt Authentication + Login Required capability.
+# .. toggle_description: Supports staged rollout of redirecting to LMS login for Jwt Authentication with Login Required.
+# .. toggle_category: micro-frontend
+# .. toggle_use_cases: incremental_release
+# .. toggle_creation_date: 2019-08-09
+# .. toggle_expiration_date: 2020-12-31
+# .. toggle_warnings: See enable_jwt_auth_with_login_required
+# .. toggle_tickets: DEPR-42
+# .. toggle_status: supported
+ENABLE_LMS_LOGIN_FOR_LOGIN_REQUIRED_FLAG_NAME = 'enable_lms_login_for_login_required'
+
+# .. toggle_name: enable_jwt_auth_with_login_required
+# .. toggle_type: waffle_flag
+# .. toggle_default: False
+# .. toggle_description: Supports staged rollout of Jwt Authentication with Login Required capability.
 # .. toggle_category: micro-frontend
 # .. toggle_use_cases: incremental_release
 # .. toggle_creation_date: 2019-08-09
@@ -49,7 +62,7 @@ CLIENT_SIDE_CHECKOUT_FLAG_NAME = 'enable_client_side_checkout'
 # .. toggle_warnings:
 # .. toggle_tickets: DEPR-42
 # .. toggle_status: supported
-ENABLE_JWT_AUTH_LOGIN_REQUIRED_FLAG_NAME = 'enable_jwt_auth_login_required'
+ENABLE_JWT_AUTH_WITH_LOGIN_REQUIRED_FLAG_NAME = 'enable_jwt_auth_with_login_required'
 
 # .. toggle_name: enable_microfrontend_for_basket_page
 # .. toggle_type: waffle_flag

--- a/ecommerce/extensions/payment/constants.py
+++ b/ecommerce/extensions/payment/constants.py
@@ -38,6 +38,19 @@ CYBERSOURCE_CARD_TYPE_MAP = {
 
 CLIENT_SIDE_CHECKOUT_FLAG_NAME = 'enable_client_side_checkout'
 
+# .. toggle_name: enable_jwt_auth_login_required
+# .. toggle_type: waffle_flag
+# .. toggle_default: False
+# .. toggle_description: Supports staged rollout of Jwt Authentication + Login Required capability.
+# .. toggle_category: micro-frontend
+# .. toggle_use_cases: incremental_release
+# .. toggle_creation_date: 2019-08-09
+# .. toggle_expiration_date: 2020-12-31
+# .. toggle_warnings:
+# .. toggle_tickets: DEPR-42
+# .. toggle_status: supported
+ENABLE_JWT_AUTH_LOGIN_REQUIRED_FLAG_NAME = 'enable_jwt_auth_login_required'
+
 # .. toggle_name: enable_microfrontend_for_basket_page
 # .. toggle_type: waffle_flag
 # .. toggle_default: False
@@ -46,7 +59,7 @@ CLIENT_SIDE_CHECKOUT_FLAG_NAME = 'enable_client_side_checkout'
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2019-06-25
 # .. toggle_expiration_date: 2020-12-31
-# .. toggle_warnings: Also set SiteConfiguration for enable_microfrontend_for_basket_page and payment_microfrontend_url.
+# .. toggle_warnings: Also set SiteConfiguration for enable_microfrontend_for_basket_page and payment_microfrontend_url. Also see enable_jwt_auth_login_required.
 # .. toggle_tickets: DEPR-42
 # .. toggle_status: supported
 ENABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME = 'enable_microfrontend_for_basket_page'

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -221,7 +221,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'ecommerce.core.authentication.EcommerceJwtAuthLoginRequiredMiddleware',
+    'ecommerce.core.authentication.EcommerceJwtAuthWithLoginRequiredMiddleware',
     'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -221,7 +221,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'ecommerce.core.authentication.UseJwtCookieMiddleware',
+    'ecommerce.core.authentication.EcommerceJwtAuthWithLoginRequiredMiddleware',
     'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -221,7 +221,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'ecommerce.core.authentication.EcommerceJwtAuthWithLoginRequiredMiddleware',
+    'ecommerce.core.authentication.EcommerceJwtAuthLoginRequiredMiddleware',
     'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -221,6 +221,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
+    'ecommerce.core.authentication.UseJwtCookieMiddleware',
     'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',


### PR DESCRIPTION
The new payment microfrontend relies on Jwt Authentication, so the
ecommerce social-auth SSO flow is a waste of time. Therefore, when
hitting /basket/add, which happens immediately before redirecting to the
payment mfe, we want it to be able to use the Jwt Cookies if it is
going to redirect to the payment mfe.

ARCH-1051

During implementation, it because clear that we could enable JwtAuthentication with a fallback to the existing ecommerce SSO flow.  This already provides an advantage for users that had logged in within an hour before going to the Payment MFE, because the Jwt Cookies would not have expired.

This PR has good information and code for when and if we wish to transition to go further and transition to using the LMS login in place of the existing EdXOAuth2 SSO.
Note: most of the work was added to https://github.com/edx/edx-drf-extensions/pull/86/files .  This PR shows how you might override parts of that.

Regarding JWT Authentication:
- This PR takes a step in the right direction, showing how JWT Authentication could be added to certain endpoints.  It also shows how waffle flags could be used to transition the login redirect toward the LMS login.
- Additional thought required about how to transition to LMS login and JWT Authentication for all of Ecommerce, if this becomes a requirement for the RBAC implementation.

Regarding using LMS login in place of EdXOAuth2 SSO:
- LMS login may be faster (fewer redirects), but this is not certain.
- LMS login does not yet support auto-login when an LMS session exists. This can be implemented using refresh token logic.
- LMS login support in ecommerce devstack has two issues: 1) the site configuration lms url is the internal devstack url, rather than localhost, and 2) the lms redirect logic doesn't allow redirects to http. 
- Although it may improve performance to call refresh token from Jwt Authentication if it fails: 1) this would slow down endpoints that could fall back to an ecommerce session, and 2) this will be less and less important the more microfrontends we have that will keep the tokens (and jwt cookie) refreshed.