### PR TITLE
Add management command to seed ecommerce with an enterprise coupon

### DIFF
--- a/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
         )
 
     def get_access_token(self):
-        """ 
+        """
         Returns an access token and expiration date from the OAuth provider:
             (str, datetime)
         """

--- a/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -5,8 +5,8 @@ from __future__ import absolute_import, unicode_literals
 
 import datetime
 import logging
-import requests
 
+import requests
 from django.core.management.base import BaseCommand
 from django.utils.timezone import now
 from edx_rest_api_client.client import EdxRestApiClient

--- a/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -154,11 +154,11 @@ class Command(BaseCommand):
         enterprise_customer_uuid = options['enterprise_customer']
         self.site = SiteConfiguration.objects.first()
 
-        ecommerce_api_url = self.site.build_ecommerce_url() + '/api/v2'
+        ecommerce_api_url = '{}/api/v2'.format(self.site.build_ecommerce_url())
         enterprise_api_url = self.site.enterprise_api_url
 
-        enterprise_customer_request_url = enterprise_api_url + 'enterprise-customer/'
-        enterprise_catalog_request_url = enterprise_api_url + 'enterprise_catalogs/'
+        enterprise_customer_request_url = '{}enterprise-customer/'.format(enterprise_api_url)
+        enterprise_catalog_request_url = '{}enterprise_catalogs/'.format(enterprise_api_url)
 
         # Set up request headers with JWT access token
         self.headers = self._get_headers()

--- a/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
             type=str,
         )
 
-    def _get_access_token(self):
+    def get_access_token(self):
         """ Returns an access token and expiration date from the OAuth provider.
 
         Returns:
@@ -62,14 +62,14 @@ class Command(BaseCommand):
             oauth_access_token_url, key, secret, token_type='jwt'
         )
 
-    def _get_headers(self):
+    def get_headers(self):
         """
         Returns a dict containing the authenticated JWT access token
         """
-        access_token, __ = self._get_access_token()
+        access_token, __ = self.get_access_token()
         return {'Authorization': 'JWT ' + access_token}
 
-    def _get_enterprise_customer(self, url, enterprise_customer_uuid=None):
+    def get_enterprise_customer(self, url, enterprise_customer_uuid=None):
         """ Returns an enterprise customer """
         logger.info('\nFetching an enterprise customer...')
         try:
@@ -82,7 +82,7 @@ class Command(BaseCommand):
         except IndexError:
             logger.error('No enterprise customer found.')
 
-    def _get_enterprise_catalog(self, url):
+    def get_enterprise_catalog(self, url):
         """
         Returns a catalog associated with a specified enterprise customer
         """
@@ -100,7 +100,7 @@ class Command(BaseCommand):
         except IndexError:
             logger.error('No catalog found for enterprise (%s)', self.enterprise_customer.get('uuid'))
 
-    def _create_coupon(self, ecommerce_api_url):
+    def create_coupon(self, ecommerce_api_url):
         """
         Creates and returns a coupon associated with the specified
         enterprise customer and catalog
@@ -161,22 +161,22 @@ class Command(BaseCommand):
         enterprise_catalog_request_url = '{}enterprise_catalogs/'.format(enterprise_api_url)
 
         # Set up request headers with JWT access token
-        self.headers = self._get_headers()
+        self.headers = self.get_headers()
 
         # Fetch enterprise customer
-        self.enterprise_customer = self._get_enterprise_customer(
+        self.enterprise_customer = self.get_enterprise_customer(
             url=enterprise_customer_request_url,
             enterprise_customer_uuid=enterprise_customer_uuid,
         )
 
         if self.enterprise_customer:
             # Fetch enterprise customer catalog
-            self.enterprise_catalog = self._get_enterprise_catalog(
+            self.enterprise_catalog = self.get_enterprise_catalog(
                 url=enterprise_catalog_request_url,
             )
 
         if self.enterprise_catalog:
             # Create a new enterprise coupon associated with the
             # above enterprise customer/catalog
-            self.coupon = self._create_coupon(ecommerce_api_url=ecommerce_api_url)
+            self.coupon = self.create_coupon(ecommerce_api_url=ecommerce_api_url)
             logger.info('\nEnterprise coupon successfully created: %s', self.coupon)

--- a/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -38,6 +38,7 @@ class Command(BaseCommand):
     help = 'Seeds an enterprise coupon for an existing enterprise customer.'
 
     def add_arguments(self, parser):
+        """ Adds argument(s) to the the command """
         parser.add_argument(
             '--enterprise-customer',
             action='store',
@@ -48,9 +49,8 @@ class Command(BaseCommand):
         )
 
     def get_access_token(self):
-        """ Returns an access token and expiration date from the OAuth provider.
-
-        Returns:
+        """ 
+        Returns an access token and expiration date from the OAuth provider:
             (str, datetime)
         """
         logger.info('\nFetching access token for site...')
@@ -81,6 +81,7 @@ class Command(BaseCommand):
             return response.json().get('results')[0]
         except IndexError:
             logger.error('No enterprise customer found.')
+            return None
 
     def get_enterprise_catalog(self, url):
         """
@@ -88,6 +89,7 @@ class Command(BaseCommand):
         """
         if not self.enterprise_customer:
             logger.error('An enterprise customer was not specified.')
