### PR TITLE
Drop OIDC support

### DIFF
--- a/ecommerce/core/management/commands/create_or_update_site.py
+++ b/ecommerce/core/management/commands/create_or_update_site.py
@@ -70,38 +70,29 @@ class Command(BaseCommand):
                             type=str,
                             default='',
                             help='Payment processor used for client-side payments')
-        parser.add_argument('--client-id',
-                            action='store',
-                            dest='client_id',
-                            type=str,
-                            required=True,
-                            help='client ID')
-        parser.add_argument('--client-secret',
-                            action='store',
-                            dest='client_secret',
-                            type=str,
-                            required=True,
-                            help='client secret')
-        # TODO: Post-DOP-removal, make the next four params required - and remove the previous two params.
         parser.add_argument('--sso-client-id',
                             action='store',
                             dest='sso_client_id',
                             type=str,
+                            required=True,
                             help='SSO client ID for individual user auth')
         parser.add_argument('--sso-client-secret',
                             action='store',
                             dest='sso_client_secret',
                             type=str,
+                            required=True,
                             help='SSO client secret for individual user auth')
         parser.add_argument('--backend-service-client-id',
                             action='store',
                             dest='backend_service_client_id',
                             type=str,
+                            required=True,
                             help='Backend-service client ID for IDA-to-IDA auth')
         parser.add_argument('--backend-service-client-secret',
                             action='store',
                             dest='backend_service_client_secret',
                             type=str,
+                            required=True,
                             help='Backend-service client secret for IDA-to-IDA auth')
         parser.add_argument('--segment-key',
                             action='store',
@@ -165,8 +156,6 @@ class Command(BaseCommand):
         partner_name = options.get('partner_name')
         lms_url_root = options.get('lms_url_root')
         lms_public_url_root = options.get('lms_public_url_root')
-        client_id = options.get('client_id')
-        client_secret = options.get('client_secret')
         sso_client_id = options.get('sso_client_id')
         sso_client_secret = options.get('sso_client_secret')
         backend_service_client_id = options.get('backend_service_client_id')
@@ -204,12 +193,6 @@ class Command(BaseCommand):
             'SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT': lms_url_root,
             'SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL': '{lms_url_root}/logout'.format(lms_url_root=lms_url_root),
             'SOCIAL_AUTH_EDX_OAUTH2_ISSUERS': [lms_url_root],
-            # NOTE: These settings are deprecated and will be removed in a future release.
-            'SOCIAL_AUTH_EDX_OIDC_URL_ROOT': '{lms_url_root}/oauth2'.format(lms_url_root=lms_url_root),
-            'SOCIAL_AUTH_EDX_OIDC_KEY': client_id,
-            'SOCIAL_AUTH_EDX_OIDC_SECRET': client_secret,
-            'SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY': client_secret,
-            'SOCIAL_AUTH_EDX_OIDC_ISSUERS': [lms_url_root]
         }
 
         if lms_public_url_root:

--- a/ecommerce/core/management/commands/tests/test_create_or_update_site.py
+++ b/ecommerce/core/management/commands/tests/test_create_or_update_site.py
@@ -23,8 +23,6 @@ class CreateOrUpdateSiteCommandTests(TestCase):
         self.lms_public_url_root = 'http://public.fake.server'
         self.payment_processors = 'cybersource,paypal'
         self.client_side_payment_processor = 'cybersource'
-        self.client_id = 'ecommerce-key'
-        self.client_secret = 'ecommerce-secret'
         self.sso_client_id = 'sso_ecommerce-key'
         self.sso_client_secret = 'sso_ecommerce-secret'
         self.backend_service_client_id = 'backend_service_ecommerce-key'
@@ -44,26 +42,6 @@ class CreateOrUpdateSiteCommandTests(TestCase):
         self.assertEqual(site_configuration.lms_url_root, self.lms_url_root)
         self.assertEqual(site_configuration.payment_processors, self.payment_processors)
         self.assertEqual(site_configuration.client_side_payment_processor, self.client_side_payment_processor)
