### PR TITLE
Pass query params to disable back button

### DIFF
--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -368,7 +368,13 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
 
         order = Order.objects.first()
         receipt_page_url = get_receipt_page_url(self.site.siteconfiguration)
-        expected_url = format_url(base=receipt_page_url, params={'order_number': order.number})
+        expected_url = format_url(
+            base=receipt_page_url,
+            params={
+                'order_number': order.number,
+                'disable_back_button': 1,
+            },
+        )
 
         self.assertRedirects(response, expected_url, status_code=302, fetch_redirect_response=False)
 

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -256,7 +256,13 @@ class CouponRedeemView(EdxOrderPlacementMixin, View):
         if basket.total_excl_tax == 0:
             try:
                 order = self.place_free_order(basket)
-                return HttpResponseRedirect(get_receipt_page_url(site_configuration, order.number))
+                return HttpResponseRedirect(
+                    get_receipt_page_url(
+                        site_configuration,
+                        order.number,
+                        disable_back_button=True,
+                    ),
+                )
             except:  # pylint: disable=bare-except
                 logger.exception('Failed to create a free order for basket [%d]', basket.id)
                 return absolute_redirect(self.request, 'checkout:error')

--- a/ecommerce/extensions/checkout/tests/test_views.py
+++ b/ecommerce/extensions/checkout/tests/test_views.py
@@ -106,7 +106,8 @@ class FreeCheckoutViewTests(EnterpriseServiceMockMixin, TestCase):
         order = Order.objects.first()
         expected_url = get_receipt_page_url(
             order_number=order.number,
-            site_configuration=order.site.siteconfiguration
+            site_configuration=order.site.siteconfiguration,
+            disable_back_button=True,
         )
         self.assertRedirects(response, expected_url, fetch_redirect_response=False)
 

--- a/ecommerce/extensions/checkout/utils.py
+++ b/ecommerce/extensions/checkout/utils.py
@@ -31,13 +31,16 @@ def get_credit_provider_details(credit_provider_id, site_configuration):
         return None
 
 
