### PR TITLE
fix example in history backfill command

### DIFF
--- a/ecommerce/core/management/commands/backfill_history.py
+++ b/ecommerce/core/management/commands/backfill_history.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
     Backfill history for models using django-simple-history.
     This is a one-off and would be removed after it is executed.
     Example usage:
-    $ ./manage.py backfill_history --batchsize 1000 --sleep_between 1 --settings=devstack
+    $ ./manage.py backfill_history --batch_size 1000 --sleep_between 1 --input_root /tmp/data/ --settings=devstack
     """
 
     help = (
@@ -61,7 +61,7 @@ class Command(BaseCommand):
         )
 
         parser.add_argument(
-            "--size",
+            "--batch_size",
             action="store",
             default=self.DEFAULT_SIZE,
             type=int,
@@ -71,6 +71,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--input_root",
             action="store",
+            help="Path containing data files from snapshot for history backfill"
         )
 
     def chunks(self, ids, chunk_size):
@@ -82,7 +83,7 @@ class Command(BaseCommand):
         return values
 
     def handle(self, *args, **options):
-        batch_size = options['size']
+        batch_size = options['batch_size']
         sleep_between = options['sleep_between']
         input_root = options['input_root']
 


### PR DESCRIPTION
This is just a little fix to make sure that the example is accurate so that devops doesn't get confused when running this management command.