### PR TITLE
ARCH-1101: add query param to coupon redeem redirect

### DIFF
--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -464,7 +464,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         self.mock_access_token_response()
 
         self.create_coupon(catalog=self.catalog, code=COUPON_CODE, benefit_value=5)
-        expected_url = self.get_full_url(path=reverse('basket:summary'))
+        expected_url = self.get_full_url(path=reverse('basket:summary')) + '?coupon_redeem_redirect=1'
         self.assert_redemption_page_redirects(expected_url)
 
     @httpretty.activate

--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -464,8 +464,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         self.mock_access_token_response()
 
         self.create_coupon(catalog=self.catalog, code=COUPON_CODE, benefit_value=5)
-        expected_url = self.get_full_url(path=reverse('basket:summary')) + '?coupon_redeem_redirect=1'
-        self.assert_redemption_page_redirects(expected_url)
+        self.assert_redemption_page_redirects(self.get_coupon_redeem_success_expected_redirect_url())
 
     @httpretty.activate
     def test_basket_redirect_enrollment_code(self):
@@ -732,8 +731,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         self.mock_access_token_response()
 
         self.create_coupon(catalog=self.catalog, code=COUPON_CODE, benefit_value=5)
-        expected_url = self.get_full_url(path=reverse('basket:summary'))
-        self.assert_redemption_page_redirects(expected_url)
+        self.assert_redemption_page_redirects(self.get_coupon_redeem_success_expected_redirect_url())
 
     @httpretty.activate
     def test_inactive_user_email_domain_restricted_coupon_redemption(self):
@@ -748,6 +746,9 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
 
         response = self.client.get(self.redeem_url_with_params())
         self.assert_redirected_to_email_confirmation(response)
+
+    def get_coupon_redeem_success_expected_redirect_url(self):
+        return self.get_full_url(path=reverse('basket:summary')) + '?coupon_redeem_redirect=1'
 
 
 @ddt.ddt

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -33,7 +33,7 @@ from ecommerce.enterprise.utils import (
     get_enterprise_customer_from_voucher
 )
 from ecommerce.extensions.api import exceptions
-from ecommerce.extensions.basket.utils import prepare_basket
+from ecommerce.extensions.basket.utils import prepare_basket, redirect_url_to_basket_or_payment
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
 from ecommerce.extensions.checkout.utils import get_receipt_page_url
 from ecommerce.extensions.offer.utils import get_redirect_to_email_confirmation_if_required
@@ -285,7 +285,11 @@ class CouponRedeemView(EdxOrderPlacementMixin, APIView):
                         _('This coupon code is not valid for this course. Try a different course.'))
                 self.request.basket.vouchers.remove(voucher)
 
-        return absolute_redirect(self.request, 'basket:summary')
+        # The coupon_redeem_redirect query param is used to communicate to the Payment MFE that it may redirect
+        # and should not display the payment form before making that determination.
+        # TODO: It would be cleaner if the user could be redirected to their final destination up front.
+        redirect_url = redirect_url_to_basket_or_payment(self.request) + "?coupon_redeem_redirect=1"
+        return HttpResponseRedirect(redirect_url)
 
 
 class EnrollmentCodeCsvView(View):

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -33,7 +33,7 @@ from ecommerce.enterprise.utils import (
     get_enterprise_customer_from_voucher
 )
 from ecommerce.extensions.api import exceptions
-from ecommerce.extensions.basket.utils import prepare_basket, get_payment_microfrontend_or_basket_url
+from ecommerce.extensions.basket.utils import get_payment_microfrontend_or_basket_url, prepare_basket
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
 from ecommerce.extensions.checkout.utils import get_receipt_page_url
 from ecommerce.extensions.offer.utils import get_redirect_to_email_confirmation_if_required

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -33,7 +33,7 @@ from ecommerce.enterprise.utils import (
     get_enterprise_customer_from_voucher
 )
 from ecommerce.extensions.api import exceptions
-from ecommerce.extensions.basket.utils import prepare_basket, redirect_url_to_basket_or_payment
+from ecommerce.extensions.basket.utils import prepare_basket, get_payment_microfrontend_or_basket_url
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
 from ecommerce.extensions.checkout.utils import get_receipt_page_url
 from ecommerce.extensions.offer.utils import get_redirect_to_email_confirmation_if_required
@@ -288,7 +288,7 @@ class CouponRedeemView(EdxOrderPlacementMixin, APIView):
         # The coupon_redeem_redirect query param is used to communicate to the Payment MFE that it may redirect
         # and should not display the payment form before making that determination.
         # TODO: It would be cleaner if the user could be redirected to their final destination up front.