+            return None
 
         logger.info('\nFetching catalog for enterprise customer (%s)...', self.enterprise_customer.get('uuid'))
         try:
@@ -99,6 +101,7 @@ class Command(BaseCommand):
             return response.json().get('results')[0]
         except IndexError:
             logger.error('No catalog found for enterprise (%s)', self.enterprise_customer.get('uuid'))
+            return None
 
     def create_coupon(self, ecommerce_api_url):
         """
@@ -107,6 +110,7 @@ class Command(BaseCommand):
         """
         if not self.enterprise_customer or not self.enterprise_catalog:
             logger.error('An enterprise customer and/or catalog was not specified.')
+            return None
 
         logger.info('\nCreating an enterprise coupon...')
         category = Category.objects.get(name='coupons')

--- a/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -87,7 +87,7 @@ class Command(BaseCommand):
         """
         if not self.enterprise_customer:
             logger.error('An enterprise customer was not specified.')
-    
+
         logger.info('\nFetching catalog for enterprise customer (%s)...', self.enterprise_customer.get('uuid'))
         try:
             response = requests.get(
@@ -108,7 +108,7 @@ class Command(BaseCommand):
             logger.error('An enterprise customer and/or catalog was not specified.')
 
         logger.info('\nCreating an enterprise coupon...')
-        category = Category.objects.get(slug='bulk-enrollment-upon-redemption')
+        category, __ = Category.objects.get_or_create(slug='bulk-enrollment-upon-redemption')
         request_obj = {
             "category": {
                 "id": category.id,

--- a/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -5,8 +5,8 @@ from __future__ import absolute_import, unicode_literals
 
 import datetime
 import logging
-
 import requests
+
 from django.core.management.base import BaseCommand
 from django.utils.timezone import now
 from edx_rest_api_client.client import EdxRestApiClient

--- a/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -69,7 +69,7 @@ class Command(BaseCommand):
         access_token, __ = self._get_access_token()
         return {'Authorization': 'JWT ' + access_token}
 
-    def _get_enterprise_customer(self, url, enterprise_customer_uuid = None):
+    def _get_enterprise_customer(self, url, enterprise_customer_uuid=None):
         """ Returns an enterprise customer """
         logger.info('\nFetching an enterprise customer...')
         try:

--- a/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -109,7 +109,7 @@ class Command(BaseCommand):
             logger.error('An enterprise customer and/or catalog was not specified.')
 
         logger.info('\nCreating an enterprise coupon...')
-        category = Category.objects.first()
+        category = Category.objects.get(name='coupons')
         request_obj = {
             "category": {
                 "id": category.id,

--- a/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -1,0 +1,158 @@
+"""
+Management command for assigning enterprise roles to existing enterprise users.
+"""
+from __future__ import absolute_import, unicode_literals
+
+import datetime
+import logging
+
+import requests
+from django.core.management.base import BaseCommand
+from django.utils.timezone import now
+from edx_rest_api_client.client import EdxRestApiClient
+from oscar.core.loading import get_model
+
+from ecommerce.core.constants import ENROLLMENT_CODE_PRODUCT_CLASS_NAME
+from ecommerce.core.models import SiteConfiguration
+from ecommerce.invoice.models import Invoice
+
+Category = get_model('catalogue', 'Category')
+Benefit = get_model('offer', 'Benefit')
+Voucher = get_model('voucher', 'Voucher')
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Management command for populating Ecommerce with an enterprise coupon
+
+    Example usage:
+        $ ./manage.py seed_enterprise_devstack_data
+    """
+    help = 'Seeds an enterprise coupon for an existing enterprise customer.'
+
+    def _get_access_token(self, site):
+        """ Returns an access token and expiration date from the OAuth provider.
+
+        Returns:
+            (str, datetime)
+        """
+        LOGGER.info('\nFetching access token for site...')
+        oauth2_provider_url = site.oauth_settings.get('SOCIAL_AUTH_EDX_OIDC_URL_ROOT')
+        key = site.oauth_settings.get('BACKEND_SERVICE_EDX_OAUTH2_KEY')
+        secret = site.oauth_settings.get('BACKEND_SERVICE_EDX_OAUTH2_SECRET')
+        oauth_access_token_url = oauth2_provider_url + '/access_token/'
+        return EdxRestApiClient.get_oauth_access_token(
+            oauth_access_token_url, key, secret, token_type='jwt'
+        )
+
+    def _get_site(self):
+        """ Returns the default site configuration """
+        return SiteConfiguration.objects.first()
+
+    def _get_headers(self, site):
+        """
+        Returns a headers dict containing the authenticated JWT access token
+        """
+        access_token, __ = self._get_access_token(site)
+        return {'Authorization': 'JWT ' + access_token}
+
+    def _get_enterprise_customer(self, url, headers):
+        """ Returns an enterprise customer """
+        LOGGER.info('\nFetching an enterprise customer...')
+        response = requests.get(url, headers=headers)
+        return response.json().get('results')[0]
+
+    def _get_enterprise_catalog(self, url, enterprise_customer, headers):
+        """
+        Returns a catalog associated with a specified enterprise customer
+        """
+        LOGGER.info('\nFetching catalog for enterprise customer (%s)...', enterprise_customer.get('uuid'))
+        response = requests.get(
+            url,
+            params={'enterprise_customer': enterprise_customer.get('uuid')},
+            headers=headers,
+        )
+        return response.json().get('results')[0]
+
+    def _create_coupon(self, url, ecommerce_api_url, enterprise_customer, enterprise_catalog, headers):
+        """
+        Creates and returns a coupon associated with the specified
+        enterprise customer and catalog
+        """
+        LOGGER.info('\nCreating an enterprise coupon...')
+        category = Category.objects.get(slug='bulk-enrollment-upon-redemption')
+        request_obj = {
+            "category": {
+                "id": category.id,
+                "name": category.name,
+            },
+            "code": "",
+            "id": None,
+            "price": 0,
+            "quantity": 1,
+            "enterprise_catalog_url": ecommerce_api_url + '/enterprise/customer_catalogs/',
+            "coupon_type": ENROLLMENT_CODE_PRODUCT_CLASS_NAME,
+            "voucher_type": Voucher.MULTI_USE,
+            "benefit_type": Benefit.PERCENTAGE,
+            "catalog_type": "Single course",
+            "invoice_discount_type": Invoice.PERCENTAGE,
+            "invoice_type": Invoice.POSTPAID,
+            "tax_deduction": "No",
+            "title": "Test Enterprise Coupon 1",
+            "enterprise_customer": {
+                'id': enterprise_customer.get('uuid'),
+                'name': enterprise_customer.get('name'),
+            },
+            "enterprise_customer_catalog": enterprise_catalog.get('uuid'),
+            "start_date": str(now() - datetime.timedelta(days=10)),
+            "end_date": str(now() + datetime.timedelta(days=10)),
+            "max_uses": 10,
+            "invoice_number": "",
+            "invoice_payment_date": None,
+            "invoice_discount_value": 100,
+            "start_datetime": str(now() - datetime.timedelta(days=10)),
+            "end_datetime": str(now() + datetime.timedelta(days=10)),
+            "benefit_value": 100
+        }
+        response = requests.post(url, json=request_obj, headers=headers)
+        return response.json()
+
+    def handle(self, *args, **options):
+        """
+        Entry point for managment command execution.
+        """
+        site = self._get_site()
+
+        ecommerce_api_url = site.build_ecommerce_url() + '/api/v2'
+        enterprise_api_url = site.enterprise_api_url
+
+        enterprise_customer_request_url = enterprise_api_url + 'enterprise-customer/'
+        enterprise_catalog_request_url = enterprise_api_url + 'enterprise_catalogs/'
+        enterprise_coupons_request_url = ecommerce_api_url + '/enterprise/coupons/'
+
+        # Set up request headers with JWT access token
+        headers = self._get_headers(site)
+
+        # Fetch enterprise customer
+        enterprise_customer = self._get_enterprise_customer(url=enterprise_customer_request_url, headers=headers)
+
+        # Fetch enterprise customer catalog
+        enterprise_catalog = self._get_enterprise_catalog(
+            url=enterprise_catalog_request_url,
+            enterprise_customer=enterprise_customer,
+            headers=headers,
+        )
+
+        # Create a new enterprise coupon associated with the
+        # above enterprise customer/catalog
+        coupon = self._create_coupon(
+            url=enterprise_coupons_request_url,
+            ecommerce_api_url=ecommerce_api_url,
+            enterprise_customer=enterprise_customer,
+            enterprise_catalog=enterprise_catalog,
+            headers=headers,
+        )
+
+        LOGGER.info('\nEnterprise coupon successfully created: %s', coupon)