-        self.assertEqual(
-            site_configuration.oauth_settings['SOCIAL_AUTH_EDX_OIDC_KEY'],
-            self.client_id,
-        )
-        self.assertEqual(
-            site_configuration.oauth_settings['SOCIAL_AUTH_EDX_OIDC_SECRET'],
-            self.client_secret,
-        )
-        self.assertEqual(
-            site_configuration.oauth_settings['SOCIAL_AUTH_EDX_OIDC_URL_ROOT'],
-            'http://fake.server/oauth2',
-        )
-        self.assertEqual(
-            site_configuration.oauth_settings['SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY'],
-            self.client_secret,
-        )
-        self.assertEqual(
-            site_configuration.oauth_settings['SOCIAL_AUTH_EDX_OIDC_ISSUERS'],
-            [self.lms_url_root],
-        )
         self.assertEqual(
             site_configuration.oauth_settings['SOCIAL_AUTH_EDX_OAUTH2_ISSUERS'],
             [self.lms_url_root],
@@ -109,14 +87,12 @@ class CreateOrUpdateSiteCommandTests(TestCase):
                       site_domain,
                       partner_code,
                       lms_url_root,
-                      client_id,
-                      client_secret,
+                      sso_client_id,
+                      sso_client_secret,
+                      backend_service_client_id,
+                      backend_service_client_secret,
                       from_email,
                       lms_public_url_root=None,
-                      sso_client_id=None,
-                      sso_client_secret=None,
-                      backend_service_client_id=None,
-                      backend_service_client_secret=None,
                       site_id=None,
                       site_name=None,
                       partner_name=None,
@@ -138,8 +114,10 @@ class CreateOrUpdateSiteCommandTests(TestCase):
             '--site-domain={site_domain}'.format(site_domain=site_domain),
             '--partner-code={partner_code}'.format(partner_code=partner_code),
             '--lms-url-root={lms_url_root}'.format(lms_url_root=lms_url_root),
-            '--client-id={client_id}'.format(client_id=client_id),
-            '--client-secret={client_secret}'.format(client_secret=client_secret),
+            '--sso-client-id={}'.format(sso_client_id),
+            '--sso-client-secret={}'.format(sso_client_secret),
+            '--backend-service-client-id={}'.format(backend_service_client_id),
+            '--backend-service-client-secret={}'.format(backend_service_client_secret),
             '--from-email={from_email}'.format(from_email=from_email)
         ]
 
@@ -190,15 +168,6 @@ class CreateOrUpdateSiteCommandTests(TestCase):
                 discovery_api_url=discovery_api_url
             ))
 
-        if sso_client_id:
-            command_args.append('--sso-client-id={}'.format(sso_client_id))
-        if sso_client_secret:
-            command_args.append('--sso-client-secret={}'.format(sso_client_secret))
-        if backend_service_client_id:
-            command_args.append('--backend-service-client-id={}'.format(backend_service_client_id))
-        if backend_service_client_secret:
-            command_args.append('--backend-service-client-secret={}'.format(backend_service_client_secret))
-
         call_command(self.command_name, *command_args)
 
     def test_create_site(self):
@@ -211,8 +180,10 @@ class CreateOrUpdateSiteCommandTests(TestCase):
             lms_url_root=self.lms_url_root,
             client_side_payment_processor=self.client_side_payment_processor,
             payment_processors=self.payment_processors,
-            client_id=self.client_id,
-            client_secret=self.client_secret,
+            sso_client_id=self.sso_client_id,
+            sso_client_secret=self.sso_client_secret,
+            backend_service_client_id=self.backend_service_client_id,
+            backend_service_client_secret=self.backend_service_client_secret,
             segment_key=self.segment_key,
             from_email=self.from_email,
             discovery_api_url=self.discovery_api_url,
@@ -241,8 +212,10 @@ class CreateOrUpdateSiteCommandTests(TestCase):
             lms_url_root=self.lms_url_root,
             payment_processors=self.payment_processors,
             client_side_payment_processor=self.client_side_payment_processor,
