### PR TITLE
BOM-1487: preserve 30 max_length for last_name

### DIFF
--- a/ecommerce/core/admin.py
+++ b/ecommerce/core/admin.py
@@ -7,7 +7,7 @@ from django.utils.translation import ugettext_lazy as _
 from edx_rbac.admin import UserRoleAssignmentAdmin
 
 from ecommerce.core.constants import USER_LIST_VIEW_SWITCH
-from ecommerce.core.forms import EcommerceFeatureRoleAssignmentAdminForm
+from ecommerce.core.forms import EcommerceFeatureRoleAssignmentAdminForm, EcommerceUserChangeForm
 from ecommerce.core.models import BusinessClient, EcommerceFeatureRoleAssignment, SiteConfiguration, User
 
 
@@ -19,6 +19,7 @@ class SiteConfigurationAdmin(admin.ModelAdmin):
 
 @admin.register(User)
 class EcommerceUserAdmin(UserAdmin):
+    form = EcommerceUserChangeForm
     list_display = ('username', 'email', 'full_name', 'first_name', 'last_name', 'is_staff')
     fieldsets = (
         (None, {'fields': ('username', 'password')}),

--- a/ecommerce/core/forms.py
+++ b/ecommerce/core/forms.py
@@ -2,6 +2,8 @@
 
 from __future__ import absolute_import
 
+from django import forms
+from django.contrib.auth.forms import UserChangeForm
 from edx_rbac.admin.forms import UserRoleAssignmentAdminForm
 
 from ecommerce.core.models import EcommerceFeatureRoleAssignment
@@ -19,3 +21,15 @@ class EcommerceFeatureRoleAssignmentAdminForm(UserRoleAssignmentAdminForm):
 
         model = EcommerceFeatureRoleAssignment
         fields = '__all__'
+
+
+class EcommerceUserChangeForm(UserChangeForm):
+    """
+    Admin form for EcommerceUserChange
+    """
+    # This is the recommended solution by Django to preserve the 30 character limit.
+    # This is necessary in preparation for the Django 2 upgrade, because the upcoming
+    # migration to increase the length of last_name is being faked for edx.org in
+    # Production to avoid this large migration.
+    # See https://docs.djangoproject.com/en/3.0/releases/2.0/#abstractuser-last-name-max-length-increased-to-150
+    last_name = forms.CharField(max_length=30, required=False)

--- a/ecommerce/core/tests/test_admin.py
+++ b/ecommerce/core/tests/test_admin.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import
 
+from django import forms
 from django.contrib import messages
 from django.urls import reverse
 
+from ecommerce.core.admin import EcommerceUserAdmin
 from ecommerce.core.constants import USER_LIST_VIEW_SWITCH
 from ecommerce.core.tests import toggle_switch
 from ecommerce.tests.factories import UserFactory
@@ -43,3 +45,12 @@ class UserAdminTests(TestCase):
         """
         self.assertIsNotNone(self.user.lms_user_id)
         self.assertEqual(UserFactory.lms_user_id, self.user.lms_user_id)
+
+    def test_user_admin_last_name(self):
+        """ Test that the user admin form preserves the 30 length limit for last_name. """
+        form = EcommerceUserAdmin.form(instance=self.user)
+        valid_last_name = "Valid last name"
+        form.fields['last_name'].clean(valid_last_name)
+        invalid_last_name = "x" * 31  # last name too long
+        with self.assertRaises(forms.ValidationError):
+            form.fields['last_name'].clean(invalid_last_name)


### PR DESCRIPTION
Implements the recommended solution by Django to preserve the 30
character limit for last_name. This is necessary in preparation for the
Django 2 upgrade, because the upcoming migration to increase the length
of last_name is being faked for edx.org in Production to avoid this
large migration.

See https://docs.djangoproject.com/en/3.0/releases/2.0/#abstractuser-last-name-max-length-increased-to-150

BOM-1487