### PR TITLE
[REV-1123] Update cache key for calculate endpoint

### DIFF
--- a/ecommerce/extensions/api/v2/views/baskets.py
+++ b/ecommerce/extensions/api/v2/views/baskets.py
@@ -512,13 +512,16 @@ class BasketCalculateView(generics.GenericAPIView):
             )
 
         cache_key = None
+        bundle_id = request.GET.get('bundle')
         if use_default_basket:
             # For an anonymous user we can directly get the cached price, because
             # there can't be any enrollments or entitlements.
+            # We want bundle_id to be in the cache_key, since calls without bundle_id will produce different results
             cache_key = get_cache_key(
-                site_comain=request.site,
+                site_domain=request.site,
                 resource_name='calculate',
-                skus=skus
+                skus=skus,
+                bundle_id=bundle_id
             )
             cached_response = TieredCache.get_cached_response(cache_key)
             logger.info('bundle debugging 2: request [%s] referrer [%s] url [%s] Cache key [%s] response [%s]'


### PR DESCRIPTION
I have confirmed using the debugging logs from the previous PR that the lms program dashboard is calling calculate without providing the bundle parameter. That dashboard shares the same cache key with prospectus, which does provide the bundle parameter.
This likely contributes to the inconsistent values. If my hypothesis is correct, this change should ensure that prospectus calls to calculate are more frequently correct. The lms program dashboard would then consistently not show the discount, which will need to be addressed in follow up work.

https://openedx.atlassian.net/browse/REV-1123