### PR TITLE
Redirect to DSC if enterprise offer applied with 100% discount

### DIFF
--- a/ecommerce/enterprise/tests/mixins.py
+++ b/ecommerce/enterprise/tests/mixins.py
@@ -515,7 +515,7 @@ class EnterpriseServiceMockMixin(object):
             condition = EnterpriseCustomerConditionFactory(enterprise_customer_name=enterprise_customer_name)
         else:
             condition = EnterpriseCustomerConditionFactory()
-        EnterpriseOfferFactory(partner=self.partner, benefit=benefit, condition=condition)
+        enterprise_offer = EnterpriseOfferFactory(partner=self.partner, benefit=benefit, condition=condition)
         self.mock_enterprise_learner_api(
             learner_id=self.user.id,
             enterprise_customer_uuid=str(condition.enterprise_customer_uuid),
@@ -526,6 +526,7 @@ class EnterpriseServiceMockMixin(object):
             condition.enterprise_customer_uuid,
             enterprise_customer_catalog_uuid=condition.enterprise_customer_catalog_uuid,
         )
+        return enterprise_offer
 
     def mock_with_access_to(self,
                             enterprise_id,

--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -24,6 +24,7 @@ from six.moves.urllib.parse import urlencode
 from slumber.exceptions import SlumberHttpBaseException
 
 from ecommerce.core.constants import SYSTEM_ENTERPRISE_LEARNER_ROLE
+from ecommerce.core.url_utils import absolute_url, get_lms_dashboard_url
 from ecommerce.enterprise.api import fetch_enterprise_learner_data
 from ecommerce.enterprise.exceptions import EnterpriseDoesNotExist
 from ecommerce.extensions.offer.models import OFFER_PRIORITY_ENTERPRISE
@@ -239,6 +240,7 @@ def get_enterprise_customer_consent_failed_context_data(request, voucher):
         request.site,
         voucher
     )
