### PR TITLE
ENT-2309 | Adding banner on receipt page to point enterprise learners…

### DIFF
--- a/ecommerce/extensions/checkout/tests/test_views.py
+++ b/ecommerce/extensions/checkout/tests/test_views.py
@@ -192,6 +192,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.enterprise_learner_data_no_portal = {
             'results': [{
                 'enterprise_customer': {
+                    'name': 'Test Company',
                     'enable_learner_portal': False,
                     'learner_portal_hostname': ''
                 }
@@ -200,6 +201,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.enterprise_learner_data_with_portal = {
             'results': [{
                 'enterprise_customer': {
+                    'name': 'Test Company',
                     'enable_learner_portal': True,
                     'learner_portal_hostname': 'https://www.edx.org'
                 }
@@ -481,7 +483,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         response_messages = list(response.context['messages'])
 
         expected_message = (
-            'Your company has a dedicated page where you can see all of '
+            'Your company, Test Company, has a dedicated page where you can see all of '
             'your sponsored courses. Go to <a href="https://www.edx.org">'
             'https://www.edx.org</a>.'
         )

--- a/ecommerce/extensions/checkout/tests/test_views.py
+++ b/ecommerce/extensions/checkout/tests/test_views.py
@@ -354,6 +354,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
     @httpretty.activate
     def test_get_receipt_for_existing_order_as_staff_user(self, mock_learner_data):
         """ Staff users can preview Receipts for all Orders."""
+        mock_learner_data.return_value = self.non_enterprise_learner_data
         staff_user = self.create_user(is_staff=True)
         order = self._create_order_for_receipt(staff_user)
         response = self._visit_receipt_page_with_another_user(order, staff_user)

--- a/ecommerce/extensions/checkout/tests/test_views.py
+++ b/ecommerce/extensions/checkout/tests/test_views.py
@@ -9,6 +9,7 @@ import six.moves.urllib.parse  # pylint: disable=import-error
 import six.moves.urllib.request  # pylint: disable=import-error
 from django.conf import settings
 from django.urls import reverse
+from mock import patch
 from oscar.core.loading import get_model
 from oscar.test import factories
 
@@ -187,6 +188,24 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         super(ReceiptResponseViewTests, self).setUp()
         self.user = self.create_user()
         self.client.login(username=self.user.username, password=self.password)
+        # Note: actual response is far more rich. Just including the bits relevant to us
+        self.enterprise_learner_data_no_portal = {
+            'results': [{
+                'enterprise_customer': {
+                    'enable_learner_portal': False,
+                    'learner_portal_hostname': ''
+                }
+            }]
+        }
+        self.enterprise_learner_data_with_portal = {
+            'results': [{
+                'enterprise_customer': {
+                    'enable_learner_portal': True,
+                    'learner_portal_hostname': 'https://www.edx.org'
+                }
+            }]
+        }
+        self.non_enterprise_learner_data = {}
 
     def _get_receipt_response(self, order_number):
         """
@@ -248,8 +267,10 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
                                                    next=six.moves.urllib.parse.quote(self.path))
         self.assertRedirects(response, expected_url, target_status_code=302)
 
-    def test_get_receipt_for_nonexisting_order(self):
+    @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
+    def test_get_receipt_for_nonexisting_order(self, mock_learner_data):
         """ The view should return 404 status if the Order is not found. """
+        mock_learner_data.return_value = self.non_enterprise_learner_data
         order_number = 'ABC123'
         response = self._get_receipt_response(order_number)
         self.assertEqual(response.status_code, 404)
@@ -280,9 +301,11 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         payment_method = ReceiptResponseView().get_payment_method(order)
         self.assertEqual(payment_method, '{} {}'.format(source.card_type, source.label))
 
+    @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
     @httpretty.activate
-    def test_get_receipt_for_existing_order(self):
+    def test_get_receipt_for_existing_order(self, mock_learner_data):
         """ Order owner should be able to see the Receipt Page."""
+        mock_learner_data.return_value = self.non_enterprise_learner_data
         order = self._create_order_for_receipt(self.user)
         response = self._get_receipt_response(order.number)
         context_data = {
@@ -294,10 +317,12 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertEqual(response.status_code, 200)
         self.assertDictContainsSubset(context_data, response.context_data)
 
+    @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
     @httpretty.activate
-    def test_get_receipt_for_existing_entitlement_order(self):
+    def test_get_receipt_for_existing_entitlement_order(self, mock_learner_data):
         """ Order owner should be able to see the Receipt Page."""
 
+        mock_learner_data.return_value = self.non_enterprise_learner_data
         order = self._create_order_for_receipt(self.user, entitlement=True, id_verification_required=True)
         response = self._get_receipt_response(order.number)
         context_data = {
@@ -309,10 +334,12 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertEqual(response.status_code, 200)
         self.assertDictContainsSubset(context_data, response.context_data)
 
+    @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
     @httpretty.activate
-    def test_get_receipt_for_entitlement_order_no_id_required(self):
+    def test_get_receipt_for_entitlement_order_no_id_required(self, mock_learner_data):
         """ Order owner should be able to see the Receipt Page with no ID verification in context."""
 
+        mock_learner_data.return_value = self.non_enterprise_learner_data
         order = self._create_order_for_receipt(self.user, entitlement=True, id_verification_required=False)
         response = self._get_receipt_response(order.number)
         context_data = {
@@ -323,8 +350,9 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertEqual(response.status_code, 200)
         self.assertDictContainsSubset(context_data, response.context_data)
 
+    @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
     @httpretty.activate
-    def test_get_receipt_for_existing_order_as_staff_user(self):
+    def test_get_receipt_for_existing_order_as_staff_user(self, mock_learner_data):
         """ Staff users can preview Receipts for all Orders."""
         staff_user = self.create_user(is_staff=True)
         order = self._create_order_for_receipt(staff_user)
@@ -337,9 +365,11 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertEqual(response.status_code, 200)
         self.assertDictContainsSubset(context_data, response.context_data)
 
+    @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
     @httpretty.activate
-    def test_get_receipt_for_existing_order_user_not_owner(self):
+    def test_get_receipt_for_existing_order_user_not_owner(self, mock_learner_data):
         """ Users that don't own the Order shouldn't be able to see the Receipt. """
+        mock_learner_data.return_value = self.non_enterprise_learner_data
         other_user = self.create_user()
         order = self._create_order_for_receipt(other_user)
         response = self._visit_receipt_page_with_another_user(order, other_user)
@@ -348,9 +378,11 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertEqual(response.status_code, 404)
         self.assertDictContainsSubset(context_data, response.context_data)
 
+    @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
     @httpretty.activate
-    def test_order_data_for_credit_seat(self):
+    def test_order_data_for_credit_seat(self, mock_learner_data):
         """ Ensure that the context is updated with Order data. """
+        mock_learner_data.return_value = self.non_enterprise_learner_data
         order = self.create_order(credit=True)
         self.mock_verification_status_api(
             self.site,
@@ -367,8 +399,10 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.context_data['display_credit_messaging'])
 
+    @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
     @httpretty.activate
-    def test_order_value_unlocalized_for_tracking(self):
+    def test_order_value_unlocalized_for_tracking(self, mock_learner_data):
+        mock_learner_data.return_value = self.non_enterprise_learner_data
         order = self._create_order_for_receipt(self.user)
         self.client.cookies.load({settings.LANGUAGE_COOKIE_NAME: 'fr'})
         response = self._get_receipt_response(order.number)
@@ -377,12 +411,14 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         order_value_string = 'data-total-amount="{}"'.format(order.total_incl_tax)
         self.assertContains(response, order_value_string)
 
+    @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
     @httpretty.activate
-    def test_dashboard_link_for_course_purchase(self):
+    def test_dashboard_link_for_course_purchase(self, mock_learner_data):
         """
         The dashboard link at the bottom of the receipt for a course purchase
         should point to the user dashboard.
         """
+        mock_learner_data.return_value = self.non_enterprise_learner_data
         order = self._create_order_for_receipt(self.user)
         response = self._get_receipt_response(order.number)
         context_data = {
@@ -392,12 +428,14 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertEqual(response.status_code, 200)
         self.assertDictContainsSubset(context_data, response.context_data)
 
+    @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
     @httpretty.activate
-    def test_dashboard_link_for_bundle_purchase(self):
+    def test_dashboard_link_for_bundle_purchase(self, mock_learner_data):
         """
         The dashboard link at the bottom of the receipt for a bundle purchase
         should point to the program dashboard.
         """
+        mock_learner_data.return_value = self.non_enterprise_learner_data
         order = self._create_order_for_receipt(self.user)
         BasketAttribute.objects.update_or_create(
             basket=order.basket,
@@ -413,9 +451,63 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertEqual(response.status_code, 200)
         self.assertDictContainsSubset(context_data, response.context_data)
 
+    @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
     @httpretty.activate
-    def test_order_without_basket(self):
+    def test_order_without_basket(self, mock_learner_data):
+        mock_learner_data.return_value = self.non_enterprise_learner_data
         order = self.create_order()
         Basket.objects.filter(id=order.basket.id).delete()
         response = self._get_receipt_response(order.number)
         self.assertEqual(response.status_code, 200)
+
+    @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
+    @httpretty.activate
+    def test_enterprise_learner_dashboard_link_in_messages(self, mock_learner_data):
+        """
+        The receipt page should include a message with a link to the enterprise
+        learner portal for a learner if response from enterprise shows the portal
+        is configured.
+        """
+        mock_learner_data.return_value = self.enterprise_learner_data_with_portal
+        order = self._create_order_for_receipt(self.user)
+        BasketAttribute.objects.update_or_create(
+            basket=order.basket,
+            attribute_type=BasketAttributeType.objects.get(name='bundle_identifier'),
+            value_text='test_bundle'
+        )
+
+        response = self._get_receipt_response(order.number)
+        response_messages = list(response.context['messages'])
+
+        expected_message = (
+            'Your company has a dedicated page where you can see all of '
+            'your sponsored courses. Go to <a href="https://www.edx.org">'
+            'https://www.edx.org</a>.'
+        )
+        actual_message = str(response_messages[0])
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response_messages), 1)
+        self.assertEqual(expected_message, actual_message)
+
+    @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
+    @httpretty.activate
+    def test_no_enterprise_learner_dashboard_link_in_messages(self, mock_learner_data):
+        """
+        The receipt page should NOT include a message with a link to the enterprise
+        learner portal for a learner if response from enterprise shows the portal
+        is not configured.
+        """
+        mock_learner_data.return_value = self.enterprise_learner_data_no_portal
+        order = self._create_order_for_receipt(self.user)
+        BasketAttribute.objects.update_or_create(
+            basket=order.basket,
+            attribute_type=BasketAttributeType.objects.get(name='bundle_identifier'),
+            value_text='test_bundle'
+        )
+
+        response = self._get_receipt_response(order.number)
+        response_messages = list(response.context['messages'])
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response_messages), 0)

--- a/ecommerce/extensions/checkout/views.py
+++ b/ecommerce/extensions/checkout/views.py
@@ -268,8 +268,7 @@ class ReceiptResponseView(ThankYouView):
                     'Your company, {enterprise_customer_name}, has a dedicated page where '
                     'you can see all of your sponsored courses. '
                     'Go to <a href="{hostname}">{hostname}</a>.'
-                )
-                message = message.format(
+                ).format(
                     enterprise_customer_name=enterprise_customer['name'],
                     hostname=learner_portal_hostname
                 )

--- a/ecommerce/extensions/checkout/views.py
+++ b/ecommerce/extensions/checkout/views.py
@@ -156,14 +156,14 @@ class ReceiptResponseView(ThankYouView):
     def get(self, request, *args, **kwargs):
         try:
             response = super(ReceiptResponseView, self).get(request, *args, **kwargs)
-            self.add_message_if_enterprise_user(request)
-            return response
         except Http404:
             self.template_name = 'edx/checkout/receipt_not_found.html'
             context = {
                 'order_history_url': request.site.siteconfiguration.build_lms_url('account/settings'),
             }
             return self.render_to_response(context=context, status=404)
+        self.add_message_if_enterprise_user(request)
+        return response
 
     def get_context_data(self, **kwargs):  # pylint: disable=arguments-differ
         context = super(ReceiptResponseView, self).get_context_data(**kwargs)

--- a/ecommerce/extensions/checkout/views.py
+++ b/ecommerce/extensions/checkout/views.py
@@ -265,9 +265,12 @@ class ReceiptResponseView(ThankYouView):
             learner_portal_hostname = enterprise_customer['learner_portal_hostname']
             if enable_learner_portal and learner_portal_hostname:
                 message = (
-                    'Your company has a dedicated page where you can see all of your sponsored courses. '
-                    'Go to <a href="{hostname}">{hostname}</a>.'.format(
-                        hostname=learner_portal_hostname
-                    )
+                    'Your company, {enterprise_customer_name}, has a dedicated page where '
+                    'you can see all of your sponsored courses. '
+                    'Go to <a href="{hostname}">{hostname}</a>.'
+                )
+                message = message.format(
+                    enterprise_customer_name=enterprise_customer['name'],
+                    hostname=learner_portal_hostname
                 )
                 messages.add_message(request, messages.INFO, message, extra_tags='safe')

--- a/ecommerce/extensions/checkout/views.py
+++ b/ecommerce/extensions/checkout/views.py
@@ -258,13 +258,16 @@ class ReceiptResponseView(ThankYouView):
 
     def add_message_if_enterprise_user(self, request):
         learner_data = fetch_enterprise_learner_data(request.site, request.user)
-        if (learner_data.get('results') and
-                learner_data['results'][0]['enterprise_customer']['enable_learner_portal'] and
-                learner_data['results'][0]['enterprise_customer']['learner_portal_hostname']):
-            message = (
-                'Your company has a dedicated page where you can see all of your sponsored courses. '
-                'Go to <a href="{hostname}">{hostname}</a>.'.format(
-                    hostname=learner_data['results'][0]['enterprise_customer']['learner_portal_hostname']
+        learner_data_results = learner_data.get('results')
+        if learner_data_results:
+            enterprise_customer = learner_data_results[0]['enterprise_customer']
+            enable_learner_portal = enterprise_customer['enable_learner_portal']
+            learner_portal_hostname = enterprise_customer['learner_portal_hostname']
+            if enable_learner_portal and learner_portal_hostname:
+                message = (
+                    'Your company has a dedicated page where you can see all of your sponsored courses. '
+                    'Go to <a href="{hostname}">{hostname}</a>.'.format(
+                        hostname=learner_portal_hostname
+                    )
                 )
-            )
-            messages.add_message(request, messages.INFO, message, extra_tags='safe')
+                messages.add_message(request, messages.INFO, message, extra_tags='safe')

--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -24,14 +24,6 @@
   {% include 'edx/partials/_student_navbar.html' %}
 {% endblock navbar %}
 
-{{ 'hey im in the template\n\n\n\n\n\n\n\n\n\n\n\n' }}
-{{ messages }}
-
-
-
-
-
-
 {% block content %}
   <div id="receipt-container"
        class="receipt container content-container"

--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -24,6 +24,14 @@
   {% include 'edx/partials/_student_navbar.html' %}
 {% endblock navbar %}
 
+{{ 'hey im in the template\n\n\n\n\n\n\n\n\n\n\n\n' }}
+{{ messages }}
+
+
+
+
+
+
 {% block content %}
   <div id="receipt-container"
        class="receipt container content-container"
@@ -31,6 +39,8 @@
        data-order-id="{{ order.number }}"
        data-total-amount="{{ order.total_incl_tax | unlocalize }}"
        data-back-button="{{ disable_back_button | default:0 }}">
+       {% include 'partials/alert_messages.html' %}
+
       <h2 class="thank-you">{% trans "Thank you for your order!" as tmsg %}{{ tmsg | force_escape }}</h2>
 
       <div class="list-info">


### PR DESCRIPTION
… to the learner dashboard if it is configured for their enterprise

looks like this on devstack:

<img width="829" alt="Screen Shot 2019-10-11 at 3 17 13 PM" src="https://user-images.githubusercontent.com/7385292/66678606-46b47280-ec3a-11e9-86e2-e5753e39f0cc.png">
