### PR TITLE
BOM-1465

### DIFF
--- a/ecommerce/extensions/catalogue/tests/test_models.py
+++ b/ecommerce/extensions/catalogue/tests/test_models.py
@@ -102,7 +102,7 @@ class ProductTests(CouponMixin, DiscoveryTestMixin, TestCase):
         coupon_product = self._create_coupon_product_with_attributes(notify_email=notify_email)
         self.assertEqual(coupon_product.attr.notify_email, notify_email)
 
-    @ddt.data('batman', 1, {'some': 'dict'}, ['array'])
+    @ddt.data('batman', {'some': 'dict'}, ['array'])
     def test_create_product_with_incorrect_notify_email(self, notify_email):
         """
         Verify creating product with invalid notify_email type raises ValidationError.

--- a/ecommerce/extensions/voucher/models.py
+++ b/ecommerce/extensions/voucher/models.py
@@ -68,6 +68,9 @@ class Voucher(AbstractVoucher):
         super(Voucher, self).clean()  # pylint: disable=bad-super-call
 
     def clean_code(self):
+        if isinstance(self.code, bytes):
+            self.code = self.code.decode('utf-8')
+
         if not self.code:
             log_message_and_raise_validation_error('Failed to create Voucher. Voucher code must be set.')
         if not self.code.isalnum():


### PR DESCRIPTION
BOM-1464
BOM-1465


https://github.com/django/django/blob/stable/1.11.x/django/core/validators.py#L196
django email validator remove force_text and `int` is failing there when it tries to check
` '@' in 1`  This test data is no more require.