### PR TITLE
ARCH-1051: enable jwt auth for add to basket

### DIFF
--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -14,7 +14,9 @@ from django.utils.decorators import method_decorator
 from django.utils.text import slugify
 from django.utils.translation import ugettext as _
 from django.views.generic import TemplateView, View
+from edx_rest_framework_extensions.permissions import LoginRedirectIfUnauthenticated
 from oscar.core.loading import get_class, get_model
+from rest_framework.views import APIView
 
 from ecommerce.core.url_utils import absolute_redirect, get_ecommerce_url
 from ecommerce.core.views import StaffOnlyMixin
@@ -140,10 +142,10 @@ class CouponOfferView(TemplateView):
         return super(CouponOfferView, self).get(request, *args, **kwargs)
 
 
-class CouponRedeemView(EdxOrderPlacementMixin, View):
+class CouponRedeemView(EdxOrderPlacementMixin, APIView):
+    permission_classes = (LoginRedirectIfUnauthenticated,)
 
     @method_decorator(set_enterprise_cookie)
-    @method_decorator(login_required)
     def get(self, request):  # pylint: disable=too-many-statements
         """
         Looks up the passed code and adds the matching product to a basket,

--- a/ecommerce/extensions/basket/app.py
+++ b/ecommerce/extensions/basket/app.py
@@ -17,7 +17,7 @@ class BasketApplication(app.BasketApplication):
             url(r'^vouchers/add/$', self.add_voucher_view.as_view(), name='vouchers-add'),
             url(r'^vouchers/(?P<pk>\d+)/remove/$', self.remove_voucher_view.as_view(), name='vouchers-remove'),
             url(r'^saved/$', login_required(self.saved_view.as_view()), name='saved'),
-            url(r'^add/$', login_required(self.basket_add_items_view.as_view()), name='basket-add'),
+            url(r'^add/$', self.basket_add_items_view.as_view(), name='basket-add'),
         ]
         return self.post_process_urls(urls)
 

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -12,6 +12,7 @@ from django.http import HttpResponseBadRequest, HttpResponseRedirect
 from django.shortcuts import render
 from django.utils.html import escape
 from django.utils.translation import ugettext as _
+from edx_rest_framework_extensions.permissions import LoginRedirectIfUnauthenticated
 from opaque_keys.edx.keys import CourseKey
 from oscar.apps.basket.views import VoucherAddView as BaseVoucherAddView
 from oscar.apps.basket.views import *  # pylint: disable=wildcard-import, unused-wildcard-import
@@ -128,11 +129,13 @@ def _use_payment_microfrontend(request):
         return False
 
 
-class BasketAddItemsView(View):
+class BasketAddItemsView(APIView):
     """
     View that adds multiple products to a user's basket.
     An additional coupon code can be supplied so the offer is applied to the basket.
     """
+    permission_classes = (LoginRedirectIfUnauthenticated,)
+
     def get(self, request):
         try:
             skus = self._get_skus(request)

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -221,6 +221,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
+    'edx_rest_framework_extensions.auth.jwt.middleware.JwtRedirectToLoginIfUnauthenticatedMiddleware',
     'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -55,7 +55,7 @@ edx-auth-backends==2.0.1
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==2.0.0
-edx-drf-extensions==2.3.8
+edx-drf-extensions==2.4.0
 edx-ecommerce-worker==0.7.2
 edx-opaque-keys==1.0.1
 edx-rbac==1.0.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -69,7 +69,7 @@ edx-auth-backends==2.0.1
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==2.0.0
-edx-drf-extensions==2.3.8
+edx-drf-extensions==2.4.0
 edx-ecommerce-worker==0.7.2
 edx-i18n-tools==0.4.8
 edx-opaque-keys==1.0.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -57,7 +57,7 @@ edx-auth-backends==2.0.1
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==2.0.0
-edx-drf-extensions==2.3.8
+edx-drf-extensions==2.4.0
 edx-ecommerce-worker==0.7.2
 edx-opaque-keys==1.0.1
 edx-rbac==1.0.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -66,7 +66,7 @@ edx-auth-backends==2.0.1
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==2.0.0
-edx-drf-extensions==2.3.8
+edx-drf-extensions==2.4.0
 edx-ecommerce-worker==0.7.2
 edx-opaque-keys==1.0.1
 edx-rbac==1.0.2


### PR DESCRIPTION
The new payment microfrontend relies on Jwt Authentication, so
enabling Jwt Authentication on add basket avoids the slow ecommerce
OAuth2 redirects when the JWT cookies from login have not yet expired.

ARCH-1051

**Notes:**
- This replaces https://github.com/edx/ecommerce/pull/2531 which attempted to also switch to LMS login. That PR still has useful changes for the future showing how to override the middleware for A/B testing.
- This does not include a flag to turn on/off the extra JWT Auth.  If it has issues, it would require a rollback.
- I included an update to the Enterprise CouponRedeemView, but that adds a little risk and testing.  I think it is minimal, so leaned towards leaving it, but could be convinced otherwise.
- I don't think the receipt view will be as simple to update because it is a subclass of a particular view.

Also, this same change could probably be made to Enterprise CouponRedeem and the Receipt URL, but leaving that for a separate PR. 

Before Merge:
- [ ] Run `make upgrade` to get edx-drf-extensions==2.4.0
- [ ] Rebase and squash