### PR TITLE
Add Custom Applicator to calculate view

### DIFF
--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -573,7 +573,7 @@ def get_enterprise_id_for_user(site, user):
 
     try:
         enterprise_learner_response = fetch_enterprise_learner_data(site, user)
-    except (ReqConnectionError, KeyError, SlumberHttpBaseException, Timeout) as exc:
+    except (AttributeError, ReqConnectionError, KeyError, SlumberHttpBaseException, Timeout) as exc:
         logging.exception('Unable to retrieve enterprise learner data for the user!'
                           'User: %s, Exception: %s', user, exc)
         return None

--- a/ecommerce/extensions/api/v2/views/baskets.py
+++ b/ecommerce/extensions/api/v2/views/baskets.py
@@ -36,6 +36,7 @@ from ecommerce.extensions.payment.helpers import get_default_processor_class, ge
 
 Applicator = get_class('offer.applicator', 'Applicator')
 Basket = get_model('basket', 'Basket')
+CustomApplicator = get_class('offer.applicator', 'CustomApplicator')
 logger = logging.getLogger(__name__)
 Order = get_model('order', 'Order')
 OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
@@ -381,6 +382,7 @@ class BasketCalculateView(generics.GenericAPIView):
             with transaction.atomic():
                 basket = Basket(owner=user, site=request.site)
                 basket.strategy = Selector().strategy(user=user, request=request)
+                bundle_id = request.GET.get('bundle')
 
                 for product in products:
                     basket.add_product(product, 1)
@@ -389,7 +391,7 @@ class BasketCalculateView(generics.GenericAPIView):
                     basket.vouchers.add(voucher)
 
                 # Calculate any discounts on the basket.
-                Applicator().apply(basket, user=user, request=request)
+                CustomApplicator().apply(basket, user=user, request=request, bundle_id=bundle_id)
 
                 discounts = []
                 if basket.offer_discounts:

--- a/ecommerce/extensions/offer/tests/test_applicator.py
+++ b/ecommerce/extensions/offer/tests/test_applicator.py
@@ -49,7 +49,7 @@ class CustomApplicatorTests(TestCase):
             mock_get_jwt.return_value = {
                 'roles': ['{}:{}'.format(SYSTEM_ENTERPRISE_LEARNER_ROLE, uuid4())]
             }
-            offers = self.applicator.get_offers(self.basket, self.user)
+            offers = self.applicator._get_offers(self.basket, self.user)  # pylint: disable=protected-access
         self.assertEqual(offers, expected_offers)
 
     def test_get_offers_with_bundle(self):
@@ -70,11 +70,12 @@ class CustomApplicatorTests(TestCase):
         ProgramOfferFactory()
         site_offers = ConditionalOfferFactory.create_batch(3) + offers_in_db
 
-        self.applicator.get_program_offers = mock.Mock()
+        self.applicator._get_program_offers = mock.Mock()  # pylint: disable=protected-access
 
         self.assert_correct_offers(site_offers)
 
-        self.assertFalse(self.applicator.get_program_offers.called)  # Verify there was no attempt to match off a bundle
+        # Verify there was no attempt to match off a bundle
+        self.assertFalse(self.applicator._get_program_offers.called)  # pylint: disable=protected-access
 
     @override_flag(CUSTOM_APPLICATOR_LOG_FLAG, active=True)
     def test_log_is_fired_when_get_offers_with_bundle(self):
@@ -100,7 +101,7 @@ class CustomApplicatorTests(TestCase):
         existing_offers = list(ConditionalOffer.active.filter(offer_type=ConditionalOffer.SITE))
         site_offers = ConditionalOfferFactory.create_batch(3) + existing_offers
 
-        self.applicator.get_program_offers = mock.Mock()
+        self.applicator._get_program_offers = mock.Mock()  # pylint: disable=protected-access
 
         with LogCapture(LOGGER_NAME) as logger:
             self.assert_correct_offers(site_offers)
@@ -112,8 +113,8 @@ class CustomApplicatorTests(TestCase):
                         self.basket, None, self.user),
                 )
             )
-
-        self.assertFalse(self.applicator.get_program_offers.called)  # Verify there was no attempt to match off a bundle
+        # Verify there was no attempt to match off a bundle
+        self.assertFalse(self.applicator._get_program_offers.called)  # pylint: disable=protected-access
 
     def test_get_site_offers(self):
         """ Verify get_site_offers returns correct objects based on filter"""
@@ -166,7 +167,8 @@ class CustomApplicatorTests(TestCase):
 
         with mock.patch('ecommerce.extensions.offer.applicator.get_enterprise_id_for_user') as mock_ent_id:
             mock_ent_id.return_value = enterprise_id
-            enterprise_offers = self.applicator.get_enterprise_offers(
+            # pylint: disable=protected-access
+            enterprise_offers = self.applicator._get_enterprise_offers(
                 'some-site',
                 self.user
             )


### PR DESCRIPTION
Right now the about pages and basket add view are using different mechanisms to calculate price of programs, which is causing confusion for leaners. 
For Program `IBM Data Science`, https://www.edx.org/es/professional-certificate/ibm-data-science ,the about page shows,
<img width="560" alt="Screenshot 2020-02-03 at 4 51 11 PM" src="https://user-images.githubusercontent.com/40633976/73651108-8b5e9080-46a5-11ea-9cb6-2cebb8fbbbda.png">
and the basket calculates the total as
<img width="548" alt="Screenshot 2020-02-03 at 4 51 33 PM" src="https://user-images.githubusercontent.com/40633976/73651116-93b6cb80-46a5-11ea-8c23-d455ae45398a.png">

The Applicator used on about page is applying offer of another program (`Python Data Science`) when it shouldn't be doing that. Using CustomApplicator on CalculateView will solve this issue 