### PR TITLE
display hyphen for unknown contract discount type

### DIFF
--- a/ecommerce/static/js/models/enterprise_coupon_model.js
+++ b/ecommerce/static/js/models/enterprise_coupon_model.js
@@ -31,7 +31,7 @@ define([
                 quantity: 1,
                 enterprise_catalog_url: '/api/v2/enterprise/customer_catalogs/',
                 contract_discount_type: 'Percentage',
-                contract_discount_value: null,
+                contract_discount_value: null
             },
 
             couponValidation: {
@@ -43,8 +43,8 @@ define([
                 },
                 contract_discount_value: {
                     required: true,
-                    pattern: 'number',
-                },
+                    pattern: 'number'
+                }
             },
 
             initialize: function() {

--- a/ecommerce/static/js/views/enterprise_coupon_form_view.js
+++ b/ecommerce/static/js/views/enterprise_coupon_form_view.js
@@ -113,7 +113,7 @@ define([
                         }
                         return val;
                     }
-                },
+                }
             },
 
             events: {
@@ -200,7 +200,7 @@ define([
                     'title',
                     'email_domains',
                     'contract_discount_value',
-                    'contract_discount_type',
+                    'contract_discount_type'
                 ];
             },
 

--- a/ecommerce/static/templates/enterprise_coupon_detail.html
+++ b/ecommerce/static/templates/enterprise_coupon_detail.html
@@ -93,9 +93,11 @@
             <div class="heading"><%= gettext('Contract discount value:') %></div>
             <div class="value">
                 <% if(coupon.contract_discount_type == 'Percentage') { %>
-                  <%= coupon.contract_discount_value %>%
+                    <%= coupon.contract_discount_value %>%
+                <% } else if(coupon.contract_discount_type == 'Absolute') { %>
+                    $<%= coupon.contract_discount_value %>
                 <% } else { %>
-                  $<%= coupon.contract_discount_value %>
+                    -
                 <%}%>
             </div>
         </div>


### PR DESCRIPTION
* displays `-` when there's a missing/unknown contract discount type
* eslint trailing comma fix in a few places