### PR TITLE
BOM-1436: add testing through Django 2.2 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,24 +32,63 @@ script:
   - docker exec -t -e TRAVIS=1 ecommerce_testing bash -c "
       cd /edx/app/ecommerce/ecommerce/ &&
       PATH=\$PATH:/edx/app/ecommerce/nodeenvs/ecommerce/bin:/snap/bin
-      make $TARGETS
+      DJANGO_ENV=$DJANGO_ENV make $TARGETS
     "
 
 matrix:
   include:
     - python: 3.5
       env:
+        DJANGO_ENV=django111
         TESTNAME=quality-and-js
         TARGETS="requirements.js check_translations_up_to_date validate_translations clean_static static quality validate_js check_keywords"
     - python: 3.5
-      env: TESTNAME=test-python TARGETS="requirements.js clean_static static validate_python"
-    - python: 3.6
       env:
-        TESTNAME=quality-and-js-.3.6
+        DJANGO_ENV=django22
+        TESTNAME=quality-and-js
         TARGETS="requirements.js check_translations_up_to_date validate_translations clean_static static quality validate_js check_keywords"
-    - python: 3.6
-      env: TESTNAME=test-python-3.6 TARGETS="requirements.js clean_static static validate_python"
+    - python: 3.5
+      env:
+        DJANGO_ENV=django111
+        TESTNAME=test-python
+        TARGETS="requirements.js clean_static static validate_python"
       after_success:
         - pip install -U codecov
         - docker exec ecommerce_testing /edx/app/ecommerce/ecommerce/.travis/run_coverage.sh
         - codecov
+    - python: 3.5
+      env:
+        DJANGO_ENV=django20
+        TESTNAME=test-python
+        TARGETS="requirements.js clean_static static validate_python"
+    - python: 3.5
+      env:
+        DJANGO_ENV=django21
+        TESTNAME=test-python
+        TARGETS="requirements.js clean_static static validate_python"
+    - python: 3.5
+      env:
+        DJANGO_ENV=django22
+        TESTNAME=test-python
+        TARGETS="requirements.js clean_static static validate_python"
+  allow_failures:
+    - python: 3.5
+      env:
+        DJANGO_ENV=django22
+        TESTNAME=quality-and-js
+        TARGETS="requirements.js check_translations_up_to_date validate_translations clean_static static quality validate_js check_keywords"
+    - python: 3.5
+      env:
+        DJANGO_ENV=django20
+        TESTNAME=test-python
+        TARGETS="requirements.js clean_static static validate_python"
+    - python: 3.5
+      env:
+        DJANGO_ENV=django21
+        TESTNAME=test-python
+        TARGETS="requirements.js clean_static static validate_python"
+    - python: 3.5
+      env:
+        DJANGO_ENV=django22
+        TESTNAME=test-python
+        TARGETS="requirements.js clean_static static validate_python"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -81,7 +81,7 @@ path.py==7.2              # via -r requirements/base.in
 paypalrestsdk==1.13.1     # via -r requirements/base.in
 pbr==5.4.4                # via stevedore
 phonenumbers==8.12.1      # via django-oscar, django-phonenumber-field
-pillow==7.0.0             # via django-oscar
+pillow==7.1.0             # via django-oscar
 premailer==2.9.2          # via -r requirements/base.in
 psutil==1.2.1             # via edx-django-utils
 purl==1.5                 # via django-oscar

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,17 +1,13 @@
 -r test.txt
 -r docs.txt
--r e2e.txt
 
 django-debug-toolbar
 
 # i18n
 transifex-client
-edx-i18n-tools
 
 # Visual Studio Code Debugger
 ptvsd
 
 # For devserver code reloading
 pyinotify==0.9.6 # This breaks OSX virtualenv installation
-
-python-memcached==1.58

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,7 +10,7 @@ analytics-python==1.2.9   # via -r requirements/test.txt
 anyjson==0.3.3            # via -r requirements/test.txt, kombu
 appdirs==1.4.3            # via -r requirements/test.txt, zeep
 astroid==2.3.3            # via -r requirements/test.txt, pylint
-attrs==19.3.0             # via -r requirements/e2e.txt, -r requirements/test.txt, pytest, zeep
+attrs==19.3.0             # via -r requirements/test.txt, pytest, zeep
 babel==2.8.0              # via -r requirements/docs.txt, -r requirements/test.txt, django-oscar, django-phonenumber-field, sphinx
 beautifulsoup4==4.8.2     # via -r requirements/test.txt, webtest
 billiard==3.3.0.23        # via -r requirements/test.txt, celery
