### PR TITLE
ARCH-1147: add error logging for payment errors

### DIFF
--- a/ecommerce/extensions/payment/tests/mixins.py
+++ b/ecommerce/extensions/payment/tests/mixins.py
@@ -26,6 +26,7 @@ from ecommerce.extensions.payment.constants import CARD_TYPES
 from ecommerce.extensions.payment.exceptions import (
     AuthorizationError,
     ExcessivePaymentForOrderError,
+    InvalidSignatureError,
     RedundantPaymentNotificationError
 )
 from ecommerce.extensions.payment.helpers import sign
@@ -128,36 +129,6 @@ class CybersourceMixin(PaymentEventsMixin):
         # Validate that PaymentEvents exist
         paid_type = PaymentEventType.objects.get(code='paid')
         self.assert_payment_event_exists(self.basket, paid_type, reference, self.processor_name)
-
-    def _assert_processing_failure(self, notification, error_message, log_level='ERROR'):
-        """Verify that payment processing operations fail gracefully."""
-        logger_name = 'ecommerce.extensions.payment.views.cybersource'
-        with LogCapture(logger_name) as logger:
-            self.client.post(self.path, notification)
-
-            ppr_id = self.assert_processor_response_recorded(
-                self.processor_name,
-                notification['transaction_id'],
-                notification,
-                basket=self.basket
-            )
-
-            error_message = error_message.format(
-                basket_id=self.basket.id, response_id=ppr_id, order_number=notification['req_reference_number']
-            )
-
-            logger.check_present(
-                (
-                    logger_name,
-                    'INFO',
-                    'Received CyberSource payment notification for transaction [{transaction_id}], '
-                    'associated with basket [{basket_id}].'.format(
-                        transaction_id=notification['transaction_id'],
-                        basket_id=self.basket.id
-                    )
-                ),
-                (logger_name, log_level, error_message)
-            )
 
     def generate_signature(self, secret_key, data):
         """ Generate a signature for the given data dict. """
@@ -408,6 +379,7 @@ class CybersourceMixin(PaymentEventsMixin):
 @ddt.ddt
 class CybersourceNotificationTestsMixin(CybersourceMixin):
     """ Mixin with test methods for testing CyberSource payment views. """
+    CYBERSOURCE_VIEW_LOGGER_NAME = 'ecommerce.extensions.payment.views.cybersource'
 
     def setUp(self):
         super(CybersourceNotificationTestsMixin, self).setUp()
@@ -483,18 +455,23 @@ class CybersourceNotificationTestsMixin(CybersourceMixin):
         )
 
     @ddt.data(
-        (PaymentError, 'ERROR', 'CyberSource payment failed for basket [{basket_id}]. '
-                                'The payment response [Unknown Error] was recorded in entry [{response_id}].'),
-        (UserCancelled, 'INFO', 'CyberSource payment did not complete for basket [{basket_id}] because '
-                                '[UserCancelled]. The payment response [Unknown Error] was recorded in '
-                                'entry [{response_id}].'),
-        (TransactionDeclined, 'INFO', 'CyberSource payment did not complete for basket [{basket_id}] because '
-                                      '[TransactionDeclined]. The payment response [Unknown Error] was recorded'
-                                      ' in entry [{response_id}].'),
-        (KeyError, 'ERROR', 'Attempts to handle payment for basket [{basket_id}] failed. The payment response '
-                            '[Unknown Error] was recorded in entry [{response_id}].'),
-        (AuthorizationError, 'INFO', 'Payment Authorization was declined for basket [{basket_id}]. The payment '
-                                     'response was recorded in entry [{response_id}].'),
+        (InvalidSignatureError, 'InvalidSignatureError', 'ERROR', 'CyberSource response was invalid. '),
+        (PaymentError, 'PaymentError', 'ERROR', ''),
+        (UserCancelled, 'UserCancelled', 'INFO', ''),
+        (TransactionDeclined, 'TransactionDeclined', 'INFO', ''),
+        (KeyError, 'KeyError', 'ERROR', ''),
+        (AuthorizationError, 'AuthorizationError', 'INFO', ''),
+    )
+    @ddt.unpack
+    def test_payment_handling_standard_errors(self, error_class, error_class_name, log_level, message_prefix):
+        error_message = (
+            'CyberSource payment failed due to [{error_class}] for transaction [{transaction_id}], order '
+            '[{order_number}], and basket [{basket_id}]. The complete payment response [Unknown Error] was recorded '
+            'in entry [{response_id}].'
+        )
+        self._test_payment_handling_errors(error_class, log_level, message_prefix + error_message, error_class_name)
+
+    @ddt.data(
         (ExcessivePaymentForOrderError, 'INFO', 'Received duplicate CyberSource payment notification with different '
                                                 'transaction ID for basket [{basket_id}] which is associated with an '
                                                 'existing order [{order_number}]. Payment collected twice, '
@@ -504,7 +481,10 @@ class CybersourceNotificationTestsMixin(CybersourceMixin):
                                                     'an existing order [{order_number}]. No payment was collected.')
     )
     @ddt.unpack
