### PR TITLE
Send order date to LMS.

### DIFF
--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -21,7 +21,8 @@ from rest_framework import status
 
 from ecommerce.core.constants import (
     DONATIONS_FROM_CHECKOUT_TESTS_PRODUCT_TYPE_NAME,
-    ENROLLMENT_CODE_PRODUCT_CLASS_NAME
+    ENROLLMENT_CODE_PRODUCT_CLASS_NAME,
+    ISO_8601_FORMAT
 )
 from ecommerce.core.url_utils import get_lms_enrollment_api_url, get_lms_entitlement_api_url
 from ecommerce.courses.models import Course
@@ -304,6 +305,11 @@ class EnrollmentFulfillmentModule(BaseFulfillmentModule):
                         'namespace': 'order',
                         'name': 'order_number',
                         'value': order.number
+                    },
+                    {
+                        'namespace': 'order',
+                        'name': 'date_placed',
+                        'value': order.date_placed.strftime(ISO_8601_FORMAT)
                     }
                 ]
             }

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -19,6 +19,7 @@ from ecommerce.core.constants import (
     COURSE_ENTITLEMENT_PRODUCT_CLASS_NAME,
     DONATIONS_FROM_CHECKOUT_TESTS_PRODUCT_TYPE_NAME,
     ENROLLMENT_CODE_PRODUCT_CLASS_NAME,
+    ISO_8601_FORMAT,
     SEAT_PRODUCT_CLASS_NAME
 )
 from ecommerce.core.url_utils import get_lms_enrollment_api_url, get_lms_entitlement_api_url
@@ -177,6 +178,11 @@ class EnrollmentFulfillmentModuleTests(ProgramTestMixin, DiscoveryTestMixin, Ful
                     'namespace': 'order',
                     'name': 'order_number',
                     'value': self.order.number
+                },
+                {
+                    'namespace': 'order',
+                    'name': 'date_placed',
+                    'value': self.order.date_placed.strftime(ISO_8601_FORMAT)
                 }
             ]
         }
@@ -382,6 +388,11 @@ class EnrollmentFulfillmentModuleTests(ProgramTestMixin, DiscoveryTestMixin, Ful
                     'namespace': 'order',
                     'name': 'order_number',
                     'value': self.order.number
+                },
+                {
+                    'namespace': 'order',
+                    'name': 'date_placed',
+                    'value': self.order.date_placed.strftime(ISO_8601_FORMAT)
                 },
                 {
                     'namespace': 'credit',


### PR DESCRIPTION
Send order placement date to LMS while fulfilling the order so that we don't need to call ecommerce every time while checking for refund status.

PROD-454