### PR TITLE
BOM-1198: use haystack commit with Django 2.1 support

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -58,3 +58,6 @@ zeep
 git+https://github.com/django-compressor/django-appconf.git@5169ce2c92d9836e0b3ab3ec645727d9d5225d1a#egg=django-appconf
 
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django
+
+# adds Django 2.1 support (still need Django 2.2 support)
+git+https://github.com/django-haystack/django-haystack.git@78b8b0ce7492ee14cfe8288461d4afe5d490c177#egg=django-haystack

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,7 +31,7 @@ django-crum==0.7.5        # via edx-rbac
 django-extensions==2.2.9  # via -r requirements/base.in
 django-extra-views==0.11.0  # via django-oscar
 django-filter==2.2.0      # via -r requirements/base.in
-django-haystack==2.8.1    # via django-oscar
+git+https://github.com/django-haystack/django-haystack.git@78b8b0ce7492ee14cfe8288461d4afe5d490c177#egg=django-haystack  # via -r requirements/base.in, django-oscar
 django-libsass==0.8       # via -r requirements/base.in
 django-model-utils==3.2.0  # via edx-rbac
 django-oscar==2.0.4       # via -r requirements/base.in
@@ -57,7 +57,7 @@ edx-django-utils==3.1     # via -r requirements/base.in, edx-drf-extensions
 edx-drf-extensions==5.0.2  # via -r requirements/base.in, edx-rbac
 edx-ecommerce-worker==0.7.2  # via -r requirements/base.in
 edx-opaque-keys==2.0.2    # via -r requirements/base.in, edx-drf-extensions
-edx-rbac==1.1.1           # via -r requirements/base.in
+edx-rbac==1.1.2           # via -r requirements/base.in
 edx-rest-api-client==1.9.2  # via -c requirements/pins.txt, -r requirements/base.in, edx-ecommerce-worker
 factory-boy==2.12.0       # via django-oscar
 faker==4.0.2              # via factory-boy

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -39,7 +39,7 @@ django-debug-toolbar==2.2  # via -r requirements/dev.in
 django-extensions==2.2.9  # via -r requirements/test.txt
 django-extra-views==0.11.0  # via -r requirements/test.txt, django-oscar
 django-filter==2.2.0      # via -r requirements/test.txt
-django-haystack==2.8.1    # via -r requirements/test.txt, django-oscar
+git+https://github.com/django-haystack/django-haystack.git@78b8b0ce7492ee14cfe8288461d4afe5d490c177#egg=django-haystack  # via -r requirements/test.txt, django-oscar
 django-libsass==0.8       # via -r requirements/test.txt
 django-model-utils==3.2.0  # via -r requirements/test.txt, edx-rbac
 django-oscar==2.0.4       # via -r requirements/test.txt
@@ -68,7 +68,7 @@ edx-drf-extensions==5.0.2  # via -r requirements/test.txt, edx-rbac
 edx-ecommerce-worker==0.7.2  # via -r requirements/test.txt
 edx-i18n-tools==0.5.0     # via -r requirements/dev.in
 edx-opaque-keys==2.0.2    # via -r requirements/test.txt, edx-drf-extensions
-edx-rbac==1.1.1           # via -r requirements/test.txt
+edx-rbac==1.1.2           # via -r requirements/test.txt
 edx-rest-api-client==1.9.2  # via -r requirements/e2e.txt, -r requirements/test.txt, edx-ecommerce-worker
 edx-sphinx-theme==1.0.2   # via -r requirements/docs.txt
 factory-boy==2.12.0       # via -r requirements/test.txt, django-oscar
@@ -79,7 +79,7 @@ future==0.18.2            # via -r requirements/test.txt, pyjwkest
 httpretty==0.9.7          # via -r requirements/test.txt
 idna==2.9                 # via -r requirements/docs.txt, -r requirements/e2e.txt, -r requirements/test.txt, requests
 imagesize==1.2.0          # via -r requirements/docs.txt, sphinx
-importlib-metadata==1.5.2  # via -r requirements/e2e.txt, -r requirements/test.txt, inflect, pluggy, pytest, pytest-randomly, tox
+importlib-metadata==1.6.0  # via -r requirements/e2e.txt, -r requirements/test.txt, inflect, pluggy, pytest, pytest-randomly, tox
 inflect==3.0.2            # via -r requirements/test.txt, jinja2-pluralize
 isodate==0.6.0            # via -r requirements/test.txt, zeep
 isort==4.3.21             # via -r requirements/test.txt, pylint

--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -9,7 +9,7 @@ certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 edx-rest-api-client==1.9.2  # via -c requirements/pins.txt, -r requirements/e2e.in
 idna==2.9                 # via requests
