### PR TITLE
create html report and fix flaky test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ fast_diff_coverage:
 	diff-cover coverage.xml --compare-branch=$(DIFF_COVER_BASE_BRANCH)
 
 e2e:
-	pytest e2e --junitxml=e2e/xunit.xml
+	pytest e2e --html=log/html_report.html --junitxml=e2e/xunit.xml
 
 extract_translations:
 	python manage.py makemessages -l en -v1 -d django --ignore="docs/*" --ignore="src/*" --ignore="i18n/*" --ignore="assets/*" --ignore="node_modules/*" --ignore="ecommerce/static/bower_components/*" --ignore="ecommerce/static/build/*"

--- a/e2e/requirements.txt
+++ b/e2e/requirements.txt
@@ -1,5 +1,4 @@
 # Packages required to run e2e tests
-bok-choy==0.7.0
 edx-rest-api-client==1.7.1
 pytest==3.1.3
 pytest-random-order==0.5.4


### PR DESCRIPTION
- create pytest html report, including screenshots of failing
tests
- fix flaky payment page test and add back US address test.
The flakiness was due to filling in the form before it was
enabled (i.e. clickable).