--- a/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -62,12 +62,6 @@ class Command(BaseCommand):
             oauth_access_token_url, key, secret, token_type='jwt'
         )
 
-    def _get_default_site(self):
-        """ Returns the default site configuration """
-        if not self.site:
-            self.site = SiteConfiguration.objects.first()
-        return self.site
-
     def _get_headers(self):
         """
         Returns a headers dict containing the authenticated JWT access token

--- a/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -108,7 +108,7 @@ class Command(BaseCommand):
             logger.error('An enterprise customer and/or catalog was not specified.')
 
         logger.info('\nCreating an enterprise coupon...')
-        category, __ = Category.objects.get_or_create(slug='bulk-enrollment-upon-redemption')
+        category = Category.objects.get(slug='coupons')
         request_obj = {
             "category": {
                 "id": category.id,

--- a/ecommerce/enterprise/tests/test_seed_enterprise_devstack_data_command.py
+++ b/ecommerce/enterprise/tests/test_seed_enterprise_devstack_data_command.py
@@ -113,7 +113,7 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
 
         result = self.command.get_enterprise_customer(url=url)
         mock_request.assert_called_with(url, headers={}, params=None)
-        assert result == None
+        assert result is None
 
     @patch('requests.get')
     def test_get_enterprise_catalog(self, mock_request):
@@ -157,7 +157,7 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
         )
         result = self.command.get_enterprise_catalog(url=url)
         mock_request.assert_called_with(url, headers={}, params={'enterprise_customer': self.ent_customer_uuid})
-        assert result == None
+        assert result is None
 
     @patch('requests.post')
     def test_create_coupon(self, mock_request):

--- a/ecommerce/enterprise/tests/test_seed_enterprise_devstack_data_command.py
+++ b/ecommerce/enterprise/tests/test_seed_enterprise_devstack_data_command.py
@@ -11,6 +11,7 @@ from django.core.management import call_command
 from django.utils.timezone import now
 from mock import Mock, patch
 from oscar.core.loading import get_model
+from oscar.test.factories import CategoryFactory
 
 from ecommerce.enterprise.management.commands.seed_enterprise_devstack_data import Command as seed_command
 from ecommerce.tests.factories import SiteConfigurationFactory
@@ -24,14 +25,84 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
     Tests the seed enterprise devstack data management command.
     """
     logger = 'ecommerce.enterprise.management.commands.seed_enterprise_devstack_data.logger'
