### PR TITLE
ENT-2317 - Send Enterprise purchase info to HubSpot

### DIFF
--- a/ecommerce/enterprise/tests/mixins.py
+++ b/ecommerce/enterprise/tests/mixins.py
@@ -515,7 +515,7 @@ class EnterpriseServiceMockMixin(object):
             condition = EnterpriseCustomerConditionFactory(enterprise_customer_name=enterprise_customer_name)
         else:
             condition = EnterpriseCustomerConditionFactory()
-        EnterpriseOfferFactory(partner=self.partner, benefit=benefit, condition=condition)
+        enterprise_offer = EnterpriseOfferFactory(partner=self.partner, benefit=benefit, condition=condition)
         self.mock_enterprise_learner_api(
             learner_id=self.user.id,
             enterprise_customer_uuid=str(condition.enterprise_customer_uuid),
@@ -526,6 +526,7 @@ class EnterpriseServiceMockMixin(object):
             condition.enterprise_customer_uuid,
             enterprise_customer_catalog_uuid=condition.enterprise_customer_catalog_uuid,
         )
+        return enterprise_offer
 
     def mock_with_access_to(self,
                             enterprise_id,

--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -24,6 +24,7 @@ from six.moves.urllib.parse import urlencode
 from slumber.exceptions import SlumberHttpBaseException
 
 from ecommerce.core.constants import SYSTEM_ENTERPRISE_LEARNER_ROLE
+from ecommerce.core.url_utils import absolute_url, get_lms_dashboard_url
 from ecommerce.enterprise.api import fetch_enterprise_learner_data
 from ecommerce.enterprise.exceptions import EnterpriseDoesNotExist
 from ecommerce.extensions.offer.models import OFFER_PRIORITY_ENTERPRISE
@@ -239,6 +240,7 @@ def get_enterprise_customer_consent_failed_context_data(request, voucher):
         request.site,
         voucher
     )
