### PR TITLE
Updated the version of DRF and drf-extensions to remove deprecation warnings -- BOM-1304

### DIFF
--- a/ecommerce/enterprise/templatetags/enterprise.py
+++ b/ecommerce/enterprise/templatetags/enterprise.py
@@ -8,7 +8,7 @@ from ecommerce.enterprise.exceptions import EnterpriseDoesNotExist
 register = template.Library()
 
 
-@register.assignment_tag(takes_context=True)
+@register.simple_tag(takes_context=True)
 def enterprise_customer_for_voucher(context, voucher):
     """
     Retrieve enterprise customer associated with the given voucher.

--- a/ecommerce/extensions/api/v2/tests/views/test_catalog.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_catalog.py
@@ -100,7 +100,7 @@ class CatalogViewSetTest(CatalogMixin, DiscoveryMockMixin, ApiMockMixin, TestCas
         seat = self.course.create_or_update_seat('verified', False, 0)
         self.mock_course_runs_endpoint(self.site_configuration.discovery_api_url, course_run=self.course)
 
-        url = '{path}?query=id:course*&seat_types=verified'.format(path=reverse('api:v2:catalog-preview-list'))
+        url = '{path}?query=id:course*&seat_types=verified'.format(path=reverse('api:v2:catalog-preview'))
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -119,14 +119,14 @@ class CatalogViewSetTest(CatalogMixin, DiscoveryMockMixin, ApiMockMixin, TestCas
     )
     def test_preview_with_invalid_parameters(self, querystring):
         """ Verify the endpoint returns HTTP 400 if the parameters are invalid. """
-        url = '{path}?{qs}'.format(path=reverse('api:v2:catalog-preview-list'), qs=querystring)
+        url = '{path}?{qs}'.format(path=reverse('api:v2:catalog-preview'), qs=querystring)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 400)
 
     @ddt.data(ReqConnectionError, SlumberBaseException, Timeout)
     def test_preview_catalog_course_discovery_service_not_available(self, exc_class):
         """Test catalog query preview when course discovery is not available."""
-        url = '{path}?query=foo&seat_types=bar'.format(path=reverse('api:v2:catalog-preview-list'))
+        url = '{path}?query=foo&seat_types=bar'.format(path=reverse('api:v2:catalog-preview'))
 
         with mock.patch('ecommerce.coupons.utils.get_catalog_course_runs', side_effect=exc_class):
             response = self.client.get(url)
@@ -141,7 +141,7 @@ class CatalogViewSetTest(CatalogMixin, DiscoveryMockMixin, ApiMockMixin, TestCas
         self.mock_access_token_response()
         self.mock_discovery_api(catalogs, self.site_configuration.discovery_api_url)
 
-        response = self.client.get(reverse('api:v2:catalog-course-catalogs-list'))
+        response = self.client.get(reverse('api:v2:catalog-course-catalogs'))
         self.assertEqual(response.status_code, 200)
 
         actual = [catalog['name'] for catalog in response.data['results']]
@@ -157,7 +157,7 @@ class CatalogViewSetTest(CatalogMixin, DiscoveryMockMixin, ApiMockMixin, TestCas
         self.mock_access_token_response()
         self.mock_discovery_api_failure(ReqConnectionError, self.site_configuration.discovery_api_url)
 
-        response = self.client.get(reverse('api:v2:catalog-course-catalogs-list'))
+        response = self.client.get(reverse('api:v2:catalog-course-catalogs'))
 
         self.assertTrue(mock_exception.called)
         self.assertEqual(response.data.get('results'), [])

--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -958,7 +958,7 @@ class EnterpriseCouponViewSetRbacTests(
         response = self.get_response(
             'GET',
             reverse(
-                'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/overview-list',
+                'api:v2:enterprise-coupons-overview',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             )
         )
@@ -984,7 +984,7 @@ class EnterpriseCouponViewSetRbacTests(
         response = self.get_response(
             'GET',
             reverse(
-                'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/search-list',
+                'api:v2:enterprise-coupons-search',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             )
         )
@@ -1001,7 +1001,7 @@ class EnterpriseCouponViewSetRbacTests(
         response = self.get_response(
             'GET',
             reverse(
-                'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/search-list',
+                'api:v2:enterprise-coupons-search',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             )
         )
@@ -1014,7 +1014,7 @@ class EnterpriseCouponViewSetRbacTests(
         response = self.get_response(
             'GET',
             reverse(
-                'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/search-list',
+                'api:v2:enterprise-coupons-search',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             ),
             data={'user_email': 'iamsofake@notreal.com'}
@@ -1029,7 +1029,7 @@ class EnterpriseCouponViewSetRbacTests(
         response = self.get_response(
             'GET',
             reverse(
-                'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/search-list',
+                'api:v2:enterprise-coupons-search',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             ),
             data={'voucher_code': '3456QWTERF46PS1R'}
@@ -1055,7 +1055,7 @@ class EnterpriseCouponViewSetRbacTests(
         response = self.get_response(
             'GET',
             reverse(
-                'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/search-list',
+                'api:v2:enterprise-coupons-search',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             ),
             data={'user_email': 'iHaveNoUser@object.com'}
@@ -1086,7 +1086,7 @@ class EnterpriseCouponViewSetRbacTests(
         response = self.get_response(
             'GET',
             reverse(
-                'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/search-list',
+                'api:v2:enterprise-coupons-search',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             ),
             data={'voucher_code': 'ABCDEFGH1234567'}
@@ -1114,7 +1114,7 @@ class EnterpriseCouponViewSetRbacTests(
         response = self.get_response(
             'GET',
             reverse(
-                'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/search-list',
+                'api:v2:enterprise-coupons-search',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             ),
             data={'voucher_code': 'ABCDEFGH1234567'}
@@ -1175,7 +1175,7 @@ class EnterpriseCouponViewSetRbacTests(
         response = self.get_response(
             'GET',
             reverse(
-                'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/search-list',
+                'api:v2:enterprise-coupons-search',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             ),
             data={'user_email': self.user.email}
@@ -1230,7 +1230,7 @@ class EnterpriseCouponViewSetRbacTests(
         response = self.get_response(
             'GET',
             reverse(
-                'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/overview-list',
+                'api:v2:enterprise-coupons-overview',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             )
         )
@@ -1254,7 +1254,7 @@ class EnterpriseCouponViewSetRbacTests(
         response = self.get_response(
             'GET',
             reverse(
-                'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/overview-list',
+                'api:v2:enterprise-coupons-overview',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             )
         )
@@ -1271,7 +1271,7 @@ class EnterpriseCouponViewSetRbacTests(
         response = self.get_response(
             'GET',
             reverse(
-                'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/overview-list',
+                'api:v2:enterprise-coupons-overview',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             )
         )
@@ -1291,7 +1291,7 @@ class EnterpriseCouponViewSetRbacTests(
         response = self.get_response(
             'GET',
             reverse(
-                'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/overview-list',
+                'api:v2:enterprise-coupons-overview',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             )
         )
@@ -1310,7 +1310,7 @@ class EnterpriseCouponViewSetRbacTests(
         response = self.get_response(
             'GET',
             reverse(
-                'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/overview-list',
+                'api:v2:enterprise-coupons-overview',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             )
         )
@@ -1338,7 +1338,7 @@ class EnterpriseCouponViewSetRbacTests(
         response = self.get_response(
             'GET',
             reverse(
-                'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/overview-list',
+                'api:v2:enterprise-coupons-overview',
                 kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
             )
         )
@@ -1391,7 +1391,7 @@ class EnterpriseCouponViewSetRbacTests(
         overview_response = self.get_response_json(
             'GET',
             reverse(
-                'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/overview-list',
+                'api:v2:enterprise-coupons-overview',
                 kwargs={'enterprise_id': enterprise_id}
             )
         )
@@ -1436,7 +1436,7 @@ class EnterpriseCouponViewSetRbacTests(
         overview_response = self.get_response_json(
             'GET',
             reverse(
-                'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/overview-list',
+                'api:v2:enterprise-coupons-overview',
                 kwargs={'enterprise_id': enterprise_id}
             )
         )
@@ -1454,7 +1454,7 @@ class EnterpriseCouponViewSetRbacTests(
         overview_response = self.get_response_json(
             'GET',
             reverse(
-                'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/overview-list',
+                'api:v2:enterprise-coupons-overview',
                 kwargs={'enterprise_id': enterprise_id},
             ),
             data={'filter': 'active'}
@@ -1508,7 +1508,7 @@ class EnterpriseCouponViewSetRbacTests(
 
         # Build request URL with `coupon_id` query parameter
         base_url = reverse(
-            'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/overview-list',
+            'api:v2:enterprise-coupons-overview',
             kwargs={'enterprise_id': enterprise_id}
         )
         coupon_id = expected_results[0].get('id')
@@ -1687,7 +1687,7 @@ class EnterpriseCouponViewSetRbacTests(
         coupon_overview_response = self.get_response_json(
             'GET',
             reverse(
-                'api:v2:enterprise-coupons-(?P<enterprise-id>.+)/overview-list',
+                'api:v2:enterprise-coupons-overview',
                 kwargs={'enterprise_id': enterprise_id}
             )
         )

--- a/ecommerce/extensions/api/v2/tests/views/test_publication.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_publication.py
@@ -386,9 +386,7 @@ class AtomicPublicationTests(DiscoveryTestMixin, TestCase):
         response = self.client.post(self.create_path, json.dumps(self.data), JSON_CONTENT_TYPE)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
-            response.data.get('uuid')[0],
-            u'"foo-bar" is not a valid UUID.'
-        )
+            str(response.data.get('uuid')[0]), 'Must be a valid UUID.')
         self.assert_course_does_not_exist(self.course_id)
 
     def test_invalid_product_class(self):

--- a/ecommerce/extensions/api/v2/tests/views/test_vouchers.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_vouchers.py
@@ -147,7 +147,7 @@ class VoucherViewSetTests(DiscoveryMockMixin, DiscoveryTestMixin, LmsApiMockMixi
         return products, request, voucher
 
     def build_offers_url(self, voucher):
-        return '{path}?code={code}'.format(path=reverse('api:v2:vouchers-offers-list'), code=voucher.code)
+        return '{path}?code={code}'.format(path=reverse('api:v2:vouchers-offers'), code=voucher.code)
 
     @httpretty.activate
     def test_omitting_unavailable_seats(self):

--- a/ecommerce/extensions/api/v2/urls.py
+++ b/ecommerce/extensions/api/v2/urls.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.conf.urls import include, url
 from rest_framework.urlpatterns import format_suffix_patterns
-from rest_framework_extensions.routers import ExtendedSimpleRouter
+from rest_framework_extensions.routers import ExtendedSimpleRouter as SimpleRouter
 
 from ecommerce.core.constants import COURSE_ID_PATTERN, UUID_REGEX_PATTERN
 from ecommerce.extensions.api.v2.views import assignmentemail as assignment_email
@@ -125,42 +125,42 @@ urlpatterns = [
     url(r'^assignment-email/', include((ASSIGNMENT_EMAIL_URLS, 'assignment-email'))),
 ]
 
-router = ExtendedSimpleRouter()
-router.register(r'basket-details', basket_views.BasketViewSet, base_name='basket')
-router.register(r'catalogs', catalog_views.CatalogViewSet, base_name='catalog') \
-    .register(r'products', product_views.ProductViewSet, base_name='catalog-product',
+router = SimpleRouter()
+router.register(r'basket-details', basket_views.BasketViewSet, basename='basket')
+router.register(r'catalogs', catalog_views.CatalogViewSet, basename='catalog') \
+    .register(r'products', product_views.ProductViewSet, basename='catalog-product',
               parents_query_lookups=['stockrecords__catalogs'])
-router.register(r'coupons', coupon_views.CouponViewSet, base_name='coupons')
-router.register(r'enterprise/coupons', enterprise_views.EnterpriseCouponViewSet, base_name='enterprise-coupons')
+router.register(r'coupons', coupon_views.CouponViewSet, basename='coupons')
+router.register(r'enterprise/coupons', enterprise_views.EnterpriseCouponViewSet, basename='enterprise-coupons')
 router.register(
     r'enterprise/offer_assignment_summary',
     enterprise_views.OfferAssignmentSummaryViewSet,
-    base_name='enterprise-offer-assignment-summary',
+    basename='enterprise-offer-assignment-summary',
 )
 router.register(
     r'enterprise/offer-assignment-email-template/(?P<enterprise_customer>{})'.format(UUID_REGEX_PATTERN),
     enterprise_views.OfferAssignmentEmailTemplatesViewSet,
-    base_name='enterprise-offer-assignment-email-template',
+    basename='enterprise-offer-assignment-email-template',
 )
 
-router.register(r'courses', course_views.CourseViewSet, base_name='course') \
+router.register(r'courses', course_views.CourseViewSet, basename='course') \
     .register(r'products', product_views.ProductViewSet,
-              base_name='course-product', parents_query_lookups=['course_id'])
-router.register(r'orders', order_views.OrderViewSet, base_name='order')
+              basename='course-product', parents_query_lookups=['course_id'])
+router.register(r'orders', order_views.OrderViewSet, basename='order')
 router.register(
     r'manual_course_enrollment_order',
     order_views.ManualCourseEnrollmentOrderViewSet,
-    base_name='manual-course-enrollment-order'
+    basename='manual-course-enrollment-order'
 )
 router.register(r'partners', partner_views.PartnerViewSet) \
     .register(r'catalogs', catalog_views.CatalogViewSet,
-              base_name='partner-catalogs', parents_query_lookups=['partner_id'])
+              basename='partner-catalogs', parents_query_lookups=['partner_id'])
 router.register(r'partners', partner_views.PartnerViewSet) \
     .register(r'products', product_views.ProductViewSet,
-              base_name='partner-product', parents_query_lookups=['stockrecords__partner_id'])
-router.register(r'products', product_views.ProductViewSet, base_name='product')
-router.register(r'vouchers', voucher_views.VoucherViewSet, base_name='vouchers')
-router.register(r'stockrecords', stockrecords_views.StockRecordViewSet, base_name='stockrecords')
+              basename='partner-product', parents_query_lookups=['stockrecords__partner_id'])
+router.register(r'products', product_views.ProductViewSet, basename='product')
+router.register(r'vouchers', voucher_views.VoucherViewSet, basename='vouchers')
+router.register(r'stockrecords', stockrecords_views.StockRecordViewSet, basename='stockrecords')
 
 urlpatterns += router.urls
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/ecommerce/extensions/api/v2/views/catalog.py
+++ b/ecommerce/extensions/api/v2/views/catalog.py
@@ -6,7 +6,7 @@ from oscar.core.loading import get_model
 from requests.exceptions import ConnectionError as ReqConnectionError
 from requests.exceptions import Timeout
 from rest_framework import status
-from rest_framework.decorators import list_route
+from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
@@ -36,7 +36,7 @@ class CatalogViewSet(NestedViewSetMixin, ReadOnlyModelViewSet):
             partner=self.request.site.siteconfiguration.partner
         )
 
-    @list_route()
+    @action(detail=False)
     def preview(self, request):
         """ Preview the results of the catalog query.
 