-    def test_payment_handling_error(self, error_class, log_level, error_message):
+    def test_payment_handling_unique_errors(self, error_class, log_level, error_message):
+        self._test_payment_handling_errors(error_class, log_level, error_message)
+
+    def _test_payment_handling_errors(self, error_class, log_level, error_message, error_class_name=None):
         """
         Verify that CyberSource's merchant notification is saved to the database despite an error handling payment.
         """
@@ -516,7 +496,8 @@ class CybersourceNotificationTestsMixin(CybersourceMixin):
             self._assert_processing_failure(
                 notification,
                 error_message,
-                log_level
+                log_level,
+                error_class_name,
             )
             self.assertTrue(fake_handle_payment.called)
 
@@ -577,6 +558,111 @@ class CybersourceNotificationTestsMixin(CybersourceMixin):
         )
 
         self._assert_processing_failure(notification, msg, 'INFO')
+
+    def test_invalid_order_id(self):
+        """ Verify the view redirects to the error page when the order id is invalid. """
+        notification = self.generate_notification(
+            self.basket,
+            req_reference_number='invalid-order-id'
+        )
+
+        logger_name = self.CYBERSOURCE_VIEW_LOGGER_NAME
+        with LogCapture(logger_name) as cybersource_logger:
+            response = self.client.post(self.path, notification)
+            self.assertRedirects(response, self.get_full_url(reverse('payment_error')))
+
+            cybersource_logger.check_present(
+                (
+                    logger_name,
+                    'ERROR',
+                    (
+                        'Error generating basket_id from CyberSource notification with transaction [{}]'
+                        ' and order [{}].'.format(
+                            notification.get('transaction_id'),
+                            'invalid-order-id',
+                        )
+                    )
+                ),
+            )
+
+    def test_unexpected_validate_notification_error(self):
+        """ Verify the view redirects to the error page when the payment unexpectedly fails. """
+        notification = self.generate_notification(self.basket)
+
+        logger_name = self.CYBERSOURCE_VIEW_LOGGER_NAME
+        # force an unexpected exception
+        with mock.patch.object(self.view, '_get_basket', side_effect=Exception):
+            with LogCapture(logger_name) as cybersource_logger:
+                response = self.client.post(self.path, notification)
+                self.assertRedirects(response, self.get_full_url(reverse('payment_error')))
+
+                cybersource_logger.check_present(
+                    (
+                        logger_name,
+                        'ERROR',
+                        (
+                            'Unhandled exception processing CyberSource payment notification for transaction [{}], '
+                            'order [{}], and basket [{}].'.format(
+                                notification.get('transaction_id'),
+                                self.basket.order_number,
+                                self.basket.id,
+                            )
+                        )
+                    ),
+                )
+
+    def test_handle_post_order_exception(self):
+        """ Verify the view redirects to the error page when handle_post_order fails. """
+        notification = self.generate_notification(
+            self.basket,
+            billing_address=self.billing_address,
+        )
+
+        logger_name = self.CYBERSOURCE_VIEW_LOGGER_NAME
+        with mock.patch.object(self.view, 'handle_post_order', side_effect=Exception):
+            with LogCapture(logger_name) as cybersource_logger:
+                response = self.client.post(self.path, notification)
+                self.assertRedirects(response, self.get_full_url(reverse('payment_error')))
+
+                cybersource_logger.check_present(
+                    (
+                        logger_name,
+                        'ERROR',
+                        (
+                            'Error when handling post order for transaction [{}], associated with order [{}] and '
+                            'basket [{}].'.format(
+                                notification.get('transaction_id'),
+                                self.basket.order_number,
+                                self.basket.id,
+                            )
+                        )
+                    ),
+                )
+
+    def test_missing_billing_address(self):
+        """ Verify the view redirects to the error page when the billing address is missing. """
+        notification = self.generate_notification(self.basket)
+
+        logger_name = self.CYBERSOURCE_VIEW_LOGGER_NAME
+        with LogCapture(logger_name) as cybersource_logger:
+            response = self.client.post(self.path, notification)
+            self.assertRedirects(response, self.get_full_url(reverse('payment_error')))
+
+            cybersource_logger.check_present(
+                (
+                    logger_name,
+                    'ERROR',
+                    (
+                        # TODO: Update this once we know what this should be
+                        'There should be an error for transaction [{}], associated with order [{}] and '
+                        'basket [{}].'.format(
+                            notification.get('transaction_id'),
+                            self.basket.order_number,
+                            self.basket.id,
+                        )
+                    )
+                ),
+            )
 
     @ddt.data(('line2', 'foo'), ('state', 'bar'))
     @ddt.unpack
