### PR TITLE
Send Enterprise purchase data to HubSpot for tracking and analysis

### DIFF
--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -318,7 +318,8 @@ def basket_add_organization_attribute(basket, request_data):
             attribute_type=organization_attribute,
             value_text=business_client.strip()
         )
-    if purchaser:
+        # Also add the 'purchaser' attribute to the carts of all business client purchases. This way we can track
+        # how many people read/paid attention to the checkbox during purchases.
         purchaser_attribute, __ = BasketAttributeType.objects.get_or_create(name=PURCHASER_BEHALF_ATTRIBUTE)
         BasketAttribute.objects.get_or_create(
             basket=basket,

--- a/ecommerce/extensions/checkout/tests/test_mixins.py
+++ b/ecommerce/extensions/checkout/tests/test_mixins.py
@@ -21,7 +21,7 @@ from ecommerce.extensions.analytics.utils import (
     parse_tracking_context,
     translate_basket_line_for_segment
 )
-from ecommerce.extensions.basket.constants import EMAIL_OPT_IN_ATTRIBUTE
+from ecommerce.extensions.basket.constants import EMAIL_OPT_IN_ATTRIBUTE, PURCHASER_BEHALF_ATTRIBUTE
 from ecommerce.extensions.basket.utils import basket_add_organization_attribute
 from ecommerce.extensions.checkout.exceptions import BasketNotFreeError
 from ecommerce.extensions.checkout.mixins import OFFER_ASSIGNED, OFFER_REDEEMED, EdxOrderPlacementMixin
@@ -195,8 +195,11 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin,
         basket = BasketFactory(owner=user, site=self.site)
         basket.add_product(enrollment_code, quantity=1)
         order = create_order(number=1, basket=basket, user=user)
-        request_data = {'organization': 'Dummy Business Client'}
-        # Manually add organization attribute on the basket for testing
+        request_data = {
+            'organization': 'Dummy Business Client',
+            PURCHASER_BEHALF_ATTRIBUTE: 'False',
+        }
+        # Manually add organization and purchaser attributes on the basket for testing
         basket_add_organization_attribute(basket, request_data)
 
         EdxOrderPlacementMixin().handle_post_order(order)
@@ -219,8 +222,11 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin,
         basket = BasketFactory(owner=user, site=self.site)
         basket.add_product(verified_product, quantity=1)
         order = create_order(number=1, basket=basket, user=user)
-        request_data = {'organization': 'Dummy Business Client'}
-        # Manually add organization attribute on the basket for testing
+        request_data = {
+            'organization': 'Dummy Business Client',
+            PURCHASER_BEHALF_ATTRIBUTE: 'False',
+        }
+        # Manually add organization and purchaser attributes on the basket for testing
         basket_add_organization_attribute(basket, request_data)
 
         EdxOrderPlacementMixin().handle_post_order(order)

--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -9,6 +9,7 @@ import abc
 import datetime
 import json
 import logging
+import urllib
 
 import requests
 import six
@@ -27,18 +28,22 @@ from ecommerce.core.constants import (
 from ecommerce.core.url_utils import get_lms_enrollment_api_url, get_lms_entitlement_api_url
 from ecommerce.courses.models import Course
 from ecommerce.courses.utils import mode_for_product
+from ecommerce.enterprise.conditions import BasketAttributeType
 from ecommerce.enterprise.utils import (
     get_enterprise_customer_uuid_from_voucher,
     get_or_create_enterprise_customer_user
 )
 from ecommerce.extensions.analytics.utils import audit_log, parse_tracking_context
 from ecommerce.extensions.api.v2.views.coupons import CouponViewSet
+from ecommerce.extensions.basket.constants import PURCHASER_BEHALF_ATTRIBUTE
+from ecommerce.extensions.basket.models import BasketAttribute
 from ecommerce.extensions.checkout.utils import get_receipt_page_url
 from ecommerce.extensions.fulfillment.status import LINE
 from ecommerce.extensions.voucher.models import OrderLineVouchers
 from ecommerce.extensions.voucher.utils import create_vouchers
 from ecommerce.notifications.notifications import send_notification
 
+BasketAttributeType = get_model('basket', 'BasketAttributeType')
 Benefit = get_model('offer', 'Benefit')
 Option = get_model('catalogue', 'Option')
 Product = get_model('catalogue', 'Product')
@@ -557,9 +562,136 @@ class EnrollmentCodeFulfillmentModule(BaseFulfillmentModule):
 
             line.set_status(LINE.COMPLETE)
 
+        # if this is an Enterprise purchase then transmit information about the order over to HubSpot
+        if self.determine_if_enterprise_purchase(order):
+            self.send_fulfillment_data_to_hubspot(order)
+
         self.send_email(order)
         logger.info("Finished fulfilling 'Enrollment code' product types for order [%s]", order.number)
         return order, lines
+
+    def determine_if_enterprise_purchase(self, order):
+        """ Added as part of ENT-2317. Inspects the order/basket to determine if the purchaser checked the "purchased
+        on behalf of my company" checkbox at time of purchase, which drives whether we should send this order
+         information over to HubSpot.
+
+            Args:
+                order (Order): The Order associated with the lines to be fulfilled.
+
+            Returns:
+                A boolean reflecting whether or not this purchase was made on behalf of a company or organization driven
+                by the value of the associated attribute for the order/basket in question.
+        """
+        enterprise_purchase = False
+        try:
+            # extract basket info needed to determine if purchase was made on behalf of an Enterprise
+            basket_attrib_purchaser = BasketAttribute.objects.get(
+                basket=order.basket,
+                attribute_type=BasketAttributeType.objects.get(name=PURCHASER_BEHALF_ATTRIBUTE))
+            enterprise_purchase = basket_attrib_purchaser.value_text == "True"
+        except (BasketAttribute.DoesNotExist, BasketAttributeType.DoesNotExist):
+            logger.exception("Error occurred attempting to retrieve Basket Attribute '%s' from basket for order [%s]",
+                             PURCHASER_BEHALF_ATTRIBUTE, order.number)
+
+        return enterprise_purchase
+
+    def send_fulfillment_data_to_hubspot(self, order):
+        """ Added as part of ENT-2317. Sends fulfillment data to the HubSpot Form API with info about the purchase.
+
+            Args:
+                order (Order): The Order associated with the lines to be fulfilled.
+
+            Returns:
+                The response from the requests call. Primarily being used for unit testing.
+        """
+        response = ""
+        try:
+            headers = {"Content-Type": 'application/x-www-form-urlencoded'}
+            # Build the URI for the HubSpot Forms API. See more here:
+            # https://developers.hubspot.com/docs/methods/forms/submit_form which takes the form from
+            # 'https://forms.hubspot.com/uploads/form/v2/{portal_id}/{form_id}?&'
+            endpoint = "{}{}/{}?&".format(
+                settings.HUBSPOT_FORMS_API_URI, settings.HUBSPOT_PORTAL_ID, settings.HUBSPOT_SALES_LEAD_FORM_GUID)
+            data = self.get_order_fulfillment_data_for_hubspot(order)
+
+            logger.info("Sending data to HubSpot for order [%s]", order.number)
+            response = requests.post(url=endpoint, data=data, headers=headers, timeout=1)
+            logger.debug("HubSpot response: %d", response.status_code)
+        except Timeout:
+            logger.error("Timeout occurred attempting to send data to HubSpot for order [%s]", order.number)
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("Error occurred attempting to send data to HubSpot for order [%s]", order.number)
+
+        return response
+
+    def get_order_fulfillment_data_for_hubspot(self, order):
+        """ Added as part of ENT-2317. Retrieves any data needed to build the URL Encoded request body for the HubSpot
+        API Forms request we will be submitting. Information we will be sending to HubSpot includes:
+            - First and Last name
+            - Email
+            - Course Number and Name purchased
+            - Quantity purchased
+            - Total dollar amount
+            - Company/Organization
+            - Address
+
+            Args:
+                order (Order): The Order associated with the lines to be fulfilled.
+
+            Returns:
+                A URL encoded string that will be the body of the request are sending to HubSpot containing
+                fulfillment data about the order that was just processed.
+        """
+        logger.info("Gathering fulfillment data for submission to HubSpot for order [%s]", order.number)
+
+        # need to do this to be able to grab the organization/company name, this isn't available in the order/lines
+        organization = ""
+        try:
+            organization = BasketAttribute.objects.get(
+                basket=order.basket,
+                attribute_type=BasketAttributeType.objects.get(name="organization"))
+        except (BasketAttribute.DoesNotExist, BasketAttributeType.DoesNotExist):
+            logger.exception("Error occurred attempting to retrieve Basket Attribute 'organization' from basket for "
+                             "order [%s]", order.number)
+
+        # need to build out the address accordingly
+        street_address = order.billing_address.line1
+        # check if 'line2' is empty, if not then make sure we include that in the address info
+        if order.billing_address.line2:
+            street_address = "{}, {}".format(order.billing_address.line1, order.billing_address.line2)
+
+        # When filling our our order page and selecting "United States" the string that gets populated in
+        # order.billing_address.country.name is 'United States of America'. This will cause the mailing country to not
+        # be populated on the HubSpot side in the form submission as 'United States of America' does not appear to
+        # match what HubSpot is looking for. I did some digging in the form attributes and it looks like the HubSpot
+        # side may be looking for 'United States'.
+        #
+        # I tested the theory below and changed it from 'United States of America' to 'United States' and the mailing
+        # country was populated in the contact on form submission.
+        country_name = order.billing_address.country.name
+        if country_name == 'United States of America':
+            country_name = 'United States'
+
+        # get course name and number purchased from order information
+        product = order.lines.first().product
+        course = Course.objects.get(id=product.attr.course_key)
+
+        data = urllib.urlencode({
+            'firstname': order.billing_address.first_name,
+            'lastname': order.billing_address.last_name,
+            'email': order.basket.owner.email,
+            'address': street_address,
+            'city': order.billing_address.line4,
+            'state': order.billing_address.state,
+            'country': country_name,
+            'company': organization.value_text,
+            'deal_value': order.basket.total_incl_tax,
+            'ecommerce_course_name': course.name,
+            'ecommerce_course_id': course.id,
+            'bulk_purchase_quantity': order.num_items
+        })
+
+        return data
 
     def revoke_line(self, line):
         """ Revokes the specified line.

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -3,11 +3,13 @@ from __future__ import absolute_import
 
 import datetime
 import json
+import urllib
 import uuid
 
 import ddt
 import httpretty
 import mock
+from django.conf import settings
 from django.test import override_settings
 from oscar.core.loading import get_class, get_model
 from oscar.test import factories
@@ -24,9 +26,12 @@ from ecommerce.core.constants import (
 )
 from ecommerce.core.url_utils import get_lms_enrollment_api_url, get_lms_entitlement_api_url
 from ecommerce.coupons.tests.mixins import CouponMixin
+from ecommerce.courses.models import Course
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.courses.utils import mode_for_product
 from ecommerce.entitlements.utils import create_or_update_course_entitlement
+from ecommerce.extensions.basket.constants import PURCHASER_BEHALF_ATTRIBUTE
+from ecommerce.extensions.basket.utils import basket_add_organization_attribute
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
 from ecommerce.extensions.fulfillment.modules import (
     CouponFulfillmentModule,
@@ -536,6 +541,30 @@ class EnrollmentCodeFulfillmentModuleTests(DiscoveryTestMixin, TestCase):
     """ Test Enrollment code fulfillment. """
     QUANTITY = 5
 
+    def create_order_with_billing_address(self):
+        """ Creates an order object with a bit of extra information for HubSpot unit tests"""
+        enrollment_code = Product.objects.get(product_class__name=ENROLLMENT_CODE_PRODUCT_CLASS_NAME)
+        user = UserFactory()
+        basket = factories.BasketFactory(owner=user, site=self.site)
+        basket.add_product(enrollment_code, self.QUANTITY)
+
+        # add organization and purchaser attributes manually to the basket for testing purposes
+        basket_data = {
+            'organization': 'Dummy Business Client',
+            PURCHASER_BEHALF_ATTRIBUTE: 'True'
+        }
+        basket_add_organization_attribute(basket, basket_data)
+
+        # add some additional data the billing address to exercise some of the code paths in the unit we are testing
+        billing_address = factories.BillingAddressFactory()
+        billing_address.line2 = 'Suite 321'
+        billing_address.line4 = "City"
+        billing_address.state = "State"
+        billing_address.country.name = "United States of America"
+
+        # create new order adding in the additional billing address info
+        return create_order(number=2, basket=basket, user=user, billing_address=billing_address)
+
     def setUp(self):
         super(EnrollmentCodeFulfillmentModuleTests, self).setUp()
         course = CourseFactory(partner=self.partner)
@@ -577,6 +606,153 @@ class EnrollmentCodeFulfillmentModuleTests(DiscoveryTestMixin, TestCase):
         line = self.order.lines.first()
         with self.assertRaises(NotImplementedError):
             EnrollmentCodeFulfillmentModule().revoke_line(line)
+
+    def test_get_fulfillment_data(self):
+        """ Test for gathering data to send to HubSpot """
+        order = self.create_order_with_billing_address()
+
+        # extract some of the course info we need to build our "expected" string for comparisons later
+        product = order.lines.first().product
+        course = Course.objects.get(id=product.attr.course_key)
+
+        course_name_data = urllib.urlencode({
+            'ecommerce_course_name': course.name
+        })
+
+        course_id_data = urllib.urlencode({
+            'ecommerce_course_id': course.id
+        })
+
+        customer_email_data = urllib.urlencode({
+            'email': order.basket.owner.email
+        })
+
+        expected_request_body = "firstname=John&" \
+                                "lastname=Doe&" \
+                                "company=Dummy+Business+Client&" \
+                                "{}&" \
+                                "{}&" \
+                                "deal_value=250.00&" \
+                                "address=Streetname%2C+Suite+321&" \
+                                "bulk_purchase_quantity=5&" \
+                                "city=City&" \
+                                "country=United+States&" \
+                                "state=State&" \
+                                "{}"\
+            .format(course_name_data, course_id_data, customer_email_data)
+        generated_request_body = EnrollmentCodeFulfillmentModule().get_order_fulfillment_data_for_hubspot(order)
+        self.assertEqual(expected_request_body, generated_request_body)
+
+    def test_determine_if_enterprise_purchase_expect_true(self):
+        """ Test for being able to retrieve 'purchased_behalf_of' attribute from Basket and the checkbox is checked. """
+        # add organization and purchaser attributes manually to the basket for testing purposes
+        basket_data = {
+            'organization': 'Dummy Business Client',
+            PURCHASER_BEHALF_ATTRIBUTE: 'True'
+        }
+        basket_add_organization_attribute(self.order.basket, basket_data)
+
+        purchased_by_organization = EnrollmentCodeFulfillmentModule().determine_if_enterprise_purchase(self.order)
+        self.assertEqual(True, purchased_by_organization)
+
+    def test_determine_if_enterprise_purchase_expect_false(self):
+        """ Test for being able to retrieve 'purchased_behalf_of' attribute value from Basket and the checkbox is
+        not checked. """
+        # add organization and purchaser attributes manually to the basket for testing purposes
+        basket_data = {
+            'organization': 'Dummy Business Client',
+            PURCHASER_BEHALF_ATTRIBUTE: 'False'
+        }
+        basket_add_organization_attribute(self.order.basket, basket_data)
+
+        purchased_by_organization = EnrollmentCodeFulfillmentModule().determine_if_enterprise_purchase(self.order)
+        self.assertEqual(False, purchased_by_organization)
+
+    def test_determine_if_enterprise_purchase_no_organization(self):
+        """ Test for ensuring we send back a usable value if 'purchased_behalf_of' attribute is missing from Basket
+        for some reason. """
+        purchased_by_organization = EnrollmentCodeFulfillmentModule().determine_if_enterprise_purchase(self.order)
+        self.assertEqual(False, purchased_by_organization)
+
+    @httpretty.activate
+    def test_send_to_hubspot_happy_path(self):
+        """ Test for constructing and sending the HubSpot request. Verifies expected logs are appearing. """
+        order = self.create_order_with_billing_address()
+
+        # set the HubSpot specific settings with values that make it look close to a real world configuration
+        settings.HUBSPOT_FORMS_API_URI = "https://forms.hubspot.com/uploads/form/v2/"
+        settings.HUBSPOT_PORTAL_ID = "0"
+        settings.HUBSPOT_SALES_LEAD_FORM_GUID = "00000000-1111-2222-3333-4444444444444444"
+
+        hubspot_url = "{}{}/{}?&".format(
+            settings.HUBSPOT_FORMS_API_URI,
+            settings.HUBSPOT_PORTAL_ID,
+            settings.HUBSPOT_SALES_LEAD_FORM_GUID)
+
+        httpretty.register_uri(
+            httpretty.POST,
+            hubspot_url,
+            content_type='application/x-www-form-urlencoded',
+            status=204
+        )
+
+        logger_name = "ecommerce.extensions.fulfillment.modules"
+        with LogCapture(logger_name) as logger:
+            response = EnrollmentCodeFulfillmentModule().send_fulfillment_data_to_hubspot(order)
+            # verify we built the uri correctly
+            self.assertEqual(response.url, hubspot_url)
+            # verify that the expected logs were generated
+            logger.check_present(
+                (
+                    logger_name,
+                    'INFO',
+                    'Gathering fulfillment data for submission to HubSpot for order [{}]'.format(order.number)
+                ),
+                (
+                    logger_name,
+                    'INFO',
+                    'Sending data to HubSpot for order [{}]'.format(order.number)
+                ),
+                (
+                    logger_name,
+                    'DEBUG',
+                    'HubSpot response: 204'
+                )
+            )
+
+    @mock.patch('requests.post', mock.Mock(side_effect=Timeout))
+    def test_send_to_hubspot_timeout(self):
+        """ Test to simulate a timeout occurring when sending data to HubSpot. Verifies expected logs appear. """
+        order = self.create_order_with_billing_address()
+
+        logger_name = "ecommerce.extensions.fulfillment.modules"
+        with LogCapture(logger_name) as logger:
+            EnrollmentCodeFulfillmentModule().send_fulfillment_data_to_hubspot(order)
+            # verify that the expected logs were generated
+            logger.check_present(
+                (
+                    logger_name,
+                    'ERROR',
+                    'Timeout occurred attempting to send data to HubSpot for order [{}]'.format(order.number)
+                )
+            )
+
+    @mock.patch('requests.post', mock.Mock(side_effect=ConnectionError))
+    def test_send_to_hubspot_error(self):
+        """ Test to simulate some other error occurring when sending data to HubSpot. Verifies expected logs appear. """
+        order = self.create_order_with_billing_address()
+
+        logger_name = "ecommerce.extensions.fulfillment.modules"
+        with LogCapture(logger_name) as logger:
+            EnrollmentCodeFulfillmentModule().send_fulfillment_data_to_hubspot(order)
+            # verify that the expected logs were generated
+            logger.check_present(
+                (
+                    logger_name,
+                    'ERROR',
+                    'Error occurred attempting to send data to HubSpot for order [{}]'.format(order.number)
+                )
+            )
 
 
 class EntitlementFulfillmentModuleTests(FulfillmentTestMixin, TestCase):

--- a/ecommerce/extensions/payment/forms.py
+++ b/ecommerce/extensions/payment/forms.py
@@ -11,6 +11,8 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 from oscar.core.loading import get_class, get_model
 
+from ecommerce.extensions.basket.constants import PURCHASER_BEHALF_ATTRIBUTE
+
 logger = logging.getLogger(__name__)
 
 Applicator = get_class('offer.applicator', 'Applicator')
@@ -117,13 +119,13 @@ class PaymentForm(forms.Form):
                     )
                     self.helper.layout.fields.insert(list(self.fields.keys()).index('last_name') + 1, organization_div)
                     # Purchased on behalf of an enterprise or for personal use
-                    self.fields['purchaser'] = forms.BooleanField(
+                    self.fields[PURCHASER_BEHALF_ATTRIBUTE] = forms.BooleanField(
                         required=False,
                         label=_('I am purchasing on behalf of my employer or other professional organization')
                     )
                     purchaser_div = Div(
                         Div(
-                            Div('purchaser'),
+                            Div(PURCHASER_BEHALF_ATTRIBUTE),
                             HTML('<p class="help-block"></p>'),
                             css_class='form-item col-md-12'
                         ),

--- a/ecommerce/extensions/payment/tests/test_forms.py
+++ b/ecommerce/extensions/payment/tests/test_forms.py
@@ -10,6 +10,7 @@ from waffle.models import Switch
 from ecommerce.core.constants import ENROLLMENT_CODE_PRODUCT_CLASS_NAME, ENROLLMENT_CODE_SWITCH
 from ecommerce.core.tests import toggle_switch
 from ecommerce.courses.tests.factories import CourseFactory
+from ecommerce.extensions.basket.constants import PURCHASER_BEHALF_ATTRIBUTE
 from ecommerce.extensions.payment.forms import PaymentForm
 from ecommerce.extensions.test.factories import create_basket
 from ecommerce.tests.testcases import TestCase
@@ -179,7 +180,7 @@ class PaymentFormTests(TestCase):
         }
         form = PaymentForm(user=self.user, data=data, request=self.request)
         self.assertTrue('organization' in form.fields)
-        self.assertTrue('purchaser' in form.fields)
+        self.assertTrue(PURCHASER_BEHALF_ATTRIBUTE in form.fields)
 
     def test_organization_field_not_in_form(self):
         """
@@ -203,4 +204,4 @@ class PaymentFormTests(TestCase):
         }
         form = PaymentForm(user=self.user, data=data, request=self.request)
         self.assertFalse('organization' in form.fields)
-        self.assertFalse('purchaser' in form.fields)
+        self.assertFalse(PURCHASER_BEHALF_ATTRIBUTE in form.fields)

--- a/ecommerce/extensions/payment/tests/views/test_cybersource.py
+++ b/ecommerce/extensions/payment/tests/views/test_cybersource.py
@@ -22,6 +22,7 @@ from ecommerce.core.tests import toggle_switch
 from ecommerce.core.url_utils import get_lms_url
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.api.serializers import OrderSerializer
+from ecommerce.extensions.basket.constants import PURCHASER_BEHALF_ATTRIBUTE
 from ecommerce.extensions.basket.utils import basket_add_organization_attribute
 from ecommerce.extensions.order.constants import PaymentEventTypeName
 from ecommerce.extensions.payment.exceptions import InvalidBasketError, InvalidSignatureError
@@ -309,7 +310,8 @@ class CybersourceInterstitialViewTests(CybersourceNotificationTestsMixin, TestCa
             billing_address=self.billing_address,
         )
         request_data.update({'organization': 'Dummy Business Client'})
-        # Manually add organization attribute on the basket for testing
+        request_data.update({PURCHASER_BEHALF_ATTRIBUTE: "False"})
+        # Manually add organization and purchaser attributes on the basket for testing
         basket_add_organization_attribute(self.basket, request_data)
 
         response = self.client.post(self.path, request_data)

--- a/ecommerce/extensions/payment/tests/views/test_paypal.py
+++ b/ecommerce/extensions/payment/tests/views/test_paypal.py
@@ -25,6 +25,7 @@ from ecommerce.core.constants import (
 from ecommerce.core.models import BusinessClient, SiteConfiguration
 from ecommerce.core.tests import toggle_switch
 from ecommerce.courses.tests.factories import CourseFactory
+from ecommerce.extensions.basket.constants import PURCHASER_BEHALF_ATTRIBUTE
 from ecommerce.extensions.basket.utils import basket_add_organization_attribute
 from ecommerce.extensions.checkout.utils import get_receipt_page_url
 from ecommerce.extensions.offer.constants import DYNAMIC_DISCOUNT_FLAG
@@ -168,6 +169,7 @@ class PaypalPaymentExecutionViewTests(PaypalMixin, PaymentEventsMixin, TestCase)
 
         # Manually add organization attribute on the basket for testing
         self.RETURN_DATA.update({'organization': 'Dummy Business Client'})
+        self.RETURN_DATA.update({PURCHASER_BEHALF_ATTRIBUTE: 'False'})
         basket_add_organization_attribute(self.basket, self.RETURN_DATA)
 
         response = self.client.get(reverse('paypal:execute'), self.RETURN_DATA)

--- a/ecommerce/extensions/payment/tests/views/test_stripe.py
+++ b/ecommerce/extensions/payment/tests/views/test_stripe.py
@@ -11,6 +11,7 @@ from ecommerce.core.constants import ENROLLMENT_CODE_PRODUCT_CLASS_NAME, ENROLLM
 from ecommerce.core.models import BusinessClient
 from ecommerce.core.tests import toggle_switch
 from ecommerce.courses.tests.factories import CourseFactory
+from ecommerce.extensions.basket.constants import PURCHASER_BEHALF_ATTRIBUTE
 from ecommerce.extensions.basket.utils import basket_add_organization_attribute
 from ecommerce.extensions.checkout.utils import get_receipt_page_url
 from ecommerce.extensions.order.constants import PaymentEventTypeName
@@ -162,6 +163,7 @@ class StripeSubmitViewTests(PaymentEventsMixin, TestCase):
 
         data = self.generate_form_data(basket.id)
         data.update({'organization': 'Dummy Business Client'})
+        data.update({PURCHASER_BEHALF_ATTRIBUTE: 'False'})
 
         # Manually add organization attribute on the basket for testing
         basket_add_organization_attribute(basket, data)

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -801,5 +801,11 @@ BACKEND_SERVICE_EDX_OAUTH2_SECRET = "ecommerce-backend-service-secret"
 BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL = "http://127.0.0.1:8000/oauth2"
 EXTRA_APPS = []
 API_ROOT = None
+
 # Needed to link to the payment micro-frontend
 PAYMENT_MICROFRONTEND_URL = None
+
+# For Enterprise purchases to send purchase information to HubSpot for marketing leads
+HUBSPOT_FORMS_API_URI = "SET-ME-PLEASE"
+HUBSPOT_PORTAL_ID = "SET-ME-PLEASE"
+HUBSPOT_SALES_LEAD_FORM_GUID = "SET-ME-PLEASE"


### PR DESCRIPTION
[ENT-2317]
- Send Enterprise purchase data to HubSpot for tracking and analysis
- Add purchaser attribute to all enterprise purchase baskets for tracking of new checkbox/attribute
- Fix and add a few new unit tests