+    site_oauth_settings = {
+        'SOCIAL_AUTH_EDX_OIDC_URL_ROOT': 'http://edx.devstack.lms:18000/oauth2',
+        'BACKEND_SERVICE_EDX_OAUTH2_KEY': 'ecommerce-backend-service-key',
+        'BACKEND_SERVICE_EDX_OAUTH2_SECRET': 'ecommerce-backend-service-secret',
+    }
 
     def setUp(self):
         """
-        Set up initial data (e.g., site configuration) prior to running tests
+        Set up initial data (e.g., site configuration, category) prior to running tests
         """
         super(SeedEnterpriseDevstackDataTests, self).setUp()
-        SiteConfigurationFactory.create()
+        self.site_config = SiteConfigurationFactory.create(
+            oauth_settings=self.site_oauth_settings,
+        )
+        self.command = seed_command()
+        self.command.site = self.site_config
+        CategoryFactory.create(slug='coupons')
         self.ent_customer_uuid = str(uuid4())
+
+    @patch('ecommerce.enterprise.management.commands.seed_enterprise_devstack_data.EdxRestApiClient.get_oauth_access_token')
+    def test_get_access_token(self, mock_api_client):
+        """ TODO """
+        # sanity check that SiteConfiguration has the correct oauth_settings
+        assert self.command.site.oauth_settings == self.site_oauth_settings
+
+        self.command._get_access_token()
+        oauth_settings = self.command.site.oauth_settings
+        mock_api_client.assert_called_with(
+            '{}/access_token/'.format(oauth_settings.get('SOCIAL_AUTH_EDX_OIDC_URL_ROOT')),
+            oauth_settings.get('BACKEND_SERVICE_EDX_OAUTH2_KEY'),
+            oauth_settings.get('BACKEND_SERVICE_EDX_OAUTH2_SECRET'),
+            token_type='jwt',
+        )
+
+    @patch.object(seed_command, '_get_access_token')
+    def test_get_headers(self, mock_get_access_token):
+        """ TODO """
+        access_token = 'fake_access_token'
+        mock_get_access_token.return_value = (access_token, now())
+        headers = self.command._get_headers()
+        assert headers == {'Authorization': 'JWT {}'.format(access_token)}
+
+    @patch('requests.get')
+    def test_get_enterprise_customer(self, mock_request):
+        """ TODO """
+        url = '{}enterprise-customer/'.format(self.command.site.enterprise_api_url)
+        self.command._get_enterprise_customer(url=url)
+        mock_request.assert_called_with(url, headers={}, params=None)
+        self.command._get_enterprise_customer(
+            url=url,
+            enterprise_customer_uuid=self.ent_customer_uuid
+        )
+        mock_request.assert_called_with(
+            url,
+            headers={},
+            params={'uuid': self.ent_customer_uuid},
+        )
+
+    @patch('requests.get')
+    def test_get_enterprise_catalog(self, mock_request):
+        """ TODO """
+        url = '{}enterprise_catalogs/'.format(self.command.site.enterprise_api_url)
+        self.command.enterprise_customer = {'uuid': self.ent_customer_uuid}
+        self.command._get_enterprise_catalog(url=url)
+        mock_request.assert_called_with(
+            url,
+            headers={},
+            params={'enterprise_customer': self.ent_customer_uuid},
+        )
+
+    @patch('requests.post')
+    def test_create_coupon(self, mock_request):
+        """ TODO """
+        catalog_uuid = str(uuid4())
+        ecommerce_api_url = self.command.site.build_ecommerce_url() + '/api/v2'
+        self.command.enterprise_customer = {'uuid': self.ent_customer_uuid}
+        self.command.enterprise_catalog = {'uuid': catalog_uuid}
+        self.command._create_coupon(ecommerce_api_url)
 
     @patch('requests.post')
     @patch.object(seed_command, '_get_enterprise_catalog')

