### PR TITLE
Pin MySQL in Travis config

### DIFF
--- a/.travis/docker-compose-travis.yml
+++ b/.travis/docker-compose-travis.yml
@@ -3,7 +3,7 @@ version: "2"
 
 services:
   db:
-    image: mysql:5.6
+    image: mysql:5.6.45
     container_name: db
     command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
     environment:


### PR DESCRIPTION
5.6.46 has a bug that is breaking our test workflows. This pins the previous version until we can fix.