@@ -18,9 +18,9 @@ bleach==3.1.4             # via -r requirements/test.txt
 bok-choy==1.0.1           # via -r requirements/test.txt
 cached-property==1.5.1    # via -r requirements/test.txt, zeep
 celery==3.1.26.post2      # via -r requirements/test.txt, edx-ecommerce-worker
-certifi==2019.11.28       # via -r requirements/docs.txt, -r requirements/e2e.txt, -r requirements/test.txt, requests
+certifi==2019.11.28       # via -r requirements/docs.txt, -r requirements/test.txt, requests
 cffi==1.14.0              # via -r requirements/test.txt, cryptography
-chardet==3.0.4            # via -r requirements/docs.txt, -r requirements/e2e.txt, -r requirements/test.txt, requests
+chardet==3.0.4            # via -r requirements/docs.txt, -r requirements/test.txt, requests
 coreapi==2.3.3            # via -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi
 coverage==5.0.4           # via -r requirements/test.txt, pytest-cov
@@ -66,10 +66,10 @@ edx-django-sites-extensions==2.4.3  # via -r requirements/test.txt
 edx-django-utils==3.1     # via -r requirements/test.txt, edx-drf-extensions
 edx-drf-extensions==5.0.2  # via -r requirements/test.txt, edx-rbac
 edx-ecommerce-worker==0.7.2  # via -r requirements/test.txt
-edx-i18n-tools==0.5.0     # via -r requirements/dev.in
+edx-i18n-tools==0.5.0     # via -r requirements/test.txt
 edx-opaque-keys==2.0.2    # via -r requirements/test.txt, edx-drf-extensions
 edx-rbac==1.1.2           # via -r requirements/test.txt
-edx-rest-api-client==1.9.2  # via -r requirements/e2e.txt, -r requirements/test.txt, edx-ecommerce-worker
+edx-rest-api-client==1.9.2  # via -r requirements/test.txt, edx-ecommerce-worker
 edx-sphinx-theme==1.0.2   # via -r requirements/docs.txt
 factory-boy==2.12.0       # via -r requirements/test.txt, django-oscar
 faker==4.0.2              # via -r requirements/test.txt, factory-boy
@@ -77,9 +77,9 @@ filelock==3.0.12          # via -r requirements/test.txt, tox
 freezegun==0.3.15         # via -r requirements/test.txt
 future==0.18.2            # via -r requirements/test.txt, pyjwkest
 httpretty==0.9.7          # via -r requirements/test.txt
-idna==2.9                 # via -r requirements/docs.txt, -r requirements/e2e.txt, -r requirements/test.txt, requests
+idna==2.9                 # via -r requirements/docs.txt, -r requirements/test.txt, requests
 imagesize==1.2.0          # via -r requirements/docs.txt, sphinx
-importlib-metadata==1.6.0  # via -r requirements/e2e.txt, -r requirements/test.txt, inflect, pluggy, pytest, pytest-randomly, tox
+importlib-metadata==1.6.0  # via -r requirements/test.txt, inflect, pluggy, pytest, pytest-randomly, tox
 inflect==3.0.2            # via -r requirements/test.txt, jinja2-pluralize
 isodate==0.6.0            # via -r requirements/test.txt, zeep
 isort==4.3.21             # via -r requirements/test.txt, pylint
@@ -97,26 +97,26 @@ markupsafe==1.1.1         # via -r requirements/docs.txt, -r requirements/test.t
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock-django==0.6.10       # via -r requirements/test.txt
 mock==3.0.5               # via -r requirements/test.txt, mock-django
-more-itertools==8.2.0     # via -r requirements/e2e.txt, -r requirements/test.txt, pytest
+more-itertools==8.2.0     # via -r requirements/test.txt, pytest
 mysqlclient==1.4.6        # via -r requirements/test.txt
 ndg-httpsclient==0.5.1    # via -r requirements/test.txt
 newrelic==4.20.1.121      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
-packaging==20.3           # via -r requirements/e2e.txt, -r requirements/test.txt, pytest, tox
+packaging==20.3           # via -r requirements/test.txt, pytest, tox
 path.py==7.2              # via -r requirements/test.txt, edx-i18n-tools