--- a/ecommerce/enterprise/tests/test_seed_enterprise_devstack_data_command.py
+++ b/ecommerce/enterprise/tests/test_seed_enterprise_devstack_data_command.py
@@ -1,0 +1,72 @@
+# encoding: utf-8
+"""
+Contains the tests for creating an coupon associated with
+an enterprise customer and catalog.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+from mock import patch, Mock
+from django.utils.timezone import now
+from uuid import uuid4
+
+from django.core.management import CommandError, call_command
+from factory.django import get_model
+from ecommerce.tests.factories import SiteConfigurationFactory
+
+from ecommerce.enterprise.management.commands.seed_enterprise_devstack_data import Command as seed_command
+from ecommerce.tests.testcases import TransactionTestCase
+
+SiteConfiguration = get_model('core', 'SiteConfiguration')
+
+class SeedEnterpriseDevstackDataTests(TransactionTestCase):
+    """
+    Tests the seed enterprise devstack data management command.
+    """
+    logger = 'ecommerce.enterprise.management.commands.seed_enterprise_devstack_data.logger'
+
+    def setUp(self):
+        """
+        TODO
+        """
+        super(SeedEnterpriseDevstackDataTests, self).setUp()
+        SiteConfigurationFactory.create()
+        self.ent_customer_uuid = str(uuid4())
+
+    @patch('requests.post')
+    @patch.object(seed_command, '_get_enterprise_catalog')
+    @patch.object(seed_command, '_get_enterprise_customer')
+    @patch.object(seed_command, '_get_access_token')
+    def test_create_enterprise_coupon_successfully_with_enterprise_customer(self, mock_access_token, mock_ent_customer, mock_ent_catalog, mock_coupon_post):
+        """
+        Verify a coupon is created for an enterprise customer/catalog.
+        """
+        mock_coupon_post_res = {'data': 'some data'}
+
+        # create return values for mocked methods
+        mock_access_token.return_value = ('fake_access_token', now())
+        mock_ent_customer.return_value = {
+            'results': [
+                {
+                    'uuid': self.ent_customer_uuid,
+                    'name': 'Test Enterprise',
+                    'slug': 'test-enterprise',
+                }
+            ]
+        }
+        mock_ent_catalog.return_value = {
+            'results': [
+                {
+                    'uuid': str(uuid4()),
+                    'title': 'Test Enterprise Catalog',
+                    'enterprise_customer': self.ent_customer_uuid,
+                }
+            ]
+        }
+        mock_coupon_post.return_value = Mock(
+            status_code=200,
+            json=lambda: mock_coupon_post_res,
+        )
+        with patch(self.logger) as patched_log:
+            call_command('seed_enterprise_devstack_data')
+            patched_log.info.assert_called_with('\nEnterprise coupon successfully created: %s', mock_coupon_post_res)

--- a/ecommerce/enterprise/tests/test_seed_enterprise_devstack_data_command.py
+++ b/ecommerce/enterprise/tests/test_seed_enterprise_devstack_data_command.py
@@ -113,7 +113,7 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
 
         result = self.command.get_enterprise_customer(url=url)
         mock_request.assert_called_with(url, headers={}, params=None)
-        assert None == result
+        assert if result is None
 
     @patch('requests.get')
     def test_get_enterprise_catalog(self, mock_request):
@@ -157,7 +157,7 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
         )
         result = self.command.get_enterprise_catalog(url=url)
         mock_request.assert_called_with(url, headers={}, params={'enterprise_customer': self.ent_customer_uuid})
-        assert None == result
+        assert if result is None
 
     @patch('requests.post')
     def test_create_coupon(self, mock_request):

--- a/ecommerce/enterprise/tests/test_seed_enterprise_devstack_data_command.py
+++ b/ecommerce/enterprise/tests/test_seed_enterprise_devstack_data_command.py
@@ -41,16 +41,23 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
         )
         self.command = seed_command()
         self.command.site = self.site_config
-        CategoryFactory.create(slug='coupons')
+        CategoryFactory.create(name='coupons')
         self.ent_customer_uuid = str(uuid4())
+        self.ent_catalog_uuid = str(uuid4())
+        self.access_token = 'fake_access_token'
 
-    @patch('ecommerce.enterprise.management.commands.seed_enterprise_devstack_data.EdxRestApiClient.get_oauth_access_token')
+    @patch(
+        'ecommerce.enterprise.management.commands.seed_enterprise_devstack_data'
+        '.EdxRestApiClient.get_oauth_access_token'
+    )
     def test_get_access_token(self, mock_api_client):
-        """ TODO """
+        """ Verify _get_access_token returns the correct value """
         # sanity check that SiteConfiguration has the correct oauth_settings
         assert self.command.site.oauth_settings == self.site_oauth_settings
 
-        self.command._get_access_token()
+        expected = (self.access_token, now())
+        mock_api_client.return_value = expected
+        result = self.command._get_access_token()
         oauth_settings = self.command.site.oauth_settings
         mock_api_client.assert_called_with(
             '{}/access_token/'.format(oauth_settings.get('SOCIAL_AUTH_EDX_OIDC_URL_ROOT')),
@@ -58,86 +65,70 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
             oauth_settings.get('BACKEND_SERVICE_EDX_OAUTH2_SECRET'),
             token_type='jwt',
         )
+        assert expected == result
 
     @patch.object(seed_command, '_get_access_token')
     def test_get_headers(self, mock_get_access_token):
-        """ TODO """
-        access_token = 'fake_access_token'
-        mock_get_access_token.return_value = (access_token, now())
-        headers = self.command._get_headers()
-        assert headers == {'Authorization': 'JWT {}'.format(access_token)}
+        """ Verify _get_headers returns the correct value """
+        expected = {'Authorization': 'JWT {}'.format(self.access_token)}
+        mock_get_access_token.return_value = (self.access_token, now())
+        result = self.command._get_headers()
+        assert expected == result
 
     @patch('requests.get')
     def test_get_enterprise_customer(self, mock_request):
-        """ TODO """
+        """ Verify _get_enterprise_customer returns the correct value """
         url = '{}enterprise-customer/'.format(self.command.site.enterprise_api_url)
-        self.command._get_enterprise_customer(url=url)
+        expected = {'uuid': self.ent_customer_uuid}
+        mock_request.return_value = Mock(
+            status_code=200,
+            json=lambda: {'results': [expected]},
+        )
+
+        # NOT specifying an enterprise customer uuid
+        result = self.command._get_enterprise_customer(url=url)
         mock_request.assert_called_with(url, headers={}, params=None)
-        self.command._get_enterprise_customer(
-            url=url,
-            enterprise_customer_uuid=self.ent_customer_uuid
+        assert expected == result
+
+        # specifying an enterprise customer uuid
+        result = self.command._get_enterprise_customer(
+            url=url, enterprise_customer_uuid=self.ent_customer_uuid
         )
         mock_request.assert_called_with(
-            url,
-            headers={},
-            params={'uuid': self.ent_customer_uuid},
+            url, headers={}, params={'uuid': self.ent_customer_uuid},
         )
+        assert expected == result
 
     @patch('requests.get')
     def test_get_enterprise_catalog(self, mock_request):
-        """ TODO """
+        """ Verify _get_enterprise_catalog returns the correct value """
         url = '{}enterprise_catalogs/'.format(self.command.site.enterprise_api_url)
         self.command.enterprise_customer = {'uuid': self.ent_customer_uuid}
-        self.command._get_enterprise_catalog(url=url)
+        expected = {'uuid': self.ent_catalog_uuid}
+        mock_request.return_value = Mock(
+            status_code=200,
+            json=lambda: {'results': [expected]},
+        )
+        result = self.command._get_enterprise_catalog(url=url)
         mock_request.assert_called_with(
             url,
             headers={},
             params={'enterprise_customer': self.ent_customer_uuid},
         )
+        assert expected == result
 
     @patch('requests.post')
     def test_create_coupon(self, mock_request):
-        """ TODO """
-        catalog_uuid = str(uuid4())
+        """ Verify _create_coupon returns the correct value """
         ecommerce_api_url = self.command.site.build_ecommerce_url() + '/api/v2'
         self.command.enterprise_customer = {'uuid': self.ent_customer_uuid}
-        self.command.enterprise_catalog = {'uuid': catalog_uuid}
-        self.command._create_coupon(ecommerce_api_url)
+        self.command.enterprise_catalog = {'uuid': self.ent_catalog_uuid}
 
-    @patch('requests.post')
-    @patch.object(seed_command, '_get_enterprise_catalog')
-    @patch.object(seed_command, '_get_enterprise_customer')
-    @patch.object(seed_command, '_get_access_token')
-    def test_ent_coupon_creation(self, mock_access_token, mock_ent_customer, mock_ent_catalog, mock_coupon_post):
-        """
-        Verify a coupon is created for an enterprise customer/catalog
-        """
-        mock_coupon_post_res = {'data': 'some data'}
-
-        # create return values for mocked methods
-        mock_access_token.return_value = ('fake_access_token', now())
-        mock_ent_customer.return_value = {
-            'results': [
-                {
-                    'uuid': self.ent_customer_uuid,
-                    'name': 'Test Enterprise',
-                    'slug': 'test-enterprise',
-                }
-            ]
-        }
-        mock_ent_catalog.return_value = {
-            'results': [
-                {
-                    'uuid': str(uuid4()),
-                    'title': 'Test Enterprise Catalog',
-                    'enterprise_customer': self.ent_customer_uuid,
-                }
-            ]
-        }
-        mock_coupon_post.return_value = Mock(
+        expected = {'data': 'some data'}
+        mock_request.return_value = Mock(
             status_code=200,
-            json=lambda: mock_coupon_post_res,
+            json=lambda: expected,
         )
-        with patch(self.logger) as patched_log:
-            call_command('seed_enterprise_devstack_data')
-            patched_log.info.assert_called_with('\nEnterprise coupon successfully created: %s', mock_coupon_post_res)
+        result = self.command._create_coupon(ecommerce_api_url)
+        mock_request.assert_called()
+        assert expected == result

--- a/ecommerce/enterprise/tests/test_seed_enterprise_devstack_data_command.py
+++ b/ecommerce/enterprise/tests/test_seed_enterprise_devstack_data_command.py
@@ -1,23 +1,23 @@
 # encoding: utf-8
 """
