### PR TITLE
Add waffle flag mixin to TestCase

### DIFF
--- a/ecommerce/core/management/commands/tests/test_deactivate_superusers.py
+++ b/ecommerce/core/management/commands/tests/test_deactivate_superusers.py
@@ -6,9 +6,9 @@ from __future__ import absolute_import
 import mock
 from django.apps import apps
 from django.core.management import call_command
-from django.test import TestCase
 
 from ecommerce.core.management.commands.tests.factories import SuperUserFactory
+from ecommerce.tests.testcases import TestCase
 
 User = apps.get_model('core', 'User')
 

--- a/ecommerce/core/management/commands/tests/test_sync_hubspot.py
+++ b/ecommerce/core/management/commands/tests/test_sync_hubspot.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta
 
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from django.test import TestCase
 from django.utils.six import StringIO
 from factory.django import get_model
 from mock import patch
@@ -16,6 +15,7 @@ from slumber.exceptions import HttpClientError
 from ecommerce.core.management.commands.sync_hubspot import Command as sync_command
 from ecommerce.extensions.test.factories import create_basket, create_order
 from ecommerce.tests.factories import SiteConfigurationFactory, UserFactory
+from ecommerce.tests.testcases import TestCase
 
 SiteConfiguration = get_model('core', 'SiteConfiguration')
 Basket = get_model('basket', 'Basket')

--- a/ecommerce/core/management/commands/tests/test_verify_transactions.py
+++ b/ecommerce/core/management/commands/tests/test_verify_transactions.py
@@ -9,13 +9,13 @@ import pytz
 import six
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from django.test import TestCase
 from oscar.core.loading import get_class, get_model
 from oscar.test.factories import OrderFactory, OrderLineFactory, ProductFactory
 
 from ecommerce.core.constants import SEAT_PRODUCT_CLASS_NAME
 from ecommerce.core.management.commands.tests.factories import PaymentEventFactory
 from ecommerce.core.management.commands.verify_transactions import DEFAULT_END_DELTA_TIME, DEFAULT_START_DELTA_TIME
+from ecommerce.tests.testcases import TestCase
 
 PaymentEventType = get_model('order', 'PaymentEventType')
 PaymentEventTypeName = get_class('order.constants', 'PaymentEventTypeName')

--- a/ecommerce/extensions/api/tests/test_handlers.py
+++ b/ecommerce/extensions/api/tests/test_handlers.py
@@ -6,11 +6,12 @@ from time import time
 import jwt
 import mock
 from django.conf import settings
-from django.test import TestCase, override_settings
+from django.test import override_settings
 from waffle.testutils import override_switch
 
 from ecommerce.extensions.api.handlers import jwt_decode_handler
 from ecommerce.tests.factories import UserFactory
+from ecommerce.tests.testcases import TestCase
 
 
 def generate_jwt_token(payload, signing_key):

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -23,6 +23,7 @@ from oscar.test import factories
 from oscar.test.utils import RequestFactory
 from social_django.models import UserSocialAuth
 from threadlocals.threadlocals import set_thread_variable
+from waffle.models import Flag
 
 from ecommerce.core.constants import ALL_ACCESS_CONTEXT, SYSTEM_ENTERPRISE_ADMIN_ROLE, SYSTEM_ENTERPRISE_OPERATOR_ROLE
 from ecommerce.core.url_utils import get_lms_url
@@ -443,3 +444,17 @@ class LmsApiMockMixin(object):
             username=username
         )
         httpretty.register_uri(httpretty.POST, url, body=response, content_type=CONTENT_TYPE)
+
+
+class TestWaffleFlagMixin(object):
+    """ Updates or creates a waffle flag and activates to True. Turns on any waffle flag to all tests
+    without requiring the addition of the flag in individual methods/classes """
+    def setUp(self):
+        super(TestWaffleFlagMixin, self).setUp()
+        # Note: if you are adding a waffle flag and need to have unit tests
+        # run with the flag on, import and add the flag to the list below.
+        # Note 2: Flags should be temporary, pls link the ticket to remove
+        # the flag from this mixin with the PR that added the flag.
+        waffle_flags_list = []
+        for flag_name in waffle_flags_list:
+            Flag.objects.update_or_create(name=flag_name, defaults={'everyone': True})

--- a/ecommerce/tests/testcases.py
+++ b/ecommerce/tests/testcases.py
@@ -7,7 +7,7 @@ from django.test import TransactionTestCase as DjangoTransactionTestCase
 from edx_django_utils.cache import TieredCache
 from oscar.test.factories import CategoryFactory
 
