### PR TITLE
If the cybersource transaction_id isn't available, record an empty-string reference, rather than None

### DIFF
--- a/ecommerce/extensions/payment/processors/cybersource.py
+++ b/ecommerce/extensions/payment/processors/cybersource.py
@@ -309,7 +309,7 @@ class Cybersource(ApplePayMixin, BaseClientSidePaymentProcessor):
                     'review': AuthorizationError,
                 }.get(decision, InvalidCybersourceDecision)
 
-        transaction_id = response.get('transaction_id', None)  # Error Notifications does not include a transaction id.
+        transaction_id = response.get('transaction_id', '')  # Error Notifications do not include a transaction id.
         if transaction_id and decision == 'accept':
             if Order.objects.filter(number=response['req_reference_number']).exists():
                 if PaymentProcessorResponse.objects.filter(transaction_id=transaction_id).exists():


### PR DESCRIPTION
The goal is to fix errors like:
```
    Oct  9 21:34:19 ip-10-2-120-57 [service_variant=ecommerce][ecommerce.extensions.checkout.mixins] ERROR [ip-10-2-120-57  13577] [/edx/app/ecommerce/ecommerce/ecommerce/extensions/checkout/mixins.py:295] - Order Failure: Cybersource payment was received, but an order for basket [XXXXXX] could not be placed.
    Traceback (most recent call last):
    File "/edx/app/ecommerce/ecommerce/ecommerce/extensions/payment/views/cybersource.py", line 90, in create_order
        request=request
    File "/edx/app/ecommerce/ecommerce/ecommerce/extensions/checkout/mixins.py", line 144, in handle_order_placement
        **kwargs
    File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/oscar/apps/checkout/mixins.py", line 155, in place_order
        self.save_payment_details(order)
    File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/oscar/apps/checkout/mixins.py", line 208, in save_payment_details
        self.save_payment_events(order)
    File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/oscar/apps/checkout/mixins.py", line 219, in save_payment_events
        event.save()
    File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/django/db/models/base.py", line 808, in save
        force_update=force_update, update_fields=update_fields)
    File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/django/db/models/base.py", line 838, in save_base
        updated = self._save_table(raw, cls, force_insert, force_update, using, update_fields)
    File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/django/db/models/base.py", line 924, in _save_table
        result = self._do_insert(cls._base_manager, using, fields, update_pk, raw)
    File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/django/db/models/base.py", line 963, in _do_insert
        using=using, raw=raw)
    File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/django/db/models/manager.py", line 85, in manager_method
        return getattr(self.get_queryset(), name)(*args, **kwargs)
    File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/django/db/models/query.py", line 1079, in _insert
        return query.get_compiler(using=using).execute_sql(return_id)
    File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/django/db/models/sql/compiler.py", line 1112, in execute_sql
        cursor.execute(sql, params)
    File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/django/db/backends/utils.py", line 64, in execute
        return self.cursor.execute(sql, params)
    File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/django/db/backends/mysql/base.py", line 106, in execute
        six.reraise(utils.IntegrityError, utils.IntegrityError(*tuple(e.args)), sys.exc_info()[2])
    File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/django/db/backends/mysql/base.py", line 101, in execute
        return self.cursor.execute(query, args)
    File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/newrelic/hooks/database_dbapi2.py", line 25, in execute
        *args, **kwargs)
    File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/MySQLdb/cursors.py", line 209, in execute
        res = self._query(query)
    File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/MySQLdb/cursors.py", line 315, in _query
        db.query(q)
    File "/edx/app/ecommerce/venvs/ecommerce/local/lib/python2.7/site-packages/MySQLdb/connections.py", line 226, in query
        _mysql.connection.query(self, query)
    IntegrityError: (1048, "Column 'reference' cannot be null")
```

This is being tracked in https://openedx.atlassian.net/browse/REV-988
[REV-988]