### PR TITLE
Provide Ecom Django Refund Access

### DIFF
--- a/ecommerce/extensions/refund/admin.py
+++ b/ecommerce/extensions/refund/admin.py
@@ -4,6 +4,7 @@ import waffle
 from django.contrib import admin, messages
 from django.utils.translation import ugettext_lazy as _
 from oscar.core.loading import get_model
+from rules.contrib.admin import ObjectPermissionsModelAdmin
 
 from ecommerce.extensions.refund.constants import REFUND_LIST_VIEW_SWITCH
 
@@ -19,7 +20,7 @@ class RefundLineInline(admin.TabularInline):
 
 
 @admin.register(Refund)
-class RefundAdmin(admin.ModelAdmin):
+class RefundAdmin(ObjectPermissionsModelAdmin):
     list_display = ('id', 'order', 'user', 'status', 'total_credit_excl_tax', 'currency', 'created', 'modified',)
     list_filter = ('status',)
     show_full_result_count = False

--- a/ecommerce/extensions/refund/rules.py
+++ b/ecommerce/extensions/refund/rules.py
@@ -1,0 +1,33 @@
+"""
+Django rules for Refund
+"""
+from __future__ import absolute_import
+
+import rules
+from edx_rbac.utils import user_has_access_via_database
+
+from ecommerce.core.constants import ORDER_MANAGER_ROLE
+from ecommerce.core.models import EcommerceFeatureRoleAssignment
+
+
+@rules.predicate
+def request_user_has_refund_access(user):
+    """
+    Check that if request user has explicit access to `ORDER_MANAGER_ROLE` feature role.
+    Returns:
+        boolean: whether the request user has access or not
+    """
+    if user.is_authenticated():
+        return user_has_access_via_database(
+            user,
+            ORDER_MANAGER_ROLE,
+            EcommerceFeatureRoleAssignment
+        )
+
+    return False
+
+
+rules.add_perm('refund.add_refund', request_user_has_refund_access)
+rules.add_perm('refund.change_refund', request_user_has_refund_access)
+rules.add_perm('refund.delete_refund', request_user_has_refund_access)
+rules.add_perm('refund', rules.always_allow)


### PR DESCRIPTION
Problem:
`is_superuser` flag was set to false few months back for all staff users. Support needs access to Refund module in django admin

Solution:
Use EcommerceFeatureRole to provide `explicit` access to ecom django refund module

For django-rules reference: https://github.com/dfunckt/django-rules#permissions-in-the-admin

[PROD-540](https://openedx.atlassian.net/browse/PROD-540)