### PR TITLE
Fix paypal payment processor default configuration

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -772,7 +772,7 @@ ECOMMERCE_PAYMENT_PROCESSOR_CONFIG = {
             'transaction_key': 'SET-ME-PLEASE'
         },
         'paypal': {
-            'cancel_url': '/checkout/cancel-checkout/',
+            'cancel_checkout_path': '/checkout/cancel-checkout/',
             'client_id': 'SET-ME-PLEASE',
             'client_secret': 'SET-ME-PLEASE',
             'error_url': '/checkout/error/',


### PR DESCRIPTION
The `cancel_url` configuration setting is not used by the paypal payment
processor in ecommerce. Instead, the payment processor uses the
`cancel_checkout_path` configuration parameter.

This error has been reported by two different users:
https://discuss.overhang.io/t/ecommerce-plugin-500-error-on-fresh-setup
https://openedx.slack.com/archives/C02SNA1U4/p1573488822105900?thread_ts=1573488555.104900&cid=C02SNA1U4

The proposed fix has worked in both cases.