-def get_receipt_page_url(site_configuration, order_number=None, override_url=None):
+def get_receipt_page_url(site_configuration, order_number=None, override_url=None, disable_back_button=False):
     """ Returns the receipt page URL.
 
     Args:
         order_number (str): Order number
         site_configuration (SiteConfiguration): Site Configuration containing the flag for enabling Otto receipt page.
         override_url (str): New receipt page to override the default one.
+        disable_back_button (bool): Whether to disable the back button from receipt page. Defaults to false as the
+            receipt page is referenced in emails/etc., and we only want to disable the back button from the receipt
+            page if the user has gone through the payment flow.
 
     Returns:
         str: Receipt page URL.
@@ -45,8 +48,13 @@ def get_receipt_page_url(site_configuration, order_number=None, override_url=Non
     if override_url:
         return override_url
     else:
+        url_params = {}
+        if order_number:
+            url_params['order_number'] = order_number
+        if disable_back_button:
+            url_params['disable_back_button'] = int(disable_back_button)
         base_url = site_configuration.build_ecommerce_url(reverse('checkout:receipt'))
-        params = six.moves.urllib.parse.urlencode({'order_number': order_number}) if order_number else ''
+        params = six.moves.urllib.parse.urlencode(url_params)
 
     return '{base_url}{params}'.format(
         base_url=base_url,

--- a/ecommerce/extensions/checkout/views.py
+++ b/ecommerce/extensions/checkout/views.py
@@ -74,7 +74,8 @@ class FreeCheckoutView(EdxOrderPlacementMixin, RedirectView):
             else:
                 receipt_path = get_receipt_page_url(
                     order_number=order.number,
-                    site_configuration=order.site.siteconfiguration
+                    site_configuration=order.site.siteconfiguration,
+                    disable_back_button=True,
                 )
                 url = site.siteconfiguration.build_lms_url(receipt_path)
         else:
@@ -179,7 +180,8 @@ class ReceiptResponseView(ThankYouView):
         context.update(self.get_show_verification_banner_context(context))
         context.update({
             'explore_courses_url': get_lms_explore_courses_url(),
-            'has_enrollment_code_product': has_enrollment_code_product
+            'has_enrollment_code_product': has_enrollment_code_product,
+            'disable_back_button': self.request.GET.get('disable_back_button', 0),
         })
         return context
 

--- a/ecommerce/extensions/payment/processors/cybersource.py
+++ b/ecommerce/extensions/payment/processors/cybersource.py
@@ -185,7 +185,8 @@ class Cybersource(ApplePayMixin, BaseClientSidePaymentProcessor):
                 order_number=basket.order_number,
                 override_url=site.siteconfiguration.build_ecommerce_url(
                     reverse('cybersource:redirect')
-                )
+                ),
+                disable_back_button=True,
             ),
             'override_custom_cancel_page': self.cancel_page_url,
         }

--- a/ecommerce/extensions/payment/tests/mixins.py
+++ b/ecommerce/extensions/payment/tests/mixins.py
@@ -660,7 +660,8 @@ class CybersourceNotificationTestsMixin(CybersourceMixin):
 
         expected_redirect = get_receipt_page_url(
             self.site.siteconfiguration,
-            order_number=notification.get('req_reference_number')
+            order_number=notification.get('req_reference_number'),
+            disable_back_button=True,
         )
 
         self.assertRedirects(response, expected_redirect, fetch_redirect_response=False)

--- a/ecommerce/extensions/payment/tests/views/test_paypal.py
+++ b/ecommerce/extensions/payment/tests/views/test_paypal.py
@@ -81,7 +81,8 @@ class PaypalPaymentExecutionViewTests(PaypalMixin, PaymentEventsMixin, TestCase)
             response,
             url_redirect or get_receipt_page_url(
                 order_number=self.basket.order_number,
-                site_configuration=self.basket.site.siteconfiguration
+                site_configuration=self.basket.site.siteconfiguration,
+                disable_back_button=True,
             ),
             fetch_redirect_response=False
         )
@@ -126,7 +127,8 @@ class PaypalPaymentExecutionViewTests(PaypalMixin, PaymentEventsMixin, TestCase)
             response,
             get_receipt_page_url(
                 order_number=self.basket.order_number,
-                site_configuration=self.basket.site.siteconfiguration
+                site_configuration=self.basket.site.siteconfiguration,
+                disable_back_button=True,
             ),
             fetch_redirect_response=False
         )
@@ -163,7 +165,8 @@ class PaypalPaymentExecutionViewTests(PaypalMixin, PaymentEventsMixin, TestCase)
             response,
             get_receipt_page_url(
                 order_number=self.basket.order_number,
-                site_configuration=self.basket.site.siteconfiguration
+                site_configuration=self.basket.site.siteconfiguration,
+                disable_back_button=True,
             ),
             fetch_redirect_response=False
         )

--- a/ecommerce/extensions/payment/tests/views/test_stripe.py
+++ b/ecommerce/extensions/payment/tests/views/test_stripe.py
@@ -41,7 +41,11 @@ class StripeSubmitViewTests(PaymentEventsMixin, TestCase):
 
     def assert_successful_order_response(self, response, order_number):
         assert response.status_code == 201
-        receipt_url = get_receipt_page_url(self.site_configuration, order_number)
+        receipt_url = get_receipt_page_url(
+            self.site_configuration,
+            order_number,
+            disable_back_button=True,
+        )
         assert json.loads(response.content) == {'url': receipt_url}
 
     def assert_order_created(self, basket, billing_address, card_type, label):

--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -411,7 +411,8 @@ class CybersourceInterstitialView(CybersourceNotificationMixin, View):
     def redirect_to_receipt_page(self, notification):
         receipt_page_url = get_receipt_page_url(
             self.request.site.siteconfiguration,
-            order_number=notification.get('req_reference_number')
+            order_number=notification.get('req_reference_number'),
+            disable_back_button=True,
         )
 
         return redirect(receipt_page_url)

--- a/ecommerce/extensions/payment/views/paypal.py
+++ b/ecommerce/extensions/payment/views/paypal.py
@@ -117,7 +117,8 @@ class PaypalPaymentExecutionView(EdxOrderPlacementMixin, View):
 
         receipt_url = get_receipt_page_url(
             order_number=basket.order_number,
-            site_configuration=basket.site.siteconfiguration
+            site_configuration=basket.site.siteconfiguration,
+            disable_back_button=True,
         )
 
         try:

--- a/ecommerce/extensions/payment/views/stripe.py
+++ b/ecommerce/extensions/payment/views/stripe.py
@@ -76,6 +76,7 @@ class StripeSubmitView(EdxOrderPlacementMixin, BasePaymentSubmitView):
 
         receipt_url = get_receipt_page_url(
             site_configuration=self.request.site.siteconfiguration,
-            order_number=order_number
+            order_number=order_number,
+            disable_back_button=True,
         )
         return JsonResponse({'url': receipt_url}, status=201)

--- a/ecommerce/static/js/pages/receipt_page.js
+++ b/ecommerce/static/js/pages/receipt_page.js
@@ -51,7 +51,9 @@ define([
                 orderId = $el.data('order-id'),
                 totalAmount = $el.data('total-amount');
 
-            disableBackButton();
+            if ($el.data('back-button')) {
+                disableBackButton();
+            }
 
             if (orderId) {
                 trackPurchase(orderId, totalAmount, currency);

--- a/ecommerce/static/js/test/specs/pages/receipt_page_spec.js
+++ b/ecommerce/static/js/test/specs/pages/receipt_page_spec.js
@@ -38,7 +38,8 @@ define([
 
                     history.back();
 
-                    setTimeout(function() { expect(window.alert).toHaveBeenCalled(); }, 3000);
+                    // This just confirms that there was no full page reload from hitting the back button
+                    expect(location.hash).toEqual('');
                 });
 
                 it('should trigger track purchase', function() {

--- a/ecommerce/static/js/test/specs/pages/receipt_page_spec.js
+++ b/ecommerce/static/js/test/specs/pages/receipt_page_spec.js
@@ -22,14 +22,23 @@ define([
             });
 
             describe('onReady', function() {
-                it('should disable the back button by manipulating the fragment', function() {
+                it('should not disable the back button if default values are used for data-back-button', function() {
+                    ReceiptPage.onReady();
+
+                    expect(location.hash).toEqual('');
+                });
+
+                it('should disable the back button if value of data-back-button is set', function() {
+                    var receiptPage = document.getElementById('receipt-container');
+                    receiptPage.setAttribute('data-back-button', 1);
+
                     ReceiptPage.onReady();
 
                     expect(location.hash).toContain('#');
 
                     history.back();
 
-                    expect(location.hash).toContain('#');
+                    setTimeout(function() { expect(window.alert).toHaveBeenCalled(); }, 3000);
                 });
 
                 it('should trigger track purchase', function() {

--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -26,7 +26,8 @@
        class="receipt container content-container"
        data-currency="{{ order.currency }}"
        data-order-id="{{ order.number }}"
-       data-total-amount="{{ order.total_incl_tax | unlocalize }}">
+       data-total-amount="{{ order.total_incl_tax | unlocalize }}"
+       data-back-button="{{ disable_back_button | default:0 }}">
       <h2 class="thank-you">{% trans "Thank you for your order!" %}</h2>
 
       <div class="list-info">


### PR DESCRIPTION
Disable back button on receipt page after going through payment flow.
We do not disable the back button by default, since the receipt page is
referenced in emails and can be accessed from the order page.

REV-690