### PR TITLE
ENT-2472 | Add prepaid invoice field to enterprise coupon page (part …

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -1011,7 +1011,7 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
 
     def get_contract_discount_value(self, obj):
         try:
-            return obj.attr.enterprise_contract_metadata.discount
+            return obj.attr.enterprise_contract_metadata.discount_value
         except AttributeError:
             return None
 

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -1001,6 +1001,13 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
     voucher_type = serializers.SerializerMethodField()
     contract_discount_value = serializers.SerializerMethodField()
     contract_discount_type = serializers.SerializerMethodField()
+    prepaid_invoice_amount = serializers.SerializerMethodField()
+
+    def get_prepaid_invoice_amount(self, obj):
+        try:
+            return obj.attr.enterprise_contract_metadata.amount_paid
+        except AttributeError:
+            return None
 
     def get_contract_discount_value(self, obj):
         try:
@@ -1157,7 +1164,7 @@ class CouponSerializer(ProductPaymentInfoMixin, serializers.ModelSerializer):
             'email_domains', 'end_date', 'enterprise_customer', 'enterprise_customer_catalog',
             'id', 'last_edited', 'max_uses', 'note', 'notify_email', 'num_uses', 'payment_information',
             'program_uuid', 'price', 'quantity', 'seats', 'start_date', 'title', 'voucher_type',
-            'contract_discount_value', 'contract_discount_type',
+            'contract_discount_value', 'contract_discount_type', 'prepaid_invoice_amount',
         )
 
 

--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -121,6 +121,7 @@ class CouponViewSetTest(CouponMixin, DiscoveryTestMixin, TestCase):
             'max_uses',
             'note',
             'partner',
+            'prepaid_invoice_amount',
             'price',
             'quantity',
             'start_datetime',
@@ -445,6 +446,7 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             'enterprise_customer_catalog': enterprise_catalog_id,
             'contract_discount_value': '12.34',
             'contract_discount_type': EnterpriseContractMetadata.PERCENTAGE,
+            'prepaid_invoice_amount': '200000',
         })
 
         return self.get_response('POST', post_url, self.data)
@@ -1148,6 +1150,7 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         coupon = Product.objects.get(id=response.json()['coupon_id'])
         assert coupon.attr.enterprise_contract_metadata.discount_value == Decimal('12.34000')
         assert coupon.attr.enterprise_contract_metadata.discount_type == 'Percentage'
+        assert coupon.attr.enterprise_contract_metadata.amount_paid == Decimal('200000.00')
 
     def test_update_coupon_with_contract_discount_metadata(self):
         """
@@ -1168,18 +1171,21 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         coupon = Product.objects.get(id=coupon_id)
         assert coupon.attr.enterprise_contract_metadata.discount_value == Decimal('12.34000')
         assert coupon.attr.enterprise_contract_metadata.discount_type == 'Percentage'
+        assert coupon.attr.enterprise_contract_metadata.amount_paid == Decimal('200000.00')
 
         dtype = EnterpriseContractMetadata.FIXED
         path = reverse('api:v2:enterprise-coupons-detail', kwargs={'pk': coupon_id})
         data = {
             'contract_discount_value': '1928374',
             'contract_discount_type': dtype,
+            'prepaid_invoice_amount': '99009900'
         }
         self.get_response('PUT', path, data)
 
         coupon.attr.enterprise_contract_metadata.refresh_from_db()
         assert coupon.attr.enterprise_contract_metadata.discount_value == Decimal('1928374.00')
         assert coupon.attr.enterprise_contract_metadata.discount_type == dtype
+        assert coupon.attr.enterprise_contract_metadata.amount_paid == Decimal('99009900.00')
 
 
 class CouponCategoriesListViewTests(TestCase):

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -482,7 +482,7 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
         if prepaid_invoice_amount is not None:
             attach_or_update_contract_metadata_on_coupon(
                 coupon,
-                prepaid_invoice_amount=prepaid_invoice_amount,
+                amount_paid=prepaid_invoice_amount,
             )
 
     def update_offer_data(self, request_data, vouchers, site):

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -470,20 +470,14 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
             coupon.save()
 
         discount_value = request_data.get('contract_discount_value')
-        if discount_value is not None:
-            discount_type = request_data.get('contract_discount_type')
-            attach_or_update_contract_metadata_on_coupon(
-                coupon,
-                discount_type=discount_type,
-                discount_value=discount_value,
-            )
-
+        discount_type = request_data.get('contract_discount_type')
         prepaid_invoice_amount = request_data.get('prepaid_invoice_amount')
-        if prepaid_invoice_amount is not None:
-            attach_or_update_contract_metadata_on_coupon(
-                coupon,
-                amount_paid=prepaid_invoice_amount,
-            )
+        attach_or_update_contract_metadata_on_coupon(
+            coupon,
+            discount_type=discount_type,
+            discount_value=discount_value,
+            amount_paid=prepaid_invoice_amount,
+        )
 
     def update_offer_data(self, request_data, vouchers, site):
         """

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -45,7 +45,7 @@ from ecommerce.extensions.api.serializers import (
 from ecommerce.extensions.api.v2.utils import get_enterprise_from_product, send_new_codes_notification_email
 from ecommerce.extensions.api.v2.views.coupons import CouponViewSet
 from ecommerce.extensions.catalogue.utils import (
-    attach_contract_metadata_to_coupon_product,
+    attach_or_update_contract_metadata_on_coupon,
     attach_vouchers_to_coupon_product,
     create_coupon_product_and_stockrecord
 )
@@ -227,10 +227,11 @@ class EnterpriseCouponViewSet(CouponViewSet):
             cleaned_voucher_data.get('notify_email'),
             cleaned_voucher_data['enterprise_customer']
         )