-        redirect_url = redirect_url_to_basket_or_payment(self.request) + "?coupon_redeem_redirect=1"
+        redirect_url = get_payment_microfrontend_or_basket_url(self.request) + "?coupon_redeem_redirect=1"
         return HttpResponseRedirect(redirect_url)
 
 

--- a/ecommerce/extensions/basket/tests/test_views.py
+++ b/ecommerce/extensions/basket/tests/test_views.py
@@ -116,7 +116,8 @@ class BasketAddItemsViewTests(
             [product.stockrecords.first().partner_sku for product in products],
             utm_source='test',
         )
-        self.assertEqual(response.url, '/basket/?utm_source=test')
+        expected_url = self.get_full_url(reverse('basket:summary')) + '?utm_source=test'
+        self.assertEqual(response.url, expected_url)
 
     def test_redirect_to_basket_summary(self):
         """
@@ -144,7 +145,7 @@ class BasketAddItemsViewTests(
         response = self._get_response(self.stock_record.partner_sku, utm_source='test')
 
         expect_microfrontend = enable_redirect and set_url
-        expected_url = microfrontend_url if expect_microfrontend else '/basket/'
+        expected_url = microfrontend_url if expect_microfrontend else self.get_full_url(reverse('basket:summary'))
         expected_url += '?utm_source=test'
         self.assertRedirects(response, expected_url, status_code=303, fetch_redirect_response=False)
 

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -56,8 +56,8 @@ def redirect_url_to_basket_or_payment(request):
 def get_payment_microfrontend_url_if_configured(request):
     if _use_payment_microfrontend(request):
         return request.site.siteconfiguration.payment_microfrontend_url
-    else:
-        return None
+
+    return None
 
 
 def _force_payment_microfrontend_bucket(request):

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -15,7 +15,7 @@ from oscar.apps.basket.signals import voucher_addition
 from oscar.core.loading import get_class, get_model
 from six.moves.urllib.parse import unquote, urlencode
 
-from ecommerce.core.url_utils import absolute_redirect
+from ecommerce.core.url_utils import absolute_url
 from ecommerce.courses.utils import mode_for_product
 from ecommerce.extensions.analytics.utils import track_segment_event
 from ecommerce.extensions.experimentation.stable_bucketing import stable_bucketing_hash_group
@@ -49,7 +49,7 @@ logger = logging.getLogger(__name__)
 def redirect_url_to_basket_or_payment(request):
     redirect_url = get_payment_microfrontend_url_if_configured(request)
     if not redirect_url:
-        redirect_url = absolute_redirect(request, 'basket:summary')
+        redirect_url = absolute_url(request, 'basket:summary')
     return redirect_url
 
 

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -15,10 +15,18 @@ from oscar.apps.basket.signals import voucher_addition
 from oscar.core.loading import get_class, get_model
 from six.moves.urllib.parse import unquote, urlencode
 
+from ecommerce.core.url_utils import absolute_redirect
 from ecommerce.courses.utils import mode_for_product
+from ecommerce.extensions.analytics.utils import track_segment_event
+from ecommerce.extensions.experimentation.stable_bucketing import stable_bucketing_hash_group
 from ecommerce.extensions.offer.constants import CUSTOM_APPLICATOR_USE_FLAG
 from ecommerce.extensions.order.exceptions import AlreadyPlacedOrderException
 from ecommerce.extensions.order.utils import UserAlreadyPlacedOrder
+from ecommerce.extensions.payment.constants import (
+    ENABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME,
+    FORCE_MICROFRONTEND_BUCKET_FLAG_NAME,
+    PAYMENT_MFE_BUCKET
+)
 from ecommerce.extensions.payment.utils import embargo_check
 from ecommerce.referrals.models import Referral
 
@@ -36,6 +44,65 @@ Refund = get_model('refund', 'Refund')
 Voucher = get_model('voucher', 'Voucher')
 
 logger = logging.getLogger(__name__)
+
+
+def redirect_url_to_basket_or_payment(request):
+    redirect_url = get_payment_microfrontend_url_if_configured(request)
+    if not redirect_url:
+        redirect_url = absolute_redirect(request, 'basket:summary')
+    return redirect_url
+
+
+def get_payment_microfrontend_url_if_configured(request):
+    if _use_payment_microfrontend(request):
+        return request.site.siteconfiguration.payment_microfrontend_url
+    else:
+        return None
+
+
+def _force_payment_microfrontend_bucket(request):
+    """
+    Return whether the user for the current request should be forced into
+    the payment MFE bucket.
+    """
+    return waffle.flag_is_active(request, FORCE_MICROFRONTEND_BUCKET_FLAG_NAME)
+
+
+def _use_payment_microfrontend(request):
+    """
+    Return whether the current request should use the payment MFE.
+    """
+    if (
+            request.site.siteconfiguration.enable_microfrontend_for_basket_page and
+            request.site.siteconfiguration.payment_microfrontend_url
+    ):
+        # Force the user into the MFE bucket for testing
+        payment_mfe_bucket_forced = _force_payment_microfrontend_bucket(request)
+        if payment_mfe_bucket_forced:
+            bucket = PAYMENT_MFE_BUCKET
+        else:
+            # Bucket 50% of users to use the payment MFE for A/B testing.
+            bucket = stable_bucketing_hash_group("payment-mfe", 2, request.user.username)
+
+        payment_microfrontend_flag_enabled = waffle.flag_is_active(
+            request,
+            ENABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME
+        )
+
+        track_segment_event(
+            request.site,
+            request.user,
+            'edx.bi.experiment.user.bucketed',
+            {
+                'bucket': bucket,
+                'experiment': 'payment-mfe',
+                'forcedIntoBucket': payment_mfe_bucket_forced,
+                'paymentMfeEnabled': payment_microfrontend_flag_enabled,
+            },
+        )
+        return bucket == PAYMENT_MFE_BUCKET and payment_microfrontend_flag_enabled
+    else:
+        return False
 
 
 @newrelic.agent.function_trace()

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -46,11 +46,11 @@ Voucher = get_model('voucher', 'Voucher')
 logger = logging.getLogger(__name__)
 
 
-def redirect_url_to_basket_or_payment(request):
-    redirect_url = get_payment_microfrontend_url_if_configured(request)
-    if not redirect_url:
-        redirect_url = absolute_url(request, 'basket:summary')
-    return redirect_url
+def get_payment_microfrontend_or_basket_url(request):
+    url = get_payment_microfrontend_url_if_configured(request)
+    if not url:
+        url = absolute_url(request, 'basket:summary')
+    return url
 
 
 def get_payment_microfrontend_url_if_configured(request):

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -317,7 +317,7 @@ def _record_utm_basket_attribution(referral, request):
       Attribute this user's basket to UTM data, if applicable.
     """
     utm_cookie_name = request.site.siteconfiguration.utm_cookie_name