@@ -675,20 +761,21 @@ class CybersourceNotificationTestsMixin(CybersourceMixin):
         mock_order.filter.return_value = mock_order
         mock_order.exists.return_value = mock_value
 
-        logger_name = 'ecommerce.extensions.payment.views.cybersource'
+        logger_name = self.CYBERSOURCE_VIEW_LOGGER_NAME
         notification = self.generate_notification(self.basket, decision='ERROR', reason_code='104')
         notification.update({
             'decision': 'ERROR',
             'reason_code': '104',
         })
         notification['signature'] = self.generate_signature(self.processor.secret_key, notification)
+
         if mock_value:
-            msg = (
+            duplicate_reference_message = (
                 'Received CyberSource payment notification for basket [{}] which is associated '
                 'with existing order [{}]. No payment was collected, and no new order will be created.'
             ).format(self.basket.id, self.basket.order_number)
         else:
-            msg = ''
+            duplicate_reference_message = ''
 
         with LogCapture(logger_name) as cybersource_logger:
             self.client.post(self.path, notification)
@@ -697,14 +784,12 @@ class CybersourceNotificationTestsMixin(CybersourceMixin):
                     (
                         logger_name,
                         'INFO',
-                        ('Received CyberSource payment notification for transaction [{}], associated with basket '
-                         '[{}].').format(notification.get('transaction_id'), self.basket.id)
-
+                        self._get_payment_notification_message(notification),
                     ),
                     (
                         logger_name,
                         'INFO',
-                        msg,
+                        duplicate_reference_message,
                     )
                 )
             else:
@@ -712,11 +797,49 @@ class CybersourceNotificationTestsMixin(CybersourceMixin):
                     (
                         logger_name,
                         'INFO',
-                        ('Received CyberSource payment notification for transaction [{}], associated with basket '
-                         '[{}].').format(notification.get('transaction_id'), self.basket.id)
-
+                        self._get_payment_notification_message(notification),
                     )
                 )
+
+    def _get_payment_notification_message(self, notification):
+        return (
+            'Received CyberSource payment notification for transaction [{}], associated with order [{}] and basket '
+            '[{}].'
+        ).format(
+            notification.get('transaction_id'),
+            self.basket.order_number,
+            self.basket.id
+        )
+
+    def _assert_processing_failure(self, notification, error_message, log_level='ERROR', error_class_name=None):
+        """Verify that payment processing operations fail gracefully."""
+        logger_name = self.CYBERSOURCE_VIEW_LOGGER_NAME
+        with LogCapture(logger_name) as logger:
+            self.client.post(self.path, notification)
+
+            ppr_id = self.assert_processor_response_recorded(
+                self.processor_name,
+                notification['transaction_id'],
+                notification,
+                basket=self.basket
+            )
+
+            error_message = error_message.format(
+                basket_id=self.basket.id,
+                response_id=ppr_id,
+                transaction_id=notification['transaction_id'],
+                order_number=notification['req_reference_number'],
+                error_class=error_class_name,
+            )
+
+            logger.check_present(
+                (
+                    logger_name,
+                    'INFO',
+                    self._get_payment_notification_message(notification)
+                ),
+                (logger_name, log_level, error_message)
+            )
 
 
 class PaypalMixin(object):

--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -137,6 +137,7 @@ class CybersourceSubmitView(BasePaymentSubmitView):
 
         logger.info(
             'Parameters signed for CyberSource transaction [%s], associated with basket [%d].',
+            # TODO: transaction_id is None in logs. This should be fixed.
             parameters.get('transaction_id'),
             basket.id
         )
@@ -244,114 +245,147 @@ class CybersourceNotificationMixin(CyberSourceProcessorMixin, OrderCreationMixin
                 str(error))
             return None
 