-        attach_contract_metadata_to_coupon_product(
+        attach_or_update_contract_metadata_on_coupon(
             coupon_product,
-            cleaned_voucher_data['contract_discount_type'],
-            cleaned_voucher_data['contract_discount_value'],
+            discount_type=cleaned_voucher_data['contract_discount_type'],
+            discount_value=cleaned_voucher_data['contract_discount_value'],
+            amount_paid=cleaned_voucher_data['prepaid_invoice_amount'],
         )
 
         return coupon_product

--- a/ecommerce/static/js/models/enterprise_coupon_model.js
+++ b/ecommerce/static/js/models/enterprise_coupon_model.js
@@ -31,7 +31,8 @@ define([
                 quantity: 1,
                 enterprise_catalog_url: '/api/v2/enterprise/customer_catalogs/',
                 contract_discount_type: 'Percentage',
-                contract_discount_value: null
+                contract_discount_value: null,
+                prepaid_invoice_amount: null
             },
 
             couponValidation: {
@@ -42,7 +43,15 @@ define([
                     required: false
                 },
                 contract_discount_value: {
-                    required: true,
+                    required: function() {
+                        return !this.attributes.editing;
+                    },
+                    pattern: 'number'
+                },
+                prepaid_invoice_amount: {
+                    required: function() {
+                        return this.get('contract_discount_type') === 'Absolute';
+                    },
                     pattern: 'number'
                 }
             },

--- a/ecommerce/static/js/views/enterprise_coupon_form_view.js
+++ b/ecommerce/static/js/views/enterprise_coupon_form_view.js
@@ -113,6 +113,18 @@ define([
                         }
                         return val;
                     }
+                },
+                'input[name=prepaid_invoice_amount]': {
+                    observe: 'prepaid_invoice_amount',
+                    setOptions: {
+                        validate: true
+                    },
+                    onSet: function(val) {
+                        if (val === '') {
+                            return null;
+                        }
+                        return val;
+                    }
                 }
             },
 
@@ -200,7 +212,8 @@ define([
                     'title',
                     'email_domains',
                     'contract_discount_value',
-                    'contract_discount_type'
+                    'contract_discount_type',
+                    'prepaid_invoice_amount'
                 ];
             },
 

--- a/ecommerce/static/templates/enterprise_coupon_detail.html
+++ b/ecommerce/static/templates/enterprise_coupon_detail.html
@@ -92,14 +92,18 @@
         <div class="info-item grid-item contract-discount-value">
             <div class="heading"><%= gettext('Contract discount value:') %></div>
             <div class="value">
-                <% if(coupon.contract_discount_type == 'Percentage') { %>
+                <% if(coupon.contract_discount_value && coupon.contract_discount_type == 'Percentage') { %>
                     <%= coupon.contract_discount_value %>%
                 <% } else if(coupon.contract_discount_type == 'Absolute') { %>
-                    $<%= coupon.contract_discount_value %>
+                    $<%= coupon.contract_discount_value && coupon.contract_discount_value %>
                 <% } else { %>
                     -
                 <%}%>
             </div>
+        </div>
+        <div class="info-item grid-item prepaid-invoice-amount">
+            <div class="heading"><%= gettext('Prepaid Invoice Amount:') %></div>
+            <div class="value">$<%= coupon.prepaid_invoice_amount %></div>
         </div>
         <div class="info-item grid-item invoice-type">
             <div class="heading"><%= gettext('Invoice Type:') %></div>

--- a/ecommerce/static/templates/enterprise_coupon_form.html
+++ b/ecommerce/static/templates/enterprise_coupon_form.html
@@ -75,6 +75,14 @@
         </div>
 
         <div class="form-group">
+            <label for="prepaid-invoice-amount"><%= gettext('Prepaid invoice amount') %> *</label>
+            <div class="input-group">
+                <div class="prepaid-invoice-amount-addon input-group-addon"></div>
+                <input id="prepaid-invoice-amount" type="number" step="0.01" class="form-control prepaid-invoice-amount" name="prepaid_invoice_amount">
+            </div>
+        </div>
+
+        <div class="form-group">
             <label for="benefit-value"><%= gettext('Discount Value') %> *</label>
             <div class="input-group">
                 <div class="benefit-addon input-group-addon"></div>


### PR DESCRIPTION
…1: backend)

So far includes backend functionality and unit tests. To be added: frontend form and tests

Backend also does a minor refactor, see `attach_or_update_contract_metadata_on_coupon`, so that update and create logic can be through the same utils function that just accepts kwargs