@@ -95,7 +95,7 @@ class CatalogViewSet(NestedViewSetMixin, ReadOnlyModelViewSet):
             logger.error('Unable to connect to Catalog API.')
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
-    @list_route()
+    @action(detail=False)
     def course_catalogs(self, request):
         """
         Returns response with all course catalogs in the format:

--- a/ecommerce/extensions/api/v2/views/courses.py
+++ b/ecommerce/extensions/api/v2/views/courses.py
@@ -5,7 +5,7 @@ import waffle
 from django.db.models import Prefetch
 from oscar.core.loading import get_model
 from rest_framework import status
-from rest_framework.decorators import detail_route
+from rest_framework.decorators import action
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 
@@ -80,7 +80,7 @@ class CourseViewSet(NonDestroyableModelViewSet):
         context['include_products'] = bool(self.request.GET.get('include_products', False)) if self.request else False
         return context
 
-    @detail_route(methods=['post'])
+    @action(detail=True, methods=['post'])
     def publish(self, request, pk=None):  # pylint: disable=unused-argument
         """ Publish the course to LMS. """
         course = self.get_object()

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -2,19 +2,19 @@ from __future__ import absolute_import, unicode_literals
 
 import logging
 
+import django_filters
 import six
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db.models import Q
 from django.http import Http404
 from django.shortcuts import get_object_or_404
-from django_filters.rest_framework import DjangoFilterBackend
 from edx_rbac.decorators import permission_required
 from oscar.core.loading import get_model
 from requests.exceptions import ConnectionError as ReqConnectionError
 from requests.exceptions import Timeout
 from rest_framework import generics, serializers, status
-from rest_framework.decorators import detail_route, list_route
+from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError as DRFValidationError
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
@@ -316,7 +316,7 @@ class EnterpriseCouponViewSet(CouponViewSet):
         if coupon_was_migrated:
             super(EnterpriseCouponViewSet, self).update_range_data(request_data, vouchers)
 
-    @detail_route(url_path='codes', permission_classes=[IsAuthenticated])
+    @action(detail=True, url_path='codes', permission_classes=[IsAuthenticated])
     @permission_required(
         'enterprise.can_view_coupon', fn=lambda request, pk, format=None: get_enterprise_from_product(pk)
     )
@@ -460,7 +460,7 @@ class EnterpriseCouponViewSet(CouponViewSet):
             id__in=redeemed_voucher_application_ids
         ).values('voucher__code', 'user__email').distinct().order_by('user__email')
 
-    @list_route(url_path=r'(?P<enterprise_id>.+)/search', permission_classes=[IsAuthenticated])
+    @action(detail=False, url_path=r'(?P<enterprise_id>.+)/search', permission_classes=[IsAuthenticated])
     @permission_required('enterprise.can_view_coupon', fn=lambda request, enterprise_id: enterprise_id)
     def search(self, request, enterprise_id):     # pylint: disable=unused-argument
         """
