### PR TITLE
ENT-2660: Fixed Enrollment Type Changing to Discount Type bug

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -82,7 +82,8 @@ def is_custom_code(obj):
 
 def is_enrollment_code(obj):
     benefit = retrieve_voucher(obj).benefit
-    return benefit.type == Benefit.PERCENTAGE and benefit.value == 100
+    benefit_type = get_benefit_type(benefit)
+    return benefit_type == Benefit.PERCENTAGE and benefit.value == 100
 
 
 def retrieve_benefit(obj):


### PR DESCRIPTION
This PR fixes the bug reported in ENT-2660. Assuming that a coupon with 100% discount is always considered an Enrollment Type coupon. The expected behaviour when we create a Discount code coupon with 100% discount is that it will convert into Enrollment code coupon. 

Link: https://openedx.atlassian.net/browse/ENT-2660