-            client_id=self.client_id,
-            client_secret=self.client_secret,
+            sso_client_id=self.sso_client_id,
+            sso_client_secret=self.sso_client_secret,
+            backend_service_client_id=self.backend_service_client_id,
+            backend_service_client_secret=self.backend_service_client_secret,
             segment_key=self.segment_key,
             from_email=self.from_email,
             enable_enrollment_codes=True,
@@ -286,8 +259,6 @@ class CreateOrUpdateSiteCommandTests(TestCase):
             lms_public_url_root=self.lms_public_url_root,
             payment_processors=self.payment_processors,
             client_side_payment_processor=self.client_side_payment_processor,
-            client_id=self.client_id,
-            client_secret=self.client_secret,
             sso_client_id=self.sso_client_id,
             sso_client_secret=self.sso_client_secret,
             backend_service_client_id=self.backend_service_client_id,
@@ -337,15 +308,25 @@ class CreateOrUpdateSiteCommandTests(TestCase):
         ['--site-id=1', '--site-domain=fake.server', '--partner-name=fake_partner',
          '--theme-scss-path=site/sass/css/', '--payment-processors=cybersource',
          '--segment-key=abc', '--partner-code=fake_partner', '--lms-url-root=lms.test.fake',
-         '--client-id=1'],
+         '--sso-client-id=1'],
         ['--site-id=1', '--site-domain=fake.server', '--partner-name=fake_partner',
          '--theme-scss-path=site/sass/css/', '--payment-processors=cybersource',
          '--segment-key=abc', '--partner-code=fake_partner', '--lms-url-root=lms.test.fake',
-         '--client-id=1', '--client-secret=secret'],
+         '--sso-client-id=1', '--sso-client-secret=secret'],
         ['--site-id=1', '--site-domain=fake.server', '--partner-name=fake_partner',
          '--theme-scss-path=site/sass/css/', '--payment-processors=cybersource',
          '--segment-key=abc', '--partner-code=fake_partner', '--lms-url-root=lms.test.fake',
-         '--client-id=1', '--client-secret=secret', '--from-email=test@example.fake']
+         '--sso-client-id=1', '--sso-client-secret=secret', '--backend-service-client-id=1'],
+        ['--site-id=1', '--site-domain=fake.server', '--partner-name=fake_partner',
+         '--theme-scss-path=site/sass/css/', '--payment-processors=cybersource',
+         '--segment-key=abc', '--partner-code=fake_partner', '--lms-url-root=lms.test.fake',
+         '--sso-client-id=1', '--sso-client-secret=secret', '--backend-service-client-id=1',
+         '--backend-service-client-secret=secret'],
+        ['--site-id=1', '--site-domain=fake.server', '--partner-name=fake_partner',
+         '--theme-scss-path=site/sass/css/', '--payment-processors=cybersource',
+         '--segment-key=abc', '--partner-code=fake_partner', '--lms-url-root=lms.test.fake',
+         '--sso-client-id=1', '--sso-client-secret=secret', '--backend-service-client-id=1',
+         '--backend-service-client-secret=secret', '--from-email=test@example.fake'],
     )
     def test_missing_arguments(self, command_args):
         """ Verify CommandError is raised when required arguments are missing """

--- a/ecommerce/core/management/commands/tests/test_update_site_oauth_settings.py
+++ b/ecommerce/core/management/commands/tests/test_update_site_oauth_settings.py
@@ -51,23 +51,13 @@ class UpdateSiteOauthSettingsCommandTests(TestCase):
     def _create_test_site_configuration(self, site):
         """
         Create a fake partner and site configuration for testing.
-
-        This fake site configuration only contains old OIDC (DOP) OAUTH settings.
         """
-        original_oauth_settings = {
-            'SOCIAL_AUTH_EDX_OIDC_URL_ROOT': '{}/oauth2'.format(self.lms_url_root),
-            'SOCIAL_AUTH_EDX_OIDC_KEY': self.client_id,
-            'SOCIAL_AUTH_EDX_OIDC_SECRET': self.client_secret,
-            'SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY': self.client_secret,
-            'SOCIAL_AUTH_EDX_OIDC_ISSUERS': [self.lms_url_root],
-        }
         partner = Partner.objects.create(code=self.partner)
         site_configuration = SiteConfiguration.objects.create(
             site=site,
             partner=partner,
             lms_url_root=self.lms_url_root,
             payment_processors=self.payment_processors,
-            oauth_settings=original_oauth_settings,
             discovery_api_url=self.discovery_api_url,
         )
         return site_configuration
