### PR TITLE
ENT-2263 Added Search By Code Functionality

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -1016,7 +1016,7 @@ class EnterpriseCouponViewSetRbacTests(
                 'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/search-list',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             ),
-            data={'search_parameter': 'iamsofake@notreal.com'}
+            data={'user_email': 'iamsofake@notreal.com'}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert response.json()['results'] == []
@@ -1031,7 +1031,7 @@ class EnterpriseCouponViewSetRbacTests(
                 'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/search-list',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             ),
-            data={'search_parameter': '3456QWTERF46PS1R'}
+            data={'user_code': '3456QWTERF46PS1R'}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert response.json()['results'] == []
@@ -1057,7 +1057,7 @@ class EnterpriseCouponViewSetRbacTests(
                 'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/search-list',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             ),
-            data={'search_parameter': 'iHaveNoUser@object.com'}
+            data={'user_email': 'iHaveNoUser@object.com'}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -1088,7 +1088,7 @@ class EnterpriseCouponViewSetRbacTests(
                 'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/search-list',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             ),
-            data={'search_parameter': 'ABCDEFGH1234567'}
+            data={'user_code': 'ABCDEFGH1234567'}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -1116,7 +1116,7 @@ class EnterpriseCouponViewSetRbacTests(
                 'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/search-list',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             ),
-            data={'search_parameter': 'ABCDEFGH1234567'}
+            data={'user_code': 'ABCDEFGH1234567'}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -1177,7 +1177,7 @@ class EnterpriseCouponViewSetRbacTests(
                 'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/search-list',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             ),
-            data={'search_parameter': self.user.email}
+            data={'user_email': self.user.email}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.json()['results']

--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -1031,7 +1031,7 @@ class EnterpriseCouponViewSetRbacTests(
                 'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/search-list',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             ),
-            data={'user_code': '3456QWTERF46PS1R'}
+            data={'voucher_code': '3456QWTERF46PS1R'}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert response.json()['results'] == []
@@ -1088,7 +1088,7 @@ class EnterpriseCouponViewSetRbacTests(
                 'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/search-list',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             ),
-            data={'user_code': 'ABCDEFGH1234567'}
+            data={'voucher_code': 'ABCDEFGH1234567'}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -1116,7 +1116,7 @@ class EnterpriseCouponViewSetRbacTests(
                 'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/search-list',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             ),
-            data={'user_code': 'ABCDEFGH1234567'}
+            data={'voucher_code': 'ABCDEFGH1234567'}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -1016,7 +1016,22 @@ class EnterpriseCouponViewSetRbacTests(
                 'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/search-list',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             ),