+
     if not enterprise_customer:
         return {'error': _('There is no Enterprise Customer associated with SKU {sku}.').format(
             sku=consent_failed_sku
@@ -581,3 +583,45 @@ def get_enterprise_id_for_user(site, user):
         pass
 
     return None
+
+
+def get_enterprise_customer_from_enterprise_offer(basket):
+    """
+    Return enterprise customer uuid if the basket has an Enterprise-related offer applied.
+
+    Arguments:
+        basket (Basket): The basket object.
+
+    Returns:
+        boolean: uuid if the basket has an Enterprise-related offer applied, None otherwise.
+    """
+    for offer in basket.offer_discounts:
+        if offer['offer'].priority == OFFER_PRIORITY_ENTERPRISE:
+            return str(offer['offer'].condition.enterprise_customer_uuid)
+    return None
+
+
+def construct_enterprise_course_consent_url(request, course_id, enterprise_customer_uuid):
+    """
+    Construct the URL that should be used for redirecting the user to the Enterprise service for
+    collecting consent.
+    """
+    site = request.site
+    failure_url = '{base}?{params}'.format(
+        base=get_lms_dashboard_url(),
+        params=urlencode({
+            'enterprise_customer': enterprise_customer_uuid,
+            CONSENT_FAILED_PARAM: course_id
+        }),
+    )
+    request_params = {
+        'course_id': course_id,
+        'enterprise_customer_uuid': enterprise_customer_uuid,
+        'next': absolute_url(request, 'checkout:free-checkout'),
+        'failure_url': failure_url,
+    }
+    redirect_url = '{base}?{params}'.format(
+        base=site.siteconfiguration.enterprise_grant_data_sharing_url,
+        params=urlencode(request_params)
+    )
+    return redirect_url

--- a/ecommerce/extensions/analytics/middleware.py
+++ b/ecommerce/extensions/analytics/middleware.py
@@ -24,7 +24,7 @@ class TrackingMiddleware(MiddlewareMixin, object):
 
     """
 
-    def process_request(self, request):
+    def process_view(self, request, view_func, view_args, view_kwargs):  # pylint: disable=unused-argument
         user = request.user
         if user.is_authenticated():
             tracking_context = user.tracking_context or {}

--- a/ecommerce/extensions/analytics/tests/test_middleware.py
+++ b/ecommerce/extensions/analytics/tests/test_middleware.py
@@ -23,14 +23,14 @@ class TrackingMiddlewareTests(TestCase):
         self.request_factory = RequestFactory()
         self.user = self.create_user()
 
-    def _process_request(self, user):
+    def _process_view(self, user):
         request = self.request_factory.get('/')
         request.user = user
-        self.middleware.process_request(request)
+        self.middleware.process_view(request, None, None, None)
 
     def _assert_ga_client_id(self, ga_client_id):
         self.request_factory.cookies['_ga'] = 'GA1.2.{}'.format(ga_client_id)
-        self._process_request(self.user)
+        self._process_view(self.user)
         expected_client_id = self.user.tracking_context.get('ga_client_id')
         self.assertEqual(ga_client_id, expected_client_id)
 
@@ -55,7 +55,7 @@ class TrackingMiddlewareTests(TestCase):
         same_user = User.objects.get(id=user.id)
         self.assertIsNone(same_user.lms_user_id)
 
-        self._process_request(same_user)
+        self._process_view(same_user)
         same_user = User.objects.get(id=user.id)
         self.assertEqual(same_user.lms_user_id, lms_user_id)
 
@@ -87,7 +87,7 @@ class TrackingMiddlewareTests(TestCase):
         ]
         same_user = User.objects.get(id=user.id)
         with LogCapture(self.MODEL_LOGGER_NAME) as log:
-            self._process_request(same_user)
+            self._process_view(same_user)
             log.check_present(*expected)
 
         same_user = User.objects.get(id=user.id)
@@ -108,7 +108,7 @@ class TrackingMiddlewareTests(TestCase):
         same_user = User.objects.get(id=user.id)
         self.assertEqual(initial_lms_user_id, same_user.lms_user_id)
 
-        self._process_request(same_user)
+        self._process_view(same_user)
         same_user = User.objects.get(id=user.id)
         self.assertEqual(initial_lms_user_id, same_user.lms_user_id)
 
@@ -118,7 +118,7 @@ class TrackingMiddlewareTests(TestCase):
         same_user = User.objects.get(id=user.id)
 
         with self.assertRaises(MissingLmsUserIdException):
-            self._process_request(same_user)
+            self._process_view(same_user)
 
         same_user = User.objects.get(id=user.id)
         self.assertIsNone(same_user.lms_user_id)
@@ -139,7 +139,7 @@ class TrackingMiddlewareTests(TestCase):
 
         same_user = User.objects.get(id=user.id)
         with LogCapture(self.MODEL_LOGGER_NAME) as log:
-            self._process_request(same_user)
+            self._process_view(same_user)
             log.check_present(*expected)
 
         same_user = User.objects.get(id=user.id)
@@ -160,7 +160,7 @@ class TrackingMiddlewareTests(TestCase):
 
         same_user = User.objects.get(id=user.id)
         with LogCapture(self.MODEL_LOGGER_NAME) as log:
-            self._process_request(same_user)
+            self._process_view(same_user)
             log.check_present(*expected)
 
         same_user = User.objects.get(id=user.id)

--- a/ecommerce/extensions/basket/tests/test_utils.py
+++ b/ecommerce/extensions/basket/tests/test_utils.py
@@ -13,6 +13,7 @@ from django.db import transaction
 from django.utils.timezone import now
 from oscar.core.loading import get_model
 from oscar.test.factories import BasketFactory, ProductFactory, RangeFactory
+from waffle.testutils import override_flag
 
 from ecommerce.core.constants import ENROLLMENT_CODE_PRODUCT_CLASS_NAME
 from ecommerce.core.tests import toggle_switch
@@ -25,6 +26,7 @@ from ecommerce.extensions.basket.utils import (
     apply_voucher_on_basket_and_check_discount,
     attribute_cookie_data,
     get_basket_switch_data,
+    get_payment_microfrontend_url_if_configured,
     prepare_basket
 )
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
@@ -32,6 +34,7 @@ from ecommerce.extensions.order.constants import DISABLE_REPEAT_ORDER_CHECK_SWIT
 from ecommerce.extensions.order.exceptions import AlreadyPlacedOrderException
 from ecommerce.extensions.order.utils import UserAlreadyPlacedOrder
 from ecommerce.extensions.partner.models import StockRecord
+from ecommerce.extensions.payment.constants import DISABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME
 from ecommerce.extensions.test.factories import create_order, prepare_voucher
 from ecommerce.referrals.models import Referral
 from ecommerce.tests.testcases import TestCase, TransactionTestCase
@@ -645,6 +648,26 @@ class BasketUtilsTests(DiscoveryTestMixin, BasketMixin, TestCase):
         applied, msg = apply_voucher_on_basket_and_check_discount(invalid_voucher, self.request, basket)
         self.assertEqual(applied, False)
         self.assertEqual(msg, 'Basket does not qualify for coupon code {code}.'.format(code=invalid_voucher.code))
+
+    @ddt.data(
+        (True, '/payment', False, '/payment'),  # Microfrontend not disabled
+        (True, '/payment', True, None),  # Microfrontend disabled
+    )
+    @ddt.unpack
+    def test_disable_microfrontend_for_basket_page_flag(
+            self,
+            microfrontend_enabled,
+            payment_microfrontend_url,
+            disable_microfrontend_flag_active,
+            expected_result
+    ):
+        """
+        Verify that the `disable_microfrontend_for_basket_page_flag` correctly disables the microfrontend url retrieval
+        """
+        with override_flag(DISABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME, active=disable_microfrontend_flag_active):
+            self.site_configuration.enable_microfrontend_for_basket_page = microfrontend_enabled
+            self.site_configuration.payment_microfrontend_url = payment_microfrontend_url
+            self.assertEqual(get_payment_microfrontend_url_if_configured(self.request), expected_result)
 
 
 class BasketUtilsTransactionTests(TransactionTestCase):

--- a/ecommerce/extensions/basket/tests/test_views.py
+++ b/ecommerce/extensions/basket/tests/test_views.py
@@ -41,11 +41,7 @@ from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
 from ecommerce.extensions.offer.constants import DYNAMIC_DISCOUNT_FLAG
 from ecommerce.extensions.offer.utils import format_benefit_value
 from ecommerce.extensions.order.utils import UserAlreadyPlacedOrder
-from ecommerce.extensions.payment.constants import (
-    CLIENT_SIDE_CHECKOUT_FLAG_NAME,
-    ENABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME,
-    FORCE_MICROFRONTEND_BUCKET_FLAG_NAME
-)
+from ecommerce.extensions.payment.constants import CLIENT_SIDE_CHECKOUT_FLAG_NAME
 from ecommerce.extensions.payment.forms import PaymentForm
 from ecommerce.extensions.payment.tests.processors import DummyProcessor
 from ecommerce.extensions.test.factories import create_order, prepare_voucher
@@ -137,8 +133,6 @@ class BasketAddItemsViewTests(
 
     @ddt.data(*itertools.product((True, False), (True, False)))
     @ddt.unpack
-    @override_flag(ENABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME, active=True)
-    @override_flag(FORCE_MICROFRONTEND_BUCKET_FLAG_NAME, active=True)
     def test_microfrontend_for_single_course_purchase_if_configured(self, enable_redirect, set_url):
         microfrontend_url = self.configure_redirect_to_microfrontend(enable_redirect, set_url)
         response = self._get_response(self.stock_record.partner_sku, utm_source='test')
@@ -148,8 +142,6 @@ class BasketAddItemsViewTests(
         expected_url += '?utm_source=test'
         self.assertRedirects(response, expected_url, status_code=303, fetch_redirect_response=False)
 
-    @override_flag(ENABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME, active=True)
-    @override_flag(FORCE_MICROFRONTEND_BUCKET_FLAG_NAME, active=True)
     def test_microfrontend_for_enrollment_code_seat(self):
         microfrontend_url = self.configure_redirect_to_microfrontend()
 
@@ -636,8 +628,6 @@ class BasketSummaryViewTests(EnterpriseServiceMockMixin, DiscoveryTestMixin, Dis
         line_data = response.context['formset_lines_data'][0][1]
         self.assertEqual(line_data['seat_type'], enrollment_code.attr.seat_type.capitalize())
 
-    @override_flag(ENABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME, active=True)
-    @override_flag(FORCE_MICROFRONTEND_BUCKET_FLAG_NAME, active=True)
     def test_microfrontend_for_single_course_purchase(self):
         microfrontend_url = self.configure_redirect_to_microfrontend()
 
@@ -646,8 +636,6 @@ class BasketSummaryViewTests(EnterpriseServiceMockMixin, DiscoveryTestMixin, Dis
         response = self.client.get(self.path)
         self.assertRedirects(response, microfrontend_url, status_code=302, fetch_redirect_response=False)
 
-    @override_flag(ENABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME, active=True)
-    @override_flag(FORCE_MICROFRONTEND_BUCKET_FLAG_NAME, active=True)
     def test_microfrontend_with_consent_failed_param(self):
         microfrontend_url = self.configure_redirect_to_microfrontend()
 
@@ -657,8 +645,6 @@ class BasketSummaryViewTests(EnterpriseServiceMockMixin, DiscoveryTestMixin, Dis
         expected_redirect_url = '{}?{}'.format(microfrontend_url, params)
         self.assertRedirects(response, expected_redirect_url, status_code=302, fetch_redirect_response=False)
 
-    @override_flag(ENABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME, active=True)
-    @override_flag(FORCE_MICROFRONTEND_BUCKET_FLAG_NAME, active=True)
     def test_microfrontend_for_enrollment_code_seat_type(self):
         microfrontend_url = self.configure_redirect_to_microfrontend()
 

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -358,7 +358,8 @@ def basket_add_organization_attribute(basket, request_data):
             attribute_type=organization_attribute,
             value_text=business_client.strip()
         )
-    if purchaser:
+        # Also add the 'purchaser' attribute to the carts of all business client purchases. This way we can track
+        # how many people read/paid attention to the checkbox during purchases.
         purchaser_attribute, __ = BasketAttributeType.objects.get_or_create(name=PURCHASER_BEHALF_ATTRIBUTE)
         BasketAttribute.objects.get_or_create(
             basket=basket,

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -318,7 +318,8 @@ def basket_add_organization_attribute(basket, request_data):
             attribute_type=organization_attribute,
             value_text=business_client.strip()
         )
-    if purchaser:
+        # Also add the 'purchaser' attribute to the carts of all business client purchases. This way we can track
+        # how many people read/paid attention to the checkbox during purchases.
         purchaser_attribute, __ = BasketAttributeType.objects.get_or_create(name=PURCHASER_BEHALF_ATTRIBUTE)
         BasketAttribute.objects.get_or_create(
             basket=basket,

--- a/ecommerce/extensions/checkout/tests/test_mixins.py
+++ b/ecommerce/extensions/checkout/tests/test_mixins.py
@@ -21,7 +21,7 @@ from ecommerce.extensions.analytics.utils import (
     parse_tracking_context,
     translate_basket_line_for_segment
 )
-from ecommerce.extensions.basket.constants import EMAIL_OPT_IN_ATTRIBUTE
+from ecommerce.extensions.basket.constants import EMAIL_OPT_IN_ATTRIBUTE, PURCHASER_BEHALF_ATTRIBUTE
 from ecommerce.extensions.basket.utils import basket_add_organization_attribute
 from ecommerce.extensions.checkout.exceptions import BasketNotFreeError
 from ecommerce.extensions.checkout.mixins import OFFER_ASSIGNED, OFFER_REDEEMED, EdxOrderPlacementMixin
@@ -195,8 +195,11 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin,
         basket = BasketFactory(owner=user, site=self.site)
         basket.add_product(enrollment_code, quantity=1)
         order = create_order(number=1, basket=basket, user=user)
-        request_data = {'organization': 'Dummy Business Client'}
-        # Manually add organization attribute on the basket for testing
+        request_data = {
+            'organization': 'Dummy Business Client',
+            PURCHASER_BEHALF_ATTRIBUTE: 'False',
+        }
+        # Manually add organization and purchaser attributes on the basket for testing
         basket_add_organization_attribute(basket, request_data)
 
         EdxOrderPlacementMixin().handle_post_order(order)
@@ -219,8 +222,11 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin,
         basket = BasketFactory(owner=user, site=self.site)
         basket.add_product(verified_product, quantity=1)
         order = create_order(number=1, basket=basket, user=user)
-        request_data = {'organization': 'Dummy Business Client'}
-        # Manually add organization attribute on the basket for testing
+        request_data = {
+            'organization': 'Dummy Business Client',
+            PURCHASER_BEHALF_ATTRIBUTE: 'False',
+        }
+        # Manually add organization and purchaser attributes on the basket for testing
         basket_add_organization_attribute(basket, request_data)
 
         EdxOrderPlacementMixin().handle_post_order(order)

--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -599,7 +599,7 @@ class EnrollmentCodeFulfillmentModule(BaseFulfillmentModule):
             logger.debug("Sending request to endpoint '%s' with data '%s' and headers '%s'", endpoint, data, headers)
             response = requests.post(url=endpoint, data=data, headers=headers)
             logger.info("Result: %d", response.status_code)
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             logger.exception("Error occurred attempting to submit order fulfillment data to HubSpot")
 
     def get_fulfillment_data(self, order):
@@ -629,7 +629,7 @@ class EnrollmentCodeFulfillmentModule(BaseFulfillmentModule):
                 basket=order.basket,
                 attribute_type=BasketAttributeType.objects.get(name="organization"))
         except BasketAttribute.DoesNotExist:
-            logger.error("Error occurred attempting to retrieve organization from from current basket")
+            logger.exception("Error occurred attempting to retrieve organization from from current basket")
 
         # need to build out the address accordingly
         street_address = order.billing_address.line1

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -634,8 +634,30 @@ class EnrollmentCodeFulfillmentModuleTests(DiscoveryTestMixin, TestCase):
                                 "state=State&" \
                                 "{}"\
             .format(course_name_data, course_id_data, customer_email_data)
-        generated_request_body = EnrollmentCodeFulfillmentModule().get_fulfillment_data(order)
+        generated_request_body = EnrollmentCodeFulfillmentModule().get_order_fulfillment_data_for_hubspot(order)
         self.assertEqual(expected_request_body, generated_request_body)
+
+    def test_determine_if_enterprise_purchase_expect_true(self):
+        # add organization and purchaser attributes manually to the basket for testing purposes
+        basket_data = {
+            'organization': 'Dummy Business Client',
+            PURCHASER_BEHALF_ATTRIBUTE: 'True'
+        }
+        basket_add_organization_attribute(self.order.basket, basket_data)
+
+        purchased_by_organization = EnrollmentCodeFulfillmentModule().determine_if_enterprise_purchase(self.order)
+        self.assertEqual(True, purchased_by_organization)
+
+    def test_determine_if_enterprise_purchase_expect_false(self):
+        # add organization and purchaser attributes manually to the basket for testing purposes
+        basket_data = {
+            'organization': 'Dummy Business Client',
+            PURCHASER_BEHALF_ATTRIBUTE: 'False'
+        }
+        basket_add_organization_attribute(self.order.basket, basket_data)
+
+        purchased_by_organization = EnrollmentCodeFulfillmentModule().determine_if_enterprise_purchase(self.order)
+        self.assertEqual(False, purchased_by_organization)
 
 
 class EntitlementFulfillmentModuleTests(FulfillmentTestMixin, TestCase):

--- a/ecommerce/extensions/payment/constants.py
+++ b/ecommerce/extensions/payment/constants.py
@@ -38,34 +38,17 @@ CYBERSOURCE_CARD_TYPE_MAP = {
 
 CLIENT_SIDE_CHECKOUT_FLAG_NAME = 'enable_client_side_checkout'
 
-# .. toggle_name: enable_microfrontend_for_basket_page
+# .. toggle_name: disable_microfrontend_for_basket_page
 # .. toggle_type: waffle_flag
 # .. toggle_default: False
-# .. toggle_description: Supports staged rollout of a new micro-frontend-based implementation of the basket page.
+# .. toggle_description: Allows viewing the old basket page even when using a new micro-frontend based basket page
 # .. toggle_category: micro-frontend
-# .. toggle_use_cases: incremental_release, open_edx
-# .. toggle_creation_date: 2019-06-25
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2019-10-03
 # .. toggle_expiration_date: 2020-12-31
-# .. toggle_warnings: Also set SiteConfiguration for enable_microfrontend_for_basket_page and payment_microfrontend_url.
 # .. toggle_tickets: DEPR-42
 # .. toggle_status: supported
-ENABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME = 'enable_microfrontend_for_basket_page'
-
-# .. toggle_name: force_microfrontend_for_basket_page
-# .. toggle_type: waffle_flag
-# .. toggle_default: False
-# .. toggle_description: Supports manual testing of a new micro-frontend-based implementation of the basket page.
-# .. toggle_category: micro-frontend
-# .. toggle_use_cases: testing, open_edx
-# .. toggle_creation_date: 2019-07-29
-# .. toggle_expiration_date: 2019-12-31
-# .. toggle_warnings: See enable_microfrontend_for_basket_page
-# .. toggle_tickets: DEPR-42
-# .. toggle_status: supported
-FORCE_MICROFRONTEND_BUCKET_FLAG_NAME = 'force_microfrontend_bucket'
-
-# Bucket id for users being bucketed into the Payment MFE
-PAYMENT_MFE_BUCKET = 1
+DISABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME = 'disable_microfrontend_for_basket_page'
 
 # Paypal only supports 4 languages, which are prioritized by country.
 # https://developer.paypal.com/docs/classic/api/locale_codes/

--- a/ecommerce/extensions/payment/forms.py
+++ b/ecommerce/extensions/payment/forms.py
@@ -11,6 +11,8 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 from oscar.core.loading import get_class, get_model
 
+from ecommerce.extensions.basket.constants import PURCHASER_BEHALF_ATTRIBUTE
+
 logger = logging.getLogger(__name__)
 
 Applicator = get_class('offer.applicator', 'Applicator')
@@ -117,13 +119,13 @@ class PaymentForm(forms.Form):
                     )
                     self.helper.layout.fields.insert(list(self.fields.keys()).index('last_name') + 1, organization_div)
                     # Purchased on behalf of an enterprise or for personal use
-                    self.fields['purchaser'] = forms.BooleanField(
+                    self.fields[PURCHASER_BEHALF_ATTRIBUTE] = forms.BooleanField(
                         required=False,
                         label=_('I am purchasing on behalf of my employer or other professional organization')
                     )
                     purchaser_div = Div(
                         Div(
-                            Div('purchaser'),
+                            Div(PURCHASER_BEHALF_ATTRIBUTE),
                             HTML('<p class="help-block"></p>'),
                             css_class='form-item col-md-12'
                         ),

--- a/ecommerce/extensions/payment/migrations/0020_auto_20191004_1520.py
+++ b/ecommerce/extensions/payment/migrations/0020_auto_20191004_1520.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def create_flag(apps, schema_editor):
+    """
+    Create the disable_microfrontend_for_basket_page flag if it does not already exist.
+
+    Set `everyone` to None so that it's Unknown in the admin
+    """
+    Flag = apps.get_model('waffle', 'Flag')
+    Flag.objects.get_or_create(
+        name='disable_microfrontend_for_basket_page',
+        defaults={'everyone': None, 'superusers': False}
+    )
+
+
+def delete_flag(apps, schema_editor):
+    """Delete the disable_microfrontend_for_basket_page flag."""
+    Flag = apps.get_model('waffle', 'Flag')
+    Flag.objects.filter(name='disable_microfrontend_for_basket_page').delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('payment', '0019_auto_20180628_2011'),
+        ('waffle', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_flag, reverse_code=delete_flag),
+    ]

--- a/ecommerce/extensions/payment/tests/test_forms.py
+++ b/ecommerce/extensions/payment/tests/test_forms.py
@@ -10,6 +10,7 @@ from waffle.models import Switch
 from ecommerce.core.constants import ENROLLMENT_CODE_PRODUCT_CLASS_NAME, ENROLLMENT_CODE_SWITCH
 from ecommerce.core.tests import toggle_switch
 from ecommerce.courses.tests.factories import CourseFactory
+from ecommerce.extensions.basket.constants import PURCHASER_BEHALF_ATTRIBUTE
 from ecommerce.extensions.payment.forms import PaymentForm
 from ecommerce.extensions.test.factories import create_basket
 from ecommerce.tests.testcases import TestCase
@@ -179,7 +180,7 @@ class PaymentFormTests(TestCase):
         }
         form = PaymentForm(user=self.user, data=data, request=self.request)
         self.assertTrue('organization' in form.fields)
-        self.assertTrue('purchaser' in form.fields)
+        self.assertTrue(PURCHASER_BEHALF_ATTRIBUTE in form.fields)
 
     def test_organization_field_not_in_form(self):
         """
@@ -203,4 +204,4 @@ class PaymentFormTests(TestCase):
         }
         form = PaymentForm(user=self.user, data=data, request=self.request)
         self.assertFalse('organization' in form.fields)
-        self.assertFalse('purchaser' in form.fields)
+        self.assertFalse(PURCHASER_BEHALF_ATTRIBUTE in form.fields)

--- a/ecommerce/extensions/payment/tests/views/test_cybersource.py
+++ b/ecommerce/extensions/payment/tests/views/test_cybersource.py
@@ -23,6 +23,7 @@ from ecommerce.core.tests import toggle_switch
 from ecommerce.core.url_utils import get_lms_url
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.api.serializers import OrderSerializer
+from ecommerce.extensions.basket.constants import PURCHASER_BEHALF_ATTRIBUTE
 from ecommerce.extensions.basket.utils import basket_add_organization_attribute
 from ecommerce.extensions.order.constants import PaymentEventTypeName
 from ecommerce.extensions.payment.constants import ENABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME
@@ -311,7 +312,8 @@ class CybersourceInterstitialViewTests(CybersourceNotificationTestsMixin, TestCa
             billing_address=self.billing_address,
         )
         request_data.update({'organization': 'Dummy Business Client'})
-        # Manually add organization attribute on the basket for testing
+        request_data.update({PURCHASER_BEHALF_ATTRIBUTE: "False"})
+        # Manually add organization and purchaser attributes on the basket for testing
         basket_add_organization_attribute(self.basket, request_data)
 
         response = self.client.post(self.path, request_data)

--- a/ecommerce/extensions/payment/tests/views/test_cybersource.py
+++ b/ecommerce/extensions/payment/tests/views/test_cybersource.py
@@ -15,7 +15,6 @@ from oscar.apps.payment.exceptions import TransactionDeclined
 from oscar.core.loading import get_class, get_model
 from oscar.test import factories
 from testfixtures import LogCapture
-from waffle.testutils import override_flag
 
 from ecommerce.core.constants import ENROLLMENT_CODE_PRODUCT_CLASS_NAME, ENROLLMENT_CODE_SWITCH
 from ecommerce.core.models import BusinessClient
@@ -25,7 +24,6 @@ from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.api.serializers import OrderSerializer
 from ecommerce.extensions.basket.utils import basket_add_organization_attribute
 from ecommerce.extensions.order.constants import PaymentEventTypeName
-from ecommerce.extensions.payment.constants import ENABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME
 from ecommerce.extensions.payment.exceptions import InvalidBasketError, InvalidSignatureError
 from ecommerce.extensions.payment.processors.cybersource import Cybersource
 from ecommerce.extensions.payment.tests.mixins import CybersourceMixin, CybersourceNotificationTestsMixin
@@ -402,7 +400,6 @@ class ApplePayStartSessionViewTests(LoginMixin, TestCase):
         """ The view should POST to the given URL and return the response. """
         self._call_to_apple_pay_and_assert_response(status, body)
 
-    @override_flag(ENABLE_MICROFRONTEND_FOR_BASKET_PAGE_FLAG_NAME, active=True)
     @responses.activate
     @ddt.data(*itertools.product((True, False), (True, False)))
     @ddt.unpack

--- a/ecommerce/extensions/payment/tests/views/test_cybersource.py
+++ b/ecommerce/extensions/payment/tests/views/test_cybersource.py
@@ -22,6 +22,7 @@ from ecommerce.core.tests import toggle_switch
 from ecommerce.core.url_utils import get_lms_url
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.api.serializers import OrderSerializer
+from ecommerce.extensions.basket.constants import PURCHASER_BEHALF_ATTRIBUTE
 from ecommerce.extensions.basket.utils import basket_add_organization_attribute
 from ecommerce.extensions.order.constants import PaymentEventTypeName
 from ecommerce.extensions.payment.exceptions import InvalidBasketError, InvalidSignatureError
@@ -309,7 +310,8 @@ class CybersourceInterstitialViewTests(CybersourceNotificationTestsMixin, TestCa
             billing_address=self.billing_address,
         )
         request_data.update({'organization': 'Dummy Business Client'})
-        # Manually add organization attribute on the basket for testing
+        request_data.update({PURCHASER_BEHALF_ATTRIBUTE: "False"})
+        # Manually add organization and purchaser attributes on the basket for testing
         basket_add_organization_attribute(self.basket, request_data)
 
         response = self.client.post(self.path, request_data)

--- a/ecommerce/extensions/payment/tests/views/test_paypal.py
+++ b/ecommerce/extensions/payment/tests/views/test_paypal.py
@@ -25,6 +25,7 @@ from ecommerce.core.constants import (
 from ecommerce.core.models import BusinessClient, SiteConfiguration
 from ecommerce.core.tests import toggle_switch
 from ecommerce.courses.tests.factories import CourseFactory
+from ecommerce.extensions.basket.constants import PURCHASER_BEHALF_ATTRIBUTE
 from ecommerce.extensions.basket.utils import basket_add_organization_attribute
 from ecommerce.extensions.checkout.utils import get_receipt_page_url
 from ecommerce.extensions.offer.constants import DYNAMIC_DISCOUNT_FLAG
@@ -168,6 +169,7 @@ class PaypalPaymentExecutionViewTests(PaypalMixin, PaymentEventsMixin, TestCase)
 
         # Manually add organization attribute on the basket for testing
         self.RETURN_DATA.update({'organization': 'Dummy Business Client'})
+        self.RETURN_DATA.update({PURCHASER_BEHALF_ATTRIBUTE: 'False'})
         basket_add_organization_attribute(self.basket, self.RETURN_DATA)
 
         response = self.client.get(reverse('paypal:execute'), self.RETURN_DATA)

--- a/ecommerce/extensions/payment/tests/views/test_stripe.py
+++ b/ecommerce/extensions/payment/tests/views/test_stripe.py
@@ -11,6 +11,7 @@ from ecommerce.core.constants import ENROLLMENT_CODE_PRODUCT_CLASS_NAME, ENROLLM
 from ecommerce.core.models import BusinessClient
 from ecommerce.core.tests import toggle_switch
 from ecommerce.courses.tests.factories import CourseFactory
+from ecommerce.extensions.basket.constants import PURCHASER_BEHALF_ATTRIBUTE
 from ecommerce.extensions.basket.utils import basket_add_organization_attribute
 from ecommerce.extensions.checkout.utils import get_receipt_page_url
 from ecommerce.extensions.order.constants import PaymentEventTypeName
@@ -162,6 +163,7 @@ class StripeSubmitViewTests(PaymentEventsMixin, TestCase):
 
         data = self.generate_form_data(basket.id)
         data.update({'organization': 'Dummy Business Client'})
+        data.update({PURCHASER_BEHALF_ATTRIBUTE: 'False'})
 
         # Manually add organization attribute on the basket for testing
         basket_add_organization_attribute(basket, data)

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -801,5 +801,11 @@ BACKEND_SERVICE_EDX_OAUTH2_SECRET = "ecommerce-backend-service-secret"
 BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL = "http://127.0.0.1:8000/oauth2"
 EXTRA_APPS = []
 API_ROOT = None
+
 # Needed to link to the payment micro-frontend
 PAYMENT_MICROFRONTEND_URL = None
+
+# For Enterprise purchases to send purchase information to HubSpot for marketing leads
+HUBSPOT_FORMS_API_URI = "SET-ME-PLEASE"
+HUBSPOT_PORTAL_ID = "SET-ME-PLEASE"
+HUBSPOT_SALES_LEAD_FORM_GUID = "SET-ME-PLEASE"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -54,7 +54,7 @@ edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==2.0.0
-edx-drf-extensions==2.4.0
+edx-drf-extensions==2.4.1
 edx-ecommerce-worker==0.7.2
 edx-opaque-keys==1.0.1
 edx-rbac==1.0.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -68,7 +68,7 @@ edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==2.0.0
-edx-drf-extensions==2.4.0
+edx-drf-extensions==2.4.1
 edx-ecommerce-worker==0.7.2
 edx-i18n-tools==0.4.8
 edx-opaque-keys==1.0.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -56,7 +56,7 @@ edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==2.0.0
-edx-drf-extensions==2.4.0
+edx-drf-extensions==2.4.1
 edx-ecommerce-worker==0.7.2
 edx-opaque-keys==1.0.1
 edx-rbac==1.0.3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -65,7 +65,7 @@ edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==2.0.0
-edx-drf-extensions==2.4.0
+edx-drf-extensions==2.4.1
 edx-ecommerce-worker==0.7.2
 edx-opaque-keys==1.0.1
 edx-rbac==1.0.3


### PR DESCRIPTION
[ENT-2317]
- Send Enterprise order details to HubSpot so the data can analyzed and processed.
- Update - Add the "purchased_for_organization" attribute to all (Enterprise purchase) baskets for tracking statistics around new checkbox
- Pull in TJ's branch with fix for new basket attribute
- Add new configuration parameters for HubSpot integration work