### PR TITLE
Allow refund editing on admin.

### DIFF
--- a/ecommerce/extensions/refund/admin.py
+++ b/ecommerce/extensions/refund/admin.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import waffle
 from django.contrib import admin, messages
+from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 from oscar.core.loading import get_model
 from rules.contrib.admin import ObjectPermissionsModelAdmin
@@ -41,3 +42,20 @@ class RefundAdmin(ObjectPermissionsModelAdmin):
 
         queryset = super(RefundAdmin, self).get_queryset(request)
         return queryset
+
+    def get_object(self, request, object_id, from_field=None):
+        """
+        Return an instance matching the field and value provided, the primary
+        key is used if no field is provided. Return ``None`` if no match is
+        found or the object_id fails validation.
+        """
+        if not waffle.switch_is_active(REFUND_LIST_VIEW_SWITCH):
+            # pylint: disable=protected-access
+            field = Refund._meta.pk if from_field is None else Refund._meta.get_field(from_field)
+            try:
+                object_id = field.to_python(object_id)
+                return Refund.objects.get(**{field.name: object_id})
+            except (Refund.DoesNotExist, ValidationError, ValueError):
+                return None
+
+        return super(RefundAdmin, self).get_object(request, object_id, from_field=from_field)

--- a/ecommerce/extensions/refund/tests/test_admin.py
+++ b/ecommerce/extensions/refund/tests/test_admin.py
@@ -8,6 +8,7 @@ from ecommerce.core.constants import ORDER_MANAGER_ROLE
 from ecommerce.core.models import EcommerceFeatureRole, EcommerceFeatureRoleAssignment
 from ecommerce.core.tests import toggle_switch
 from ecommerce.extensions.refund.constants import REFUND_LIST_VIEW_SWITCH
+from ecommerce.extensions.refund.tests.factories import RefundFactory
 from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.testcases import TestCase
 
@@ -45,6 +46,15 @@ class RefundAdminTests(TestCase):
         message = list(response.context['messages'])[0]
         self.assertEqual(message.level, messages.WARNING)
         self.assertEqual(message.message, msg)
+
+    def test_edit_view_with_disable_switch(self):
+        """ Test that edit refund page still works even if the switch is disabled. """
+        toggle_switch(REFUND_LIST_VIEW_SWITCH, False)
+        refund = RefundFactory()
+        edit_page_url = reverse('admin:refund_refund_change', args=(refund.id,))
+        response = self.client.get(edit_page_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, refund.order.number)
 
     def test_explicit_access(self):
         """


### PR DESCRIPTION
If `enable_refund_list_view` is disabled allow editing single refund instance from admin by hitting the URL directly.

PROD-974