### PR TITLE
Grab email and order total from Order instead of the Basket instance.

### DIFF
--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -642,6 +642,12 @@ class EnrollmentCodeFulfillmentModule(BaseFulfillmentModule):
                 A URL encoded string that will be the body of the request are sending to HubSpot containing
                 fulfillment data about the order that was just processed.
         """
+        # Debug code for an issue we ran into on Stage. This will be removed.
+        try:
+            logger.info("Basket strategy: [%s]", order.basket.strategy)
+        except:  # pylint: disable=bare-except
+            logger.exception("Error occurred attempting to retrieve Basket 'Strategy' from order [%s]", order.number)
+
         logger.info("Gathering fulfillment data for submission to HubSpot for order [%s]", order.number)
 
         # need to do this to be able to grab the organization/company name, this isn't available in the order/lines
@@ -679,13 +685,13 @@ class EnrollmentCodeFulfillmentModule(BaseFulfillmentModule):
         data = urllib.urlencode({
             'firstname': order.billing_address.first_name,
             'lastname': order.billing_address.last_name,
-            'email': order.basket.owner.email,
+            'email': order.email,
             'address': street_address,
             'city': order.billing_address.line4,
             'state': order.billing_address.state,
             'country': country_name,
             'company': organization.value_text,
-            'deal_value': order.basket.total_incl_tax,
+            'deal_value': order.total_incl_tax,
             'ecommerce_course_name': course.name,
             'ecommerce_course_id': course.id,
             'bulk_purchase_quantity': order.num_items


### PR DESCRIPTION
[ENT-2317]
Debugging through an issue on Stage and wanted to simplify how we are retrieving some of the data.
- Grab email address from Order instead of the Basket
- Grab total deal amount from Order instead of the Basket
- Add a log statement to help debug an issue we were seeing on Stage env