### PR TITLE
BOM-1466: fix pylint Django 2.2 issues

### DIFF
--- a/ecommerce/extensions/basket/admin.py
+++ b/ecommerce/extensions/basket/admin.py
@@ -16,7 +16,8 @@ class PaymentProcessorResponseInline(admin.TabularInline):
     can_delete = False
     readonly_fields = ('id', 'processor_name', 'transaction_id', 'created', 'response')
 
-    def has_add_permission(self, request):
+    # TODO: Remove pylint disable after Django 2.2 upgrade
+    def has_add_permission(self, request, obj=None):  # pylint: disable=arguments-differ,unused-argument
         # Users are not allowed to add PaymentProcessorResponse objects
         return False
 
@@ -26,7 +27,8 @@ class BasketAttributeInLine(admin.TabularInline):
     readonly_fields = ('id', 'attribute_type', 'value_text',)
     extra = 0
 
-    def has_add_permission(self, request):
+    # TODO: Remove pylint disable after Django 2.2 upgrade
+    def has_add_permission(self, request, obj=None):  # pylint: disable=arguments-differ,unused-argument
         # Users are not allowed to add BasketAttribute objects
         return False
 

--- a/ecommerce/theming/finders.py
+++ b/ecommerce/theming/finders.py
@@ -57,6 +57,12 @@ class ThemeFilesFinder(BaseFinder):
 
         super(ThemeFilesFinder, self).__init__(*args, **kwargs)
 
+    def check(self, **kwargs):  # pylint: disable=unused-argument
+        """
+        Verifies the finder is configured correctly.
+        """
+        return []  # pragma: no cover
+
     def list(self, ignore_patterns):
         """
         List all files in all theme storages.


### PR DESCRIPTION
Original failures:
```
************* Module ecommerce.theming.finders
ecommerce/theming/finders.py:33:0: W0223: Method 'check' is abstract in class 'BaseFinder' but is not overridden (abstract-method)
************* Module ecommerce.extensions.basket.admin
ecommerce/extensions/basket/admin.py:19:4: W0221: Parameters differ from overridden 'has_add_permission' method (arguments-differ)
ecommerce/extensions/basket/admin.py:29:4: W0221: Parameters differ from overridden 'has_add_permission' method (arguments-differ)
```

BOM-1466