-Contains the tests for creating an coupon associated with
-an enterprise customer and catalog.
+Contains the tests for creating an coupon associated with enterprise customer and catalog.
 """
 
 from __future__ import absolute_import, unicode_literals
 
-from mock import patch, Mock
-from django.utils.timezone import now
 from uuid import uuid4
 
-from django.core.management import CommandError, call_command
-from factory.django import get_model
-from ecommerce.tests.factories import SiteConfigurationFactory
+from django.core.management import call_command
+from django.utils.timezone import now
+from mock import Mock, patch
+from oscar.core.loading import get_model
 
 from ecommerce.enterprise.management.commands.seed_enterprise_devstack_data import Command as seed_command
+from ecommerce.tests.factories import SiteConfigurationFactory
 from ecommerce.tests.testcases import TransactionTestCase
 
 SiteConfiguration = get_model('core', 'SiteConfiguration')
+
 
 class SeedEnterpriseDevstackDataTests(TransactionTestCase):
     """
@@ -27,7 +27,7 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
 
     def setUp(self):
         """
-        TODO
+        Set up initial data (e.g., site configuration) prior to running tests
         """
         super(SeedEnterpriseDevstackDataTests, self).setUp()
         SiteConfigurationFactory.create()
@@ -37,9 +37,9 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
     @patch.object(seed_command, '_get_enterprise_catalog')
     @patch.object(seed_command, '_get_enterprise_customer')
     @patch.object(seed_command, '_get_access_token')
