### PR TITLE
ARCH-418: Remove jwt_refresh_cookie

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -452,7 +452,6 @@ JWT_AUTH = {
     'JWT_PUBLIC_SIGNING_JWK_SET': None,
     'JWT_AUTH_COOKIE_HEADER_PAYLOAD': 'edx-jwt-cookie-header-payload',
     'JWT_AUTH_COOKIE_SIGNATURE': 'edx-jwt-cookie-signature',
-    'JWT_AUTH_REFRESH_COOKIE': 'edx-jwt-refresh-cookie'
 }
 
 # Service user for worker processes.


### PR DESCRIPTION
The login_refresh endpoint in the LMS was updated to be based on the
user's session, rather than requiring an additional refresh cookie, so
removing any references to the unused refresh cookie and
JWT_AUTH_REFRESH_COOKIE setting.

ARCH-418