### PR TITLE
ARCH-1197: fix TrackingMiddleware bug

### DIFF
--- a/ecommerce/extensions/analytics/middleware.py
+++ b/ecommerce/extensions/analytics/middleware.py
@@ -24,7 +24,7 @@ class TrackingMiddleware(MiddlewareMixin, object):
 
     """
 
-    def process_request(self, request):
+    def process_view(self, request, view_func, view_args, view_kwargs):  # pylint: disable=unused-argument
         user = request.user
         if user.is_authenticated():
             tracking_context = user.tracking_context or {}

--- a/ecommerce/extensions/analytics/tests/test_middleware.py
+++ b/ecommerce/extensions/analytics/tests/test_middleware.py
@@ -23,14 +23,14 @@ class TrackingMiddlewareTests(TestCase):
         self.request_factory = RequestFactory()
         self.user = self.create_user()
 
-    def _process_request(self, user):
+    def _process_view(self, user):
         request = self.request_factory.get('/')
         request.user = user
-        self.middleware.process_request(request)
+        self.middleware.process_view(request, None, None, None)
 
     def _assert_ga_client_id(self, ga_client_id):
         self.request_factory.cookies['_ga'] = 'GA1.2.{}'.format(ga_client_id)
-        self._process_request(self.user)
+        self._process_view(self.user)
         expected_client_id = self.user.tracking_context.get('ga_client_id')
         self.assertEqual(ga_client_id, expected_client_id)
 
@@ -55,7 +55,7 @@ class TrackingMiddlewareTests(TestCase):
         same_user = User.objects.get(id=user.id)
         self.assertIsNone(same_user.lms_user_id)
 
-        self._process_request(same_user)
+        self._process_view(same_user)
         same_user = User.objects.get(id=user.id)
         self.assertEqual(same_user.lms_user_id, lms_user_id)
 
@@ -87,7 +87,7 @@ class TrackingMiddlewareTests(TestCase):
         ]
         same_user = User.objects.get(id=user.id)
         with LogCapture(self.MODEL_LOGGER_NAME) as log:
-            self._process_request(same_user)
+            self._process_view(same_user)
             log.check_present(*expected)
 
         same_user = User.objects.get(id=user.id)
@@ -108,7 +108,7 @@ class TrackingMiddlewareTests(TestCase):
         same_user = User.objects.get(id=user.id)
         self.assertEqual(initial_lms_user_id, same_user.lms_user_id)
 
-        self._process_request(same_user)
+        self._process_view(same_user)
         same_user = User.objects.get(id=user.id)
         self.assertEqual(initial_lms_user_id, same_user.lms_user_id)
 
@@ -118,7 +118,7 @@ class TrackingMiddlewareTests(TestCase):
         same_user = User.objects.get(id=user.id)
 
         with self.assertRaises(MissingLmsUserIdException):
-            self._process_request(same_user)
+            self._process_view(same_user)
 
         same_user = User.objects.get(id=user.id)
         self.assertIsNone(same_user.lms_user_id)
@@ -139,7 +139,7 @@ class TrackingMiddlewareTests(TestCase):
 
         same_user = User.objects.get(id=user.id)
         with LogCapture(self.MODEL_LOGGER_NAME) as log:
-            self._process_request(same_user)
+            self._process_view(same_user)
             log.check_present(*expected)
 
         same_user = User.objects.get(id=user.id)
@@ -160,7 +160,7 @@ class TrackingMiddlewareTests(TestCase):
 
         same_user = User.objects.get(id=user.id)
         with LogCapture(self.MODEL_LOGGER_NAME) as log:
-            self._process_request(same_user)
+            self._process_view(same_user)
             log.check_present(*expected)
 
         same_user = User.objects.get(id=user.id)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -54,7 +54,7 @@ edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==2.0.0
-edx-drf-extensions==2.4.0
+edx-drf-extensions==2.4.1
 edx-ecommerce-worker==0.7.2
 edx-opaque-keys==1.0.1
 edx-rbac==1.0.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -68,7 +68,7 @@ edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==2.0.0
-edx-drf-extensions==2.4.0
+edx-drf-extensions==2.4.1
 edx-ecommerce-worker==0.7.2
 edx-i18n-tools==0.4.8
 edx-opaque-keys==1.0.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -56,7 +56,7 @@ edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==2.0.0
-edx-drf-extensions==2.4.0
+edx-drf-extensions==2.4.1
 edx-ecommerce-worker==0.7.2
 edx-opaque-keys==1.0.1
 edx-rbac==1.0.3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -65,7 +65,7 @@ edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==2.0.0
-edx-drf-extensions==2.4.0
+edx-drf-extensions==2.4.1
 edx-ecommerce-worker==0.7.2
 edx-opaque-keys==1.0.1
 edx-rbac==1.0.3


### PR DESCRIPTION
The fix had two parts:
1. fix edx-drf-extensions to update the request.user for jwt
authentication.
2. Update the middleware to use process_view, which is where
request.user is made available.

ARCH-1197