-    def validate_notification(self, notification):
+    def get_ids_from_notification(self, notification):
+        transaction_id = notification.get('transaction_id')
+        order_number = notification.get('req_reference_number')
+        try:
+            basket_id = OrderNumberGenerator().basket_id(order_number)
+        except:  # pylint: disable=bare-except
+            logger.error(
+                'Error generating basket_id from CyberSource notification with transaction [%s] and order [%s].',
+                transaction_id,
+                order_number,
+            )
+        return (transaction_id, order_number, basket_id)
+
+    # Note: method has too-many-statements, but it enables tracking that all exception handling gets logged
+    def validate_notification(self, notification):  # pylint: disable=too-many-statements
         # Note (CCB): Orders should not be created until the payment processor has validated the response's signature.
         # This validation is performed in the handle_payment method. After that method succeeds, the response can be
         # safely assumed to have originated from CyberSource.
         basket = None
-        transaction_id = None
+        notification = notification or {}
+        unhandled_exception_logging = True
 
         try:
-            transaction_id = notification.get('transaction_id')
-            order_number = notification.get('req_reference_number')
-            basket_id = OrderNumberGenerator().basket_id(order_number)
 
-            logger.info(
-                'Received CyberSource payment notification for transaction [%s], associated with basket [%d].',
-                transaction_id,
-                basket_id
-            )
-
-            basket = self._get_basket(basket_id)
-
-            if not basket:
-                logger.error('Received CyberSource payment notification for non-existent basket [%s].', basket_id)
-                raise InvalidBasketError
-
-            if basket.status != Basket.FROZEN:
-                # We don't know how serious this situation is at this point, hence
-                # the INFO level logging. This notification is most likely CyberSource
-                # telling us that they've declined an attempt to pay for an existing order.
-                logger.info(
-                    'Received CyberSource payment notification for basket [%d] which is in a non-frozen state, [%s]',
-                    basket.id, basket.status
-                )
-        finally:
-            # Store the response in the database regardless of its authenticity.
-            ppr = self.payment_processor.record_processor_response(
-                notification, transaction_id=transaction_id, basket=basket
-            )
-
-        # Explicitly delimit operations which will be rolled back if an exception occurs.
-        with transaction.atomic():
             try:
-                self.handle_payment(notification, basket)
-            except InvalidSignatureError:
+                transaction_id, order_number, basket_id = self.get_ids_from_notification(notification)
+
+                logger.info(
+                    'Received CyberSource payment notification for transaction [%s], associated with order [%s]'
+                    ' and basket [%d].',
+                    transaction_id,
+                    order_number,
+                    basket_id
+                )
+
+                basket = self._get_basket(basket_id)
+
+                if not basket:
+                    logger.error('Received CyberSource payment notification for non-existent basket [%s].', basket_id)
+                    unhandled_exception_logging = False
+                    raise InvalidBasketError
+
+                if basket.status != Basket.FROZEN:
+                    # We don't know how serious this situation is at this point, hence
+                    # the INFO level logging. This notification is most likely CyberSource
+                    # telling us that they've declined an attempt to pay for an existing order.
+                    logger.info(
+                        'Received CyberSource payment notification for basket [%d] which is in a non-frozen state,'
+                        ' [%s]',
+                        basket.id, basket.status
+                    )
+            finally:
+                # Store the response in the database regardless of its authenticity.
+                ppr = self.payment_processor.record_processor_response(
+                    notification, transaction_id=transaction_id, basket=basket
+                )
+
+            # Explicitly delimit operations which will be rolled back if an exception occurs.
+            with transaction.atomic():
+                try:
+                    self.handle_payment(notification, basket)
+                except (UserCancelled, TransactionDeclined, AuthorizationError) as exception:
+                    self._log_cybersource_payment_failure(
+                        exception, basket, order_number, transaction_id, notification, ppr,
+                        logger_function=logger.info,
+                    )
+                    unhandled_exception_logging = False
+                    raise
+                except DuplicateReferenceNumber:
+                    logger.info(
+                        'Received CyberSource payment notification for basket [%d] which is associated '
+                        'with existing order [%s]. No payment was collected, and no new order will be created.',
+                        basket.id,
+                        order_number
+                    )
+                    unhandled_exception_logging = False
+                    raise
+                except RedundantPaymentNotificationError:
+                    logger.info(
+                        'Received redundant CyberSource payment notification with same transaction ID for basket [%d] '
+                        'which is associated with an existing order [%s]. No payment was collected.',
+                        basket.id,
+                        order_number
+                    )
+                    unhandled_exception_logging = False
+                    raise
+                except ExcessivePaymentForOrderError:
+                    logger.info(
+                        'Received duplicate CyberSource payment notification with different transaction ID for basket '
+                        '[%d] which is associated with an existing order [%s]. Payment collected twice, request a '
+                        'refund.',
+                        basket.id,
+                        order_number
+                    )
+                    unhandled_exception_logging = False
+                    raise
+                except InvalidSignatureError as exception:
+                    self._log_cybersource_payment_failure(
+                        exception, basket, order_number, transaction_id, notification, ppr,
+                        message_prefix='CyberSource response was invalid.',
+                    )
+                    unhandled_exception_logging = False
+                    raise
+                except (PaymentError, Exception) as exception:
+                    self._log_cybersource_payment_failure(
+                        exception, basket, order_number, transaction_id, notification, ppr,
+                    )
+                    unhandled_exception_logging = False
+                    raise
+
+        except:  # pylint: disable=bare-except
+            if unhandled_exception_logging:
                 logger.exception(
-                    'Received an invalid CyberSource response. The payment response was recorded in entry [%d].',
-                    ppr.id
+                    'Unhandled exception processing CyberSource payment notification for transaction [%s], order [%s], '
+                    'and basket [%d].',
+                    transaction_id,
+                    order_number,
+                    basket_id
                 )
