### PR TITLE
add .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,15 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  version: 3.5
+  install:
+    - requirements: requirements/docs.txt


### PR DESCRIPTION
This can declare python version to be the same as the one used to
run make upgrade that creates the requirements/docs.txt file.