-    utm_cookie = request.COOKIES.get(utm_cookie_name, "{}")
+    utm_cookie = request.COOKIES.get(utm_cookie_name, "{}") if utm_cookie_name else {}
     utm = json.loads(utm_cookie)
 
     for attr_name in ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content']:

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -45,7 +45,7 @@ from ecommerce.extensions.basket.utils import (
     get_basket_switch_data,
     get_payment_microfrontend_url_if_configured,
     prepare_basket,
-    redirect_url_to_basket_or_payment,
+    get_payment_microfrontend_or_basket_url,
     validate_voucher
 )
 from ecommerce.extensions.offer.constants import DYNAMIC_DISCOUNT_FLAG
@@ -162,7 +162,7 @@ class BasketAddItemsView(APIView):
                 raise RedirectException(response=code_redemption_redirect)
 
     def _redirect_response_to_basket_or_payment(self, request):
-        redirect_url = redirect_url_to_basket_or_payment(request)
+        redirect_url = get_payment_microfrontend_or_basket_url(request)
         redirect_url = add_utm_params_to_url(redirect_url, list(self.request.GET.items()))
         return HttpResponseRedirect(redirect_url, status=303)
 

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -43,9 +43,9 @@ from ecommerce.extensions.basket.utils import (
     add_utm_params_to_url,
     apply_voucher_on_basket_and_check_discount,
     get_basket_switch_data,
+    get_payment_microfrontend_or_basket_url,
     get_payment_microfrontend_url_if_configured,
     prepare_basket,
-    get_payment_microfrontend_or_basket_url,
     validate_voucher
 )
 from ecommerce.extensions.offer.constants import DYNAMIC_DISCOUNT_FLAG

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -43,10 +43,11 @@ from ecommerce.extensions.basket.utils import (
     add_utm_params_to_url,
     apply_voucher_on_basket_and_check_discount,
     get_basket_switch_data,
+    get_payment_microfrontend_url_if_configured,
     prepare_basket,
+    redirect_url_to_basket_or_payment,
     validate_voucher
 )