-                raise
-            except (UserCancelled, TransactionDeclined) as exception:
-                logger.info(
-                    'CyberSource payment did not complete for basket [%d] because [%s]. '
-                    'The payment response [%s] was recorded in entry [%d].',
-                    basket.id,
-                    exception.__class__.__name__,
-                    notification.get("message", "Unknown Error"),
-                    ppr.id
-                )
-                raise
-            except DuplicateReferenceNumber:
-                logger.info(
-                    'Received CyberSource payment notification for basket [%d] which is associated '
-                    'with existing order [%s]. No payment was collected, and no new order will be created.',
-                    basket.id,
-                    order_number
-                )
-                raise
-            except RedundantPaymentNotificationError:
-                logger.info(
-                    'Received redundant CyberSource payment notification with same transaction ID for basket [%d] '
-                    'which is associated with an existing order [%s]. No payment was collected.',
-                    basket.id,
-                    order_number
-                )
-                raise
-            except ExcessivePaymentForOrderError:
-                logger.info(
-                    'Received duplicate CyberSource payment notification with different transaction ID for basket [%d] '
-                    'which is associated with an existing order [%s]. Payment collected twice, request a refund.',
-                    basket.id,
-                    order_number
-                )
-                raise
-            except AuthorizationError:
-                logger.info(
-                    'Payment Authorization was declined for basket [%d]. The payment response was '
-                    'recorded in entry [%d].',
-                    basket.id,
-                    ppr.id,
-                )
-            except PaymentError:
-                logger.exception(
-                    'CyberSource payment failed for basket [%d]. The payment response [%s] was recorded in entry [%d].',
-                    basket.id,
-                    notification.get("message", "Unknown Error"),
-                    ppr.id
-                )
-                raise
-            except:  # pylint: disable=bare-except
-                logger.exception(
-                    'Attempts to handle payment for basket [%d] failed. The payment response [%s] was recorded in'
-                    ' entry [%d].',
-                    basket.id,
-                    notification.get("message", "Unknown Error"),
-                    ppr.id
-                )
-                raise
+            raise
 
         return basket
+
+    def _log_cybersource_payment_failure(
+            self, exception, basket, order_number, transaction_id, notification, ppr,
+            message_prefix=None, logger_function=None
+    ):
+        """ Logs standard payment response as exception log unless logger_function supplied. """
+        message_prefix = message_prefix + ' ' if message_prefix else ''
+        logger_function = logger_function if logger_function else logger.exception
+        logger_function(
+            message_prefix +
+            'CyberSource payment failed due to [%s] for transaction [%s], order [%s], and basket [%d]. '
+            'The complete payment response [%s] was recorded in entry [%d].',
+            exception.__class__.__name__,
+            transaction_id,
+            order_number,
+            basket.id,
+            notification.get("message", "Unknown Error"),
+            ppr.id
+        )
 
 
 class CybersourceInterstitialView(CybersourceNotificationMixin, View):
