### PR TITLE
Revert "Revert "[REV-1123] Update debugging logs now that the unreliable cache is fixed""

### DIFF
--- a/ecommerce/extensions/api/v2/views/baskets.py
+++ b/ecommerce/extensions/api/v2/views/baskets.py
@@ -414,7 +414,7 @@ class BasketCalculateView(generics.GenericAPIView):
             raise
         return response
 
-    def get(self, request):
+    def get(self, request):  # pylint: disable=too-many-statements
         """ Calculate basket totals given a list of sku's
 
         Create a temporary basket add the sku's and apply an optional voucher code.
@@ -462,6 +462,7 @@ class BasketCalculateView(generics.GenericAPIView):
         is_anonymous = request.GET.get('is_anonymous', 'false').lower() == 'true'
 
         use_default_basket = is_anonymous
+        use_default_basket_case = 0
 
         # validate query parameters
         if requested_username and is_anonymous:
@@ -484,6 +485,7 @@ class BasketCalculateView(generics.GenericAPIView):
                     # doesn't yet have an account in ecommerce. These users have
                     # never purchased before.
                     use_default_basket = True
+                    use_default_basket_case = 1
             else:
                 return HttpResponseForbidden('Unauthorized user credentials')
 
@@ -493,6 +495,7 @@ class BasketCalculateView(generics.GenericAPIView):
             # TODO: LEARNER-5057: Remove this special case for the marketing user
             # once logs show no more requests with no parameters (see above).
             use_default_basket = True
+            use_default_basket_case = 2
 
         if use_default_basket:
             basket_owner = None
@@ -518,17 +521,13 @@ class BasketCalculateView(generics.GenericAPIView):
                 skus=skus
             )
             cached_response = TieredCache.get_cached_response(cache_key)
-            logger.info('bundle debugging 1: Cache key [%s] site [%s] skus [%s] response [%s]',
-                        str(cache_key), str(request.site), str(skus), str(cached_response))
             if cached_response.is_found:
                 return Response(cached_response.value)
 
         response = self._calculate_temporary_basket_atomic(basket_owner, request, products, voucher, skus, code)
-        logger.info('bundle debugging 2: Cache key [%s] response [%s] skus [%s] timeout [%s]',
-                    str(cache_key), str(response), str(skus), str(settings.ANONYMOUS_BASKET_CALCULATE_CACHE_TIMEOUT))
         if response and use_default_basket:
-            logger.info('bundle debugging 3: setting cache: Cache key [%s] response [%s] skus [%s]',
-                        str(cache_key), str(response), str(skus))
+            logger.info('bundle debugging 3: Cache key [%s] response [%s] skus [%s] case [%s]',
+                        str(cache_key), str(response), str(skus), str(use_default_basket_case))
             TieredCache.set_all_tiers(cache_key, response, settings.ANONYMOUS_BASKET_CALCULATE_CACHE_TIMEOUT)
 
         return Response(response)

--- a/ecommerce/extensions/offer/applicator.py
+++ b/ecommerce/extensions/offer/applicator.py
@@ -38,6 +38,23 @@ class Applicator(OscarApplicator):
                 we get an error when trying to create the bundle_id BasketAttribute.
         """
         offers = self.get_offers(basket, user, request, bundle_id)
+
+        try:
+            logger.info('bundle debugging 4: basket [%s] user [%s] request [%s] bundle_id [%s]',
+                        str(basket), str(user), str(request), str(bundle_id))
+            for o in offers:
+                logger.info(
+                    'bundle debugging 5: basket [%s] id [%s] name [%s] exclusive [%s] priority [%s] offertype [%s]'
+                    'status [%s] num_applications [%s] max_global_applications [%s] total_discount [%s] max_d [%s]'
+                    'is_available [%s] is_condition_partially_satisfied [%s] is_condition_satisfied [%s] ',
+                    str(basket), str(o.id), str(o.name), str(o.exclusive), str(o.priority), str(o.offer_type),
+                    str(o.status), str(o.num_applications), str(o.max_global_applications), str(o.total_discount),
+                    str(o.max_discount), str(o.is_available()), str(o.is_condition_partially_satisfied(basket)),
+                    str(o.is_condition_satisfied(basket))
+                )
+        except:  # pylint: disable=bare-except
+            pass
+
         self.apply_offers(basket, offers)
 
     def get_offers(self, basket, user=None, request=None, bundle_id=None):  # pylint: disable=arguments-differ


### PR DESCRIPTION
It seems like reverting this confirmed it was not the issue with the e2e tests yesterday so it should be fine to put it back (and the other PRs that were reverted)