### PR TITLE
Change tracking middleware to use two phases

### DIFF
--- a/ecommerce/extensions/analytics/tests/test_middleware.py
+++ b/ecommerce/extensions/analytics/tests/test_middleware.py
@@ -28,9 +28,16 @@ class TrackingMiddlewareTests(TestCase):
         request.user = user
         self.middleware.process_request(request)
 
+    def _process_response(self, user):
+        request = self.request_factory.get('/')
+        request.user = user
+
+        response = self.client.get('/')
+        self.middleware.process_response(request, response)
+
     def _assert_ga_client_id(self, ga_client_id):
         self.request_factory.cookies['_ga'] = 'GA1.2.{}'.format(ga_client_id)
-        self._process_request(self.user)
+        self._process_response(self.user)
         expected_client_id = self.user.tracking_context.get('ga_client_id')
         self.assertEqual(ga_client_id, expected_client_id)
 


### PR DESCRIPTION
This shifts the middleware's attempt to get the ga_client_id to the
process_response phase, while leaving the add_lms_user_id call in the
process_request phase.
Additionally adds temporary logging to try and identify whether this
fixes the issue and whether or not other eventing may be broken by this
change.

REV-977