### PR TITLE
DISCO-1607: Being more defensive in commands

### DIFF
--- a/ecommerce/core/management/commands/create_demo_data.py
+++ b/ecommerce/core/management/commands/create_demo_data.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import datetime
 
 from django.core.management.base import BaseCommand
+from django.db.models import Q
 from django.utils import timezone
 from oscar.core.loading import get_model
 from waffle.models import Flag
@@ -69,8 +70,19 @@ class Command(BaseCommand):
         })
 
         # Create the audit and verified seats
-        course.create_or_update_seat('', False, 0)
-        course.create_or_update_seat('verified', True, price, expires=expires, create_enrollment_code=True)
+        audit_sku = None
+        verified_sku = None
+        if course.seat_products.exists():
+            audit_seat = course.seat_products.filter(~Q(attributes__name='certificate_type')).first()
+            audit_sku = audit_seat and audit_seat.stockrecords.first().partner_sku
+            verified_seat = course.seat_products.filter(attribute_values__value_text='verified').first()
+            verified_sku = verified_seat and verified_seat.stockrecords.first().partner_sku
+
+        # Have to pass in the skus in case it is an update
+        course.create_or_update_seat('', False, 0, sku=audit_sku)
+        course.create_or_update_seat(
+            'verified', True, price, expires=expires, create_enrollment_code=True, sku=verified_sku
+        )
         self.stdout.write(
             self.style.SUCCESS('Created audit and verified seats for [{course_id}]'.format(course_id=course_id))
         )

--- a/ecommerce/core/tests/test_create_demo_data.py
+++ b/ecommerce/core/tests/test_create_demo_data.py
@@ -1,13 +1,16 @@
 from __future__ import absolute_import
 
 import sys
+from datetime import datetime
 
 import httpretty
 import mock
+import pytz
 from django.core.management import call_command
 from django.utils.six import StringIO
 
 from ecommerce.courses.models import Course
+from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
 from ecommerce.tests.testcases import TestCase
 
@@ -33,6 +36,29 @@ class CreateDemoDataTests(DiscoveryTestMixin, TestCase):
         and publish that data to the LMS.
         """
         self.mock_access_token_response()
+
+        with mock.patch.object(Course, 'publish_to_lms', return_value=None) as mock_publish:
+            call_command('create_demo_data', '--partner={}'.format(self.partner.short_code))
+            mock_publish.assert_called_once_with()
+
+        self.assert_seats_created('course-v1:edX+DemoX+Demo_Course', 'edX Demonstration Course', 149)
+
+    @httpretty.activate
+    def test_handle_with_existing_course(self):
+        """ The command should create the demo course with audit and verified seats,
+        and publish that data to the LMS.
+        """
+        self.mock_access_token_response()
+
+        course = CourseFactory(
+            id='course-v1:edX+DemoX+Demo_Course',
+            name='edX Demonstration Course',
+            verification_deadline=datetime(year=2022, month=4, day=24, tzinfo=pytz.utc),
+            partner=self.partner
+        )
+
+        seat_attrs = {'certificate_type': '', 'expires': None, 'price': 0.00, 'id_verification_required': False}
+        course.create_or_update_seat(**seat_attrs)
 
         with mock.patch.object(Course, 'publish_to_lms', return_value=None) as mock_publish:
             call_command('create_demo_data', '--partner={}'.format(self.partner.short_code))

--- a/ecommerce/courses/models.py
+++ b/ecommerce/courses/models.py
@@ -139,6 +139,7 @@ class Course(models.Model):
 
         return name
 
+    @transaction.atomic
     def create_or_update_seat(
             self,
             certificate_type,

--- a/ecommerce/extensions/catalogue/management/commands/migrate_course.py
+++ b/ecommerce/extensions/catalogue/management/commands/migrate_course.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.management import BaseCommand
 from django.db import transaction
+from django.db.models import Q
 from edx_rest_api_client.client import EdxRestApiClient
 
 from ecommerce.courses.models import Course
@@ -128,8 +129,22 @@ class MigratedCourse:
             price = mode['min_price']
             expires = mode.get('expiration_datetime')
             expires = parse(expires) if expires else None
+            # Have to pass in the sku in case it is an update
+            sku = None
+            if self.course.seat_products.exists():
+                if certificate_type == Course.certificate_type_for_mode('audit'):
+                    # Yields a match if attribute names do not include 'certificate_type'.
+                    certificate_type_query = ~Q(attributes__name='certificate_type')
+                else:
+                    # Yields a match if attribute with name 'certificate_type' matches provided value.
+                    certificate_type_query = Q(
+                        attributes__name='certificate_type',
+                        attribute_values__value_text=certificate_type
+                    )
+                seat = self.course.seat_products.filter(certificate_type_query).first()
+                sku = seat and seat.stockrecords.first().partner_sku
             self.course.create_or_update_seat(
-                certificate_type, id_verification_required, price, expires=expires, remove_stale_modes=False
+                certificate_type, id_verification_required, price, expires=expires, remove_stale_modes=False, sku=sku
             )
 
 

--- a/ecommerce/extensions/catalogue/tests/test_migrate_course.py
+++ b/ecommerce/extensions/catalogue/tests/test_migrate_course.py
@@ -46,7 +46,6 @@ class CourseMigrationTestMixin(DiscoveryTestMixin):
     prices = {
         'honor': 0,
         'verified': 10,
-        'no-id-professional': 100,
         'professional': 1000,
         'audit': 0,
         'credit': 0,


### PR DESCRIPTION
It was noticed that our sandbox builds were failing due to
create_demo_data already having the course and seats existing
and so this starts being more defensive in creation and checking
for existence first