### PR TITLE
Switch to enterprise catalog behind waffle flag

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -376,6 +376,11 @@ class SiteConfiguration(models.Model):
         return settings.ENTERPRISE_API_URL
 
     @property
+    def enterprise_catalog_api_url(self):
+        """ Returns the URL for the Enterprise Catalog service. """
+        return settings.ENTERPRISE_CATALOG_API_URL
+
+    @property
     def enterprise_grant_data_sharing_url(self):
         """ Returns the URL for the Enterprise data sharing permission view. """
         return self.build_enterprise_service_url('grant_data_sharing_permissions')
@@ -443,6 +448,20 @@ class SiteConfiguration(models.Model):
 
         """
         return EdxRestApiClient(self.enterprise_api_url, jwt=self.access_token)
+
+    @cached_property
+    def enterprise_catalog_api_client(self):
+        """
+        Returns a REST API client for the provided enterprise catalog service
+
+        Example:
+            site.siteconfiguration.enterprise_catalog_api_client.enterprise-catalog.get()
+
+        Returns:
+            EdxRestApiClient: The client to access the Enterprise Catalog service.
+
+        """
+        return EdxRestApiClient(self.enterprise_catalog_api_url, jwt=self.access_token)
 
     @cached_property
     def consent_api_client(self):

--- a/ecommerce/enterprise/conditions.py
+++ b/ecommerce/enterprise/conditions.py
@@ -111,7 +111,8 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
 
         try:
             catalog_contains_course = catalog_contains_course_runs(
-                basket.site, course_run_ids, enterprise_customer, enterprise_customer_catalog_uuid=enterprise_catalog
+                basket.site, course_run_ids, enterprise_customer, enterprise_customer_catalog_uuid=enterprise_catalog,
+                request=basket.strategy.request
             )
         except (ReqConnectionError, KeyError, SlumberHttpBaseException, Timeout) as exc:
             logger.exception('[Code Redemption Failure] Unable to apply enterprise offer because '

--- a/ecommerce/enterprise/constants.py
+++ b/ecommerce/enterprise/constants.py
@@ -6,3 +6,6 @@ ENTERPRISE_OFFERS_FOR_COUPONS_SWITCH = 'enable_enterprise_offers_for_coupons'
 
 # Waffle switch used to enable/disable using role based access control.
 USE_ROLE_BASED_ACCESS_CONTROL = 'use_role_based_access_control'
+
+# Waffle flag used to switch over ecommerce's usage of the enterprise catalog service
+USE_ENTERPRISE_CATALOG = 'use_enterprise_catalog'

--- a/ecommerce/enterprise/migrations/0010_add_use_enterprise_catalog_flag.py
+++ b/ecommerce/enterprise/migrations/0010_add_use_enterprise_catalog_flag.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+from django.db import migrations
+
+from ecommerce.enterprise.constants import USE_ENTERPRISE_CATALOG
+
+
+def create_flag(apps, schema_editor):
+    """Create the `use_enterprise_catalog` flag if it does not already exist."""
+    Flag = apps.get_model('waffle', 'Flag')
+    Flag.objects.get_or_create(
+        name=USE_ENTERPRISE_CATALOG,
+        defaults={'everyone': None, 'superusers': False},
+    )
+
+
+def delete_flag(apps, schema_editor):
+    """Delete the `use_enterprise_catalog` flag if one exists."""
+    Flag = apps.get_model('waffle', 'Flag')
+    Flag.objects.filter(name=USE_ENTERPRISE_CATALOG).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('enterprise', '0009_remove_enterprise_offers_for_coupons'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_flag, delete_flag)
+    ]

--- a/ecommerce/enterprise/tests/mixins.py
+++ b/ecommerce/enterprise/tests/mixins.py
@@ -481,7 +481,7 @@ class EnterpriseServiceMockMixin:
             required=False,
         )
 
-    def mock_catalog_contains_course_runs(self, course_run_ids, enterprise_customer_uuid,
+    def mock_catalog_contains_course_runs(self, course_run_ids, enterprise_customer_uuid, api_url,
                                           enterprise_customer_catalog_uuid=None, contains_content=True,
                                           raise_exception=False):
         self.mock_access_token_response()
@@ -490,7 +490,7 @@ class EnterpriseServiceMockMixin:
         httpretty.register_uri(
             method=httpretty.GET,
             uri='{}enterprise-customer/{}/contains_content_items/?{}'.format(
-                self.site.siteconfiguration.enterprise_api_url,
+                api_url,
                 enterprise_customer_uuid,
                 query_params
             ),
@@ -501,7 +501,7 @@ class EnterpriseServiceMockMixin:
             httpretty.register_uri(
                 method=httpretty.GET,
                 uri='{}enterprise_catalogs/{}/contains_content_items/?{}'.format(
-                    self.site.siteconfiguration.enterprise_api_url,
+                    api_url,
                     enterprise_customer_catalog_uuid,
                     query_params
                 ),
@@ -509,7 +509,7 @@ class EnterpriseServiceMockMixin:
                 content_type='application/json'
             )
 
-    def prepare_enterprise_offer(self, percentage_discount_value=100, enterprise_customer_name=None):
+    def prepare_enterprise_offer(self, api_url, percentage_discount_value=100, enterprise_customer_name=None):
         benefit = EnterprisePercentageDiscountBenefitFactory(value=percentage_discount_value)
         if enterprise_customer_name is not None:
             condition = EnterpriseCustomerConditionFactory(enterprise_customer_name=enterprise_customer_name)
@@ -524,6 +524,7 @@ class EnterpriseServiceMockMixin:
         self.mock_catalog_contains_course_runs(
             [self.course_run.id],
             condition.enterprise_customer_uuid,
+            api_url,
             enterprise_customer_catalog_uuid=condition.enterprise_customer_catalog_uuid,
         )
         return enterprise_offer

--- a/ecommerce/enterprise/tests/test_conditions.py
+++ b/ecommerce/enterprise/tests/test_conditions.py
@@ -64,6 +64,7 @@ class EnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, DiscoveryTest
         self.mock_catalog_contains_course_runs(
             [self.course_run.id],
             self.condition.enterprise_customer_uuid,
+            self.site.siteconfiguration.enterprise_api_url,
             enterprise_customer_catalog_uuid=self.condition.enterprise_customer_catalog_uuid,
         )
         self.assertTrue(self.condition.is_satisfied(offer, basket))
@@ -81,6 +82,7 @@ class EnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, DiscoveryTest
         self.mock_catalog_contains_course_runs(
             [self.course_run.id],
             self.condition.enterprise_customer_uuid,
+            self.site.siteconfiguration.enterprise_api_url,
             enterprise_customer_catalog_uuid=self.condition.enterprise_customer_catalog_uuid,
             contains_content=is_satisfied,
         )
@@ -138,6 +140,7 @@ class EnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, DiscoveryTest
         self.mock_catalog_contains_course_runs(
             [self.course_run.id],
             self.condition.enterprise_customer_uuid,
+            self.site.siteconfiguration.enterprise_api_url,
             enterprise_customer_catalog_uuid=self.condition.enterprise_customer_catalog_uuid,
         )
         self.assertFalse(self.condition.is_satisfied(offer, basket))
@@ -165,6 +168,7 @@ class EnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, DiscoveryTest
         self.mock_catalog_contains_course_runs(
             [self.course_run.id],
             enterprise_id,
+            self.site.siteconfiguration.enterprise_api_url,
             enterprise_customer_catalog_uuid=self.condition.enterprise_customer_catalog_uuid,
         )
         return offer, basket
@@ -277,6 +281,7 @@ class EnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, DiscoveryTest
         self.mock_catalog_contains_course_runs(
             [self.course_run.id],
             self.condition.enterprise_customer_uuid,
+            self.site.siteconfiguration.enterprise_api_url,
             enterprise_customer_catalog_uuid=self.condition.enterprise_customer_catalog_uuid,
             contains_content=False
         )
@@ -296,6 +301,7 @@ class EnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, DiscoveryTest
         self.mock_catalog_contains_course_runs(
             [self.course_run.id],
             self.condition.enterprise_customer_uuid,
+            self.site.siteconfiguration.enterprise_api_url,
             enterprise_customer_catalog_uuid=self.condition.enterprise_customer_catalog_uuid,
             contains_content=False,
             raise_exception=True

--- a/ecommerce/enterprise/tests/test_utils.py
+++ b/ecommerce/enterprise/tests/test_utils.py
@@ -404,6 +404,7 @@ class EnterpriseUtilsTests(EnterpriseServiceMockMixin, TestCase):
         self.mock_catalog_contains_course_runs(
             [course.id],
             str(offer.condition.enterprise_customer_uuid),
+            self.site.siteconfiguration.enterprise_api_url,
             enterprise_customer_catalog_uuid=str(offer.condition.enterprise_customer_catalog_uuid),
             contains_content=True,
         )

--- a/ecommerce/extensions/basket/tests/test_views.py
+++ b/ecommerce/extensions/basket/tests/test_views.py
@@ -285,7 +285,7 @@ class BasketAddItemsViewTests(CouponMixin, DiscoveryTestMixin, DiscoveryMockMixi
         Verify redirect to FreeCheckoutView when basket is free
         and an Enterprise-related offer is applied.
         """
