### PR TITLE
ENT-2445 | Ability to hide code batches from e-commerce and/or the Code Management Tool 

### DIFF
--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -453,7 +453,6 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
             )
             Invoice.objects.filter(order__basket=baskets.first()).update(business_client=client)
             coupon.attr.enterprise_customer_uuid = enterprise_customer
-            coupon.save()
 
         coupon_price = request_data.get('price')
         if coupon_price:
@@ -462,11 +461,14 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
         note = request_data.get('note')
         if note is not None:
             coupon.attr.note = note
-            coupon.save()
 
         if 'notify_email' in request_data:
             coupon.attr.notify_email = request_data.get('notify_email')
-            coupon.save()
+
+        if 'inactive' in request_data:
+            coupon.attr.inactive = request_data.get('inactive')
+
+        coupon.save()
 
         discount_value = request_data.get('contract_discount_value')
         prepaid_invoice_amount = request_data.get('prepaid_invoice_amount')

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -181,7 +181,17 @@ class EnterpriseCouponViewSet(CouponViewSet):
         enterprise_id = self.kwargs.get('enterprise_id')
         if enterprise_id:
             filter_kwargs['attribute_values__value_text'] = enterprise_id
-        return Product.objects.filter(**filter_kwargs).distinct()
+
+        coupons = Product.objects.filter(**filter_kwargs)
+
+        if self.request.query_params.get('filter') == 'active':
+            active_coupon = ~Q(attributes__code='inactive') | Q(
+                attributes__code='inactive',
+                attribute_values__value_boolean=False
+            )
+            coupons = coupons.filter(active_coupon)
+
+        return coupons.distinct()
 
     def get_serializer_class(self):
         if self.action == 'list':

--- a/ecommerce/extensions/catalogue/migrations/0046_coupon_inactive_attribute.py
+++ b/ecommerce/extensions/catalogue/migrations/0046_coupon_inactive_attribute.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+from django.db import migrations
+from oscar.core.loading import get_model
+
+from ecommerce.core.constants import COUPON_PRODUCT_CLASS_NAME
+
+ProductAttribute = get_model("catalogue", "ProductAttribute")
+ProductClass = get_model("catalogue", "ProductClass")
+
+
+def create_inactive_attribute(apps, schema_editor):
+    """Create coupon inactive attribute."""
+    ProductAttribute.skip_history_when_saving = True
+
+    coupon = ProductClass.objects.get(name=COUPON_PRODUCT_CLASS_NAME)
+    product_attribute = ProductAttribute(
+        product_class=coupon,
+        name='Inactive',
+        code='inactive',
+        type=ProductAttribute.BOOLEAN,
+        required=False
+    )
+    product_attribute.save()
+
+
+def remove_inactive_attribute(apps, schema_editor):
+    """Remove coupon inactive attribute."""
+    coupon = ProductClass.objects.get(name=COUPON_PRODUCT_CLASS_NAME)
+
+    ProductAttribute.skip_history_when_saving = True
+    ProductAttribute.objects.get(product_class=coupon, code='inactive').delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('catalogue', '0045_add_edx_employee_coupon_category')
+    ]
+    operations = [
+        migrations.RunPython(create_inactive_attribute, remove_inactive_attribute)
+    ]

--- a/ecommerce/static/js/test/specs/views/enterprise_coupon_create_edit_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/enterprise_coupon_create_edit_view_spec.js
@@ -89,6 +89,9 @@ define([
                     var voucherType = view.$el.find('[name=voucher_type]'),
                         startDate = Utils.stripTimezone(model.get('start_date')),
                         endDate = Utils.stripTimezone(model.get('end_date'));
+                    expect(view.$el.find('[name=inactive]').val()).toEqual(
+                        model.get('inactive') ? 'inactive' : 'active'
+                    );
                     expect(view.$el.find('[name=title]').val()).toEqual(model.get('title'));
                     expect(view.$el.find('[name=code_type]').val()).toEqual('Enrollment code');
                     expect(view.$el.find('[name=start_date]').val()).toEqual(startDate);

--- a/ecommerce/static/js/views/enterprise_coupon_form_view.js
+++ b/ecommerce/static/js/views/enterprise_coupon_form_view.js
@@ -44,6 +44,15 @@ define([
             ],
 
             couponBindings: {
+                'input[name=inactive]': {
+                    observe: 'inactive',
+                    onGet: function(val) {
+                        return val ? 'inactive' : 'active';
+                    },
+                    onSet: function(val) {
+                        return val === 'inactive';
+                    }
+                },
                 'input[name=enterprise_customer]': {
                     observe: 'enterprise_customer',
                     onGet: function(val) {
@@ -221,6 +230,7 @@ define([
                     'enterprise_customer',
                     'enterprise_customer_catalog',
                     'notify_email',
+                    'inactive',
                     'invoice_discount_type',
                     'invoice_discount_value',
                     'invoice_number',

--- a/ecommerce/static/templates/enterprise_coupon_form.html
+++ b/ecommerce/static/templates/enterprise_coupon_form.html
@@ -1,4 +1,21 @@
 <div class="row">
+    <% if(editing) {%>
+    <div class="fields col-md-12">
+        <div class="form-group">
+            <label><%= gettext('Status') %> *</label>
+            <div class="Status row">
+                <div class="form-inline col-md-3">
+                    <input id="active" type="radio" name="inactive" value="active">
+                    <label for="active" class="normal-font-weight"><%= gettext('Active') %></label>
+                </div>
+                <div class="form-inline col-md-3">
+                    <input id="inactive" type="radio" name="inactive" value="inactive">
+                    <label for="inactive" class="normal-font-weight"><%= gettext('Inactive') %></label>
+                </div>
+            </div>
+        </div>
+    </div>
+    <%}%>
     <div class="fields col-md-6">
         <div class="form-group">
             <label for="title"><%= gettext('Coupon Name') %> *</label>


### PR DESCRIPTION
=> Added active and inactive radio button in ecommerce coupon admin page
for enterprise coupons.
=> Updated status code for INACTIVE coupons
=> Updated EnterpriseCouponViewSet to filter active coupons if filter 'active' exists in params
=>Created CouponMixin and moved get_code_status in that class.
=>Added tests

[ENT-2445](https://openedx.atlassian.net/browse/ENT-2445)

Related PR:
https://github.com/edx/frontend-app-admin-portal/pull/235