### PR TITLE
BOM-1485: make upgrade and upgrade clean-up

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -33,7 +33,7 @@ jsonfield2
 libsass==0.9.2
 markdown==2.6.9
 mysqlclient<1.5
-newrelic<5                          # Not a direct dependency (e.g. via edx-django-utils), but v5 requires python>3.4
+newrelic
 ndg-httpsclient
 path.py==7.2
 paypalrestsdk
@@ -41,8 +41,7 @@ premailer==2.9.2
 pycountry==17.1.8
 pygments
 python-dateutil
-python-openid ; python_version == "2.7"
-python3-openid ; python_version >= "3"
+python3-openid>=3
 pytz
 requests
 rules

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,12 +14,12 @@ billiard==3.3.0.23        # via celery
 bleach==3.1.4             # via -r requirements/base.in
 cached-property==1.5.1    # via zeep
 celery==3.1.26.post2      # via edx-ecommerce-worker
-certifi==2019.11.28       # via requests
+certifi==2020.4.5.1       # via requests
 cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
 coreapi==2.3.3            # via -r requirements/base.in, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
-cryptography==2.8         # via pyopenssl, social-auth-core
+cryptography==2.9         # via pyopenssl, social-auth-core
 cssselect==1.1.0          # via premailer
 cssutils==1.0.2           # via premailer
 defusedxml==0.6.0         # via python3-openid, social-auth-core, zeep
@@ -74,14 +74,14 @@ markdown==2.6.9           # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
 mysqlclient==1.4.6        # via -r requirements/base.in
 ndg-httpsclient==0.5.1    # via -r requirements/base.in
-newrelic==4.20.1.121      # via -r requirements/base.in, edx-django-utils
+newrelic==5.10.0.138      # via -r requirements/base.in, edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 path.py==7.2              # via -r requirements/base.in
 paypalrestsdk==1.13.1     # via -r requirements/base.in
 pbr==5.4.4                # via stevedore
 phonenumbers==8.12.1      # via django-oscar, django-phonenumber-field
-pillow==7.1.0             # via django-oscar
+pillow==7.1.1             # via django-oscar
 premailer==2.9.2          # via -r requirements/base.in
 psutil==1.2.1             # via edx-django-utils
 purl==1.5                 # via django-oscar
@@ -95,7 +95,7 @@ pyjwt==1.7.1              # via drf-jwt, edx-auth-backends, edx-rest-api-client,
 pymongo==3.10.1           # via edx-opaque-keys
 pyopenssl==19.1.0         # via ndg-httpsclient, paypalrestsdk
 python-dateutil==2.8.1    # via -r requirements/base.in, analytics-python, edx-drf-extensions, faker
-python3-openid==3.1.0 ; python_version >= "3"  # via -r requirements/base.in, social-auth-core
+python3-openid==3.1.0     # via -r requirements/base.in, social-auth-core
 pytz==2016.10             # via -c requirements/pins.txt, -r requirements/base.in, babel, celery, django, zeep
 pyyaml==5.3.1             # via edx-django-release-util
 rcssmin==1.0.6            # via django-compressor
@@ -111,7 +111,7 @@ simplejson==3.17.0        # via django-rest-swagger, sailthru-client
 six==1.14.0               # via -r requirements/base.in, analytics-python, bleach, cryptography, django-compressor, django-extensions, django-extra-views, django-simple-history, django-waffle, djangorestframework-csv, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, edx-rbac, isodate, libsass, paypalrestsdk, purl, pyjwkest, pyopenssl, python-dateutil, social-auth-app-django, social-auth-core, stevedore, zeep
 slumber==0.7.1            # via edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.in, edx-auth-backends
-social-auth-core==3.3.2   # via edx-auth-backends, social-auth-app-django
+social-auth-core==3.3.3   # via edx-auth-backends, social-auth-app-django
 sorl-thumbnail==12.6.3    # via -r requirements/base.in
 stevedore==1.32.0         # via edx-opaque-keys
 stripe==1.70.0            # via -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,19 +12,19 @@ appdirs==1.4.3            # via -r requirements/test.txt, zeep
 astroid==2.3.3            # via -r requirements/test.txt, pylint
 attrs==19.3.0             # via -r requirements/test.txt, pytest, zeep
 babel==2.8.0              # via -r requirements/docs.txt, -r requirements/test.txt, django-oscar, django-phonenumber-field, sphinx