-pathlib2==2.3.5           # via -r requirements/e2e.txt, -r requirements/test.txt, pytest
+pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 paypalrestsdk==1.13.1     # via -r requirements/test.txt
 pbr==5.4.4                # via -r requirements/test.txt, stevedore
 phonenumbers==8.12.1      # via -r requirements/test.txt, django-oscar, django-phonenumber-field
-pillow==7.0.0             # via -r requirements/test.txt, django-oscar
-pluggy==0.13.1            # via -r requirements/e2e.txt, -r requirements/test.txt, diff-cover, pytest, tox
-polib==1.1.0              # via edx-i18n-tools
+pillow==7.1.0             # via -r requirements/test.txt, django-oscar
+pluggy==0.13.1            # via -r requirements/test.txt, diff-cover, pytest, tox
+polib==1.1.0              # via -r requirements/test.txt, edx-i18n-tools
 premailer==2.9.2          # via -r requirements/test.txt
 psutil==1.2.1             # via -r requirements/test.txt, edx-django-utils
 ptvsd==4.3.2              # via -r requirements/dev.in
 purl==1.5                 # via -r requirements/test.txt, django-oscar
-py==1.8.1                 # via -r requirements/e2e.txt, -r requirements/test.txt, pytest, tox
+py==1.8.1                 # via -r requirements/test.txt, pytest, tox
 pyasn1==0.4.8             # via -r requirements/test.txt, ndg-httpsclient
 pycodestyle==2.5.0        # via -r requirements/test.txt
 pycountry==17.1.8         # via -r requirements/test.txt
@@ -125,25 +125,25 @@ pycryptodomex==3.9.7      # via -r requirements/test.txt, pyjwkest
 pygments==2.6.1           # via -r requirements/docs.txt, -r requirements/test.txt, diff-cover, sphinx
 pyinotify==0.9.6          # via -r requirements/dev.in
 pyjwkest==1.4.2           # via -r requirements/test.txt, edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/e2e.txt, -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pyjwt==1.7.1              # via -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint==2.4.4             # via -r requirements/test.txt
 pymongo==3.10.1           # via -r requirements/test.txt, edx-opaque-keys
 pyopenssl==19.1.0         # via -r requirements/test.txt, ndg-httpsclient, paypalrestsdk
-pyparsing==2.4.6          # via -r requirements/e2e.txt, -r requirements/test.txt, packaging
-pytest-base-url==1.4.1    # via -r requirements/e2e.txt, pytest-selenium
+pyparsing==2.4.6          # via -r requirements/test.txt, packaging
+pytest-base-url==1.4.1    # via -r requirements/test.txt, pytest-selenium
 pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-django-ordering==1.2.0  # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt, pytest-django-ordering
-pytest-html==1.22.1       # via -r requirements/e2e.txt, pytest-selenium
-pytest-metadata==1.8.0    # via -r requirements/e2e.txt, pytest-html
-pytest-randomly==3.2.1    # via -r requirements/e2e.txt
-pytest-selenium==1.17.0   # via -r requirements/e2e.txt
-pytest-timeout==1.3.4     # via -r requirements/e2e.txt
-pytest-variables==1.9.0   # via -r requirements/e2e.txt, pytest-selenium
-pytest==5.3.5             # via -r requirements/e2e.txt, -r requirements/test.txt, pytest-base-url, pytest-cov, pytest-django, pytest-django-ordering, pytest-html, pytest-metadata, pytest-randomly, pytest-selenium, pytest-timeout, pytest-variables
+pytest-html==1.22.1       # via -r requirements/test.txt, pytest-selenium
+pytest-metadata==1.8.0    # via -r requirements/test.txt, pytest-html
+pytest-randomly==3.2.1    # via -r requirements/test.txt
+pytest-selenium==1.17.0   # via -r requirements/test.txt
+pytest-timeout==1.3.4     # via -r requirements/test.txt
+pytest-variables==1.9.0   # via -r requirements/test.txt, pytest-selenium
+pytest==5.3.5             # via -r requirements/test.txt, pytest-base-url, pytest-cov, pytest-django, pytest-django-ordering, pytest-html, pytest-metadata, pytest-randomly, pytest-selenium, pytest-timeout, pytest-variables
 python-dateutil==2.8.1    # via -r requirements/test.txt, analytics-python, edx-drf-extensions, faker, freezegun
