### PR TITLE
Add learner portal localhost to cors origin whitelist

### DIFF
--- a/ecommerce/settings/devstack.py
+++ b/ecommerce/settings/devstack.py
@@ -38,6 +38,7 @@ CORS_ORIGIN_WHITELIST = (
     'http://localhost:1991',
     'http://localhost:1996',
     'http://localhost:1998',
+    'http://localhost:8734',
 )
 CORS_ALLOW_HEADERS = corsheaders_default_headers + (
     'use-jwt-cookie',


### PR DESCRIPTION
While trying to hit an ecommerce endpoint in the Enterprise learner-portal frontend locally, I get a CORS error. This PR adds `http://localhost:8734` to the `CORS_ORIGIN_WHITELIST` setting to allow requests from the learner-portal locally.