### PR TITLE
[REV-1123] Ensure get_cache_key function produces the same output for the same input

### DIFF
--- a/ecommerce/core/utils.py
+++ b/ecommerce/core/utils.py
@@ -30,6 +30,8 @@ def get_cache_key(**kwargs):
     """
     Get MD5 encoded cache key for given arguments.
 
+    Note: This function will not work correctly if any of the arguments are dictionaries
+
     Here is the format of key before MD5 encryption.
         key1:value1__key2:value2 ...
 
@@ -45,7 +47,7 @@ def get_cache_key(**kwargs):
     Returns:
          An MD5 encoded key uniquely identified by the key word arguments.
     """
-    key = '__'.join([u'{}:{}'.format(item, value) for item, value in six.iteritems(kwargs)])
+    key = '__'.join([u'{}:{}'.format(item, value) for item, value in sorted(six.iteritems(kwargs))])
 
     return hashlib.md5(key.encode('utf-8')).hexdigest()
 


### PR DESCRIPTION
The get_cache_key function was taking keyword arguments, turning them into a string and hashing them to produce a cache key for use in various ecommerce code
Because keyword arguments are unordered (before python 3.6) the same inputs would result in different cache keys. The side effect of this is worse performance (more cache misses) and also the potential for caching different values (as is the case here).
I believe this is part of the cause of the inconsistent behavior part of the issue described in the ticket https://openedx.atlassian.net/browse/REV-1123 . 

Changing this will result in all calls to get_cache_key being cache misses temporarily. 
However, throughput for basket calculate and basket add which appear to be two of the highest traffic endpoints is quite low. 
https://rpm.newrelic.com/accounts/88178/applications/5519285/transactions#sort_by=throughput&id=5b225765625472616e73616374696f6e2f46756e6374696f6e2f65636f6d6d657263652e657874656e73696f6e732e6261736b65742e76696577733a4261736b65744164644974656d73566965772e676574222c22225d . 
Nevertheless, I've reached out to devops regarding whether we should take precautionary measures with the cache .  

This is not the full fix for the ticket but should make the ticket much easier to debug