### PR TITLE
DISCO-1604: Fixing credit seat editing

### DIFF
--- a/ecommerce/courses/models.py
+++ b/ecommerce/courses/models.py
@@ -148,10 +148,12 @@ class Course(models.Model):
             expires=None,
             credit_hours=None,
             remove_stale_modes=True,
-            create_enrollment_code=False
+            create_enrollment_code=False,
+            product_id=None,
     ):
         """
-        Creates course seat products.
+        Creates and updates course seat products.
+        IMPORTANT: Requires the product_id to be passed in for updates.
 
         Arguments:
             certificate_type(str): The seat type.
@@ -165,6 +167,7 @@ class Course(models.Model):
             credit_hours(int): Number of credit hours provided.
             remove_stale_modes(bool): Remove stale modes.
             create_enrollment_code(bool): Whether an enrollment code is created in addition to the seat.
+            product_id(int): The database id for the product. Used to perform a GET.
 
         Returns:
             Product:  The seat that has been created or updated.
@@ -172,39 +175,8 @@ class Course(models.Model):
         certificate_type = certificate_type.lower()
         course_id = six.text_type(self.id)
 
-        if certificate_type == self.certificate_type_for_mode('audit'):
-            # Yields a match if attribute names do not include 'certificate_type'.
-            certificate_type_query = ~Q(attributes__name='certificate_type')
-        else:
-            # Yields a match if attribute with name 'certificate_type' matches provided value.
-            certificate_type_query = Q(
-                attributes__name='certificate_type',
-                attribute_values__value_text=certificate_type
-            )
-
-        id_verification_required_query = Q(
-            attributes__name='id_verification_required',
-            attribute_values__value_boolean=id_verification_required
-        )
-
-        if credit_provider is None:
-            # Yields a match if attribute names do not include 'credit_provider'.
-            credit_provider_query = ~Q(attributes__name='credit_provider')
-        else:
-            # Yields a match if attribute with name 'credit_provider' matches provided value.
-            credit_provider_query = Q(
-                attributes__name='credit_provider',
-                attribute_values__value_text=credit_provider
-            )
-
-        seats = self.seat_products.filter(certificate_type_query)
         try:
-            seat = seats.filter(
-                id_verification_required_query
-            ).get(
-                credit_provider_query
-            )
-
+            seat = self.seat_products.get(id=product_id)
             logger.info(
                 'Retrieved course seat child product with certificate type [%s] for [%s] from database.',
                 certificate_type,
@@ -222,8 +194,13 @@ class Course(models.Model):
         seat.structure = Product.CHILD
         seat.parent = self.parent_seat_product
         seat.is_discountable = True
-        seat.title = self.get_course_seat_name(certificate_type, id_verification_required)
         seat.expires = expires
+
+        id_verification_required_query = Q(
+            attributes__name='id_verification_required',
+            attribute_values__value_boolean=id_verification_required
+        )
+        seat.title = self.get_course_seat_name(certificate_type, id_verification_required)
 
         seat.save()
 
@@ -271,10 +248,14 @@ class Course(models.Model):
                 attributes__name='id_verification_required',
                 attribute_values__value_boolean=not id_verification_required
             )
+            certificate_type_query = Q(
+                attributes__name='certificate_type',
+                attribute_values__value_text=certificate_type
+            )
 
             # Delete seats with a different verification requirement, assuming the seats
             # have not been purchased.
-            seats.annotate(orders=Count('line')).filter(
+            self.seat_products.filter(certificate_type_query).annotate(orders=Count('line')).filter(
                 id_verification_required_query,
                 orders=0
             ).delete()

--- a/ecommerce/courses/tests/test_models.py
+++ b/ecommerce/courses/tests/test_models.py
@@ -130,7 +130,7 @@ class CourseTests(DiscoveryTestMixin, TestCase):
 
         # Test seat update
         price = 10
-        course.create_or_update_seat(certificate_type, id_verification_required, price)
+        course.create_or_update_seat(certificate_type, id_verification_required, price, product_id=seat.id)
 
         # Again, only two seats with one being the parent seat product.
         self.assertEqual(course.products.count(), 2)
@@ -199,7 +199,7 @@ class CourseTests(DiscoveryTestMixin, TestCase):
         certificate_type = 'credit'
         id_verification_required = True
         price = 10
-        course.create_or_update_seat(
+        credit_seat = course.create_or_update_seat(
             certificate_type,
             id_verification_required,
             price,
@@ -213,7 +213,8 @@ class CourseTests(DiscoveryTestMixin, TestCase):
             id_verification_required,
             price,
             credit_provider=credit_provider,
-            credit_hours=credit_hours
+            credit_hours=credit_hours,
+            product_id=credit_seat.id,
         )
         self.assert_course_seat_valid(
             credit_seat,

--- a/ecommerce/credit/tests/test_views.py
+++ b/ecommerce/credit/tests/test_views.py
@@ -119,12 +119,12 @@ class CheckoutPageTest(DiscoveryTestMixin, TestCase, JwtMixin):
             u"this course credit."
         )
 
-    def _assert_success_checkout_page(self):
+    def _assert_success_checkout_page(self, product_id=None):
         """ Verify that checkout page load successfully, and has necessary context. """
 
         # Create the credit seat
         self.course.create_or_update_seat(
-            'credit', True, self.price, self.provider, credit_hours=self.credit_hours
+            'credit', True, self.price, self.provider, credit_hours=self.credit_hours, product_id=product_id
         )
 
         self._enable_payment_providers()
@@ -201,7 +201,7 @@ class CheckoutPageTest(DiscoveryTestMixin, TestCase, JwtMixin):
         calls return successfully.
         """
         # Create the credit seat
