### PR TITLE
Send course purchase email

### DIFF
--- a/ecommerce/extensions/checkout/tests/test_signals.py
+++ b/ecommerce/extensions/checkout/tests/test_signals.py
@@ -40,22 +40,30 @@ class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
         self.request.user = self.user
         toggle_switch('ENABLE_NOTIFICATIONS', True)
 
-    def prepare_order(self, seat_type, credit_provider_id=None):
+    def prepare_order(self, seat_type, credit_provider_id=None, price=50):
         """
         Prepares order for a post-checkout test.
 
         Args:
             seat_type (str): Course seat type
             credit_provider_id (str): Credit provider associated with the course seat.
+            price : Price of the course
 
         Returns:
             Order
         """
         course = CourseFactory(partner=self.partner)
-        seat = course.create_or_update_seat(seat_type, False, 50, credit_provider_id, None, 2)
+        seat = course.create_or_update_seat(seat_type, False, price, credit_provider_id, None, 2)
         basket = factories.BasketFactory(owner=self.user, site=self.site)
         basket.add_product(seat, 1)
         order = create_order(basket=basket, user=self.user)
+        return order
+
+    def prepare_coupon_order(self):
+        coupon = self.create_coupon()
+        basket = factories.BasketFactory(owner=self.user, site=self.site)
+        basket.add_product(coupon, 1)
+        order = create_order(number=1, basket=basket, user=self.user)
         return order
 
     def mock_get_program_data(self, is_full):
@@ -117,8 +125,33 @@ class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
             )
         )
 
-    def test_post_checkout_callback_no_credit_provider(self):
+    def test_post_checkout_callback_non_credit_course(self):
+        """
+        Test that if basket has a seat product and no credit provider
+        is present, then send course purchase email
+        """
         order = self.prepare_order('verified')
+        send_course_purchase_email(None, user=self.user, order=order)
+        product = order.lines.first().product
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].from_email, order.site.siteconfiguration.from_email)
+        self.assertEqual(mail.outbox[0].subject, 'Order Placed')
+        self.assertIn(product.title, mail.outbox[0].body)
+
+    def test_post_checkout_callback_free_checkout(self):
+        """
+        Test that during freecheckout no email is sent
+        """
+        order = self.prepare_order('verified', price=0)
+        send_course_purchase_email(None, user=self.user, order=order)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_post_checkout_callback_no_credit_provider(self):
+        """
+        Test that if no credit_provider_id is present for credit course,
+        error is logged
+        """
+        order = self.prepare_order('credit')
         with LogCapture(LOGGER_NAME) as logger:
             send_course_purchase_email(None, user=self.user, order=order)
             logger.check(
@@ -128,6 +161,62 @@ class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
                     'Failed to send credit receipt notification. Credit seat product [{}] has no provider.'.format(
                         order.lines.first().product.id
                     )
+                )
+            )
+
+    def test_post_checkout_callback_no_provider_data(self):
+        """
+        Test that if no provider data is present against a credit provider
+        id, no email is sent
+        """
+        order = self.prepare_order('credit', credit_provider_id='HGW')
+        send_course_purchase_email(None, user=self.user, order=order)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_post_checkout_callback_entitlement_product(self):
+        """
+        Test that order placement email is sent if learner purchases
+        entitlement
+        """
+        entitlement = self.create_entitlement_product()
+        basket = factories.BasketFactory(owner=self.user, site=self.site)
+        basket.add_product(entitlement)
+        order = create_order(basket=basket, user=self.user)
+        send_course_purchase_email(None, user=self.user, order=order)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].from_email, order.site.siteconfiguration.from_email)
+        self.assertEqual(mail.outbox[0].subject, 'Order Placed')
+        self.assertIn(entitlement.title, mail.outbox[0].body)
+
+    def test_post_checkout_callback_non_seat_or_entitlement_product(self):
+        """
+        Test that no email is sent if basket contains a single product
+        of non seat or non entitlement type
+        """
+        order = self.prepare_coupon_order()
+        send_course_purchase_email(None, user=self.user, order=order)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_more_than_one_product(self):
+        """
+        Test that we do not send email if basket contains more
+        than one product
+        """
+        coupon = self.create_coupon()
+        course = CourseFactory(partner=self.partner)
+        seat = course.create_or_update_seat('verified', False, 50, None, None, 2)
+        basket = factories.BasketFactory(owner=self.user, site=self.site)
+        basket.add_product(seat)
+        basket.add_product(coupon)
+        order = create_order(basket=basket, user=self.user)
+
+        with LogCapture(LOGGER_NAME) as logger:
+            send_course_purchase_email(None, user=self.user, order=order)
+            logger.check(
+                (
+                    LOGGER_NAME,
+                    'INFO',
+                    'Currently support receipt emails for order with one item.'
                 )
             )
 
