### PR TITLE
minor fix to declare variables before try block

### DIFF
--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -265,8 +265,6 @@ class CybersourceNotificationMixin(CyberSourceProcessorMixin, OrderCreationMixin
         # safely assumed to have originated from CyberSource.
         basket = None
         transaction_id = None
-        order_number = None
-        basket_id = None
         notification = notification or {}
         unhandled_exception_logging = True
 

--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -264,6 +264,9 @@ class CybersourceNotificationMixin(CyberSourceProcessorMixin, OrderCreationMixin
         # This validation is performed in the handle_payment method. After that method succeeds, the response can be
         # safely assumed to have originated from CyberSource.
         basket = None
+        transaction_id = None
+        order_number = None
+        basket_id = None
         notification = notification or {}
         unhandled_exception_logging = True
 


### PR DESCRIPTION
I killed this line when I first refactored this code in https://github.com/edx/ecommerce/pull/2558.

The assignment of `transaction_id` could probably never fail, but just in case, since it is used in the finally block, I want to restore it.

ARCH-1147