### PR TITLE
update offer assignments upon multi_use_per_customer coupon update

### DIFF
--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -60,6 +60,7 @@ from ecommerce.extensions.offer.constants import (
     VOUCHER_PARTIAL_REDEEMED,
     VOUCHER_REDEEMED
 )
+from ecommerce.extensions.offer.utils import update_assignments_for_multi_use_per_customer
 from ecommerce.extensions.voucher.utils import (
     create_enterprise_vouchers,
     update_voucher_offer,
@@ -296,6 +297,7 @@ class EnterpriseCouponViewSet(CouponViewSet):
             voucher.offers.add(updated_enterprise_offer)
             if updated_orginal_offer:
                 voucher.offers.add(updated_orginal_offer)
+            update_assignments_for_multi_use_per_customer(voucher)
 
         if coupon_was_migrated:
             super(EnterpriseCouponViewSet, self).update_range_data(request_data, vouchers)


### PR DESCRIPTION
**Description:** This will create offer assignments when a `MULTI_USE_PER_CUSTOMER` coupon is updated provided that there are some assignments exist already. This should fix issue because new offer assignment will be created upon coupon update, for the `ENT-2441` we need to update the coupon from django admin, we need to `Edit` the coupon and then `Save` it without changing anythin.

**JIRA:** https://openedx.atlassian.net/browse/ENT-2441