+
     if not enterprise_customer:
         return {'error': _('There is no Enterprise Customer associated with SKU {sku}.').format(
             sku=consent_failed_sku
@@ -581,3 +583,45 @@ def get_enterprise_id_for_user(site, user):
         pass
 
     return None
+
+
+def get_enterprise_customer_from_enterprise_offer(basket):
+    """
+    Return enterprise customer uuid if the basket has an Enterprise-related offer applied.
+
+    Arguments:
+        basket (Basket): The basket object.
+
+    Returns:
+        boolean: uuid if the basket has an Enterprise-related offer applied, None otherwise.
+    """
+    for offer in basket.offer_discounts:
+        if offer['offer'].priority == OFFER_PRIORITY_ENTERPRISE:
+            return str(offer['offer'].condition.enterprise_customer_uuid)
+    return None
+
+
+def construct_enterprise_course_consent_url(request, course_id, enterprise_customer_uuid):
+    """
+    Construct the URL that should be used for redirecting the user to the Enterprise service for
+    collecting consent.
+    """
+    site = request.site
+    failure_url = '{base}?{params}'.format(
+        base=get_lms_dashboard_url(),
+        params=urlencode({
+            'enterprise_customer': enterprise_customer_uuid,
+            CONSENT_FAILED_PARAM: course_id
+        }),
+    )
+    request_params = {
+        'course_id': course_id,
+        'enterprise_customer_uuid': enterprise_customer_uuid,
+        'next': absolute_url(request, 'checkout:free-checkout'),
+        'failure_url': failure_url,
+    }
+    redirect_url = '{base}?{params}'.format(
+        base=site.siteconfiguration.enterprise_grant_data_sharing_url,
+        params=urlencode(request_params)
+    )
+    return redirect_url

--- a/ecommerce/extensions/basket/tests/test_views.py
+++ b/ecommerce/extensions/basket/tests/test_views.py
@@ -33,6 +33,7 @@ from ecommerce.core.url_utils import absolute_url, get_lms_url
 from ecommerce.coupons.tests.mixins import CouponMixin, DiscoveryMockMixin
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
+from ecommerce.enterprise.utils import construct_enterprise_course_consent_url
 from ecommerce.extensions.analytics.utils import translate_basket_line_for_segment
 from ecommerce.extensions.basket.constants import EMAIL_OPT_IN_ATTRIBUTE
 from ecommerce.extensions.basket.tests.mixins import BasketMixin
@@ -537,7 +538,14 @@ class PaymentApiViewTests(PaymentApiResponseTestMixin, BasketMixin, DiscoveryMoc
         """
         self.course_run.create_or_update_seat('verified', True, Decimal(10))
         self.create_basket_and_add_product(self.course_run.seat_products[0])
-        self.prepare_enterprise_offer()
+        enterprise_offer = self.prepare_enterprise_offer()
+
+        opts = {
+            'ec_uuid': str(enterprise_offer.condition.enterprise_customer_uuid),
+            'course_id': self.course_run.seat_products[0].course_id,
+            'username': self.user.username,
+        }
+        self.mock_consent_get(**opts)
 
         response = self.client.get(self.path)
         self.assertEqual(response.status_code, 200)
@@ -566,6 +574,51 @@ class PaymentApiViewTests(PaymentApiResponseTestMixin, BasketMixin, DiscoveryMoc
 
     def test_segment_exception_log(self):
         self.verify_exception_logged_on_segment_error()
+
+    @httpretty.activate
+    def test_enterprise_offer_free_basket_redirect_to_dsc(self):
+        """
+        Verify redirect to Data Sharing Consent page if basket is free
+        and an Enterprise-related offer is applied and Enterprise customer
+        required the consent.
+        """
+        self.course_run.create_or_update_seat('verified', True, Decimal(10))
+        self.create_basket_and_add_product(self.course_run.seat_products[0])
+        enterprise_offer = self.prepare_enterprise_offer()
+
+        opts = {
+            'ec_uuid': str(enterprise_offer.condition.enterprise_customer_uuid),
+            'course_id': self.course_run.seat_products[0].course_id,
+            'username': self.user.username,
+            'required': True
+        }
+        self.mock_consent_response(**opts)
+
+        response = self.client.get(self.path)
+        self.assertEqual(response.status_code, 200)
+
+        expected_redirect_url = construct_enterprise_course_consent_url(
+            self.request,
+            self.course_run.seat_products[0].course_id,
+            str(enterprise_offer.condition.enterprise_customer_uuid)
+        )
+        self.assertEqual(response.data['redirect'], expected_redirect_url)
+
+    def test_enterprise_offer_free_basket_with_wrong_basket(self):
+        """
+        Verify that we don't redirect to Data Sharing Consent page if basket is free
+        and an Enterprise-related offer is applied but basket contains more than 1 products.
+        """
+        seat1 = self.create_seat(self.course, seat_price=100, cert_type='verified')
+        seat2 = self.create_seat(self.course_run, seat_price=100, cert_type='verified')
+        basket = self.create_basket_and_add_product(seat1)
+        basket.add(seat2)
+        self.prepare_enterprise_offer()
+
+        response = self.client.get(self.path)
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(response.data['redirect'], absolute_url(self.request, 'checkout:free-checkout'))
 
 
 @httpretty.activate
@@ -980,7 +1033,14 @@ class BasketSummaryViewTests(EnterpriseServiceMockMixin, DiscoveryTestMixin, Dis
     def test_enterprise_free_basket_redirect(self):
         self.course_run.create_or_update_seat('verified', True, Decimal(100))
         self.create_basket_and_add_product(self.course_run.seat_products[0])
-        self.prepare_enterprise_offer(enterprise_customer_name='Foo Enterprise')
+        enterprise_offer = self.prepare_enterprise_offer(enterprise_customer_name='Foo Enterprise')
+
+        opts = {
+            'ec_uuid': str(enterprise_offer.condition.enterprise_customer_uuid),
+            'course_id': self.course_run.seat_products[0].course_id,
+            'username': self.user.username,
+        }
+        self.mock_consent_get(**opts)
 
         response = self.client.get(self.path)
         self.assertRedirects(


### PR DESCRIPTION
**Description:** During enrollment, if enterprise customer has enabled data sharing consent, the enterprise learner is not prompted for DSC if an enterprise offer with 100% discount applied to basket. This PR will redirect the learner to DSC page if enterprise customer required the consent.

**JIRA:** [ENT-2250](https://openedx.atlassian.net/browse/ENT-2250)

**Sandbox:** https://mammar.sandbox.edx.org/

**Testing:** This PR is deployed on sandbox.

**Test Data:** Below data exists on sandbox for testing
**verified course:** https://mammar.sandbox.edx.org/courses/course-v1:edX+JS101+2019_T1/about
**enterprise customer uuid:** cc8a0260-36d0-4520-8e1a-154d0431aa9c
**linked enterprise learners:** enterprise_learner_5XX@example.com to enterprise_learner_550@example.com

**NOTE:** **It would be great if reviewers/testers can pick different learner emails to avoid confusion**

**Testing Instructions:** One way to test the scenario could be like below
1. Login to LMS with any of the linked learners
2. Explorer the courses
3. Enroll into verified course
4. It takes the learner to payment MFE
5. Learner will be redirected to DSC page
6. If learner provides the consent then learner will be able to see the course content else it will be redirect to LMS dashboard and a consent declined notification will shown in the dashboard page.
7. If learner decline the consent and then go to course page, learner will again prompted for DSC.

