### PR TITLE
ARCH-1210: set toggle to set request.user for jwt cookie authentication

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -636,7 +636,8 @@ EDX_DRF_EXTENSIONS = {
     'JWT_PAYLOAD_MERGEABLE_USER_ATTRIBUTES': (
         'tracking_context',
     ),
-    "OAUTH2_USER_INFO_URL": "http://127.0.0.1:8000/oauth2/user_info"
+    'OAUTH2_USER_INFO_URL': 'http://127.0.0.1:8000/oauth2/user_info',
+    'ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE': True,
 }
 
 # Enrollment codes voucher end datetime used for setting the end dates for vouchers

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -54,7 +54,7 @@ edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==2.0.0
-edx-drf-extensions==2.4.1
+edx-drf-extensions==2.4.2
 edx-ecommerce-worker==0.7.2
 edx-opaque-keys==1.0.1
 edx-rbac==1.0.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -68,7 +68,7 @@ edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==2.0.0
-edx-drf-extensions==2.4.1
+edx-drf-extensions==2.4.2
 edx-ecommerce-worker==0.7.2
 edx-i18n-tools==0.4.8
 edx-opaque-keys==1.0.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -56,7 +56,7 @@ edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==2.0.0
-edx-drf-extensions==2.4.1
+edx-drf-extensions==2.4.2
 edx-ecommerce-worker==0.7.2
 edx-opaque-keys==1.0.1
 edx-rbac==1.0.3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -65,7 +65,7 @@ edx-auth-backends==2.0.2
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.4.0
 edx-django-utils==2.0.0
-edx-drf-extensions==2.4.1
+edx-drf-extensions==2.4.2
 edx-ecommerce-worker==0.7.2
 edx-opaque-keys==1.0.1
 edx-rbac==1.0.3


### PR DESCRIPTION
The functionality added to edx-drf-extensions 2.4.1 now requires a
toggle to be set to work in 2.4.2. This sets the toggle to set the
request.user when using jwt cookie authentication.

ARCH-1210

**Related PRs:**
- https://github.com/edx/edx-internal/pull/1200
- https://github.com/edx/edx-drf-extensions/pull/90