-            data={'user_email': 'iamsofake@notreal.com'}
+            data={'search_parameter': 'iamsofake@notreal.com'}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert response.json()['results'] == []
+
+    def test_search_code_does_not_exist(self):
+        """
+        Test that 200 with empty results is returned if we cant find the code
+        """
+        response = self.get_response(
+            'GET',
+            reverse(
+                'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/search-list',
+                kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
+            ),
+            data={'search_parameter': '3456QWTERF46PS1R'}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert response.json()['results'] == []
@@ -1042,7 +1057,66 @@ class EnterpriseCouponViewSetRbacTests(
                 'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/search-list',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             ),
-            data={'user_email': 'iHaveNoUser@object.com'}
+            data={'search_parameter': 'iHaveNoUser@object.com'}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        results = response.json()['results']
+        assert len(results) == 1
+        assert results[0]['voucher_id'] == voucher1.id
+        assert results[0]['code'] == voucher1.code
+        assert results[0]['course_key'] is None
+
+    def test_search_code_with_offer_assignment(self):
+        """
+        Test that 200 with populated results is returned if search is made by code,
+        and code has offer_assignment
+        """
+        coupon1 = self.create_coupon(
+            benefit_type=Benefit.PERCENTAGE,
+            benefit_value=40,
+            enterprise_customer=self.data['enterprise_customer']['id'],
+            enterprise_customer_catalog='aaaaaaaa-2c44-487b-9b6a-24eee973f9a4',
+            code='ABCDEFGH1234567',
+        )
+        voucher1 = coupon1.coupon_vouchers.first().vouchers.first()
+        self.assign_user_to_code(coupon1.id, ['iHaveNoUser@object.com'], ['ABCDEFGH1234567'])
+
+        response = self.get_response(
+            'GET',
+            reverse(
+                'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/search-list',
+                kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
+            ),
+            data={'search_parameter': 'ABCDEFGH1234567'}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        results = response.json()['results']
+        assert len(results) == 1
+        assert results[0]['voucher_id'] == voucher1.id
+        assert results[0]['code'] == voucher1.code
+        assert results[0]['course_key'] is None
+
+    def test_search_code_without_offer_assignment(self):
+        """
+        Test that 200 with populated results is returned if an unassigned code is searched
+        """
+        coupon1 = self.create_coupon(
+            benefit_type=Benefit.PERCENTAGE,
+            benefit_value=40,
+            enterprise_customer=self.data['enterprise_customer']['id'],
+            enterprise_customer_catalog='aaaaaaaa-2c44-487b-9b6a-24eee973f9a4',
+            code='ABCDEFGH1234567',
+        )
+        voucher1 = coupon1.coupon_vouchers.first().vouchers.first()
+        response = self.get_response(
+            'GET',
+            reverse(
+                'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/search-list',
+                kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
+            ),
+            data={'search_parameter': 'ABCDEFGH1234567'}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -1103,7 +1177,7 @@ class EnterpriseCouponViewSetRbacTests(
                 'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/search-list',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             ),
-            data={'user_email': self.user.email}
+            data={'search_parameter': self.user.email}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.json()['results']

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -5,6 +5,7 @@ import logging
 import six
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.core.validators import validate_email
 from django.db.models import Q
 from django.http import Http404
 from django.shortcuts import get_object_or_404
@@ -450,24 +451,31 @@ class EnterpriseCouponViewSet(CouponViewSet):
         """
         Return coupon information based on query param values provided.
         """
-        user_email = self.request.query_params.get('user_email', None)
-        if not user_email:
-            raise Http404("No user_email query parameter provided.")
-
+        search_parameter = self.request.query_params.get('search_parameter', None)
+        if not search_parameter:
+            raise Http404("No search query parameter provided.")
+        # Check if we received an email or a code in search
         try:
-            user = User.objects.get(email=user_email)
+            is_email = True
+            validate_email(search_parameter)
+        except ValidationError:
+            is_email = False
+        try:
+            user = User.objects.get(email=search_parameter)
         except ObjectDoesNotExist:
             user = None
 
         enterprise_vouchers = self._collect_enterprise_vouchers_for_search(
-            user_email,
+            search_parameter,
             user,
+            is_email
         )
 
         redemptions_and_assignments = self._form_search_response_data_from_vouchers(
             enterprise_vouchers,
-            user_email,
+            search_parameter,
             user,
+            is_email
         )
 
         page = self.paginate_queryset(redemptions_and_assignments)
@@ -477,27 +485,30 @@ class EnterpriseCouponViewSet(CouponViewSet):
         )
         return self.get_paginated_response(serializer.data)
 
-    def _collect_enterprise_vouchers_for_search(self, user_email, user):
+    def _collect_enterprise_vouchers_for_search(self, search_parameter, user, is_email):
         """
         Gather vouchers based on offerAssignments and voucherApplications
         associated with the user (and enterprise specified in request url)
 
         Returns queryset of Voucher objects, with related tables prefetched.
         """
-
         # We want vouchers associated with this enterprise. Note:
         # self.get_queryset() here filters (coupon) products out for
         # the enterprise_id value handed to this view
         enterprise_vouchers = Voucher.objects.filter(
             coupon_vouchers__coupon__in=self.get_queryset()
         )
+        # When search is made by code, only one voucher will exist so return it directly
+        if not is_email:
+            voucher = enterprise_vouchers.filter(code=search_parameter)
+            return voucher
         # We want vouchers with OfferAssignments related to the user email
         # that do not have a voucher_application (aka they have been assigned
         # but not redeemed)
         no_voucher_application = Q(voucher_application__isnull=True)
         offer_assignments = OfferAssignment.objects.filter(
             no_voucher_application,
-            user_email=user_email,
+            user_email=search_parameter,
             status__in=[OFFER_ASSIGNED, OFFER_ASSIGNMENT_EMAIL_PENDING],
         )
         vouchers_from_offer_assignments = Q(
@@ -527,7 +538,7 @@ class EnterpriseCouponViewSet(CouponViewSet):
             'applications__order__lines__product__course',
         )
 
-    def _form_search_response_data_from_vouchers(self, vouchers, user_email, user):
+    def _form_search_response_data_from_vouchers(self, vouchers, search_parameter, user, is_email):
         """
         Build a list of dictionaries that contains the relevant information
         for each voucher_application (redemption) or offer_assignment (assignment).
@@ -553,19 +564,32 @@ class EnterpriseCouponViewSet(CouponViewSet):
                     redemptions_and_assignments.append(redemption_data)
 
             no_voucher_application = Q(voucher_application__isnull=True)
+            filter_kwargs = {
+                'code': voucher.code,
+                'status__in': [OFFER_ASSIGNED, OFFER_ASSIGNMENT_EMAIL_PENDING],
+            }
+            if is_email:
+                filter_kwargs['user_email'] = search_parameter
             offer_assignments = OfferAssignment.objects.filter(
                 no_voucher_application,
-                code=voucher.code,
-                user_email=user_email,
-                status__in=[OFFER_ASSIGNED, OFFER_ASSIGNMENT_EMAIL_PENDING],
-            ).distinct()
-            for _ in offer_assignments:
-                redemption_data = dict(coupon_data)
-                redemption_data['course_title'] = None
-                redemption_data['course_key'] = None
-                redemption_data['redeemed_date'] = None
-                redemptions_and_assignments.append(redemption_data)
-
+                **filter_kwargs).distinct()
+            coupon_data['is_assigned'] = offer_assignments.count()
+            # For the case when an unassigned voucher code is searched
+            if offer_assignments.count() == 0:
+                if not is_email:
+                    redemption_data = dict(coupon_data)
+                    redemption_data['course_title'] = None
+                    redemption_data['course_key'] = None
+                    redemption_data['redeemed_date'] = None
+                    redemptions_and_assignments.append(redemption_data)
+            else:
+                for offer_assignment in offer_assignments:
+                    redemption_data = dict(coupon_data)
+                    redemption_data['course_title'] = None
+                    redemption_data['course_key'] = None
+                    redemption_data['redeemed_date'] = None
+                    redemption_data['user_email'] = offer_assignment.user_email
+                    redemptions_and_assignments.append(redemption_data)
         return redemptions_and_assignments
 
     @list_route(url_path=r'(?P<enterprise_id>.+)/overview', permission_classes=[IsAuthenticated])

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -541,6 +541,17 @@ class EnterpriseCouponViewSet(CouponViewSet):
         construction of pagination.
         """
 
+        def _prepare_redemption_data(coupon_data, offer_assignment=None):
+            """
+            Prepares redemption data for the received voucher in coupon_data
+            """
+            redemption_data = dict(coupon_data)
+            redemption_data['course_title'] = None
+            redemption_data['course_key'] = None
+            redemption_data['redeemed_date'] = None
+            redemption_data['user_email'] = offer_assignment.user_email if offer_assignment else None
+            redemptions_and_assignments.append(redemption_data)
+
         redemptions_and_assignments = []
         for voucher in vouchers:
             coupon_data = {
@@ -571,21 +582,11 @@ class EnterpriseCouponViewSet(CouponViewSet):
             # For the case when an unassigned voucher code is searched
             if offer_assignments.count() == 0:
                 if not user_email:
-                    redemption_data = self._prepare_redemption_data(coupon_data)
-                    redemptions_and_assignments.append(redemption_data)
+                    _prepare_redemption_data(coupon_data)
             else:
                 for offer_assignment in offer_assignments:
-                    redemption_data = self._prepare_redemption_data(coupon_data, offer_assignment)
-                    redemptions_and_assignments.append(redemption_data)
+                    _prepare_redemption_data(coupon_data, offer_assignment)
         return redemptions_and_assignments
-
-    def _prepare_redemption_data(self, coupon_data, offer_assignment=None):
-        redemption_data = dict(coupon_data)
-        redemption_data['course_title'] = None
-        redemption_data['course_key'] = None
-        redemption_data['redeemed_date'] = None
-        redemption_data['user_email'] = offer_assignment.user_email if offer_assignment else None
-        return redemption_data
 
     @list_route(url_path=r'(?P<enterprise_id>.+)/overview', permission_classes=[IsAuthenticated])
     @permission_required('enterprise.can_view_coupon', fn=lambda request, enterprise_id: enterprise_id)


### PR DESCRIPTION
**ENT 2263**: customers need to be able to search for codes in batches.

This pull request is an enhancement of search functionality in **Code Management Portal**. As requested in the ticket (**ENT-2263**), enterprise admins can now make a search by code as well. The search results would help them figure out which voucher code belongs to which coupon batch and will also give them useful information about the assignment of the _searched_ voucher.

**STEPS TO TEST IT:**
- Open Code Management Portal
- Pick out any voucher from any of the coupons shown below
- Copy/Paste the code in the search bar at the top
- See results