-python-dotenv==0.12.0     # via -r requirements/e2e.txt
-python-memcached==1.58    # via -r requirements/dev.in
+python-dotenv==0.12.0     # via -r requirements/test.txt
+python-memcached==1.58    # via -r requirements/test.txt
 python-slugify==1.2.6     # via transifex-client
 python3-openid==3.1.0 ; python_version >= "3"  # via -r requirements/test.txt, social-auth-core
 pytz==2016.10             # via -r requirements/docs.txt, -r requirements/test.txt, babel, celery, django, zeep
@@ -151,17 +151,17 @@ pyyaml==5.3.1             # via -r requirements/test.txt, edx-django-release-uti
 rcssmin==1.0.6            # via -r requirements/test.txt, django-compressor
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
 requests-toolbelt==0.9.1  # via -r requirements/test.txt, zeep
-requests==2.23.0          # via -r requirements/docs.txt, -r requirements/e2e.txt, -r requirements/test.txt, analytics-python, coreapi, edx-drf-extensions, edx-rest-api-client, paypalrestsdk, pyjwkest, pytest-base-url, pytest-selenium, requests-oauthlib, requests-toolbelt, responses, sailthru-client, slumber, social-auth-core, sphinx, stripe, transifex-client, zeep
+requests==2.23.0          # via -r requirements/docs.txt, -r requirements/test.txt, analytics-python, coreapi, edx-drf-extensions, edx-rest-api-client, paypalrestsdk, pyjwkest, pytest-base-url, pytest-selenium, requests-oauthlib, requests-toolbelt, responses, sailthru-client, slumber, social-auth-core, sphinx, stripe, transifex-client, zeep
 responses==0.10.12        # via -r requirements/test.txt
 rest-condition==1.0.3     # via -r requirements/test.txt, edx-drf-extensions
 rjsmin==1.1.0             # via -r requirements/test.txt, django-compressor
 rules==2.2                # via -r requirements/test.txt
 sailthru-client==2.2.3    # via -r requirements/test.txt
-selenium==3.141.0         # via -r requirements/e2e.txt, -r requirements/test.txt, bok-choy, pytest-selenium
+selenium==3.141.0         # via -r requirements/test.txt, bok-choy, pytest-selenium
 semantic-version==2.8.4   # via -r requirements/test.txt, edx-drf-extensions
 simplejson==3.17.0        # via -r requirements/test.txt, django-rest-swagger, sailthru-client
-six==1.14.0               # via -r requirements/docs.txt, -r requirements/e2e.txt, -r requirements/test.txt, analytics-python, astroid, bleach, bok-choy, cryptography, diff-cover, django-compressor, django-extensions, django-extra-views, django-simple-history, django-waffle, djangorestframework-csv, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, edx-rbac, edx-sphinx-theme, freezegun, httpretty, isodate, libsass, mock, packaging, pathlib2, paypalrestsdk, purl, pyjwkest, pyopenssl, python-dateutil, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, tox, transifex-client, webtest, zeep
-slumber==0.7.1            # via -r requirements/e2e.txt, -r requirements/test.txt, edx-rest-api-client
+six==1.14.0               # via -r requirements/docs.txt, -r requirements/test.txt, analytics-python, astroid, bleach, bok-choy, cryptography, diff-cover, django-compressor, django-extensions, django-extra-views, django-simple-history, django-waffle, djangorestframework-csv, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, edx-rbac, edx-sphinx-theme, freezegun, httpretty, isodate, libsass, mock, packaging, pathlib2, paypalrestsdk, purl, pyjwkest, pyopenssl, python-dateutil, python-memcached, responses, social-auth-app-django, social-auth-core, sphinx, stevedore, tox, transifex-client, webtest, zeep
+slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/docs.txt, sphinx
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/test.txt, edx-auth-backends
 social-auth-core==3.3.2   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
@@ -181,14 +181,14 @@ typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 unicodecsv==0.14.1        # via -r requirements/test.txt, djangorestframework-csv
 unidecode==1.1.1          # via python-slugify
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
-urllib3==1.25.8           # via -r requirements/docs.txt, -r requirements/e2e.txt, -r requirements/test.txt, requests, selenium, transifex-client
+urllib3==1.25.8           # via -r requirements/docs.txt, -r requirements/test.txt, requests, selenium, transifex-client
 virtualenv==16.7.9        # via -r requirements/test.txt, tox
 waitress==1.4.3           # via -r requirements/test.txt, webtest
