### PR TITLE
BOM-1471: fix uuid test failures in Django 2.2

### DIFF
--- a/ecommerce/enterprise/tests/test_forms.py
+++ b/ecommerce/enterprise/tests/test_forms.py
@@ -90,12 +90,12 @@ class EnterpriseOfferFormTests(EnterpriseServiceMockMixin, TestCase):
         enterprise_offer.enterprise_contract_metadata = ecm
         form = EnterpriseOfferForm(instance=enterprise_offer)
         self.assertEqual(
-            form['enterprise_customer_uuid'].value(),
-            enterprise_offer.condition.enterprise_customer_uuid.hex
+            uuid.UUID(form['enterprise_customer_uuid'].value()),
+            enterprise_offer.condition.enterprise_customer_uuid
         )
         self.assertEqual(
-            form['enterprise_customer_catalog_uuid'].value(),
-            enterprise_offer.condition.enterprise_customer_catalog_uuid.hex
+            uuid.UUID(form['enterprise_customer_catalog_uuid'].value()),
+            enterprise_offer.condition.enterprise_customer_catalog_uuid
         )
         self.assertEqual(form['benefit_type'].value(), enterprise_offer.benefit.proxy().benefit_class_type)
         self.assertEqual(form['benefit_value'].value(), enterprise_offer.benefit.value)

--- a/ecommerce/programs/tests/test_forms.py
+++ b/ecommerce/programs/tests/test_forms.py
@@ -49,7 +49,7 @@ class ProgramOfferFormTests(ProgramTestMixin, TestCase):
         """ The constructor should pull initial data from the passed-in instance. """
         program_offer = factories.ProgramOfferFactory()
         form = ProgramOfferForm(instance=program_offer)
-        self.assertEqual(form['program_uuid'].value(), program_offer.condition.program_uuid.hex)
+        self.assertEqual(uuid.UUID(form['program_uuid'].value()), program_offer.condition.program_uuid)
         self.assertEqual(form['benefit_type'].value(), program_offer.benefit.proxy().benefit_class_type)
         self.assertEqual(form['benefit_value'].value(), program_offer.benefit.value)
 


### PR DESCRIPTION
JIRA: [BOM-1471](https://openedx.atlassian.net/browse/BOM-1471)

To improve readability, the UUIDField form field now displays values with dashes, e.g. 550e8400-e29b-41d4-a716-446655440000 instead of 550e8400e29b41d4a716446655440000.

https://docs.djangoproject.com/en/3.0/releases/2.2/#miscellaneous