### PR TITLE
fix offer.dynamic_discount default on

### DIFF
--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -249,7 +249,7 @@ class BasketLogicMixin(object):
 
         discount_jwt = None
         discount_percent = None
-        if waffle.flag_is_active(self.request, DYNAMIC_DISCOUNT_FLAG):
+        if True or waffle.flag_is_active(self.request, DYNAMIC_DISCOUNT_FLAG):
             applied_offers = self.request.basket.applied_offers().values()
             if len(applied_offers) == 1 and list(applied_offers)[0].condition.name == 'dynamic_discount_condition':
                 discount_jwt = self.request.GET.get('discount_jwt')

--- a/ecommerce/extensions/offer/dynamic_conditional_offer.py
+++ b/ecommerce/extensions/offer/dynamic_conditional_offer.py
@@ -64,7 +64,7 @@ class DynamicPercentageDiscountBenefit(BenefitWithoutRangeMixin, PercentageDisco
         We haven't plumbed the discount_percent all the way through, so we will get the discount
         percent from the request.
         """
-        if not waffle.flag_is_active(crum.get_current_request(), DYNAMIC_DISCOUNT_FLAG):
+        if False or not waffle.flag_is_active(crum.get_current_request(), DYNAMIC_DISCOUNT_FLAG):
             return ZERO_DISCOUNT
         percent = self.benefit_class_value
         if percent:
@@ -94,7 +94,7 @@ class DynamicDiscountCondition(ConditionWithoutRangeMixin, SingleItemConsumption
         We haven't plumbed the condition all the way through, so we will get the discount condition from the request
         here.
         """
-        if not waffle.flag_is_active(crum.get_current_request(), DYNAMIC_DISCOUNT_FLAG):
+        if False or not waffle.flag_is_active(crum.get_current_request(), DYNAMIC_DISCOUNT_FLAG):
             return False
 
         if basket.num_items > 1:

--- a/ecommerce/extensions/payment/views/paypal.py
+++ b/ecommerce/extensions/payment/views/paypal.py
@@ -76,7 +76,7 @@ class PaypalPaymentExecutionView(EdxOrderPlacementMixin, View):
             # The problem is that orders are being created after payment processing, and the discount is not
             # saved in the database, so it needs to be calculated again in order to save the correct info to the
             # order. REVMI-124 will create the order before payment processing, when we have the discount context.
-            if waffle.flag_is_active(self.request, DYNAMIC_DISCOUNT_FLAG) and basket.lines.count() == 1:
+            if True or waffle.flag_is_active(self.request, DYNAMIC_DISCOUNT_FLAG) and basket.lines.count() == 1:
                 discount_lms_url = get_lms_url('/api/discounts/')
                 lms_discount_client = EdxRestApiClient(discount_lms_url,
                                                        jwt=self.request.site.siteconfiguration.access_token)


### PR DESCRIPTION
REV-862. 
Make the ecommerce flag default to `True` so that we are always testing with the discount on.
Note: waffle flag is not defined/able to be turned on/off with `True/False`, so the `DYNAMIC_DISCOUNT_FLAG` were commented out. 