### PR TITLE
ENT-2622: Making logic to find learner's enterprise consistent

### DIFF
--- a/ecommerce/enterprise/conditions.py
+++ b/ecommerce/enterprise/conditions.py
@@ -11,7 +11,8 @@ from requests.exceptions import ConnectionError as ReqConnectionError
 from requests.exceptions import Timeout
 from slumber.exceptions import SlumberHttpBaseException
 
-from ecommerce.enterprise.api import catalog_contains_course_runs, fetch_enterprise_learner_data
+from ecommerce.enterprise.api import catalog_contains_course_runs
+from ecommerce.enterprise.utils import get_enterprise_id_for_user
 from ecommerce.extensions.basket.utils import ENTERPRISE_CATALOG_ATTRIBUTE_TYPE
 from ecommerce.extensions.offer.constants import OFFER_ASSIGNMENT_REVOKED, OFFER_REDEEMED
 from ecommerce.extensions.offer.mixins import ConditionWithoutRangeMixin, SingleItemConsumptionConditionMixin
@@ -80,36 +81,14 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
             course_run_ids.append(course.id)
 
         courses_in_basket = ','.join(course_run_ids)
-        learner_data = {}
-        try:
-            learner_data = fetch_enterprise_learner_data(basket.site, basket.owner)['results'][0]
-        except (ReqConnectionError, KeyError, SlumberHttpBaseException, Timeout) as exc:
-            logger.exception('[Code Redemption Failure] Unable to apply enterprise offer because '
-                             'we failed to retrieve enterprise learner data for the user. '
-                             'User: %s, Offer: %s, Message: %s, Enterprise: %s, Catalog: %s, Courses: %s',
-                             username,
-                             offer.id,
-                             exc,
-                             enterprise_customer,
-                             enterprise_catalog,
-                             courses_in_basket)
-            return False
-        except IndexError:
-            if offer.offer_type == ConditionalOffer.SITE:
-                logger.debug(
-                    'Unable to apply enterprise site offer %s because no learner data was returned for user %s',
-                    offer.id,
-                    basket.owner)
-                return False
-
-        if (learner_data and 'enterprise_customer' in learner_data and
-                enterprise_customer != learner_data['enterprise_customer']['uuid']):
+        enterprise_id = get_enterprise_id_for_user(basket.site, basket.owner)
+        if enterprise_id and enterprise_customer != enterprise_id:
             # Learner is not linked to the EnterpriseCustomer associated with this condition.
             if offer.offer_type == ConditionalOffer.VOUCHER:
                 logger.warning('[Code Redemption Failure] Unable to apply enterprise offer because Learner\'s '
                                'enterprise (%s) does not match this conditions\'s enterprise (%s). '
                                'User: %s, Offer: %s, Enterprise: %s, Catalog: %s, Courses: %s',
-                               learner_data['enterprise_customer']['uuid'],
+                               enterprise_id,
                                enterprise_customer,
                                username,
                                offer.id,


### PR DESCRIPTION
It appears we have different source of truth when we find learner's enterprise in offer condition validation. This PR makes it consistent with how offers are collected in  offer/applicator.py.
This should help resolve ENT-2622