@@ -95,28 +85,6 @@ class UpdateSiteOauthSettingsCommandTests(TestCase):
 
         # Spot check that nothing on the site object changed.
         self.assertEqual(site.domain, site_domain)
-
-        # Confirm that all the old OIDC (DOP) settings persisted.
-        self.assertEqual(
-            site_configuration.oauth_settings['SOCIAL_AUTH_EDX_OIDC_KEY'],
-            self.client_id,
-        )
-        self.assertEqual(
-            site_configuration.oauth_settings['SOCIAL_AUTH_EDX_OIDC_SECRET'],
-            self.client_secret,
-        )
-        self.assertEqual(
-            site_configuration.oauth_settings['SOCIAL_AUTH_EDX_OIDC_URL_ROOT'],
-            'http://fake.server/oauth2',
-        )
-        self.assertEqual(
-            site_configuration.oauth_settings['SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY'],
-            self.client_secret,
-        )
-        self.assertEqual(
-            site_configuration.oauth_settings['SOCIAL_AUTH_EDX_OIDC_ISSUERS'],
-            [self.lms_url_root],
-        )
 
         # Confirm that all the new OAUTH2 (DOT) settings were added.
         self.assertEqual(

--- a/ecommerce/core/tests/test_views.py
+++ b/ecommerce/core/tests/test_views.py
@@ -101,7 +101,7 @@ class LogoutViewTests(TestCase):
     def _create_user(self):
         """ Create a new user. """
         user = UserFactory(username='test', password=self.PASSWORD)
-        UserSocialAuth.objects.create(user=user, provider='edx-oidc', uid=user.username)
+        UserSocialAuth.objects.create(user=user, provider='edx-oauth2', uid=user.username)
         return user
 
     def get_logout_url(self):

--- a/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -54,7 +54,7 @@ class Command(BaseCommand):
             (str, datetime)
         """
         logger.info('\nFetching access token for site...')
-        oauth2_provider_url = self.site.oauth_settings.get('SOCIAL_AUTH_EDX_OIDC_URL_ROOT')
+        oauth2_provider_url = self.site.oauth_settings.get('BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL')
         key = self.site.oauth_settings.get('BACKEND_SERVICE_EDX_OAUTH2_KEY')
         secret = self.site.oauth_settings.get('BACKEND_SERVICE_EDX_OAUTH2_SECRET')
         oauth_access_token_url = oauth2_provider_url + '/access_token/'

--- a/ecommerce/enterprise/tests/test_seed_enterprise_devstack_data_command.py
+++ b/ecommerce/enterprise/tests/test_seed_enterprise_devstack_data_command.py
@@ -26,7 +26,7 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
     """
     logger = 'ecommerce.enterprise.management.commands.seed_enterprise_devstack_data.logger'
     site_oauth_settings = {
-        'SOCIAL_AUTH_EDX_OIDC_URL_ROOT': 'http://edx.devstack.lms:18000/oauth2',
+        'BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL': 'http://edx.devstack.lms:18000/oauth2',
         'BACKEND_SERVICE_EDX_OAUTH2_KEY': 'ecommerce-backend-service-key',
         'BACKEND_SERVICE_EDX_OAUTH2_SECRET': 'ecommerce-backend-service-secret',
     }
@@ -60,7 +60,7 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
         result = self.command.get_access_token()
         oauth_settings = self.command.site.oauth_settings
         mock_api_client.assert_called_with(
-            '{}/access_token/'.format(oauth_settings.get('SOCIAL_AUTH_EDX_OIDC_URL_ROOT')),
+            '{}/access_token/'.format(oauth_settings.get('BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL')),
             oauth_settings.get('BACKEND_SERVICE_EDX_OAUTH2_KEY'),
             oauth_settings.get('BACKEND_SERVICE_EDX_OAUTH2_SECRET'),
             token_type='jwt',

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -473,12 +473,6 @@ AUTO_AUTH_USERNAME_PREFIX = 'AUTO_AUTH_'
 
 AUTHENTICATION_BACKENDS = ('auth_backends.backends.EdXOAuth2',) + AUTHENTICATION_BACKENDS
 
-# NOTE: This old auth backend is retained as a temporary fallback in order to
-# support old browser sessions that were established using OIDC.  After a few
-# days, we should be safe to remove this line, along with deleting the rest of
-# the OIDC/DOP settings and keys in the ecommerce site configurations.
-AUTHENTICATION_BACKENDS += ('auth_backends.backends.EdXOpenIdConnect',)
-
 SOCIAL_AUTH_STRATEGY = 'ecommerce.social_auth.strategies.CurrentSiteDjangoStrategy'
 
 # Set these to the correct values for your OAuth2 provider
@@ -734,14 +728,7 @@ ECOMMERCE_URL_ROOT = "http://localhost:8002"
 OSCAR_FROM_EMAIL = 'oscar@example.com'
 PLATFORM_NAME = 'Your Platform Name Here'
 SESSION_EXPIRE_AT_BROWSER_CLOSE = False
-SOCIAL_AUTH_EDX_OIDC_KEY = 'ecommerce-key'
-SOCIAL_AUTH_EDX_OIDC_SECRET = 'ecommerce-secret'
-SOCIAL_AUTH_EDX_OIDC_URL_ROOT = 'http://127.0.0.1:8000/oauth2'
-SOCIAL_AUTH_EDX_OIDC_LOGOUT_URL = 'http://127.0.0.1:8000/logout'
-SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY = SOCIAL_AUTH_EDX_OIDC_SECRET
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
-SOCIAL_AUTH_EDX_OIDC_PUBLIC_URL_ROOT = 'http://127.0.0.1:8000/oauth2'
-SOCIAL_AUTH_EDX_OIDC_ISSUER = 'http://127.0.0.1:8000/oauth2'
 
 CORS_ORIGIN_WHITELIST = []
 CORS_URLS_REGEX = ''

--- a/ecommerce/settings/ecommerce.yml
+++ b/ecommerce/settings/ecommerce.yml
@@ -119,13 +119,6 @@ SOCIAL_AUTH_EDX_OAUTH2_KEY: ecommerce-sso-key
 SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL: http://localhost:18000/logout
 SOCIAL_AUTH_EDX_OAUTH2_SECRET: ecommerce-sso-secret
 SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT: http://127.0.0.1:8000
-SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY: ecommerce-secret
-SOCIAL_AUTH_EDX_OIDC_ISSUER: http://localhost:18000/oauth2
-SOCIAL_AUTH_EDX_OIDC_KEY: ecommerce-key
-SOCIAL_AUTH_EDX_OIDC_LOGOUT_URL: http://localhost:18000/logout
-SOCIAL_AUTH_EDX_OIDC_PUBLIC_URL_ROOT: http://localhost:18000/oauth2
-SOCIAL_AUTH_EDX_OIDC_SECRET: ecommerce-secret
-SOCIAL_AUTH_EDX_OIDC_URL_ROOT: http://edx.devstack.lms:18000/oauth2
 SOCIAL_AUTH_REDIRECT_IS_HTTPS: false
 STATICFILES_STORAGE: ecommerce.theming.storage.ThemeStorage
 STATIC_ROOT: /edx/var/ecommerce/staticfiles


### PR DESCRIPTION
OpenIDConnect is a deprecated and now unused auth mechanism, replaced by oauth2. Lets drop the support for it here, so we can drop the backend from auth-backends.

See https://github.com/edx/course-discovery/pull/2306 for prior art, where we removed OIDC from course-discovery.

Related PRs:
https://github.com/edx/devstack/pull/464
https://github.com/edx/configuration/pull/5586
https://github.com/edx/edx-internal/pull/1373
https://github.com/edx/sandbox-internal/pull/68