### PR TITLE
BOM-1467

### DIFF
--- a/ecommerce/extensions/checkout/tests/test_views.py
+++ b/ecommerce/extensions/checkout/tests/test_views.py
@@ -58,7 +58,7 @@ class FreeCheckoutViewTests(EnterpriseServiceMockMixin, TestCase):
     def test_empty_basket(self):
         """ Verify redirect to basket summary in case of empty basket. """
         response = self.client.get(self.path)
-        expected_url = self.get_full_url(reverse('basket:summary'))
+        expected_url = reverse('basket:summary')
         self.assertRedirects(response, expected_url)
 
     def test_non_free_basket(self):


### PR DESCRIPTION
WIP: This needs more RnD why django1.11 showing full url and django2 not.
```
pytest --ds=ecommerce.settings.test ecommerce/extensions/checkout/tests/test_views.py::FreeCheckoutViewTests::test_empty_basket
```
Previous Review.
https://github.com/edx/ecommerce/pull/2874#discussion_r402354948