-importlib-metadata==1.5.2  # via pluggy, pytest, pytest-randomly
+importlib-metadata==1.6.0  # via pluggy, pytest, pytest-randomly
 more-itertools==8.2.0     # via pytest
 packaging==20.3           # via pytest
 pathlib2==2.3.5           # via pytest

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -32,7 +32,7 @@ django-crum==0.7.5        # via edx-rbac
 django-extensions==2.2.9  # via -r requirements/base.in
 django-extra-views==0.11.0  # via django-oscar
 django-filter==2.2.0      # via -r requirements/base.in
-django-haystack==2.8.1    # via django-oscar
+git+https://github.com/django-haystack/django-haystack.git@78b8b0ce7492ee14cfe8288461d4afe5d490c177#egg=django-haystack  # via -r requirements/base.in, django-oscar
 django-libsass==0.8       # via -r requirements/base.in
 django-model-utils==3.2.0  # via edx-rbac
 django-oscar==2.0.4       # via -r requirements/base.in
@@ -59,7 +59,7 @@ edx-django-utils==3.1     # via -r requirements/base.in, edx-drf-extensions
 edx-drf-extensions==5.0.2  # via -r requirements/base.in, edx-rbac
 edx-ecommerce-worker==0.7.2  # via -r requirements/base.in
 edx-opaque-keys==2.0.2    # via -r requirements/base.in, edx-drf-extensions
-edx-rbac==1.1.1           # via -r requirements/base.in
+edx-rbac==1.1.2           # via -r requirements/base.in
 edx-rest-api-client==1.9.2  # via -c requirements/pins.txt, -r requirements/base.in, edx-ecommerce-worker
 factory-boy==2.12.0       # via django-oscar
 faker==4.0.2              # via factory-boy

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -37,7 +37,7 @@ django-crum==0.7.5        # via -r requirements/base.txt, edx-rbac
 django-extensions==2.2.9  # via -r requirements/base.txt
 django-extra-views==0.11.0  # via -r requirements/base.txt, django-oscar
 django-filter==2.2.0      # via -r requirements/base.txt
-django-haystack==2.8.1    # via -r requirements/base.txt, django-oscar
+git+https://github.com/django-haystack/django-haystack.git@78b8b0ce7492ee14cfe8288461d4afe5d490c177#egg=django-haystack  # via -r requirements/base.txt, django-oscar
 django-libsass==0.8       # via -r requirements/base.txt
 django-model-utils==3.2.0  # via -r requirements/base.txt, edx-rbac
 django-oscar==2.0.4       # via -r requirements/base.txt
@@ -64,7 +64,7 @@ edx-django-utils==3.1     # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==5.0.2  # via -r requirements/base.txt, edx-rbac
 edx-ecommerce-worker==0.7.2  # via -r requirements/base.txt
 edx-opaque-keys==2.0.2    # via -r requirements/base.txt, edx-drf-extensions
-edx-rbac==1.1.1           # via -r requirements/base.txt
+edx-rbac==1.1.2           # via -r requirements/base.txt
 edx-rest-api-client==1.9.2  # via -c requirements/pins.txt, -r requirements/base.txt, edx-ecommerce-worker
 factory-boy==2.12.0       # via -r requirements/base.txt, -r requirements/test.in, django-oscar
 faker==4.0.2              # via -r requirements/base.txt, factory-boy
@@ -73,7 +73,7 @@ freezegun==0.3.15         # via -r requirements/test.in
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
 httpretty==0.9.7          # via -c requirements/pins.txt, -r requirements/test.in
 idna==2.9                 # via -r requirements/base.txt, requests
-importlib-metadata==1.5.2  # via -r requirements/tox.txt, inflect, pluggy, pytest, tox
+importlib-metadata==1.6.0  # via -r requirements/tox.txt, inflect, pluggy, pytest, tox
 inflect==3.0.2            # via jinja2-pluralize
 isodate==0.6.0            # via -r requirements/base.txt, zeep
 isort==4.3.21             # via -r requirements/test.in, pylint

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 filelock==3.0.12          # via tox
-importlib-metadata==1.5.2  # via pluggy, tox
+importlib-metadata==1.6.0  # via pluggy, tox
 packaging==20.3           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox


### PR DESCRIPTION
Update ecommerce to use a django-haystack commit, version
2.8.2.dev55+g78b8b0c, that includes Django 2.1 support. This commit is
officially on v3.0b1, but django-oscar only allows haystack <3.0 on
its currently released version.

Here is the django-haystack commit that was used:
https://github.com/django-haystack/django-haystack/pull/1641/commits/78b8b0ce7492ee14cfe8288461d4afe5d490c177

BOM-1198