### PR TITLE
REV-1112 We need to remove utm params because they are not supported (or needed) for the static page test

### DIFF
--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -27,7 +27,6 @@ from requests.exceptions import Timeout
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from six.moves.urllib.parse import urlparse
 from slumber.exceptions import SlumberBaseException
 
 from ecommerce.core.exceptions import SiteConfigurationError
@@ -495,10 +494,7 @@ class BasketAddItemsView(BasketLogicMixin, APIView):
         # If a user is eligible and bucketed, REV1074 experiment information will be added to their url
         if waffle.flag_is_active(self.request, 'REV1074.enable_experiment') and skus:  # pragma: no cover
             redirect_url = add_REV1074_information_to_url_if_eligible(redirect_url, request, skus[0])
-            redirect_url = add_utm_params_to_url(redirect_url, list(self.request.GET.items()))
-            basket = 'basket_id=' + str(request.basket.id)
-            has_params = urlparse(redirect_url).query
-            redirect_url += '&' + basket if has_params else '?' + basket
+            redirect_url += '?basket_id=' + str(request.basket.id)
         else:  # pragma: no cover
             redirect_url = add_utm_params_to_url(redirect_url, list(self.request.GET.items()))
 


### PR DESCRIPTION
including these would break the redirection logic in the mfe