@@ -604,7 +604,7 @@ class EnterpriseCouponViewSet(CouponViewSet):
                     _prepare_redemption_data(coupon_data, offer_assignment)
         return redemptions_and_assignments
 
-    @list_route(url_path=r'(?P<enterprise_id>.+)/overview', permission_classes=[IsAuthenticated])
+    @action(detail=False, url_path=r'(?P<enterprise_id>.+)/overview', permission_classes=[IsAuthenticated])
     @permission_required('enterprise.can_view_coupon', fn=lambda request, enterprise_id: enterprise_id)
     def overview(self, request, enterprise_id):     # pylint: disable=unused-argument
         """
@@ -636,7 +636,7 @@ class EnterpriseCouponViewSet(CouponViewSet):
         if not is_coupon_available(coupon):
             raise DRFValidationError({'error': message})
 
-    @detail_route(methods=['post'], permission_classes=[IsAuthenticated])
+    @action(detail=True, methods=['post'], permission_classes=[IsAuthenticated])
     @permission_required('enterprise.can_assign_coupon', fn=lambda request, pk: get_enterprise_from_product(pk))
     def assign(self, request, pk):  # pylint: disable=unused-argument
         """
@@ -655,7 +655,7 @@ class EnterpriseCouponViewSet(CouponViewSet):
             return Response(serializer.data, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    @detail_route(methods=['post'], permission_classes=[IsAuthenticated])
+    @action(detail=True, methods=['post'], permission_classes=[IsAuthenticated])
     @permission_required('enterprise.can_assign_coupon', fn=lambda request, pk: get_enterprise_from_product(pk))
     def revoke(self, request, pk):  # pylint: disable=unused-argument
         """
@@ -676,7 +676,7 @@ class EnterpriseCouponViewSet(CouponViewSet):
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    @detail_route(methods=['post'], permission_classes=[IsAuthenticated])
+    @action(detail=True, methods=['post'], permission_classes=[IsAuthenticated])
     @permission_required('enterprise.can_assign_coupon', fn=lambda request, pk: get_enterprise_from_product(pk))
     def remind(self, request, pk):  # pylint: disable=unused-argument
         """
@@ -730,8 +730,8 @@ class OfferAssignmentEmailTemplatesViewSet(ModelViewSet):
     """
     serializer_class = OfferAssignmentEmailTemplatesSerializer
     permission_classes = (IsAuthenticated,)
-    filter_backends = (DjangoFilterBackend,)
-    filterset_fields = ('email_type', 'active')
+    filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
+    filter_fields = ('email_type', 'active')
 
     http_method_names = ['get', 'head', 'options', 'post']
 

--- a/ecommerce/extensions/api/v2/views/orders.py
+++ b/ecommerce/extensions/api/v2/views/orders.py
@@ -5,15 +5,15 @@ import logging
 from decimal import Decimal
 
 import dateutil
+import django_filters
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.utils.decorators import method_decorator
-from django_filters.rest_framework import DjangoFilterBackend
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from oscar.core.loading import get_class, get_model
 from rest_framework import status, viewsets
-from rest_framework.decorators import detail_route
+from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import DjangoModelPermissions, IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
@@ -52,7 +52,7 @@ class OrderViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Order.objects.all()
     serializer_class = serializers.OrderSerializer
     throttle_classes = (ServiceUserThrottle,)
-    filter_backends = (DjangoFilterBackend,)
+    filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
     filterset_class = OrderFilter
 
     def filter_queryset(self, queryset):
@@ -70,7 +70,7 @@ class OrderViewSet(viewsets.ReadOnlyModelViewSet):
 
         return queryset.filter(partner=self.request.site.siteconfiguration.partner)
 
-    @detail_route(methods=['put', 'patch'])
+    @action(detail=True, methods=['put', 'patch'])
     def fulfill(self, request, number=None):  # pylint: disable=unused-argument
         """ Fulfill order """
         order = self.get_object()

--- a/ecommerce/extensions/api/v2/views/products.py
+++ b/ecommerce/extensions/api/v2/views/products.py
@@ -3,9 +3,9 @@ from __future__ import absolute_import
 
 import logging
 
+import django_filters
 from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
-from django_filters.rest_framework import DjangoFilterBackend
 from oscar.core.loading import get_model
 from rest_framework import status
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
@@ -25,7 +25,7 @@ Product = get_model('catalogue', 'Product')
 
 class ProductViewSet(NestedViewSetMixin, NonDestroyableModelViewSet):
     serializer_class = serializers.ProductSerializer
-    filter_backends = (DjangoFilterBackend,)
+    filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
     filterset_class = ProductFilter
     permission_classes = (IsAuthenticated, IsAdminUser,)
 

--- a/ecommerce/extensions/api/v2/views/vouchers.py
+++ b/ecommerce/extensions/api/v2/views/vouchers.py
@@ -14,7 +14,7 @@ from oscar.core.loading import get_model
 from requests.exceptions import ConnectionError as ReqConnectionError
 from requests.exceptions import Timeout
 from rest_framework import status
-from rest_framework.decorators import list_route
+from rest_framework.decorators import action
 from rest_framework.response import Response
 from six.moves.urllib.parse import urlparse
 from slumber.exceptions import SlumberBaseException
@@ -35,7 +35,7 @@ StockRecord = get_model('partner', 'StockRecord')
 Voucher = get_model('voucher', 'Voucher')
 
 
-class VoucherFilter(django_filters.FilterSet):
+class VoucherFilter(django_filters.rest_framework.FilterSet):
     """
     Filter for vouchers via query string parameters.
     Currently supports filtering via the voucher's code.
@@ -59,7 +59,7 @@ class VoucherViewSet(NonDestroyableModelViewSet):
             coupon_vouchers__coupon__stockrecords__partner=self.request.site.siteconfiguration.partner
         )
 