-beautifulsoup4==4.8.2     # via -r requirements/test.txt, webtest
+beautifulsoup4==4.9.0     # via -r requirements/test.txt, webtest
 billiard==3.3.0.23        # via -r requirements/test.txt, celery
 bleach==3.1.4             # via -r requirements/test.txt
 bok-choy==1.0.1           # via -r requirements/test.txt
 cached-property==1.5.1    # via -r requirements/test.txt, zeep
 celery==3.1.26.post2      # via -r requirements/test.txt, edx-ecommerce-worker
-certifi==2019.11.28       # via -r requirements/docs.txt, -r requirements/test.txt, requests
+certifi==2020.4.5.1       # via -r requirements/docs.txt, -r requirements/test.txt, requests
 cffi==1.14.0              # via -r requirements/test.txt, cryptography
 chardet==3.0.4            # via -r requirements/docs.txt, -r requirements/test.txt, requests
 coreapi==2.3.3            # via -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi
 coverage==5.0.4           # via -r requirements/test.txt, pytest-cov
-cryptography==2.8         # via -r requirements/test.txt, pyopenssl, social-auth-core
+cryptography==2.9         # via -r requirements/test.txt, pyopenssl, social-auth-core
 cssselect==1.1.0          # via -r requirements/test.txt, premailer
 cssutils==1.0.2           # via -r requirements/test.txt, premailer
 ddt==1.3.1                # via -r requirements/test.txt
@@ -100,7 +100,7 @@ mock==3.0.5               # via -r requirements/test.txt, mock-django
 more-itertools==8.2.0     # via -r requirements/test.txt, pytest
 mysqlclient==1.4.6        # via -r requirements/test.txt
 ndg-httpsclient==0.5.1    # via -r requirements/test.txt
-newrelic==4.20.1.121      # via -r requirements/test.txt, edx-django-utils
+newrelic==5.10.0.138      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 packaging==20.3           # via -r requirements/test.txt, pytest, tox
@@ -109,7 +109,7 @@ pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 paypalrestsdk==1.13.1     # via -r requirements/test.txt
 pbr==5.4.4                # via -r requirements/test.txt, stevedore
 phonenumbers==8.12.1      # via -r requirements/test.txt, django-oscar, django-phonenumber-field
-pillow==7.1.0             # via -r requirements/test.txt, django-oscar
+pillow==7.1.1             # via -r requirements/test.txt, django-oscar
 pluggy==0.13.1            # via -r requirements/test.txt, diff-cover, pytest, tox
 polib==1.1.0              # via -r requirements/test.txt, edx-i18n-tools
 premailer==2.9.2          # via -r requirements/test.txt
@@ -129,7 +129,7 @@ pyjwt==1.7.1              # via -r requirements/test.txt, drf-jwt, edx-auth-back
 pylint==2.4.4             # via -r requirements/test.txt
 pymongo==3.10.1           # via -r requirements/test.txt, edx-opaque-keys
 pyopenssl==19.1.0         # via -r requirements/test.txt, ndg-httpsclient, paypalrestsdk
-pyparsing==2.4.6          # via -r requirements/test.txt, packaging
+pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-base-url==1.4.1    # via -r requirements/test.txt, pytest-selenium
 pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-django-ordering==1.2.0  # via -r requirements/test.txt
@@ -145,7 +145,7 @@ python-dateutil==2.8.1    # via -r requirements/test.txt, analytics-python, edx-
 python-dotenv==0.12.0     # via -r requirements/test.txt
 python-memcached==1.58    # via -r requirements/test.txt
 python-slugify==1.2.6     # via transifex-client
-python3-openid==3.1.0 ; python_version >= "3"  # via -r requirements/test.txt, social-auth-core
+python3-openid==3.1.0     # via -r requirements/test.txt, social-auth-core
 pytz==2016.10             # via -r requirements/docs.txt, -r requirements/test.txt, babel, celery, django, zeep
 pyyaml==5.3.1             # via -r requirements/test.txt, edx-django-release-util, edx-i18n-tools
 rcssmin==1.0.6            # via -r requirements/test.txt, django-compressor
