### PR TITLE
ENT-2298 Handle unknown placeholders in email templates

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -1308,7 +1308,7 @@ class CouponCodeAssignmentSerializer(serializers.Serializer):  # pylint: disable
                 learner_email=assigned_offer.user_email,
                 code=assigned_offer.code,
                 redemptions_remaining=redemptions_remaining,
-                code_expiration_date=code_expiration_date.strftime('%d %B,%Y')
+                code_expiration_date=code_expiration_date.strftime('%d %B, %Y')
             )
         except Exception as exc:  # pylint: disable=broad-except
             logger.exception(
@@ -1526,5 +1526,5 @@ class CouponCodeRemindSerializer(CouponCodeMixin, serializers.Serializer):  # py
             code=assigned_offer.code,
             redeemed_offer_count=redeemed_offer_count,
             total_offer_count=total_offer_count,
-            code_expiration_date=code_expiration_date.strftime('%d %B,%Y')
+            code_expiration_date=code_expiration_date.strftime('%d %B, %Y')
         )

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -602,7 +602,7 @@ COURSE_CATALOG_API_URL = 'http://localhost:8008/api/v1/'
 BLACK_LIST_COUPON_COURSE_MODES = [u'audit', u'honor']
 
 # Theme settings
-# enable or disbale comprehensive theming
+# enable or disable comprehensive theming
 ENABLE_COMPREHENSIVE_THEMING = True
 
 # name for waffle switch to use for disabling theming on runtime.
@@ -700,36 +700,11 @@ NEW_CODES_EMAIL_CONFIG = {
     '''
 }
 
-OFFER_ASSIGNMENT_EMAIL_DEFAULT_TEMPLATE = '''
-    Your learning manager has provided you with a new access code to take a course at edX.
-    You may redeem this code for {REDEMPTIONS_REMAINING} courses.
-
-    edX login: {USER_EMAIL}
-    Access Code: {CODE}
-    Expiration date: {EXPIRATION_DATE}
-
-    You can insert the access code at check out under "coupon code" for applicable courses.
-
-    For any questions, please reach out to your Learning Manager.
-'''
 OFFER_ASSIGNMENT_EMAIL_DEFAULT_SUBJECT = 'New edX course assignment'
 OFFER_REVOKE_EMAIL_DEFAULT_SUBJECT = 'edX Course Assignment Revoked'
-
-OFFER_ASSIGNMENT_EMAIL_REMINDER_DEFAULT_TEMPLATE = '''
-    This is a reminder email that your learning manager has provided you with a access code to take a course at edX.
-    You have redeemed this code {REDEEMED_OFFER_COUNT} of times out of {TOTAL_OFFER_COUNT} number of available course redemptions.
-
-    edX login: {USER_EMAIL}
-    Access Code: {CODE}
-    Expiration date: {EXPIRATION_DATE}
-
-    You can insert the access code at check out under "coupon code" for applicable courses.
-
-    For any questions, please reach out to your Learning Manager.
-'''
 OFFER_ASSIGNMENT_EMAIL_REMINDER_DEFAULT_SUBJECT = 'Reminder on edX course assignment'
 
-#SAILTHRU settings
+# SAILTHRU settings
 SAILTHRU_KEY = 'sailthru key here'
 SAILTHRU_SECRET = 'sailthru secret here'
 


### PR DESCRIPTION
Since we allow learner admins to customize the email template, we need to handle unexpected parameters. This PR should handle the errors we've seen recently, but more sanitization work will likely be require in follow-up tickets.

Vaguely related fixes that are also in this PR:
- Add a space between the comma and the year in expiration dates
- Move email templates that are only used by tests from _settings/base.py_ to the test file