### PR TITLE
BOM-1470: fix Django 2.2 missing basket strategy - 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,16 @@ matrix:
         TARGETS="requirements.js check_translations_up_to_date validate_translations clean_static static quality validate_js check_keywords"
     - python: 3.5
       env:
+        DJANGO_ENV=django20
+        TESTNAME=test-python
+        TARGETS="requirements.js clean_static static validate_python"
+    - python: 3.5
+      env:
+        DJANGO_ENV=django21
+        TESTNAME=test-python
+        TARGETS="requirements.js clean_static static validate_python"
+    - python: 3.5
+      env:
         DJANGO_ENV=django22
         TESTNAME=quality-and-js
         TARGETS="requirements.js check_translations_up_to_date validate_translations clean_static static quality validate_js check_keywords"
@@ -56,37 +66,6 @@ matrix:
         - pip install -U codecov
         - docker exec ecommerce_testing /edx/app/ecommerce/ecommerce/.travis/run_coverage.sh
         - codecov
-    - python: 3.5
-      env:
-        DJANGO_ENV=django20
-        TESTNAME=test-python
-        TARGETS="requirements.js clean_static static validate_python"
-    - python: 3.5
-      env:
-        DJANGO_ENV=django21
-        TESTNAME=test-python
-        TARGETS="requirements.js clean_static static validate_python"
-    - python: 3.5
-      env:
-        DJANGO_ENV=django22
-        TESTNAME=test-python
-        TARGETS="requirements.js clean_static static validate_python"
-  allow_failures:
-    - python: 3.5
-      env:
-        DJANGO_ENV=django22
-        TESTNAME=quality-and-js
-        TARGETS="requirements.js check_translations_up_to_date validate_translations clean_static static quality validate_js check_keywords"
-    - python: 3.5
-      env:
-        DJANGO_ENV=django20
-        TESTNAME=test-python
-        TARGETS="requirements.js clean_static static validate_python"
-    - python: 3.5
-      env:
-        DJANGO_ENV=django21
-        TESTNAME=test-python
-        TARGETS="requirements.js clean_static static validate_python"
     - python: 3.5
       env:
         DJANGO_ENV=django22

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -256,7 +256,10 @@ class EnrollmentFulfillmentModuleTests(ProgramTestMixin, DiscoveryTestMixin, Ful
         offer.save()
         discount.offer_id = offer.id
         discount.save()
+        basket_strategy = self.order.basket.strategy
         self.order.refresh_from_db()
+        # restore lost basket strategy after call to refresh_from_db
+        self.order.basket.strategy = basket_strategy
 
         with mock.patch.object(Range, 'contains_product') as mock_contains:
             mock_contains.return_value = True


### PR DESCRIPTION
- Another version of the same issue.
- Also, makes Django 2.2 tests required now that they are passing.

BOM-1470

**Reviewer Note:** This is the same issue that was approved and merged here: https://github.com/edx/ecommerce/pull/2881