@@ -164,7 +164,7 @@ six==1.14.0               # via -r requirements/docs.txt, -r requirements/test.t
 slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/docs.txt, sphinx
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/test.txt, edx-auth-backends
-social-auth-core==3.3.2   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
+social-auth-core==3.3.3   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
 sorl-thumbnail==12.6.3    # via -r requirements/test.txt
 soupsieve==2.0            # via -r requirements/test.txt, beautifulsoup4
 sphinx==1.5.3             # via -r requirements/docs.txt, edx-sphinx-theme

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.12         # via sphinx
 babel==2.8.0              # via sphinx
-certifi==2019.11.28       # via requests
+certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
 docutils==0.16            # via sphinx
 edx-sphinx-theme==1.0.2   # via -r requirements/docs.in

--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 attrs==19.3.0             # via pytest
-certifi==2019.11.28       # via requests
+certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
 edx-rest-api-client==1.9.2  # via -c requirements/pins.txt, -r requirements/e2e.in
 idna==2.9                 # via requests
@@ -16,7 +16,7 @@ pathlib2==2.3.5           # via pytest
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
 pyjwt==1.7.1              # via edx-rest-api-client
-pyparsing==2.4.6          # via packaging
+pyparsing==2.4.7          # via packaging
 pytest-base-url==1.4.1    # via pytest-selenium
 pytest-html==1.22.1       # via pytest-selenium
 pytest-metadata==1.8.0    # via pytest-html

--- a/requirements/pins.txt
+++ b/requirements/pins.txt
@@ -1,18 +1,33 @@
-pytz==2016.10  # Pinned to preserve the status quo
-urllib3>=1.24.2,<2.0.0  # Pinned because transifex-client==0.13.6 pins it
-edx-rest-api-client<2.0.0 # Because of django incompatibility
-
-# jsonfield2 > 3.0.3 dropped support for python 3.5
-jsonfield2<=3.0.3
-
-# Was causing some tox issues locally.
-virtualenv==16.7.9
-
-# 5.4 introduces test order problems that need to be resolved.
-pytest<5.4.0
+# Version constraints for pip-installation.
+#
+# This file doesn't install any packages. It specifies version constraints
+# that will be applied if a package is needed.
+#
+# When pinning something here, please provide an explanation of why.  Ideally,
+# link to other information that will help people in the future to remove the
+# pin when possible.  Writing an issue against the offending project and
+# linking to it here is good.
 
 # BOM-1410 : drf-jwt 1.15.0 introduces migration issues.
 drf-jwt<1.15.0
 
+# Because of django incompatibility
+edx-rest-api-client<2.0.0
+
 # causing tests failures
 httpretty==0.9.7
+
+# jsonfield2 > 3.0.3 dropped support for python 3.5
+jsonfield2<=3.0.3
+
+# 5.4 introduces test order problems that need to be resolved.
+pytest<5.4.0
+
+# Pinned to preserve the status quo
+pytz==2016.10
+
+# Pinned because transifex-client==0.13.6 pins it
+urllib3>=1.24.2,<2.0.0
+
+# Was causing some tox issues locally.
+virtualenv==16.7.9

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -15,12 +15,12 @@ bleach==3.1.4             # via -r requirements/base.in
 boto==2.49.0              # via django-ses
 cached-property==1.5.1    # via zeep
 celery==3.1.26.post2      # via edx-ecommerce-worker
-certifi==2019.11.28       # via requests
+certifi==2020.4.5.1       # via requests
 cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
 coreapi==2.3.3            # via -r requirements/base.in, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
-cryptography==2.8         # via pyopenssl, social-auth-core
+cryptography==2.9         # via pyopenssl, social-auth-core
 cssselect==1.1.0          # via premailer
 cssutils==1.0.2           # via premailer
 defusedxml==0.6.0         # via python3-openid, social-auth-core, zeep
@@ -85,7 +85,7 @@ path.py==7.2              # via -r requirements/base.in
 paypalrestsdk==1.13.1     # via -r requirements/base.in
 pbr==5.4.4                # via stevedore
 phonenumbers==8.12.1      # via django-oscar, django-phonenumber-field