-wcwidth==0.1.9            # via -r requirements/e2e.txt, -r requirements/test.txt, pytest
+wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via -r requirements/test.txt, bleach
 webob==1.8.6              # via -r requirements/test.txt, webtest
 webtest==2.0.34           # via -r requirements/test.txt, django-webtest
 wrapt==1.11.2             # via -r requirements/test.txt, astroid
 xss-utils==0.1.2          # via -r requirements/test.txt
 zeep==3.4.0               # via -r requirements/test.txt
-zipp==1.2.0               # via -r requirements/e2e.txt, -r requirements/test.txt, importlib-metadata
+zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -85,7 +85,7 @@ path.py==7.2              # via -r requirements/base.in
 paypalrestsdk==1.13.1     # via -r requirements/base.in
 pbr==5.4.4                # via stevedore
 phonenumbers==8.12.1      # via django-oscar, django-phonenumber-field
-pillow==7.0.0             # via django-oscar
+pillow==7.1.0             # via django-oscar
 premailer==2.9.2          # via -r requirements/base.in
 psutil==1.2.1             # via edx-django-utils
 purl==1.5                 # via django-oscar

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,5 +1,6 @@
 -c pins.txt
 -r base.txt
+-r e2e.txt                  # required for quality
 -r tox.txt
 
 bok_choy
@@ -7,6 +8,7 @@ coverage
 ddt
 diff-cover
 django-webtest
+edx-i18n-tools              # required for quality
 factory-boy
 freezegun
 futures ; python_version == "2.7"
@@ -22,6 +24,7 @@ pytest-cov
 pytest-django
 pytest-django-ordering
 pysqlite ; python_version == "2.7"  # DB-API 2.0 interface for SQLite 3.x (used as the relational database for most tests)
+python-memcached==1.58      # required by collectstatic in devstack
 responses
 selenium
 testfixtures                # Provides a LogCapture utility used by several tests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,7 +9,7 @@ analytics-python==1.2.9   # via -r requirements/base.txt
 anyjson==0.3.3            # via -r requirements/base.txt, kombu
 appdirs==1.4.3            # via -r requirements/base.txt, zeep
 astroid==2.3.3            # via pylint
-attrs==19.3.0             # via -r requirements/base.txt, pytest, zeep
+attrs==19.3.0             # via -r requirements/base.txt, -r requirements/e2e.txt, pytest, zeep
 babel==2.8.0              # via -r requirements/base.txt, django-oscar, django-phonenumber-field
 beautifulsoup4==4.8.2     # via webtest
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
@@ -17,9 +17,9 @@ bleach==3.1.4             # via -r requirements/base.txt
 bok-choy==1.0.1           # via -r requirements/test.in
 cached-property==1.5.1    # via -r requirements/base.txt, zeep
 celery==3.1.26.post2      # via -r requirements/base.txt, edx-ecommerce-worker
-certifi==2019.11.28       # via -r requirements/base.txt, requests
+certifi==2019.11.28       # via -r requirements/base.txt, -r requirements/e2e.txt, requests
 cffi==1.14.0              # via -r requirements/base.txt, cryptography
-chardet==3.0.4            # via -r requirements/base.txt, requests
+chardet==3.0.4            # via -r requirements/base.txt, -r requirements/e2e.txt, requests
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
 coverage==5.0.4           # via -r requirements/test.in, pytest-cov
@@ -51,7 +51,6 @@ django-treebeard==4.3.1   # via -r requirements/base.txt, django-oscar
 django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django-webtest==1.9.7     # via -r requirements/test.in
 django-widget-tweaks==1.4.8  # via -r requirements/base.txt, django-oscar
-django==1.11.29           # via -r requirements/base.txt, django-appconf, django-cors-headers, django-crum, django-extra-views, django-filter, django-haystack, django-model-utils, django-oscar, django-phonenumber-field, django-tables2, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, mock-django, pytest-django-ordering, rest-condition, xss-utils
 djangorestframework-csv==2.1.0  # via -r requirements/base.txt
 djangorestframework-datatables==0.5.1  # via -r requirements/base.txt
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, djangorestframework-csv, djangorestframework-datatables, drf-extensions, drf-jwt, edx-drf-extensions, rest-condition
@@ -63,17 +62,18 @@ edx-django-sites-extensions==2.4.3  # via -r requirements/base.txt
 edx-django-utils==3.1     # via -r requirements/base.txt, edx-drf-extensions
 edx-drf-extensions==5.0.2  # via -r requirements/base.txt, edx-rbac
 edx-ecommerce-worker==0.7.2  # via -r requirements/base.txt
