### PR TITLE
ENT-2616 | fixed enterprise_coupon_detail.html to show correct enterprise UUID 

### DIFF
--- a/ecommerce/static/js/test/mock_data/coupons.js
+++ b/ecommerce/static/js/test/mock_data/coupons.js
@@ -195,7 +195,7 @@ define([], function() {
                 name: 'TESTCAT'
             },
             course_catalog: null,
-            enterprise_customer: '42a30ade47834489a607cd0f52ba13cf',
+            enterprise_customer: {id: '349bef52-c0fb-4901-a5b5-26e9b70a4102', name: 'test client'},
             price: '100.00',
             invoice_type: 'Prepaid',
             invoice_discount_type: 'Percentage',
@@ -235,7 +235,7 @@ define([], function() {
                 id: 4,
                 name: 'TESTCAT'
             },
-            enterprise_customer: '42a30ade47834489a607cd0f52ba13cf',
+            enterprise_customer: {id: '349bef52-c0fb-4901-a5b5-26e9b70a4102', name: 'test client'},
             enterprise_customer_catalog: 'f9098aab184245c881a20e53d8e7609a',
             invoice_type: 'Prepaid',
             invoice_discount_type: 'Percentage',

--- a/ecommerce/static/js/test/specs/views/enterprise_coupon_detail_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/enterprise_coupon_detail_view_spec.js
@@ -44,7 +44,7 @@ define([
                 expect(view.$('.category > .value').text()).toEqual(category);
                 expect(view.$('.discount-value > .value').text()).toEqual(view.discountValue());
                 expect(view.$('.enterprise-customer > .value').text()).toEqual(
-                    model.get('enterprise_customer')
+                    model.get('enterprise_customer').id
                 );
                 expect(
                     view.$('.enterprise-customer-catalog > .value > .enterprise-catalog-details-link').text()

--- a/ecommerce/static/templates/enterprise_coupon_detail.html
+++ b/ecommerce/static/templates/enterprise_coupon_detail.html
@@ -27,7 +27,7 @@
         </div>
         <div class="info-item grid-item enterprise-customer">
             <div class="heading"><%= gettext('Enterprise Customer') %></div>
-            <div class="value"><%= coupon.enterprise_customer %></div><br />
+            <div class="value"><%= coupon.enterprise_customer.id %></div><br />
         </div>
         <div class="info-item grid-item enterprise-customer-catalog">
             <div class="heading"><%= gettext('Enterprise Customer Catalog') %></div>


### PR DESCRIPTION
before:

<img width="1126" alt="Screen Shot 2020-02-06 at 5 27 57 PM" src="https://user-images.githubusercontent.com/29247391/74227710-dc433a00-4ce0-11ea-9dc0-248133bb5dac.png">

Now:
<img width="1114" alt="Screen Shot 2020-02-11 at 3 12 36 PM" src="https://user-images.githubusercontent.com/29247391/74227774-fbda6280-4ce0-11ea-81f5-7fed49fc25e5.png">
