### PR TITLE
ENT-2374 | Update URL in Enterprise Coupons automated email

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -694,7 +694,7 @@ NEW_CODES_EMAIL_CONFIG = {
         This message is to inform you that a new order has been processed for your organization. Please visit the
         following page, in your Admin Dashboard, to find new codes ready for use.
 
-        https://portal.edx.org/{enterprise_slug}/admin/codes
+        https://portal.edx.org/{enterprise_slug}/admin/coupons
 
         Having trouble accessing your codes? Please contact edX Enterprise Support at customersuccess@edx.org.
         Thank you.


### PR DESCRIPTION
[ENT-2374]
- Update 'email_body' within 'NEW_CODES_EMAIL_CONFIG' dict to point to the correct URL within our automated email for an Enterprise admin to view their coupons