### PR TITLE
ENT-2435 | Updating non enterprise coupon form to allow enterprise cu…

### DIFF
--- a/ecommerce/static/js/views/coupon_form_view.js
+++ b/ecommerce/static/js/views/coupon_form_view.js
@@ -250,10 +250,27 @@ define([
                         };
                     }
                 },
-                'input[name=enterprise_customer]': {
+                'select[name=enterprise_customer]': {
                     observe: 'enterprise_customer',
+                    selectOptions: {
+                        collection: function() {
+                            return ecommerce.coupons.enterprise_customers;
+                        },
+                        defaultOption: {id: '', name: ''},
+                        labelPath: 'name',
+                        valuePath: 'id'
+                    },
+                    setOptions: {
+                        validate: true
+                    },
                     onGet: function(val) {
                         return _.isUndefined(val) || _.isNull(val) ? '' : val.id;
+                    },
+                    onSet: function(val) {
+                        return _.isEmpty(val) ? null : {
+                            id: val,
+                            name: $('select[name=enterprise_customer] option:selected').text()
+                        };
                     }
                 },
                 'input[name=program_uuid]': {
@@ -290,6 +307,7 @@ define([
                     'client',
                     'course_seat_types',
                     'course_catalog',
+                    'enterprise_customer',
                     'end_date',
                     'invoice_discount_type',
                     'invoice_discount_value',
@@ -754,9 +772,12 @@ define([
                     if (_.isString(enterpriseCustomer)) {
                         // API returns a string value for enterprise customer
                         this.model.set('enterprise_customer', {id: enterpriseCustomer});
-                    } else if (_.isUndefined(enterpriseCustomer) || _.isNull(enterpriseCustomer)) {
-                        this.formGroup('#enterprise-customer').remove();
                     }
+                    // This removes the enterprise_customer element if EnterpriseCustomer
+                    // is null, which will necessarily happen in the case we are solving for
+                    // } else if (_.isUndefined(enterpriseCustomer) || _.isNull(enterpriseCustomer)) {
+                    //     this.formGroup('#enterprise-customer').remove();
+                    // }
                     if (this.model.get('program_uuid')) {
                         this.$('.catalog-type input').attr('disabled', true);
                     }

--- a/ecommerce/static/templates/coupon_form.html
+++ b/ecommerce/static/templates/coupon_form.html
@@ -216,7 +216,7 @@
         <% if(editing) {%>
             <div class="form-group enterprise-customer">
                 <label for="enterprise-customer"><%= gettext('Enterprise Customer:') %></label>
-                <input id="enterprise-customer" type="text" class="form-control non-editable" name="enterprise_customer">
+                <select id="enterprise-customer" class="form-control" name="enterprise_customer"></select>
                 <p class="help-block"></p>
             </div>
         <%}%>


### PR DESCRIPTION
…stomer to be added

Create screen does not have enterprise customer drop down, but the edit screen does.

Additionally, when you save the enterprise customer, the coupon then gets moved over to the other view (Enterprise Coupons)

Non-enterprise coupon create screen:
<img width="796" alt="Screen Shot 2019-11-08 at 11 33 01 AM" src="https://user-images.githubusercontent.com/7385292/68494054-bb6bd400-021b-11ea-90b2-14d1e947e872.png">

Non-enterprise coupon edit screen:
<img width="864" alt="Screen Shot 2019-11-08 at 11 33 38 AM" src="https://user-images.githubusercontent.com/7385292/68494076-c292e200-021b-11ea-829c-a2f7c66e4506.png">