-from ecommerce.tests.mixins import SiteMixin, TestServerUrlMixin, UserMixin
+from ecommerce.tests.mixins import SiteMixin, TestServerUrlMixin, TestWaffleFlagMixin, UserMixin
 
 # When all unit tests are run, the catalog category table will sometimes be empty. However, if only a single test
 # is run, Category will have been populated by migrations (in particular, see
@@ -62,7 +62,7 @@ class ViewTestMixin(TieredCacheMixin):
         self.assert_get_response_status(200)
 
 
-class TestCase(TestServerUrlMixin, UserMixin, SiteMixin, TieredCacheMixin, DjangoTestCase):
+class TestCase(TestServerUrlMixin, UserMixin, SiteMixin, TieredCacheMixin, DjangoTestCase, TestWaffleFlagMixin):
     """
     Base test case for ecommerce tests.
 

--- a/ecommerce/theming/management/commands/tests/test_create_or_update_site_theme.py
+++ b/ecommerce/theming/management/commands/tests/test_create_or_update_site_theme.py
@@ -5,8 +5,8 @@ from __future__ import absolute_import
 
 from django.contrib.sites.models import Site
 from django.core.management import CommandError, call_command
-from django.test import TestCase
 
+from ecommerce.tests.testcases import TestCase
 from ecommerce.theming.models import SiteTheme
 
 

--- a/ecommerce/theming/management/commands/tests/test_create_sites_and_partners.py
+++ b/ecommerce/theming/management/commands/tests/test_create_sites_and_partners.py
@@ -8,7 +8,7 @@ import os
 
 from django.contrib.sites.models import Site
 from django.core.management import CommandError, call_command
-from django.test import TestCase
+from django.test import TestCase as DjangoTestCase
 from oscar.core.loading import get_model
 
 from ecommerce.core.models import SiteConfiguration
@@ -20,7 +20,8 @@ Partner = get_model('partner', 'Partner')
 SITES = ["dummy"]
 
 
-class TestCreateSitesAndPartners(TestCase):
+# Our internal TestCase adds a site during setUp, therefore we will use the DjangoTestCase here.
+class TestCreateSitesAndPartners(DjangoTestCase):
     """
     Test django management command for creating Sites, SiteThemes, SiteConfigurations and Partners.
     """

--- a/ecommerce/theming/management/commands/tests/test_update_assets.py
+++ b/ecommerce/theming/management/commands/tests/test_update_assets.py
@@ -6,10 +6,11 @@ from __future__ import absolute_import
 import six
 from django.conf import settings
 from django.core.management import CommandError, call_command
-from django.test import TestCase, override_settings
+from django.test import override_settings
 from mock import Mock, patch
 from path import Path
 
+from ecommerce.tests.testcases import TestCase
 from ecommerce.theming.helpers import get_themes
 from ecommerce.theming.management.commands.update_assets import (
     SYSTEM_SASS_PATHS,

--- a/ecommerce/theming/tests/test_apps.py
+++ b/ecommerce/theming/tests/test_apps.py
@@ -5,9 +5,10 @@ from __future__ import absolute_import
 
 import mock
 from django.conf import settings
-from django.test import TestCase, override_settings
+from django.test import override_settings
 
 from ecommerce import theming
+from ecommerce.tests.testcases import TestCase
 from ecommerce.theming.apps import ThemeAppConfig
 
 

--- a/ecommerce/theming/tests/test_finders.py
+++ b/ecommerce/theming/tests/test_finders.py
@@ -4,8 +4,8 @@ Tests for comprehensive theme static files finders.
 from __future__ import absolute_import
 
 from django.conf import settings
-from django.test import TestCase
 
+from ecommerce.tests.testcases import TestCase
 from ecommerce.theming.finders import ThemeFilesFinder
 
 


### PR DESCRIPTION
[REV-874](https://openedx.atlassian.net/browse/REV-874). 
This started as a ticket to add the waffle flag for First Purchase Discount to tests in Bundle Purchases, but since FPD will eventually be implemented (not be a flag anymore), this PR adds a way to turn on a waffle - any waffle flag - to all tests without having to add `override_flag` individually to all methods/classes it requires it. 

Pls note FPD will not utilize this new way of adding flags to tests. I did not change `@override_flag(DYNAMIC_DISCOUNT_FLAG, active=True)` as this flag will be removed shortly. 