### PR TITLE
use the lms user id from the basket's owner instead of the requester,…

### DIFF
--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -223,7 +223,7 @@ class CybersourceNotificationMixin(CyberSourceProcessorMixin, OrderCreationMixin
                 lms_discount_client = EdxRestApiClient(discount_lms_url,
                                                        jwt=self.request.site.siteconfiguration.access_token)
                 ck = basket.lines.first().product.course_id
-                user_id = self.request.user.lms_user_id
+                user_id = basket.owner.lms_user_id
                 try:
                     response = lms_discount_client.user(user_id).course(ck).get()
                     self.request.POST = self.request.POST.copy()

--- a/ecommerce/extensions/payment/views/paypal.py
+++ b/ecommerce/extensions/payment/views/paypal.py
@@ -81,7 +81,7 @@ class PaypalPaymentExecutionView(EdxOrderPlacementMixin, View):
                 lms_discount_client = EdxRestApiClient(discount_lms_url,
                                                        jwt=self.request.site.siteconfiguration.access_token)
                 ck = basket.lines.first().product.course_id
-                user_id = self.request.user.lms_user_id
+                user_id = basket.owner.lms_user_id
                 try:
                     response = lms_discount_client.user(user_id).course(ck).get()
                     self.request.GET = self.request.GET.copy()


### PR DESCRIPTION
… because sometimes the requester is anonymous.

This pr should fix the e2e test that is currently failing with the dynamic discount flag turned on. The test is failing,  because for some reason, the request.user is anonymous. I'm not sure if that's just an issue with the test, or something else problematic.