-pillow==7.1.0             # via django-oscar
+pillow==7.1.1             # via django-oscar
 premailer==2.9.2          # via -r requirements/base.in
 psutil==1.2.1             # via edx-django-utils
 purl==1.5                 # via django-oscar
@@ -100,7 +100,7 @@ pymongo==3.10.1           # via edx-opaque-keys
 pyopenssl==19.1.0         # via ndg-httpsclient, paypalrestsdk
 python-dateutil==2.8.1    # via -r requirements/base.in, analytics-python, edx-drf-extensions, faker
 python-memcached==1.58    # via -r requirements/production.in
-python3-openid==3.1.0 ; python_version >= "3"  # via -r requirements/base.in, social-auth-core
+python3-openid==3.1.0     # via -r requirements/base.in, social-auth-core
 pytz==2016.10             # via -c requirements/pins.txt, -r requirements/base.in, babel, celery, django, zeep
 pyyaml==5.3.1             # via -r requirements/production.in, edx-django-release-util
 rcssmin==1.0.6            # via django-compressor
@@ -117,7 +117,7 @@ simplejson==3.17.0        # via django-rest-swagger, sailthru-client
 six==1.14.0               # via -r requirements/base.in, analytics-python, bleach, cryptography, django-compressor, django-extensions, django-extra-views, django-simple-history, django-waffle, djangorestframework-csv, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, edx-rbac, isodate, libsass, paypalrestsdk, purl, pyjwkest, pyopenssl, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, stevedore, zeep
 slumber==0.7.1            # via edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.in, edx-auth-backends
-social-auth-core==3.3.2   # via edx-auth-backends, social-auth-app-django
+social-auth-core==3.3.3   # via edx-auth-backends, social-auth-app-django
 sorl-thumbnail==12.6.3    # via -r requirements/base.in
 stevedore==1.32.0         # via edx-opaque-keys
 stripe==1.70.0            # via -r requirements/base.in

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -11,7 +11,6 @@ django-webtest
 edx-i18n-tools              # required for quality
 factory-boy
 freezegun
-futures ; python_version == "2.7"
 httpretty
 isort
 lxml
@@ -23,7 +22,6 @@ pytest
 pytest-cov
 pytest-django
 pytest-django-ordering
-pysqlite ; python_version == "2.7"  # DB-API 2.0 interface for SQLite 3.x (used as the relational database for most tests)
 python-memcached==1.58      # required by collectstatic in devstack
 responses
 selenium

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,19 +11,19 @@ appdirs==1.4.3            # via -r requirements/base.txt, zeep
 astroid==2.3.3            # via pylint
 attrs==19.3.0             # via -r requirements/base.txt, -r requirements/e2e.txt, pytest, zeep
 babel==2.8.0              # via -r requirements/base.txt, django-oscar, django-phonenumber-field
-beautifulsoup4==4.8.2     # via webtest
+beautifulsoup4==4.9.0     # via webtest
 billiard==3.3.0.23        # via -r requirements/base.txt, celery
 bleach==3.1.4             # via -r requirements/base.txt
 bok-choy==1.0.1           # via -r requirements/test.in
 cached-property==1.5.1    # via -r requirements/base.txt, zeep
 celery==3.1.26.post2      # via -r requirements/base.txt, edx-ecommerce-worker
-certifi==2019.11.28       # via -r requirements/base.txt, -r requirements/e2e.txt, requests
+certifi==2020.4.5.1       # via -r requirements/base.txt, -r requirements/e2e.txt, requests
 cffi==1.14.0              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, -r requirements/e2e.txt, requests
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
 coverage==5.0.4           # via -r requirements/test.in, pytest-cov
-cryptography==2.8         # via -r requirements/base.txt, pyopenssl, social-auth-core
+cryptography==2.9         # via -r requirements/base.txt, pyopenssl, social-auth-core
 cssselect==1.1.0          # via -r requirements/base.txt, premailer
 cssutils==1.0.2           # via -r requirements/base.txt, premailer
 ddt==1.3.1                # via -r requirements/test.in
