### PR TITLE
run linter on all systems

### DIFF
--- a/db_keyword_overrides.yml
+++ b/db_keyword_overrides.yml
@@ -6,5 +6,12 @@
 #   - ModelName.field_name
 ---
 MYSQL:
+    - WishList.key
+    - AttributeOption.option
+    - KVStore.key
+    - Voucher.usage
+    - ShippingEvent.lines
+    - PaymentEvent.lines
+    - ProductAlert.key
 SNOWFLAKE:
 STITCH:

--- a/tox.ini
+++ b/tox.ini
@@ -71,8 +71,7 @@ commands =
     compile_translations: python ../manage.py compilemessages
     detect_changed_translations: i18n_tool changed
     validate_translations: i18n_tool validate -
-    check_keywords: python manage.py check_reserved_keywords --override_file db_keyword_overrides.yml --report_file stich_keyword_report.csv --system STITCH
-    check_keywords: python manage.py check_reserved_keywords --override_file db_keyword_overrides.yml --report_file snowflake_keyword_report.csv --system SNOWFLAKE
+    check_keywords: python manage.py check_reserved_keywords --override_file db_keyword_overrides.yml
 
     tests: python -Wd -m pytest {posargs}
     tests: coverage report


### PR DESCRIPTION
I have enabled the reserved keyword linter to run for all of the default database systems (MYSQL, SNOWFLAKE, STITCH). This entailed adding any current keyword violations to the override file as to not fail CI.