-        self.course.create_or_update_seat(
+        credit_seat = self.course.create_or_update_seat(
             'credit', True, self.price, self.provider, credit_hours=self.credit_hours
         )
 
@@ -209,7 +209,7 @@ class CheckoutPageTest(DiscoveryTestMixin, TestCase, JwtMixin):
         self._mock_eligibility_api(body=self.eligibilities)
         self._mock_providers_api(body=self.provider_data)
 
-        self._assert_success_checkout_page()
+        self._assert_success_checkout_page(product_id=credit_seat.id)
 
     @httpretty.activate
     def test_get_checkout_page_with_audit_seats(self):
@@ -217,7 +217,7 @@ class CheckoutPageTest(DiscoveryTestMixin, TestCase, JwtMixin):
         calls return successfully.
         """
         # Create the credit seat
-        self.course.create_or_update_seat(
+        credit_seat = self.course.create_or_update_seat(
             'credit', True, self.price, self.provider, credit_hours=self.credit_hours
         )
 
@@ -228,7 +228,7 @@ class CheckoutPageTest(DiscoveryTestMixin, TestCase, JwtMixin):
         self._mock_eligibility_api(body=self.eligibilities)
         self._mock_providers_api(body=self.provider_data)
 
-        self._assert_success_checkout_page()
+        self._assert_success_checkout_page(product_id=credit_seat.id)
 
     @httpretty.activate
     def test_seat_unavailable(self):

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -527,7 +527,8 @@ class SeatProductHelper:
             expires=expires,
             credit_provider=credit_provider,
             credit_hours=credit_hours,
-            create_enrollment_code=create_enrollment_code
+            create_enrollment_code=create_enrollment_code,
+            product_id=product.get('id'),
         )
 
         # As a convenience to our caller, provide the SKU in the returned product serialization.

--- a/ecommerce/extensions/api/v2/tests/views/test_publication.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_publication.py
@@ -191,7 +191,9 @@ class AtomicPublicationTests(DiscoveryTestMixin, TestCase):
                 attrs['expires'] = EXPIRES if product['expires'] else None
                 attrs['price'] = Decimal(product['price'])
 
-                course.create_or_update_seat(**attrs)
+                seat = course.create_or_update_seat(**attrs)
+                # Adding this in so if we run an update, the id is passed on
+                product['id'] = seat.id
 
     def generate_update_payload(self):
         """ Returns dictionary representing the data payload sent for an update request. """


### PR DESCRIPTION
The filter conditions that originally existed would cause
editing the credit provider field on a credit seat to create
a new credit seat. Now we just look for the seat's id and
edit that row. If not found, it will create a new seat.

Note: This logic applies for all seats in the course.