-    def test_create_enterprise_coupon_successfully_with_enterprise_customer(self, mock_access_token, mock_ent_customer, mock_ent_catalog, mock_coupon_post):
+    def test_ent_coupon_creation(self, mock_access_token, mock_ent_customer, mock_ent_catalog, mock_coupon_post):
         """
-        Verify a coupon is created for an enterprise customer/catalog.
+        Verify a coupon is created for an enterprise customer/catalog
         """
         mock_coupon_post_res = {'data': 'some data'}
 

--- a/ecommerce/enterprise/tests/test_seed_enterprise_devstack_data_command.py
+++ b/ecommerce/enterprise/tests/test_seed_enterprise_devstack_data_command.py
@@ -231,6 +231,48 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
     @patch.object(seed_command, 'get_enterprise_catalog')
     @patch.object(seed_command, 'get_enterprise_customer')
     @patch.object(seed_command, 'get_access_token')
+    def test_handle_no_customer(self, mock_access_token, mock_ent_customer, mock_ent_catalog, mock_coupon_post):
+        """
+        Verify the entry point of the command without any args,
+        makes a POST request to create a coupon, but returns
+        no enterprise customer
+        """
+        # create return values for mocked methods
+        mock_access_token.return_value = (self.access_token, now())
+        mock_ent_customer.return_value = None
+        call_command('seed_enterprise_devstack_data')
+        mock_ent_catalog.assert_not_called()
+        mock_coupon_post.assert_not_called()
+
+    @patch('requests.post')
+    @patch.object(seed_command, 'get_enterprise_catalog')
+    @patch.object(seed_command, 'get_enterprise_customer')
+    @patch.object(seed_command, 'get_access_token')
+    def test_handle_no_catalog(self, mock_access_token, mock_ent_customer, mock_ent_catalog, mock_coupon_post):
+        """
+        Verify the entry point of the command without any args,
+        makes a POST request to create a coupon, but returns
+        no enterprise catalog
+        """
+        # create return values for mocked methods
+        mock_access_token.return_value = (self.access_token, now())
+        mock_ent_customer.return_value = {
+            'results': [
+                {
+                    'uuid': self.ent_customer_uuid,
+                    'name': 'Test Enterprise',
+                    'slug': 'test-enterprise',
+                }
+            ]
+        }
+        mock_ent_catalog.return_value = None
+        call_command('seed_enterprise_devstack_data')
+        mock_coupon_post.assert_not_called()
+
+    @patch('requests.post')
+    @patch.object(seed_command, 'get_enterprise_catalog')
+    @patch.object(seed_command, 'get_enterprise_customer')
+    @patch.object(seed_command, 'get_access_token')
     def test_handle_ent_customer_arg(self, mock_access_token, mock_ent_customer, mock_ent_catalog, mock_coupon_post):
         """
         Verify the entry point of the command uses the `--enterprise-customer` arg,

--- a/ecommerce/enterprise/tests/test_seed_enterprise_devstack_data_command.py
+++ b/ecommerce/enterprise/tests/test_seed_enterprise_devstack_data_command.py
@@ -65,7 +65,7 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
             oauth_settings.get('BACKEND_SERVICE_EDX_OAUTH2_SECRET'),
             token_type='jwt',
         )
-        assert expected == result
+        assert result == expected
 
     @patch.object(seed_command, 'get_access_token')
     def test_get_headers(self, mock_get_access_token):
@@ -73,7 +73,7 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
         expected = {'Authorization': 'JWT {}'.format(self.access_token)}
         mock_get_access_token.return_value = (self.access_token, now())
         result = self.command.get_headers()
-        assert expected == result
+        assert result == expected
 
     @patch('requests.get')
     def test_get_enterprise_customer(self, mock_request):
@@ -88,7 +88,7 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
         # NOT specifying an enterprise customer uuid
         result = self.command.get_enterprise_customer(url=url)
         mock_request.assert_called_with(url, headers={}, params=None)
-        assert expected == result
+        assert result == expected
 
         # specifying an enterprise customer uuid
         result = self.command.get_enterprise_customer(
@@ -97,7 +97,7 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
         mock_request.assert_called_with(
             url, headers={}, params={'uuid': self.ent_customer_uuid},
         )
-        assert expected == result
+        assert result == expected
 
     @patch('requests.get')
     def test_get_enterprise_customer_index_error(self, mock_request):
@@ -113,7 +113,7 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
 
         result = self.command.get_enterprise_customer(url=url)
         mock_request.assert_called_with(url, headers={}, params=None)
-        assert if result is None
+        assert result == None
 
     @patch('requests.get')
     def test_get_enterprise_catalog(self, mock_request):
@@ -131,7 +131,7 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
             headers={},
             params={'enterprise_customer': self.ent_customer_uuid},
         )
-        assert expected == result
+        assert result == expected
 
     @patch('requests.get')
     def test_get_enterprise_catalog_no_customer(self, mock_request):
@@ -157,7 +157,7 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
         )
         result = self.command.get_enterprise_catalog(url=url)
         mock_request.assert_called_with(url, headers={}, params={'enterprise_customer': self.ent_customer_uuid})
-        assert if result is None
+        assert result == None
 
     @patch('requests.post')
     def test_create_coupon(self, mock_request):
@@ -173,7 +173,7 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
         )
         result = self.command.create_coupon(ecommerce_api_url=ecommerce_api_url)
         mock_request.assert_called()
-        assert expected == result
+        assert result == expected
 
     @patch('requests.post')
     def test_create_coupon_no_customer(self, mock_request):

--- a/ecommerce/enterprise/tests/test_seed_enterprise_devstack_data_command.py
+++ b/ecommerce/enterprise/tests/test_seed_enterprise_devstack_data_command.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import, unicode_literals
 
 from uuid import uuid4
 
-from django.core.management import call_command
 from django.utils.timezone import now
 from mock import Mock, patch
 from oscar.core.loading import get_model
@@ -51,13 +50,13 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
         '.EdxRestApiClient.get_oauth_access_token'
     )
     def test_get_access_token(self, mock_api_client):
-        """ Verify _get_access_token returns the correct value """
+        """ Verify `get_access_token` returns the correct value """
         # sanity check that SiteConfiguration has the correct oauth_settings
         assert self.command.site.oauth_settings == self.site_oauth_settings
 
         expected = (self.access_token, now())
         mock_api_client.return_value = expected
-        result = self.command._get_access_token()
+        result = self.command.get_access_token()
         oauth_settings = self.command.site.oauth_settings
         mock_api_client.assert_called_with(
             '{}/access_token/'.format(oauth_settings.get('SOCIAL_AUTH_EDX_OIDC_URL_ROOT')),
@@ -67,17 +66,17 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
         )
         assert expected == result
 
-    @patch.object(seed_command, '_get_access_token')
+    @patch.object(seed_command, 'get_access_token')
     def test_get_headers(self, mock_get_access_token):
-        """ Verify _get_headers returns the correct value """
+        """ Verify get_headers returns the correct value """
         expected = {'Authorization': 'JWT {}'.format(self.access_token)}
         mock_get_access_token.return_value = (self.access_token, now())
-        result = self.command._get_headers()
+        result = self.command.get_headers()
         assert expected == result
 
     @patch('requests.get')
     def test_get_enterprise_customer(self, mock_request):
-        """ Verify _get_enterprise_customer returns the correct value """
+        """ Verify get_enterprise_customer returns the correct value """
         url = '{}enterprise-customer/'.format(self.command.site.enterprise_api_url)
         expected = {'uuid': self.ent_customer_uuid}
         mock_request.return_value = Mock(
@@ -86,12 +85,12 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
         )
 
         # NOT specifying an enterprise customer uuid
-        result = self.command._get_enterprise_customer(url=url)
+        result = self.command.get_enterprise_customer(url=url)
         mock_request.assert_called_with(url, headers={}, params=None)
         assert expected == result
 
         # specifying an enterprise customer uuid
-        result = self.command._get_enterprise_customer(
+        result = self.command.get_enterprise_customer(
             url=url, enterprise_customer_uuid=self.ent_customer_uuid
         )
         mock_request.assert_called_with(
@@ -101,7 +100,7 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
 
     @patch('requests.get')
     def test_get_enterprise_catalog(self, mock_request):
-        """ Verify _get_enterprise_catalog returns the correct value """
+        """ Verify get_enterprise_catalog returns the correct value """
         url = '{}enterprise_catalogs/'.format(self.command.site.enterprise_api_url)
         self.command.enterprise_customer = {'uuid': self.ent_customer_uuid}
         expected = {'uuid': self.ent_catalog_uuid}
@@ -109,7 +108,7 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
             status_code=200,
             json=lambda: {'results': [expected]},
         )
-        result = self.command._get_enterprise_catalog(url=url)
+        result = self.command.get_enterprise_catalog(url=url)
         mock_request.assert_called_with(
             url,
             headers={},
@@ -119,7 +118,7 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
 
     @patch('requests.post')
     def test_create_coupon(self, mock_request):
-        """ Verify _create_coupon returns the correct value """
+        """ Verify create_coupon returns the correct value """
         ecommerce_api_url = self.command.site.build_ecommerce_url() + '/api/v2'
         self.command.enterprise_customer = {'uuid': self.ent_customer_uuid}
         self.command.enterprise_catalog = {'uuid': self.ent_catalog_uuid}
@@ -129,6 +128,6 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
             status_code=200,
             json=lambda: expected,
         )
-        result = self.command._create_coupon(ecommerce_api_url)
+        result = self.command.create_coupon(ecommerce_api_url)
         mock_request.assert_called()
         assert expected == result


### PR DESCRIPTION
Ticket: [ENT-436](https://openedx.atlassian.net/browse/ENT-436)

Adds a management command to seed ecommerce in devstack with an initial coupon associated with an existing enterprise customer & catalog (potentially ones created from the similar management command in `edx-enterprise`).

Example:
![image](https://user-images.githubusercontent.com/2828721/68735299-3bdb5d80-05ab-11ea-863f-da2947e99783.png)