+edx-i18n-tools==0.5.0     # via -r requirements/test.in
 edx-opaque-keys==2.0.2    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.1.2           # via -r requirements/base.txt
-edx-rest-api-client==1.9.2  # via -c requirements/pins.txt, -r requirements/base.txt, edx-ecommerce-worker
+edx-rest-api-client==1.9.2  # via -c requirements/pins.txt, -r requirements/base.txt, -r requirements/e2e.txt, edx-ecommerce-worker
 factory-boy==2.12.0       # via -r requirements/base.txt, -r requirements/test.in, django-oscar
 faker==4.0.2              # via -r requirements/base.txt, factory-boy
 filelock==3.0.12          # via -r requirements/tox.txt, tox
 freezegun==0.3.15         # via -r requirements/test.in
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
 httpretty==0.9.7          # via -c requirements/pins.txt, -r requirements/test.in
-idna==2.9                 # via -r requirements/base.txt, requests
-importlib-metadata==1.6.0  # via -r requirements/tox.txt, inflect, pluggy, pytest, tox
+idna==2.9                 # via -r requirements/base.txt, -r requirements/e2e.txt, requests
+importlib-metadata==1.6.0  # via -r requirements/e2e.txt, -r requirements/tox.txt, inflect, pluggy, pytest, pytest-randomly, tox
 inflect==3.0.2            # via jinja2-pluralize
 isodate==0.6.0            # via -r requirements/base.txt, zeep
 isort==4.3.21             # via -r requirements/test.in, pylint
@@ -91,24 +91,25 @@ markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
 mock-django==0.6.10       # via -r requirements/test.in
 mock==3.0.5               # via -r requirements/test.in, mock-django
-more-itertools==8.2.0     # via pytest
+more-itertools==8.2.0     # via -r requirements/e2e.txt, pytest
 mysqlclient==1.4.6        # via -r requirements/base.txt
 ndg-httpsclient==0.5.1    # via -r requirements/base.txt
 newrelic==4.20.1.121      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
-packaging==20.3           # via -r requirements/tox.txt, pytest, tox
-path.py==7.2              # via -r requirements/base.txt
-pathlib2==2.3.5           # via pytest
+packaging==20.3           # via -r requirements/e2e.txt, -r requirements/tox.txt, pytest, tox
+path.py==7.2              # via -r requirements/base.txt, edx-i18n-tools
+pathlib2==2.3.5           # via -r requirements/e2e.txt, pytest
 paypalrestsdk==1.13.1     # via -r requirements/base.txt
 pbr==5.4.4                # via -r requirements/base.txt, stevedore
 phonenumbers==8.12.1      # via -r requirements/base.txt, django-oscar, django-phonenumber-field
-pillow==7.0.0             # via -r requirements/base.txt, django-oscar
-pluggy==0.13.1            # via -r requirements/tox.txt, diff-cover, pytest, tox
+pillow==7.1.0             # via -r requirements/base.txt, django-oscar
+pluggy==0.13.1            # via -r requirements/e2e.txt, -r requirements/tox.txt, diff-cover, pytest, tox
+polib==1.1.0              # via edx-i18n-tools
 premailer==2.9.2          # via -r requirements/base.txt
 psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
 purl==1.5                 # via -r requirements/base.txt, django-oscar
-py==1.8.1                 # via -r requirements/tox.txt, pytest, tox
+py==1.8.1                 # via -r requirements/e2e.txt, -r requirements/tox.txt, pytest, tox
 pyasn1==0.4.8             # via -r requirements/base.txt, ndg-httpsclient
 pycodestyle==2.5.0        # via -r requirements/test.in
 pycountry==17.1.8         # via -r requirements/base.txt
@@ -116,33 +117,42 @@ pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.7      # via -r requirements/base.txt, pyjwkest
 pygments==2.6.1           # via -r requirements/base.txt, diff-cover
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pyjwt==1.7.1              # via -r requirements/base.txt, -r requirements/e2e.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint==2.4.4             # via -r requirements/test.in
 pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 pyopenssl==19.1.0         # via -r requirements/base.txt, ndg-httpsclient, paypalrestsdk