-        enterprise_offer = self.prepare_enterprise_offer()
+        enterprise_offer = self.prepare_enterprise_offer(self.site.siteconfiguration.enterprise_api_url)
 
         opts = {
             'ec_uuid': str(enterprise_offer.condition.enterprise_customer_uuid),
@@ -551,7 +551,7 @@ class PaymentApiViewTests(PaymentApiResponseTestMixin, BasketMixin, DiscoveryMoc
         """
         self.course_run.create_or_update_seat('verified', True, Decimal(10))
         self.create_basket_and_add_product(self.course_run.seat_products[0])
-        enterprise_offer = self.prepare_enterprise_offer()
+        enterprise_offer = self.prepare_enterprise_offer(self.site.siteconfiguration.enterprise_api_url)
 
         opts = {
             'ec_uuid': str(enterprise_offer.condition.enterprise_customer_uuid),
@@ -597,7 +597,7 @@ class PaymentApiViewTests(PaymentApiResponseTestMixin, BasketMixin, DiscoveryMoc
         """
         self.course_run.create_or_update_seat('verified', True, Decimal(10))
         self.create_basket_and_add_product(self.course_run.seat_products[0])
-        enterprise_offer = self.prepare_enterprise_offer()
+        enterprise_offer = self.prepare_enterprise_offer(self.site.siteconfiguration.enterprise_api_url)
 
         opts = {
             'ec_uuid': str(enterprise_offer.condition.enterprise_customer_uuid),
@@ -626,7 +626,7 @@ class PaymentApiViewTests(PaymentApiResponseTestMixin, BasketMixin, DiscoveryMoc
         seat2 = self.create_seat(self.course_run, seat_price=100, cert_type='verified')
         basket = self.create_basket_and_add_product(seat1)
         basket.add(seat2)
-        self.prepare_enterprise_offer()
+        self.prepare_enterprise_offer(self.site.siteconfiguration.enterprise_api_url)
 
         response = self.client.get(self.path)
         self.assertEqual(response.status_code, 200)
@@ -1039,7 +1039,8 @@ class BasketSummaryViewTests(EnterpriseServiceMockMixin, DiscoveryTestMixin, Dis
     def test_enterprise_free_basket_redirect(self):
         self.course_run.create_or_update_seat('verified', True, Decimal(100))
         self.create_basket_and_add_product(self.course_run.seat_products[0])
-        enterprise_offer = self.prepare_enterprise_offer(enterprise_customer_name='Foo Enterprise')
+        enterprise_offer = self.prepare_enterprise_offer(self.site.siteconfiguration.enterprise_api_url,
+                                                         enterprise_customer_name='Foo Enterprise')
 
         opts = {
             'ec_uuid': str(enterprise_offer.condition.enterprise_customer_uuid),

--- a/ecommerce/extensions/checkout/tests/test_views.py
+++ b/ecommerce/extensions/checkout/tests/test_views.py
@@ -72,7 +72,7 @@ class FreeCheckoutViewTests(EnterpriseServiceMockMixin, TestCase):
     def test_enterprise_offer_program_redirect(self):
         """ Verify redirect to the program dashboard page. """
         self.prepare_basket(10, bundle=True)
-        self.prepare_enterprise_offer()
+        self.prepare_enterprise_offer(self.site.siteconfiguration.enterprise_api_url)
         self.assertEqual(Order.objects.count(), 0)
         response = self.client.get(self.path)
         self.assertEqual(Order.objects.count(), 1)
@@ -84,7 +84,7 @@ class FreeCheckoutViewTests(EnterpriseServiceMockMixin, TestCase):
     def test_enterprise_offer_course_redirect(self):
         """ Verify redirect to the courseware info page. """
         self.prepare_basket(10)
-        self.prepare_enterprise_offer()
+        self.prepare_enterprise_offer(self.site.siteconfiguration.enterprise_api_url)
         self.assertEqual(Order.objects.count(), 0)
         response = self.client.get(self.path)
         self.assertEqual(Order.objects.count(), 1)

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -641,11 +641,13 @@ AFFILIATE_COOKIE_KEY = 'affiliate_id'
 
 CRISPY_TEMPLATE_PACK = 'bootstrap3'
 
-# ENTERPRISE APP CONFIGURATION
+# ENTERPRISE CONFIGURATION
 # URL for Enterprise service
 ENTERPRISE_SERVICE_URL = 'http://localhost:8000/enterprise/'
 # Cache enterprise response from Enterprise API.
 ENTERPRISE_API_CACHE_TIMEOUT = 300  # Value is in seconds
+
+ENTERPRISE_CATALOG_SERVICE_URL = 'http://localhost:18160/'
 
 ENTERPRISE_LEARNER_PORTAL_HOSTNAME = os.environ.get('ENTERPRISE_LEARNER_PORTAL_HOSTNAME', 'localhost:8734')
 
@@ -662,7 +664,7 @@ SYSTEM_TO_FEATURE_ROLE_MAPPING = {
     STUDENT_SUPPORT_ADMIN_ROLE: [ORDER_MANAGER_ROLE],
 }
 
-# END ENTERPRISE APP CONFIGURATION
+# END ENTERPRISE CONFIGURATION
 
 # DJANGO DEBUG TOOLBAR CONFIGURATION
 # http://django-debug-toolbar.readthedocs.org/en/latest/installation.html

--- a/ecommerce/settings/local.py
+++ b/ecommerce/settings/local.py
@@ -160,3 +160,5 @@ if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
     from .private import *  # pylint: disable=import-error
 
 ENTERPRISE_API_URL = urljoin(ENTERPRISE_SERVICE_URL, 'api/v1/')
+
+ENTERPRISE_CATALOG_API_URL = urljoin(ENTERPRISE_CATALOG_SERVICE_URL, 'api/v1/')

--- a/ecommerce/settings/production.py
+++ b/ecommerce/settings/production.py
@@ -110,6 +110,8 @@ for __, configs in six.iteritems(PAYMENT_PROCESSOR_CONFIG):
 
 ENTERPRISE_API_URL = urljoin(ENTERPRISE_SERVICE_URL, 'api/v1/')
 
+ENTERPRISE_CATALOG_API_URL = urljoin(ENTERPRISE_CATALOG_SERVICE_URL, 'api/v1/')
+
 CORS_ALLOW_HEADERS = corsheaders_default_headers + (
     'use-jwt-cookie',
 )

--- a/ecommerce/settings/test.py
+++ b/ecommerce/settings/test.py
@@ -153,6 +153,8 @@ DEFAULT_SITE_THEME = "test-theme"
 
 ENTERPRISE_API_URL = urljoin(ENTERPRISE_SERVICE_URL, 'api/v1/')
 
+ENTERPRISE_CATALOG_API_URL = urljoin(ENTERPRISE_CATALOG_SERVICE_URL, 'api/v1/')
+
 # Don't bother sending fake events to Segment. Doing so creates unnecessary threads.
 SEND_SEGMENT_EVENTS = False
 


### PR DESCRIPTION
Moves ecommerce's usage of the contains_content_items endpoint to
using the new enterprise catalog service behind a waffle flag. We will
use this flag to slowly cut over traffic to using the new service and
endpoint there.

ENT-2573