-from ecommerce.extensions.experimentation.stable_bucketing import stable_bucketing_hash_group
 from ecommerce.extensions.offer.constants import DYNAMIC_DISCOUNT_FLAG
 from ecommerce.extensions.offer.dynamic_conditional_offer import get_percentage_from_request
 from ecommerce.extensions.offer.utils import (
@@ -57,12 +58,7 @@ from ecommerce.extensions.offer.utils import (
 )
 from ecommerce.extensions.order.exceptions import AlreadyPlacedOrderException
 from ecommerce.extensions.partner.shortcuts import get_partner_for_site
-from ecommerce.extensions.payment.constants import (
-    CLIENT_SIDE_CHECKOUT_FLAG_NAME,
-    ENABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME,
-    FORCE_MICROFRONTEND_BUCKET_FLAG_NAME,
-    PAYMENT_MFE_BUCKET
-)
+from ecommerce.extensions.payment.constants import CLIENT_SIDE_CHECKOUT_FLAG_NAME
 from ecommerce.extensions.payment.forms import PaymentForm
 
 Basket = get_model('basket', 'basket')
@@ -75,58 +71,6 @@ Product = get_model('catalogue', 'Product')
 StockRecord = get_model('partner', 'StockRecord')
 Voucher = get_model('voucher', 'Voucher')
 Selector = get_class('partner.strategy', 'Selector')
-
-
-def _get_payment_microfrontend_url_if_configured(request):
-    if _use_payment_microfrontend(request):
-        return request.site.siteconfiguration.payment_microfrontend_url
-    else:
-        return None
-
-
-def _force_payment_microfrontend_bucket(request):
-    """
-    Return whether the user for the current request should be forced into
-    the payment MFE bucket.
-    """
-    return waffle.flag_is_active(request, FORCE_MICROFRONTEND_BUCKET_FLAG_NAME)
-
-
-def _use_payment_microfrontend(request):
-    """
-    Return whether the current request should use the payment MFE.
-    """
-    if (
-            request.site.siteconfiguration.enable_microfrontend_for_basket_page and
-            request.site.siteconfiguration.payment_microfrontend_url
-    ):
-        # Force the user into the MFE bucket for testing
-        payment_mfe_bucket_forced = _force_payment_microfrontend_bucket(request)
-        if payment_mfe_bucket_forced:
-            bucket = PAYMENT_MFE_BUCKET
-        else:
-            # Bucket 50% of users to use the payment MFE for A/B testing.
-            bucket = stable_bucketing_hash_group("payment-mfe", 2, request.user.username)
-
-        payment_microfrontend_flag_enabled = waffle.flag_is_active(
-            request,
-            ENABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME
-        )
-
-        track_segment_event(
-            request.site,
-            request.user,
-            'edx.bi.experiment.user.bucketed',
-            {
-                'bucket': bucket,
-                'experiment': 'payment-mfe',
-                'forcedIntoBucket': payment_mfe_bucket_forced,
-                'paymentMfeEnabled': payment_microfrontend_flag_enabled,
-            },
-        )
-        return bucket == PAYMENT_MFE_BUCKET and payment_microfrontend_flag_enabled
-    else:
-        return False
 
 
 class BasketAddItemsView(APIView):
@@ -218,9 +162,7 @@ class BasketAddItemsView(APIView):
                 raise RedirectException(response=code_redemption_redirect)
 
     def _redirect_response_to_basket_or_payment(self, request):
-        redirect_url = _get_payment_microfrontend_url_if_configured(request)
-        if not redirect_url:
-            redirect_url = reverse('basket:summary')
+        redirect_url = redirect_url_to_basket_or_payment(request)
         redirect_url = add_utm_params_to_url(redirect_url, list(self.request.GET.items()))
         return HttpResponseRedirect(redirect_url, status=303)
 
@@ -536,7 +478,7 @@ class BasketSummaryView(BasketLogicMixin, BasketView):
         return super(BasketSummaryView, self).get(request, *args, **kwargs)
 
     def _redirect_to_payment_microfrontend_if_configured(self, request):
-        microfrontend_url = _get_payment_microfrontend_url_if_configured(request)
+        microfrontend_url = get_payment_microfrontend_url_if_configured(request)
         if microfrontend_url:
             # For now, the enterprise consent form validation is communicated via
             # a URL parameter, which must be forwarded via this redirect.


### PR DESCRIPTION
The CouponRedeemView redirects to the Payment MFE at times when the
Payment MFE will in turn be told to redirect elsewhere (e.g. the free
basket page).  To avoid flashing the payment form, the Payment MFE will
be sent a special query param that tells it not to display the payment
form until it knows whether or not it is needed (i.e. until it gets
a response from the server).

ARCH-1101