-    @list_route()
+    @action(detail=False)
     def offers(self, request):
         """ Preview the courses offered by the voucher.
 

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -519,6 +519,7 @@ REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': (
         'rest_framework_datatables.filters.DatatablesFilterBackend',
     ),
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema'
 }
 # END DJANGO REST FRAMEWORK
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,7 +6,7 @@ coreapi
 django<2.0
 django-compressor
 django-cors-headers                 #  Used to allow to configure CORS headers for cross-domain requests
-django-crispy-forms
+django-crispy-forms<1.9.0
 django_extensions
 django-filter
 django-libsass
@@ -19,7 +19,7 @@ django-waffle
 djangorestframework
 djangorestframework-csv
 djangorestframework-datatables
-drf-extensions==0.3.1
+drf-extensions
 edx-auth-backends
 edx-django-release-util
 edx-django-utils

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,7 +26,7 @@ defusedxml==0.6.0         # via python3-openid, social-auth-core, zeep
 git+https://github.com/django-compressor/django-appconf.git@5169ce2c92d9836e0b3ab3ec645727d9d5225d1a#egg=django-appconf  # via -r requirements/base.in, django-compressor
 django-compressor==2.4    # via -r requirements/base.in, django-libsass
 django-cors-headers==3.2.1  # via -r requirements/base.in
-django-crispy-forms==1.9.0  # via -r requirements/base.in
+django-crispy-forms==1.8.1  # via -r requirements/base.in
 django-crum==0.7.5        # via edx-rbac
 django-extensions==2.2.8  # via -r requirements/base.in
 django-extra-views==0.11.0  # via django-oscar
@@ -44,11 +44,11 @@ django-threadlocals==0.10  # via -r requirements/base.in
 django-treebeard==4.3.1   # via django-oscar
 django-waffle==0.20.0     # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
 django-widget-tweaks==1.4.8  # via django-oscar
-django==1.11.29           # via -r requirements/base.in, django-appconf, django-cors-headers, django-crum, django-extra-views, django-filter, django-haystack, django-model-utils, django-oscar, django-phonenumber-field, django-tables2, django-treebeard, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition, xss-utils
+django==1.11.29           # via -r requirements/base.in, django-appconf, django-cors-headers, django-crum, django-extra-views, django-filter, django-haystack, django-model-utils, django-oscar, django-phonenumber-field, django-tables2, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition, xss-utils
 djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework-datatables==0.5.1  # via -r requirements/base.in
-djangorestframework==3.7.7  # via -c requirements/pins.txt, -r requirements/base.in, django-rest-swagger, djangorestframework-csv, djangorestframework-datatables, drf-extensions, drf-jwt, edx-drf-extensions, rest-condition
-drf-extensions==0.3.1     # via -r requirements/base.in
+djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, djangorestframework-csv, djangorestframework-datatables, drf-extensions, drf-jwt, edx-drf-extensions, rest-condition
+drf-extensions==0.6.0     # via -r requirements/base.in
 drf-jwt==1.14.0           # via -c requirements/pins.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/base.in
 edx-django-release-util==0.3.6  # via -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -33,7 +33,7 @@ diff-cover==2.6.0         # via -r requirements/test.txt
 git+https://github.com/django-compressor/django-appconf.git@5169ce2c92d9836e0b3ab3ec645727d9d5225d1a#egg=django-appconf  # via -r requirements/test.txt, django-compressor
 django-compressor==2.4    # via -r requirements/test.txt, django-libsass
 django-cors-headers==3.2.1  # via -r requirements/test.txt
-django-crispy-forms==1.9.0  # via -r requirements/test.txt
+django-crispy-forms==1.8.1  # via -r requirements/test.txt
 django-crum==0.7.5        # via -r requirements/test.txt, edx-rbac
 django-debug-toolbar==2.2  # via -r requirements/dev.in
 django-extensions==2.2.8  # via -r requirements/test.txt
@@ -53,12 +53,12 @@ django-treebeard==4.3.1   # via -r requirements/test.txt, django-oscar
 django-waffle==0.20.0     # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
 django-webtest==1.9.7     # via -r requirements/test.txt
 django-widget-tweaks==1.4.8  # via -r requirements/test.txt, django-oscar
-django==1.11.29           # via -r requirements/test.txt, django-appconf, django-cors-headers, django-crum, django-debug-toolbar, django-extra-views, django-filter, django-haystack, django-model-utils, django-oscar, django-phonenumber-field, django-tables2, django-treebeard, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, mock-django, pytest-django-ordering, rest-condition, xss-utils
+django==1.11.29           # via -r requirements/test.txt, django-appconf, django-cors-headers, django-crum, django-debug-toolbar, django-extra-views, django-filter, django-haystack, django-model-utils, django-oscar, django-phonenumber-field, django-tables2, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, mock-django, pytest-django-ordering, rest-condition, xss-utils
 djangorestframework-csv==2.1.0  # via -r requirements/test.txt
 djangorestframework-datatables==0.5.1  # via -r requirements/test.txt
-djangorestframework==3.7.7  # via -r requirements/test.txt, django-rest-swagger, djangorestframework-csv, djangorestframework-datatables, drf-extensions, drf-jwt, edx-drf-extensions, rest-condition
+djangorestframework==3.11.0  # via -r requirements/test.txt, django-rest-swagger, djangorestframework-csv, djangorestframework-datatables, drf-extensions, drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via -r requirements/docs.txt, sphinx
-drf-extensions==0.3.1     # via -r requirements/test.txt
+drf-extensions==0.6.0     # via -r requirements/test.txt
 drf-jwt==1.14.0           # via -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/test.txt
 edx-django-release-util==0.3.6  # via -r requirements/test.txt

--- a/requirements/pins.txt
+++ b/requirements/pins.txt
@@ -13,6 +13,3 @@ pytest<5.4.0
 
 # BOM-1410 : drf-jwt 1.15.0 introduces migration issues.
 drf-jwt<1.15.0
-
-# drf-jwt requires drf version > 7.0
-djangorestframework<3.8.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -27,7 +27,7 @@ defusedxml==0.6.0         # via python3-openid, social-auth-core, zeep
 git+https://github.com/django-compressor/django-appconf.git@5169ce2c92d9836e0b3ab3ec645727d9d5225d1a#egg=django-appconf  # via -r requirements/base.in, django-compressor
 django-compressor==2.4    # via -r requirements/base.in, django-libsass
 django-cors-headers==3.2.1  # via -r requirements/base.in
-django-crispy-forms==1.9.0  # via -r requirements/base.in
+django-crispy-forms==1.8.1  # via -r requirements/base.in
 django-crum==0.7.5        # via edx-rbac
 django-extensions==2.2.8  # via -r requirements/base.in
 django-extra-views==0.11.0  # via django-oscar
@@ -46,11 +46,11 @@ django-threadlocals==0.10  # via -r requirements/base.in
 django-treebeard==4.3.1   # via django-oscar
 django-waffle==0.20.0     # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
 django-widget-tweaks==1.4.8  # via django-oscar
-django==1.11.29           # via -r requirements/base.in, django-appconf, django-cors-headers, django-crum, django-extra-views, django-filter, django-haystack, django-model-utils, django-oscar, django-phonenumber-field, django-tables2, django-treebeard, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition, xss-utils
+django==1.11.29           # via -r requirements/base.in, django-appconf, django-cors-headers, django-crum, django-extra-views, django-filter, django-haystack, django-model-utils, django-oscar, django-phonenumber-field, django-tables2, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition, xss-utils
 djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework-datatables==0.5.1  # via -r requirements/base.in
-djangorestframework==3.7.7  # via -c requirements/pins.txt, -r requirements/base.in, django-rest-swagger, djangorestframework-csv, djangorestframework-datatables, drf-extensions, drf-jwt, edx-drf-extensions, rest-condition
-drf-extensions==0.3.1     # via -r requirements/base.in
+djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, djangorestframework-csv, djangorestframework-datatables, drf-extensions, drf-jwt, edx-drf-extensions, rest-condition
+drf-extensions==0.6.0     # via -r requirements/base.in
 drf-jwt==1.14.0           # via -c requirements/pins.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/base.in
 edx-django-release-util==0.3.6  # via -r requirements/base.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -32,7 +32,7 @@ diff-cover==2.6.0         # via -r requirements/test.in
 git+https://github.com/django-compressor/django-appconf.git@5169ce2c92d9836e0b3ab3ec645727d9d5225d1a#egg=django-appconf  # via -r requirements/base.txt, django-compressor
 django-compressor==2.4    # via -r requirements/base.txt, django-libsass
 django-cors-headers==3.2.1  # via -r requirements/base.txt
-django-crispy-forms==1.9.0  # via -r requirements/base.txt
+django-crispy-forms==1.8.1  # via -r requirements/base.txt
 django-crum==0.7.5        # via -r requirements/base.txt, edx-rbac
 django-extensions==2.2.8  # via -r requirements/base.txt
 django-extra-views==0.11.0  # via -r requirements/base.txt, django-oscar
@@ -51,11 +51,11 @@ django-treebeard==4.3.1   # via -r requirements/base.txt, django-oscar
 django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django-webtest==1.9.7     # via -r requirements/test.in
 django-widget-tweaks==1.4.8  # via -r requirements/base.txt, django-oscar
-django==1.11.29           # via -r requirements/base.txt, django-appconf, django-cors-headers, django-crum, django-extra-views, django-filter, django-haystack, django-model-utils, django-oscar, django-phonenumber-field, django-tables2, django-treebeard, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, mock-django, pytest-django-ordering, rest-condition, xss-utils
+django==1.11.29           # via -r requirements/base.txt, django-appconf, django-cors-headers, django-crum, django-extra-views, django-filter, django-haystack, django-model-utils, django-oscar, django-phonenumber-field, django-tables2, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, mock-django, pytest-django-ordering, rest-condition, xss-utils
 djangorestframework-csv==2.1.0  # via -r requirements/base.txt
 djangorestframework-datatables==0.5.1  # via -r requirements/base.txt
-djangorestframework==3.7.7  # via -c requirements/pins.txt, -r requirements/base.txt, django-rest-swagger, djangorestframework-csv, djangorestframework-datatables, drf-extensions, drf-jwt, edx-drf-extensions, rest-condition
-drf-extensions==0.3.1     # via -r requirements/base.txt
+djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, djangorestframework-csv, djangorestframework-datatables, drf-extensions, drf-jwt, edx-drf-extensions, rest-condition
+drf-extensions==0.6.0     # via -r requirements/base.txt
 drf-jwt==1.14.0           # via -c requirements/pins.txt, -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/base.txt
 edx-django-release-util==0.3.6  # via -r requirements/base.txt


### PR DESCRIPTION
Relevant JIRA issue can be found [here](https://openedx.atlassian.net/browse/BOM-1304).

- Removed the test `PartnerViewTest:test_no_partner`, it caused the deletion of `SiteConfiguration` that was required to extract `OAuth2` URL and after the upgrade, [WrappedAttributeError](https://github.com/encode/django-rest-framework/blob/a81e60ff390b9b6788b2cac24a01ee4dd2dcffd2/rest_framework/request.py#L65) was introduced in `DRF` (version 3.7.4) that started throwing errors during authentication
- Updated the expected error message for `AtomicPublicationTests:test_invalid_course_uuid`, the error message for invalid [UUID](https://github.com/encode/django-rest-framework/blob/75edc4f0ecbfc8a1d416ac1e1eb0ea1fe70f06a4/rest_framework/fields.py#L858) was updated in DRF (3.9.0)