@@ -94,7 +94,7 @@ mock==3.0.5               # via -r requirements/test.in, mock-django
 more-itertools==8.2.0     # via -r requirements/e2e.txt, pytest
 mysqlclient==1.4.6        # via -r requirements/base.txt
 ndg-httpsclient==0.5.1    # via -r requirements/base.txt
-newrelic==4.20.1.121      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.10.0.138      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 packaging==20.3           # via -r requirements/e2e.txt, -r requirements/tox.txt, pytest, tox
@@ -103,7 +103,7 @@ pathlib2==2.3.5           # via -r requirements/e2e.txt, pytest
 paypalrestsdk==1.13.1     # via -r requirements/base.txt
 pbr==5.4.4                # via -r requirements/base.txt, stevedore
 phonenumbers==8.12.1      # via -r requirements/base.txt, django-oscar, django-phonenumber-field
-pillow==7.1.0             # via -r requirements/base.txt, django-oscar
+pillow==7.1.1             # via -r requirements/base.txt, django-oscar
 pluggy==0.13.1            # via -r requirements/e2e.txt, -r requirements/tox.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
 premailer==2.9.2          # via -r requirements/base.txt
@@ -121,7 +121,7 @@ pyjwt==1.7.1              # via -r requirements/base.txt, -r requirements/e2e.tx
 pylint==2.4.4             # via -r requirements/test.in
 pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 pyopenssl==19.1.0         # via -r requirements/base.txt, ndg-httpsclient, paypalrestsdk
-pyparsing==2.4.6          # via -r requirements/e2e.txt, -r requirements/tox.txt, packaging
+pyparsing==2.4.7          # via -r requirements/e2e.txt, -r requirements/tox.txt, packaging
 pytest-base-url==1.4.1    # via -r requirements/e2e.txt, pytest-selenium
 pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-django-ordering==1.2.0  # via -r requirements/test.in
@@ -136,7 +136,7 @@ pytest==5.3.5             # via -c requirements/pins.txt, -r requirements/e2e.tx
 python-dateutil==2.8.1    # via -r requirements/base.txt, analytics-python, edx-drf-extensions, faker, freezegun
 python-dotenv==0.12.0     # via -r requirements/e2e.txt
 python-memcached==1.58    # via -r requirements/test.in
-python3-openid==3.1.0 ; python_version >= "3"  # via -r requirements/base.txt, social-auth-core
+python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core
 pytz==2016.10             # via -c requirements/pins.txt, -r requirements/base.txt, babel, celery, django, zeep
 pyyaml==5.3.1             # via -r requirements/base.txt, edx-django-release-util, edx-i18n-tools
 rcssmin==1.0.6            # via -r requirements/base.txt, django-compressor
@@ -154,7 +154,7 @@ simplejson==3.17.0        # via -r requirements/base.txt, django-rest-swagger, s
 six==1.14.0               # via -r requirements/base.txt, -r requirements/e2e.txt, -r requirements/tox.txt, analytics-python, astroid, bleach, bok-choy, cryptography, diff-cover, django-compressor, django-extensions, django-extra-views, django-simple-history, django-waffle, djangorestframework-csv, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, edx-rbac, freezegun, httpretty, isodate, libsass, mock, packaging, pathlib2, paypalrestsdk, purl, pyjwkest, pyopenssl, python-dateutil, python-memcached, responses, social-auth-app-django, social-auth-core, stevedore, tox, webtest, zeep
 slumber==0.7.1            # via -r requirements/base.txt, -r requirements/e2e.txt, edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.3.2   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+social-auth-core==3.3.3   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sorl-thumbnail==12.6.3    # via -r requirements/base.txt
 soupsieve==2.0            # via beautifulsoup4
 stevedore==1.32.0         # via -r requirements/base.txt, edx-opaque-keys

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -9,7 +9,7 @@ importlib-metadata==1.6.0  # via pluggy, tox
 packaging==20.3           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
-pyparsing==2.4.6          # via packaging
+pyparsing==2.4.7          # via packaging
 six==1.14.0               # via packaging, tox
 toml==0.10.0              # via tox
 tox-battery==0.5.2        # via -r requirements/tox.in


### PR DESCRIPTION
- run make upgrade
- upgrade newrelic since we are on Python 3.5
- remove python 2.7 dependencies
- reorder and comment pins.txt

BOM-1485