### PR TITLE
ARCHBOM-1036: upgrade to edx-drf-extensions 3.0.1

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_courses.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_courses.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-import datetime
 import json
 
 import jwt
@@ -80,9 +79,7 @@ class CourseViewSetTests(ProductSerializerMixin, DiscoveryTestMixin, TestCase):
             'administrator': True,
             'username': username,
             'email': email,
-            'iss': settings.JWT_AUTH['JWT_ISSUERS'][0]['ISSUER'],
-            'exp': datetime.datetime.now(),
-            'iat': datetime.datetime.now(),
+            'iss': settings.JWT_AUTH['JWT_ISSUERS'][0]['ISSUER']
         }
         auth_header = "JWT {token}".format(
             token=jwt.encode(payload, settings.JWT_AUTH['JWT_SECRET_KEY']).decode('utf-8'))

--- a/ecommerce/extensions/api/v2/tests/views/test_refunds.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_refunds.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import datetime
 import json
 
 import ddt
@@ -105,10 +104,7 @@ class RefundCreateViewTests(RefundTestMixin, AccessTokenMixin, JwtMixin, TestCas
         self.client.logout()
 
         data = self._get_data(self.user.username, self.course_id)
-        auth_header = 'JWT ' + self.generate_token({'username': self.user.username,
-                                                    'exp': datetime.datetime.now(),
-                                                    'iat': datetime.datetime.now(),
-                                                    })
+        auth_header = 'JWT ' + self.generate_token({'username': self.user.username})
 
         response = self.client.post(self.path, data, JSON_CONTENT_TYPE, HTTP_AUTHORIZATION=auth_header)
         self.assert_ok_response(response)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -43,7 +43,7 @@ django-tables2==1.21.2    # via django-oscar
 django-threadlocals==0.10  # via -r requirements/base.in
 django-treebeard==4.3.1   # via django-oscar
 django-waffle==0.20.0     # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
-django-widget-tweaks==1.4.6  # via django-oscar
+django-widget-tweaks==1.4.8  # via django-oscar
 django==1.11.29           # via -r requirements/base.in, django-appconf, django-cors-headers, django-crum, django-extra-views, django-filter, django-haystack, django-model-utils, django-oscar, django-phonenumber-field, django-tables2, django-treebeard, edx-auth-backends, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition, xss-utils
 djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework-datatables==0.5.1  # via -r requirements/base.in
@@ -54,13 +54,13 @@ edx-auth-backends==3.0.2  # via -r requirements/base.in
 edx-django-release-util==0.3.6  # via -r requirements/base.in
 edx-django-sites-extensions==2.4.3  # via -r requirements/base.in
 edx-django-utils==3.0     # via -r requirements/base.in, edx-drf-extensions
-edx-drf-extensions==2.4.6  # via -c requirements/pins.txt, -r requirements/base.in, edx-rbac
+edx-drf-extensions==3.0.1  # via -c requirements/pins.txt, -r requirements/base.in, edx-rbac
 edx-ecommerce-worker==0.7.2  # via -r requirements/base.in
 edx-opaque-keys==2.0.1    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.1.1           # via -r requirements/base.in
 edx-rest-api-client==1.9.2  # via -c requirements/pins.txt, -r requirements/base.in, edx-ecommerce-worker
 factory-boy==2.12.0       # via django-oscar
-faker==4.0.1              # via factory-boy
+faker==4.0.2              # via factory-boy
 future==0.18.2            # via pyjwkest
 idna==2.9                 # via requests
 isodate==0.6.0            # via zeep

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -52,7 +52,7 @@ django-threadlocals==0.10  # via -r requirements/test.txt
 django-treebeard==4.3.1   # via -r requirements/test.txt, django-oscar
 django-waffle==0.20.0     # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
 django-webtest==1.9.7     # via -r requirements/test.txt
-django-widget-tweaks==1.4.6  # via -r requirements/test.txt, django-oscar
+django-widget-tweaks==1.4.8  # via -r requirements/test.txt, django-oscar
 django==1.11.29           # via -r requirements/test.txt, django-appconf, django-cors-headers, django-crum, django-debug-toolbar, django-extra-views, django-filter, django-haystack, django-model-utils, django-oscar, django-phonenumber-field, django-tables2, django-treebeard, edx-auth-backends, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, mock-django, pytest-django-ordering, rest-condition, xss-utils
 djangorestframework-csv==2.1.0  # via -r requirements/test.txt
 djangorestframework-datatables==0.5.1  # via -r requirements/test.txt
@@ -64,7 +64,7 @@ edx-auth-backends==3.0.2  # via -r requirements/test.txt
 edx-django-release-util==0.3.6  # via -r requirements/test.txt
 edx-django-sites-extensions==2.4.3  # via -r requirements/test.txt
 edx-django-utils==3.0     # via -r requirements/test.txt, edx-drf-extensions
-edx-drf-extensions==2.4.6  # via -r requirements/test.txt, edx-rbac
+edx-drf-extensions==3.0.1  # via -r requirements/test.txt, edx-rbac
 edx-ecommerce-worker==0.7.2  # via -r requirements/test.txt
 edx-i18n-tools==0.5.0     # via -r requirements/dev.in
 edx-opaque-keys==2.0.1    # via -r requirements/test.txt, edx-drf-extensions
@@ -72,7 +72,7 @@ edx-rbac==1.1.1           # via -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -r requirements/e2e.txt, -r requirements/test.txt, edx-ecommerce-worker
 edx-sphinx-theme==1.0.2   # via -r requirements/docs.txt
 factory-boy==2.12.0       # via -r requirements/test.txt, django-oscar
-faker==4.0.1              # via -r requirements/test.txt, factory-boy
+faker==4.0.2              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox
 freezegun==0.3.15         # via -r requirements/test.txt
 future==0.18.2            # via -r requirements/test.txt, pyjwkest
@@ -176,7 +176,7 @@ text-unidecode==1.3       # via -r requirements/test.txt, faker
 toml==0.10.0              # via -r requirements/test.txt, tox
 tox-battery==0.5.2        # via -r requirements/test.txt
 tox==3.14.5               # via -r requirements/test.txt, tox-battery
-transifex-client==0.13.7  # via -r requirements/dev.in
+transifex-client==0.13.8  # via -r requirements/dev.in
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 unicodecsv==0.14.1        # via -r requirements/test.txt, djangorestframework-csv
 unidecode==1.0.23         # via -r requirements/test.txt, django-oscar, python-slugify

--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -24,7 +24,7 @@ pytest-randomly==3.2.1    # via -r requirements/e2e.in
 pytest-selenium==1.17.0   # via -r requirements/e2e.in
 pytest-timeout==1.3.4     # via -r requirements/e2e.in
 pytest-variables==1.9.0   # via pytest-selenium
-pytest==5.3.5             # via -r requirements/e2e.in, pytest-base-url, pytest-html, pytest-metadata, pytest-randomly, pytest-selenium, pytest-timeout, pytest-variables
+pytest==5.3.5             # via -c requirements/pins.txt, -r requirements/e2e.in, pytest-base-url, pytest-html, pytest-metadata, pytest-randomly, pytest-selenium, pytest-timeout, pytest-variables
 python-dotenv==0.12.0     # via -r requirements/e2e.in
 requests==2.23.0          # via edx-rest-api-client, pytest-base-url, pytest-selenium, slumber
 selenium==3.141.0         # via -r requirements/e2e.in, pytest-selenium

--- a/requirements/pins.txt
+++ b/requirements/pins.txt
@@ -8,5 +8,8 @@ jsonfield2<=3.0.3
 # Was causing some tox issues locally.
 virtualenv==16.7.9
 
-# Needs fix to work in ecommerce.  See ARCHBOM-1036
-edx-drf-extensions<3.0.0
+# Upgrade to 4x of edx-drf-extensions will be handled in a follow-up PR.
+edx-drf-extensions<4.0.0
+
+# 5.4 introduces test order problems that need to be resolved.
+pytest<5.4.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -45,7 +45,7 @@ django-tables2==1.21.2    # via django-oscar
 django-threadlocals==0.10  # via -r requirements/base.in
 django-treebeard==4.3.1   # via django-oscar
 django-waffle==0.20.0     # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
-django-widget-tweaks==1.4.6  # via django-oscar
+django-widget-tweaks==1.4.8  # via django-oscar
 django==1.11.29           # via -r requirements/base.in, django-appconf, django-cors-headers, django-crum, django-extra-views, django-filter, django-haystack, django-model-utils, django-oscar, django-phonenumber-field, django-tables2, django-treebeard, edx-auth-backends, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition, xss-utils
 djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework-datatables==0.5.1  # via -r requirements/base.in
@@ -56,13 +56,13 @@ edx-auth-backends==3.0.2  # via -r requirements/base.in
 edx-django-release-util==0.3.6  # via -r requirements/base.in
 edx-django-sites-extensions==2.4.3  # via -r requirements/base.in
 edx-django-utils==3.0     # via -r requirements/base.in, edx-drf-extensions
-edx-drf-extensions==2.4.6  # via -c requirements/pins.txt, -r requirements/base.in, edx-rbac
+edx-drf-extensions==3.0.1  # via -c requirements/pins.txt, -r requirements/base.in, edx-rbac
 edx-ecommerce-worker==0.7.2  # via -r requirements/base.in
 edx-opaque-keys==2.0.1    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.1.1           # via -r requirements/base.in
 edx-rest-api-client==1.9.2  # via -c requirements/pins.txt, -r requirements/base.in, edx-ecommerce-worker
 factory-boy==2.12.0       # via django-oscar
-faker==4.0.1              # via factory-boy
+faker==4.0.2              # via factory-boy
 future==0.18.2            # via pyjwkest
 gunicorn==19.7.1          # via -r requirements/production.in
 idna==2.9                 # via requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -50,7 +50,7 @@ django-threadlocals==0.10  # via -r requirements/base.txt
 django-treebeard==4.3.1   # via -r requirements/base.txt, django-oscar
 django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django-webtest==1.9.7     # via -r requirements/test.in
-django-widget-tweaks==1.4.6  # via -r requirements/base.txt, django-oscar
+django-widget-tweaks==1.4.8  # via -r requirements/base.txt, django-oscar
 django==1.11.29           # via -r requirements/base.txt, django-appconf, django-cors-headers, django-crum, django-extra-views, django-filter, django-haystack, django-model-utils, django-oscar, django-phonenumber-field, django-tables2, django-treebeard, edx-auth-backends, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, mock-django, pytest-django-ordering, rest-condition, xss-utils
 djangorestframework-csv==2.1.0  # via -r requirements/base.txt
 djangorestframework-datatables==0.5.1  # via -r requirements/base.txt
@@ -61,13 +61,13 @@ edx-auth-backends==3.0.2  # via -r requirements/base.txt
 edx-django-release-util==0.3.6  # via -r requirements/base.txt
 edx-django-sites-extensions==2.4.3  # via -r requirements/base.txt
 edx-django-utils==3.0     # via -r requirements/base.txt, edx-drf-extensions
-edx-drf-extensions==2.4.6  # via -c requirements/pins.txt, -r requirements/base.txt, edx-rbac
+edx-drf-extensions==3.0.1  # via -c requirements/pins.txt, -r requirements/base.txt, edx-rbac
 edx-ecommerce-worker==0.7.2  # via -r requirements/base.txt
 edx-opaque-keys==2.0.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.1.1           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -c requirements/pins.txt, -r requirements/base.txt, edx-ecommerce-worker
 factory-boy==2.12.0       # via -r requirements/base.txt, -r requirements/test.in, django-oscar
-faker==4.0.1              # via -r requirements/base.txt, factory-boy
+faker==4.0.2              # via -r requirements/base.txt, factory-boy
 filelock==3.0.12          # via -r requirements/tox.txt, tox
 freezegun==0.3.15         # via -r requirements/test.in
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
@@ -124,7 +124,7 @@ pyparsing==2.4.6          # via -r requirements/tox.txt, packaging
 pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-django-ordering==1.2.0  # via -r requirements/test.in
 pytest-django==3.8.0      # via -r requirements/test.in, pytest-django-ordering
-pytest==5.3.5             # via -r requirements/test.in, pytest-cov, pytest-django, pytest-django-ordering
+pytest==5.3.5             # via -c requirements/pins.txt, -r requirements/test.in, pytest-cov, pytest-django, pytest-django-ordering
 python-dateutil==2.8.1    # via -r requirements/base.txt, analytics-python, edx-drf-extensions, faker, freezegun
 python3-openid==3.1.0 ; python_version >= "3"  # via -r requirements/base.txt, social-auth-core
 pytz==2016.10             # via -c requirements/pins.txt, -r requirements/base.txt, babel, celery, django, zeep


### PR DESCRIPTION
**Before Merge:**
- [x] Switch to actual 3.0.1 release of edx-drf-extensions (rather than commit)

Note: this reverts unecessary test fixes that were added to get 3.0.0 to pass.  Instead, fixes were added to 3.0.1.

ARCHBOM-1036