@@ -359,8 +393,8 @@ class CybersourceInterstitialView(CybersourceNotificationMixin, View):
 
     def post(self, request, *args, **kwargs):  # pylint: disable=unused-argument
         """Process a CyberSource merchant notification and place an order for paid products as appropriate."""
+        notification = request.POST.dict()
         try:
-            notification = request.POST.dict()
             basket = self.validate_notification(notification)
         except DuplicateReferenceNumber:
             # CyberSource has told us that they've declined an attempt to pay
@@ -381,6 +415,11 @@ class CybersourceInterstitialView(CybersourceNotificationMixin, View):
             # We intentionally avoid thawing the old basket here to prevent order
             # numbers from being reused. For more, refer to commit a1efc68.
             new_basket.merge(old_basket, add_quantities=False)
+            logger.info(
+                'Created new basket [%d] from old basket [%d] for declined transaction.',
+                new_basket.id,
+                old_basket_id,
+            )
 
             message = _(
                 'An error occurred while processing your payment. You have not been charged. '
@@ -393,16 +432,32 @@ class CybersourceInterstitialView(CybersourceNotificationMixin, View):
 
             messages.error(request, mark_safe(message))
 
+            # TODO:
+            # 1. TransactionDeclined message may be mishandled by Payment MFE since it contains HTML.
+            # 2. There are sometimes messages from CyberSource that would make a more helpful message for users.
+            # 3. We could have similar handling of other exceptions like UserCancelled and AuthorizationError
             return absolute_redirect(request, 'basket:summary')
         except:  # pylint: disable=bare-except
+            # logging handled by validate_notification, because not all exceptions are problematic
             return absolute_redirect(request, 'payment_error')
 
         try:
             order = self.create_order(request, basket, self._get_billing_address(notification))
-            self.handle_post_order(order)
+        except:  # pylint: disable=bare-except
+            # logging handled by create_order
+            return absolute_redirect(request, 'payment_error')
 
+        try:
+            self.handle_post_order(order)
             return self.redirect_to_receipt_page(notification)
         except:  # pylint: disable=bare-except
+            transaction_id, order_number, basket_id = self.get_ids_from_notification(notification)
+            logger.exception(
+                'Error when handling post order for transaction [%s], associated with order [%s] and basket [%d].',
+                transaction_id,
+                order_number,
+                basket_id
+            )
             return absolute_redirect(request, 'payment_error')
 
     def redirect_to_receipt_page(self, notification):

--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -251,7 +251,7 @@ class CybersourceNotificationMixin(CyberSourceProcessorMixin, OrderCreationMixin
         try:
             basket_id = OrderNumberGenerator().basket_id(order_number)
         except:  # pylint: disable=bare-except
-            logger.error(
+            logger.exception(
                 'Error generating basket_id from CyberSource notification with transaction [%s] and order [%s].',
                 transaction_id,
                 order_number,
@@ -283,9 +283,12 @@ class CybersourceNotificationMixin(CyberSourceProcessorMixin, OrderCreationMixin
                 basket = self._get_basket(basket_id)
 
                 if not basket:
-                    logger.error('Received CyberSource payment notification for non-existent basket [%s].', basket_id)
+                    error_message = (
+                        'Received CyberSource payment notification for non-existent basket [%s].' % basket_id
+                    )
+                    logger.error(error_message)
                     unhandled_exception_logging = False
-                    raise InvalidBasketError
+                    raise InvalidBasketError(error_message)
 
                 if basket.status != Basket.FROZEN:
                     # We don't know how serious this situation is at this point, hence

--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -443,17 +443,12 @@ class CybersourceInterstitialView(CybersourceNotificationMixin, View):
 
         try:
             order = self.create_order(request, basket, self._get_billing_address(notification))
-        except:  # pylint: disable=bare-except
-            # logging handled by create_order
-            return absolute_redirect(request, 'payment_error')
-
-        try:
             self.handle_post_order(order)
             return self.redirect_to_receipt_page(notification)
         except:  # pylint: disable=bare-except
             transaction_id, order_number, basket_id = self.get_ids_from_notification(notification)
             logger.exception(
-                'Error when handling post order for transaction [%s], associated with order [%s] and basket [%d].',
+                'Error processing order for transaction [%s], with order [%s] and basket [%d].',
                 transaction_id,
                 order_number,
                 basket_id


### PR DESCRIPTION
Added additional logging for CyberSource payment errors in an attempt
to capture logging for an issue that is currently going unlogged.

ARCH-1147