-pyparsing==2.4.6          # via -r requirements/tox.txt, packaging
+pyparsing==2.4.6          # via -r requirements/e2e.txt, -r requirements/tox.txt, packaging
+pytest-base-url==1.4.1    # via -r requirements/e2e.txt, pytest-selenium
 pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-django-ordering==1.2.0  # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in, pytest-django-ordering
-pytest==5.3.5             # via -c requirements/pins.txt, -r requirements/test.in, pytest-cov, pytest-django, pytest-django-ordering
+pytest-html==1.22.1       # via -r requirements/e2e.txt, pytest-selenium
+pytest-metadata==1.8.0    # via -r requirements/e2e.txt, pytest-html
+pytest-randomly==3.2.1    # via -r requirements/e2e.txt
+pytest-selenium==1.17.0   # via -r requirements/e2e.txt
+pytest-timeout==1.3.4     # via -r requirements/e2e.txt
+pytest-variables==1.9.0   # via -r requirements/e2e.txt, pytest-selenium
+pytest==5.3.5             # via -c requirements/pins.txt, -r requirements/e2e.txt, -r requirements/test.in, pytest-base-url, pytest-cov, pytest-django, pytest-django-ordering, pytest-html, pytest-metadata, pytest-randomly, pytest-selenium, pytest-timeout, pytest-variables
 python-dateutil==2.8.1    # via -r requirements/base.txt, analytics-python, edx-drf-extensions, faker, freezegun
+python-dotenv==0.12.0     # via -r requirements/e2e.txt
+python-memcached==1.58    # via -r requirements/test.in
 python3-openid==3.1.0 ; python_version >= "3"  # via -r requirements/base.txt, social-auth-core
 pytz==2016.10             # via -c requirements/pins.txt, -r requirements/base.txt, babel, celery, django, zeep
-pyyaml==5.3.1             # via -r requirements/base.txt, edx-django-release-util
+pyyaml==5.3.1             # via -r requirements/base.txt, edx-django-release-util, edx-i18n-tools
 rcssmin==1.0.6            # via -r requirements/base.txt, django-compressor
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests-toolbelt==0.9.1  # via -r requirements/base.txt, zeep
-requests==2.23.0          # via -r requirements/base.txt, analytics-python, coreapi, edx-drf-extensions, edx-rest-api-client, paypalrestsdk, pyjwkest, requests-oauthlib, requests-toolbelt, responses, sailthru-client, slumber, social-auth-core, stripe, zeep
+requests==2.23.0          # via -r requirements/base.txt, -r requirements/e2e.txt, analytics-python, coreapi, edx-drf-extensions, edx-rest-api-client, paypalrestsdk, pyjwkest, pytest-base-url, pytest-selenium, requests-oauthlib, requests-toolbelt, responses, sailthru-client, slumber, social-auth-core, stripe, zeep
 responses==0.10.12        # via -r requirements/test.in
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 rjsmin==1.1.0             # via -r requirements/base.txt, django-compressor
 rules==2.2                # via -r requirements/base.txt
 sailthru-client==2.2.3    # via -r requirements/base.txt
-selenium==3.141.0         # via -r requirements/test.in, bok-choy
+selenium==3.141.0         # via -r requirements/e2e.txt, -r requirements/test.in, bok-choy, pytest-selenium
 semantic-version==2.8.4   # via -r requirements/base.txt, edx-drf-extensions
 simplejson==3.17.0        # via -r requirements/base.txt, django-rest-swagger, sailthru-client
