### PR TITLE
pin edx-drf-extensions<3.0.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -54,7 +54,7 @@ edx-auth-backends==3.0.2  # via -r requirements/base.in
 edx-django-release-util==0.3.6  # via -r requirements/base.in
 edx-django-sites-extensions==2.4.3  # via -r requirements/base.in
 edx-django-utils==3.0     # via -r requirements/base.in, edx-drf-extensions
-edx-drf-extensions==3.0.0  # via -c requirements/pins.txt, -r requirements/base.in, edx-rbac
+edx-drf-extensions==2.4.6  # via -c requirements/pins.txt, -r requirements/base.in, edx-rbac
 edx-ecommerce-worker==0.7.2  # via -r requirements/base.in
 edx-opaque-keys==2.0.1    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.1.1           # via -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -64,7 +64,7 @@ edx-auth-backends==3.0.2  # via -r requirements/test.txt
 edx-django-release-util==0.3.6  # via -r requirements/test.txt
 edx-django-sites-extensions==2.4.3  # via -r requirements/test.txt
 edx-django-utils==3.0     # via -r requirements/test.txt, edx-drf-extensions
-edx-drf-extensions==3.0.0  # via -r requirements/test.txt, edx-rbac
+edx-drf-extensions==2.4.6  # via -r requirements/test.txt, edx-rbac
 edx-ecommerce-worker==0.7.2  # via -r requirements/test.txt
 edx-i18n-tools==0.5.0     # via -r requirements/dev.in
 edx-opaque-keys==2.0.1    # via -r requirements/test.txt, edx-drf-extensions

--- a/requirements/pins.txt
+++ b/requirements/pins.txt
@@ -7,5 +7,6 @@ jsonfield2<=3.0.3
 
 # Was causing some tox issues locally.
 virtualenv==16.7.9
-# Upgrading edx-drf-extensions major versions in separate PRs.
-edx-drf-extensions<4.0.0
+
+# Needs fix to work in ecommerce.  See ARCHBOM-1036
+edx-drf-extensions<3.0.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -56,7 +56,7 @@ edx-auth-backends==3.0.2  # via -r requirements/base.in
 edx-django-release-util==0.3.6  # via -r requirements/base.in
 edx-django-sites-extensions==2.4.3  # via -r requirements/base.in
 edx-django-utils==3.0     # via -r requirements/base.in, edx-drf-extensions
-edx-drf-extensions==3.0.0  # via -c requirements/pins.txt, -r requirements/base.in, edx-rbac
+edx-drf-extensions==2.4.6  # via -c requirements/pins.txt, -r requirements/base.in, edx-rbac
 edx-ecommerce-worker==0.7.2  # via -r requirements/base.in
 edx-opaque-keys==2.0.1    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.1.1           # via -r requirements/base.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -61,7 +61,7 @@ edx-auth-backends==3.0.2  # via -r requirements/base.txt
 edx-django-release-util==0.3.6  # via -r requirements/base.txt
 edx-django-sites-extensions==2.4.3  # via -r requirements/base.txt
 edx-django-utils==3.0     # via -r requirements/base.txt, edx-drf-extensions
-edx-drf-extensions==3.0.0  # via -c requirements/pins.txt, -r requirements/base.txt, edx-rbac
+edx-drf-extensions==2.4.6  # via -c requirements/pins.txt, -r requirements/base.txt, edx-rbac
 edx-ecommerce-worker==0.7.2  # via -r requirements/base.txt
 edx-opaque-keys==2.0.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.1.1           # via -r requirements/base.txt


### PR DESCRIPTION
This upgrade is causing a failure in ecommerce e2e tests that will be fixed in a follow-up PR.