### PR TITLE
fix auth_amount KeyError

### DIFF
--- a/ecommerce/extensions/payment/processors/cybersource.py
+++ b/ecommerce/extensions/payment/processors/cybersource.py
@@ -317,11 +317,11 @@ class Cybersource(ApplePayMixin, BaseClientSidePaymentProcessor):
                 else:
                     raise ExcessivePaymentForOrderError
 
-        # Raise an exception if the authorized amount differs from the requested amount.
-        # Note (CCB): We should never reach this point in production since partial authorization is disabled
-        # for our account, and should remain that way until we have a proper solution to allowing users to
-        # complete authorization for the entire order
-        if response['auth_amount'] and response['auth_amount'] != response['req_amount']:
+        if 'auth_amount' in response and response['auth_amount'] and response['auth_amount'] != response['req_amount']:
+            # Raise an exception if the authorized amount differs from the requested amount.
+            # Note (CCB): We should never reach this point in production since partial authorization is disabled
+            # for our account, and should remain that way until we have a proper solution to allowing users to
+            # complete authorization for the entire order
             raise PartialAuthorizationError
 
         currency = response['req_currency']


### PR DESCRIPTION
While troubleshooting another issue, I found the following exception logs.  This should fix this issue.

```
2019-07-30 09:09:53,090 ERROR 30041 [ecommerce.extensions.payment.views.cybersource] /edx/app/ecommerce/ecommerce/ecommerce/extensions/payment/views/cybersource.py:321 - Attempts to handle payment for basket [36482038] failed. The payment response [Duplicate detected: transaction may have already been processed.] was recorded in entry [2248241].
Traceback (most recent call last):
  File "/edx/app/ecommerce/ecommerce/ecommerce/extensions/payment/views/cybersource.py", line 259, in validate_notification
    self.handle_payment(notification, basket)
  File "/edx/app/ecommerce/ecommerce/ecommerce/extensions/checkout/mixins.py", line 68, in handle_payment
    handled_processor_response = self.payment_processor.handle_processor_response(response, basket=basket)
  File "/edx/app/ecommerce/ecommerce/ecommerce/extensions/payment/processors/cybersource.py", line 323, in handle_processor_response
    if response['auth_amount'] and response['auth_amount'] != response['req_amount']:
KeyError: u'auth_amount'
```