### PR TITLE
BOM-1487: fix JavaScriptCatalog error under Django 2.2

### DIFF
--- a/ecommerce/urls.py
+++ b/ecommerce/urls.py
@@ -64,7 +64,7 @@ urlpatterns = AUTH_URLS + WELL_KNOWN_URLS + [
     url(r'^enterprise/', include(('ecommerce.enterprise.urls', 'enterprise'))),
     url(r'^health/$', core_views.health, name='health'),
     url(r'^i18n/', include(('django.conf.urls.i18n'))),
-    url(r'^jsi18n/$', JavaScriptCatalog.as_view(packages=['courses']), name='javascript-catalog'),
+    url(r'^jsi18n/$', JavaScriptCatalog.as_view(), name='javascript-catalog'),
     url(r'^management/', include(('ecommerce.management.urls', 'management'))),
     url(r'^offers/', include(('ecommerce.extensions.offer.urls', 'offers'))),
     url(r'^programs/', include(('ecommerce.programs.urls', 'programs'))),


### PR DESCRIPTION
With this change, under Django 2.2, the server no longer reports a
JavaScriptCatalog error for the courses app, which doesn't contain any
JavaScript or a djangojs.po file.

[BOM-1487](https://openedx.atlassian.net/browse/BOM-1487)

Note: There is an existing file of JavaScript translations under [ecommerce/conf/locale/en/LC_MESSAGES/djangojs.po](https://github.com/edx/ecommerce/blob/30a879b41dc47db0b03e2eb3c691f95da6bc8166/ecommerce/conf/locale/en/LC_MESSAGES/djangojs.po).

Original Server Error:
```
  ...
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.5/site-packages/django/views/i18n.py", line 200, in get
    paths = self.get_paths(packages) if packages else None
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.5/site-packages/django/views/i18n.py", line 211, in get_paths
    'Invalid package(s) provided to JavaScriptCatalog: %s' % ','.join(excluded)
ValueError: Invalid package(s) provided to JavaScriptCatalog: courses
```