-six==1.14.0               # via -r requirements/base.txt, -r requirements/tox.txt, analytics-python, astroid, bleach, bok-choy, cryptography, diff-cover, django-compressor, django-extensions, django-extra-views, django-simple-history, django-waffle, djangorestframework-csv, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, edx-rbac, freezegun, httpretty, isodate, libsass, mock, packaging, pathlib2, paypalrestsdk, purl, pyjwkest, pyopenssl, python-dateutil, responses, social-auth-app-django, social-auth-core, stevedore, tox, webtest, zeep
-slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
+six==1.14.0               # via -r requirements/base.txt, -r requirements/e2e.txt, -r requirements/tox.txt, analytics-python, astroid, bleach, bok-choy, cryptography, diff-cover, django-compressor, django-extensions, django-extra-views, django-simple-history, django-waffle, djangorestframework-csv, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, edx-rbac, freezegun, httpretty, isodate, libsass, mock, packaging, pathlib2, paypalrestsdk, purl, pyjwkest, pyopenssl, python-dateutil, python-memcached, responses, social-auth-app-django, social-auth-core, stevedore, tox, webtest, zeep
+slumber==0.7.1            # via -r requirements/base.txt, -r requirements/e2e.txt, edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.3.2   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sorl-thumbnail==12.6.3    # via -r requirements/base.txt
@@ -157,14 +167,14 @@ tox==3.14.6               # via -r requirements/tox.txt, tox-battery
 typed-ast==1.4.1          # via astroid
 unicodecsv==0.14.1        # via -r requirements/base.txt, djangorestframework-csv
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
-urllib3==1.25.8           # via -c requirements/pins.txt, -r requirements/base.txt, requests, selenium
+urllib3==1.25.8           # via -c requirements/pins.txt, -r requirements/base.txt, -r requirements/e2e.txt, requests, selenium
 virtualenv==16.7.9        # via -c requirements/pins.txt, -r requirements/tox.txt, tox
 waitress==1.4.3           # via webtest
-wcwidth==0.1.9            # via pytest
+wcwidth==0.1.9            # via -r requirements/e2e.txt, pytest
 webencodings==0.5.1       # via -r requirements/base.txt, bleach
 webob==1.8.6              # via webtest
 webtest==2.0.34           # via django-webtest
 wrapt==1.11.2             # via astroid
 xss-utils==0.1.2          # via -r requirements/base.txt
 zeep==3.4.0               # via -r requirements/base.txt
-zipp==1.2.0               # via -r requirements/tox.txt, importlib-metadata
+zipp==1.2.0               # via -r requirements/e2e.txt, -r requirements/tox.txt, importlib-metadata

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist = {py35,py36}-{isort,pycodestyle,pylint,static,tests,extract_translations,dummy_translations,compile_translations, detect_changed_translations,validate_translations,check_keywords}
+envlist = py35-django{111,20,21,22}-{static,pylint,tests,theme_static,check_keywords},py35-{isort,pycodestyle,extract_translations,dummy_translations,compile_translations, detect_changed_translations,validate_translations}
 
 [pytest]
 DJANGO_SETTINGS_MODULE = ecommerce.settings.test
@@ -11,7 +11,6 @@ testpaths = ecommerce
 envdir=
     # Use the same environment for all commands running under a specific python version
     py35: {toxworkdir}/py35
-    py36: {toxworkdir}/py36
 passenv =
     CONN_MAX_AGE
     DB_ENGINE
@@ -45,12 +44,15 @@ setenv =
     PATH=$PATH:$NODE_BIN
     SELENIUM_BROWSER=firefox
 deps =
-    -r requirements/dev.txt
+    -r{toxinidir}/requirements/test.txt
+    django111: Django>=1.11,<2.0
+    django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
+    django22: Django>=2.2,<2.3
 whitelist_externals =
     /bin/bash
 changedir =
     dummy_translations,compile_translations,detect_changed_translations,validate_translations: ecommerce
-
 commands =
     static: python manage.py collectstatic --noinput --verbosity 0
 	static: python manage.py compress --force
@@ -58,7 +60,6 @@ commands =
 
     check_isort: isort --check-only --recursive --diff e2e/ ecommerce/
     run_isort: isort --recursive e2e/ ecommerce/
-
 
     pycodestyle: pycodestyle --config=.pycodestyle ecommerce e2e
 
@@ -111,9 +112,3 @@ passenv =
 deps = -r requirements/e2e.txt
 commands=
     xvfb-run --server-args="-screen 0, 1600x1200x24" pytest e2e --html=log/html_report.html --junitxml=e2e/xunit.xml
-
-[testenv:py36-e2e]
-envdir = {toxworkdir}/{envname}
-passenv = {[testenv:py35-e2e]passenv}
-deps = {[testenv:py35-e2e]deps}
-commands = {[testenv:py35-e2e]commands}


### PR DESCRIPTION
- test django 1.11,2.0,2.1,2.2
- remove python 3.6 testing

BOM-1436