### PR TITLE
[REV-1112] Omit white label e2e test users from experiment and fix utm parameters when redirecting

### DIFF
--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -491,11 +491,11 @@ class BasketAddItemsView(BasketLogicMixin, APIView):
 
     def _redirect_response_to_basket_or_payment(self, request, skus):
         redirect_url = get_payment_microfrontend_or_basket_url(request)
-        redirect_url = add_utm_params_to_url(redirect_url, list(self.request.GET.items()))
         # If a user is eligible and bucketed, REV1074 experiment information will be added to their url
         if waffle.flag_is_active(self.request, 'REV1074.enable_experiment'):  # pragma: no cover
             if skus:
                 redirect_url = add_REV1074_information_to_url_if_eligible(redirect_url, request, skus[0])
+        redirect_url = add_utm_params_to_url(redirect_url, list(self.request.GET.items()))
         return HttpResponseRedirect(redirect_url, status=303)
 
 

--- a/ecommerce/extensions/experimentation/utils.py
+++ b/ecommerce/extensions/experimentation/utils.py
@@ -36,7 +36,8 @@ def _is_eligible_for_REV1074_experiment(request):
         # TODO: I don't think this check works yet
         getattr(request.basket, 'ENTERPRISE_CATALOG_ATTRIBUTE_TYPE', None) or
         # We do not want to include zero dollar purchases
-        request.basket.total_incl_tax == 0
+        request.basket.total_incl_tax == 0 or
+        str(request.user.username).startswith('test_') and str(request.user.email).endswith('example.com')
     )
     return not omit
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/REV-1112