### PR TITLE
ENT-2345 Add purchaser basket attribute to determine who is using bulk purchase

### DIFF
--- a/ecommerce/extensions/payment/forms.py
+++ b/ecommerce/extensions/payment/forms.py
@@ -116,6 +116,20 @@ class PaymentForm(forms.Form):
                         css_class='row'
                     )
                     self.helper.layout.fields.insert(list(self.fields.keys()).index('last_name') + 1, organization_div)
+                    # Purchased on behalf of an enterprise or for personal use
+                    self.fields['purchaser'] = forms.BooleanField(
+                        required=False,
+                        label=_('I am purchasing on behalf of my employer or other professional organization')
+                    )
+                    purchaser_div = Div(
+                        Div(
+                            Div('purchaser'),
+                            HTML('<p class="help-block"></p>'),
+                            css_class='form-item col-md-12'
+                        ),
+                        css_class='row'
+                    )
+                    self.helper.layout.fields.insert(list(self.fields.keys()).index('organization') + 1, purchaser_div)
 
     basket = forms.ModelChoiceField(
         queryset=Basket.objects.all(),

--- a/ecommerce/extensions/payment/tests/test_forms.py
+++ b/ecommerce/extensions/payment/tests/test_forms.py
@@ -159,7 +159,10 @@ class PaymentFormTests(TestCase):
         self.assertEqual(actual, expected)
 
     def test_organization_field_in_form(self):
-        """ Verify the field 'organization' is present in the form when the basket has an enrollment code product. """
+        """
+        Verify the field 'organization' and 'purchased_for_organization' is present in the form
+        when the basket has an enrollment code product.
+        """
         __, __, enrollment_code = self.prepare_course_seat_and_enrollment_code()
         basket = self.create_basket_and_add_product(enrollment_code)
         self.request.basket = basket
@@ -176,6 +179,7 @@ class PaymentFormTests(TestCase):
         }
         form = PaymentForm(user=self.user, data=data, request=self.request)
         self.assertTrue('organization' in form.fields)
+        self.assertTrue('purchaser' in form.fields)
 
     def test_organization_field_not_in_form(self):
         """
@@ -199,3 +203,4 @@ class PaymentFormTests(TestCase):
         }
         form = PaymentForm(user=self.user, data=data, request=self.request)
         self.assertFalse('organization' in form.fields)
+        self.assertFalse('purchaser' in form.fields)


### PR DESCRIPTION
This adds a checkbox to the basket when purchasing a course on behalf on and institution. This only appears on the bulk purchase cart.

<img width="692" alt="image" src="https://user-images.githubusercontent.com/16495365/65968482-3d085f00-e431-11e9-9d77-69c6bba89110.png">


This checkbox will only be shown in a bulk purchase cart. This relies on PR [#2614 ](https://github.com/edx/ecommerce/pull/2614)