@@ -281,12 +370,7 @@ class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
     def test_track_completed_coupon_order(self):
         """ Make sure we do not send GA events for Coupon orders """
         with mock.patch('ecommerce.extensions.checkout.signals.track_segment_event') as mock_track:
-
-            coupon = self.create_coupon()
-            basket = factories.BasketFactory(owner=self.user, site=self.site)
-            basket.add_product(coupon)
-
-            order = factories.create_order(basket=basket, user=self.user)
+            order = self.prepare_coupon_order()
             track_completed_order(None, order)
             assert not mock_track.called
 

--- a/ecommerce/templates/customer/emails/commtype_course_purchased_body.html
+++ b/ecommerce/templates/customer/emails/commtype_course_purchased_body.html
@@ -8,10 +8,14 @@
         <!--/message HTML content -->
         <p>{% filter force_escape %}{% blocktrans %}Hi {{full_name}},{% endblocktrans %}{% endfilter %}</p>
         <br>
-        <p>{% filter force_escape %}{% blocktrans with course_title=course_title platform_name=platform_name %}Thank you for purchasing {{course_title}}. The charge below will appear on your next credit or debit card statement with a company name of {{platform_name}}.{% endblocktrans %}{% endfilter %}</p>
+        <p>{% filter force_escape %}{% blocktrans with course_title=course_title platform_name=platform_name %}Thank you for purchasing {{course_title}}. A charge will appear on your credit or debit card statement with a company name of "{{platform_name}}".{% endblocktrans %}{% endfilter %}</p>
         <br>
         <p>{% filter force_escape %}{% blocktrans %}You can access your course and complete your verification (if required) on your {{platform_name}} dashboard. {% endblocktrans %}{% endfilter %} </p>
         <p>{% filter force_escape %}{% blocktrans %}To explore other great courses, visit the {{platform_name}} website. More courses are added every day!{% endblocktrans %}{% endfilter %}</p>
+        <br>
+        <a href="{{ receipt_page_url }}" style="color: #ffffff; text-decoration: none;">
+            {% trans "View Payment Information" as tmsg %}{{ tmsg | force_escape }}
+        </a>
         <br>
         <p>{% trans "Thank you. We hope you enjoy the course!" as tmsg %}{{ tmsg | force_escape }}</p>
         <p>{% filter force_escape %}{% blocktrans %}{{platform_name}} team {% endblocktrans %}{% endfilter %}</p>

--- a/ecommerce/templates/customer/emails/commtype_course_purchased_body.txt
+++ b/ecommerce/templates/customer/emails/commtype_course_purchased_body.txt
@@ -3,10 +3,13 @@
 
 {% blocktrans %}Hi {{full_name}},{% endblocktrans %}
 
-{% blocktrans with course_title=course_title platform_name=platform_name %}Thank you for purchasing {{course_title}}. The charge below will appear on your next credit or debit card statement with a company name of {{platform_name}}.{% endblocktrans %}
+{% blocktrans with course_title=course_title platform_name=platform_name %}Thank you for purchasing {{course_title}}. A charge will appear on your credit or debit card statement with a company name of "{{platform_name}}".{% endblocktrans %}
 
 {% blocktrans %}You can access your course and complete your verification (if required) on your {{platform_name}} dashboard. {% endblocktrans %}
 {% blocktrans %}To explore other great courses, visit the {{platform_name}} website. More courses are added every day!{% endblocktrans %}
+
+{% trans "To view your payment information, visit the following website." %}
+{{receipt_page_url}}
 
 {% trans "Thank you. We hope you enjoy the course!" %}
 


### PR DESCRIPTION
Send verified course purchase email to learners. 
Previously we sent these emails for cybersource payment processor but we should send these to any user who goes through the checkout process. 

#### Notes
* Currently we only support receipt email for purchase of one product
* If credit is purchased send the credit purchase email as it was previously being sent
* If the user has paid via any payment processor send him email confirming his purchase
* Emails are not sent for free checkout