### PR TITLE
ENT-2481 No longer need to encode utf8 when writing coupon csv

### DIFF
--- a/ecommerce/extensions/voucher/views.py
+++ b/ecommerce/extensions/voucher/views.py
@@ -47,9 +47,6 @@ class CouponReportCSVView(StaffOnlyMixin, View):
         writer = csv.DictWriter(response, fieldnames=field_names)
         writer.writeheader()
         for row in rows:
-            for key, value in row.items():
-                if isinstance(row[key], six.text_type):
-                    row[key] = value.encode('utf-8')
             writer.writerow(row)
 
         return response


### PR DESCRIPTION
Since the upgrade to python3, this is unnecessary and results in strings being written with b'', which is confusing to users.

See https://stackoverflow.com/questions/38346619/how-to-handle-utf-8-text-with-python-3 for more details.