### PR TITLE
BOM-1474: Fix more ecommerce Django 2 failures

### DIFF
--- a/ecommerce/extensions/voucher/models.py
+++ b/ecommerce/extensions/voucher/models.py
@@ -68,9 +68,6 @@ class Voucher(AbstractVoucher):
         super(Voucher, self).clean()  # pylint: disable=bad-super-call
 
     def clean_code(self):
-        if isinstance(self.code, bytes):
-            self.code = self.code.decode('utf-8')
-
         if not self.code:
             log_message_and_raise_validation_error('Failed to create Voucher. Voucher code must be set.')
         if not self.code.isalnum():

--- a/ecommerce/extensions/voucher/utils.py
+++ b/ecommerce/extensions/voucher/utils.py
@@ -507,7 +507,7 @@ def _generate_code_string(length):
 
     h = hashlib.sha256()
     h.update(uuid.uuid4().bytes)
-    voucher_code = base64.b32encode(h.digest())[0:length]
+    voucher_code = base64.b32encode(h.digest())[0:length].decode('utf-8')
     if Voucher.objects.filter(code__iexact=voucher_code).exists():
         return _generate_code_string(length)
 

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -282,6 +282,7 @@ DJANGO_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.flatpages',
     'django.contrib.humanize',
+    'django.contrib.messages',
     'django.contrib.sessions',
     'django.contrib.sites',
     'django.contrib.staticfiles',


### PR DESCRIPTION
https://docs.djangoproject.com/en/2.2/ref/contrib/messages/
```
Enabling messages¶
Messages are implemented through a middleware class and 
corresponding context processor.

The default settings.py created by django-admin startproject already 
contains all the settings required to enable message functionality:

'django.contrib.messages' is in INSTALLED_APPS.

MIDDLEWARE contains 'django.contrib.sessions.middleware.SessionMiddleware' and 'django.contrib.messages.middleware.MessageMiddleware'.

The default storage backend relies on sessions. 
That’s why SessionMiddleware must be enabled and appear before MessageMiddleware in MIDDLEWARE.

The 'context_processors' option of the DjangoTemplates backend defined 
in your TEMPLATES setting contains 'django.contrib.messages.context_processors.messages'.
```

```
If you don’t want to use messages, you can remove 'django.contrib.messages' from
 your INSTALLED_APPS, the MessageMiddleware line from MIDDLEWARE, and 
the messages context processor from TEMPLATES.
```