### PR TITLE
[REV-1123] Add logs to help determine where requests with no bundle parameter are coming from

### DIFF
--- a/ecommerce/extensions/api/v2/views/baskets.py
+++ b/ecommerce/extensions/api/v2/views/baskets.py
@@ -521,14 +521,19 @@ class BasketCalculateView(generics.GenericAPIView):
                 skus=skus
             )
             cached_response = TieredCache.get_cached_response(cache_key)
+            logger.info('bundle debugging 2: request [%s] referrer [%s] url [%s] Cache key [%s] response [%s]'
+                        'skus [%s] case [%s] basket_owner [%s]',
+                        str(request), str(request.META.get('HTTP_REFERER')), str(request._request), str(cache_key),  # pylint: disable=protected-access
+                        str(cached_response), str(skus), str(use_default_basket_case), str(basket_owner))
             if cached_response.is_found:
                 return Response(cached_response.value)
 
         response = self._calculate_temporary_basket_atomic(basket_owner, request, products, voucher, skus, code)
         if response and use_default_basket:
-            logger.info('bundle debugging 3: request [%s] url [%s] Cache key [%s] response [%s] skus [%s] case [%s]',
-                        str(request), str(request._request), str(cache_key), str(response), str(skus),  # pylint: disable=protected-access
-                        str(use_default_basket_case))
+            logger.info('bundle debugging 3: request [%s] referrer [%s] url [%s] Cache key [%s] response [%s]'
+                        'skus [%s] case [%s] basket_owner [%s]',
+                        str(request), str(request.META.get('HTTP_REFERER')), str(request._request), str(cache_key),  # pylint: disable=protected-access
+                        str(response), str(skus), str(use_default_basket_case), str(basket_owner))
             TieredCache.set_all_tiers(cache_key, response, settings.ANONYMOUS_BASKET_CALCULATE_CACHE_TIMEOUT)
 
         return Response(response)


### PR DESCRIPTION
Want to see if we can tell who the referrer is for requests that are not passing the bundle parameter.  
I'm adding back the bundle debugging 2 log in case all those requests with no bundle parameter as coming in as cache hits (since bundle debugging 3 only logs cache misses) . 
https://openedx.atlassian.net/browse/REV-1123