### PR TITLE
Dynamically get just the fields needed from discovery

### DIFF
--- a/ecommerce/courses/utils.py
+++ b/ecommerce/courses/utils.py
@@ -25,7 +25,7 @@ def mode_for_product(product):
     return mode
 
 
-def get_course_info_from_catalog(site, product):
+def get_course_info_from_catalog(site, product, fields=None):
     """ Get course or course_run information from Discovery Service and cache """
     if product.is_course_entitlement_product:
         key = product.attr.UUID
@@ -41,10 +41,14 @@ def get_course_info_from_catalog(site, product):
     if course_cached_response.is_found:
         return course_cached_response.value
 
+    params = {}
+    if fields:
+        params['fields'] = ','.join(fields)
     if product.is_course_entitlement_product:
-        course = api.courses(key).get()
+        course = api.courses(key).get(**params)
     else:
-        course = api.course_runs(key).get(partner=partner_short_code)
+        params['partner'] = partner_short_code
+        course = api.course_runs(key).get(**params)
 
     TieredCache.set_all_tiers(cache_key, course, settings.COURSES_API_CACHE_TIMEOUT)
     return course

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -377,7 +377,8 @@ class BasketLogicMixin(object):
             course_data['course_key'] = CourseKey.from_string(product.attr.course_key)
 
         try:
-            course = get_course_info_from_catalog(self.request.site, product)
+            course_fields = ['title', 'image', 'short_description', 'start', 'end',]
+            course = get_course_info_from_catalog(self.request.site, product, fields=course_fields)
             try:
                 course_data['image_url'] = course['image']['src']
             except (KeyError, TypeError):


### PR DESCRIPTION
HOLD: I'm not sure this is safe to apply, `get_course_info_from_catalog` is also used by vouchers, but it's not clear which fields that expects so cached versions of the course info may be incomplete; need to confirm what fields that needs or make the caching significantly more clever about what fields are needed.