### PR TITLE
BOM-1475: fixed catalogue namespace error

### DIFF
--- a/ecommerce/extensions/config.py
+++ b/ecommerce/extensions/config.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 
+from django.conf import settings
+from django.conf.urls import url
+from django.views.generic import RedirectView
 from oscar import config
 
 from .utils import exclude_app_urls
@@ -11,9 +14,10 @@ class EdxShop(config.Shop):
     default_permissions = 'is_staff'
 
     def get_urls(self):
-        urls = super().get_urls()
+        urls = [
+            url(r'^$', RedirectView.as_view(url=settings.OSCAR_HOMEPAGE), name='home'),
+        ] + super().get_urls()
         # excluding urls of catalogue and search
         exclude_app_urls(urls, 'catalogue')
         exclude_app_urls(urls, 'search')
-
         return urls

--- a/ecommerce/tests/test_urls.py
+++ b/ecommerce/tests/test_urls.py
@@ -7,19 +7,6 @@ from ecommerce.tests.testcases import TestCase
 
 
 class TestUrls(TestCase):
-    def test_unauthorized_redirection(self):
-        """Test that users not authorized to access the Oscar front-end are redirected to the LMS dashboard."""
-        user = self.create_user()
-
-        # Log in as a user not authorized to view the Oscar front-end (no staff permissions)
-        success = self.client.login(username=user.username, password=self.password)
-        self.assertTrue(success)
-
-        response = self.client.get(reverse('dashboard:index'))
-        # Test client can't fetch external URLs, so fetch_redirect_response is set to
-        # False to avoid loading the final page
-        self.assertRedirects(response, get_lms_dashboard_url(), fetch_redirect_response=False)
-
     def test_api_docs(self):
         """
         Verify that the API docs render.
@@ -28,3 +15,40 @@ class TestUrls(TestCase):
         response = self.client.get(path)
 
         assert response.status_code == 200
+
+    def test_anonymous_homepage_redirection(self):
+        """Test that anonymous users redirected to LMS Dashboard."""
+        response = self.client.get('/')
+        self.assertRedirects(response, reverse('dashboard:index'), target_status_code=302)
+
+        response = self.client.get(response.url)
+        # Anonymous users are further redirected to login page from dashboard
+        # After login they will be redirected to respective dashboard as of their authorization
+        self.assertRedirects(response, "/dashboard/login/?next=/dashboard/", fetch_redirect_response=False)
+
+    def test_unauthorized_homepage_redirection(self):
+        """Test that users unauthorized to access the Oscar front-end are redirected to LMS Dashboard."""
+        user = self.create_user()  # unauthorized user cannot view the Oscar Dashboard
+        success = self.client.login(username=user.username, password=self.password)
+        self.assertTrue(success)
+        response = self.client.get('/')
+
+        # Unauthorized users are first redirected to oscar dashboard
+        # status code of 302 verifies further redirection on LMS dashboard
+        self.assertRedirects(response, reverse('dashboard:index'), target_status_code=302)
+        response = self.client.get(response.url)
+
+        # Test client can't fetch external URLs, so fetch_redirect_response is set to
+        # False to avoid loading the final page
+        self.assertRedirects(response, get_lms_dashboard_url(), fetch_redirect_response=False)
+
+    def test_authorized_homepage_redirection(self):
+        """Test that users authorized to access the Oscar front-end are redirected to Oscar Dashboard."""
+        user = self.create_user(is_staff=True)  # authorized user to view the Oscar Dashboard
+        success = self.client.login(username=user.username, password=self.password)
+        self.assertTrue(success)
+        response = self.client.get('/')
+
+        # Authorized users are redirected to oscar dashboard
+        # status code of 200 verifies that no further redirection on LMS dashboard
+        self.assertRedirects(response, reverse('dashboard:index'), target_status_code=200)


### PR DESCRIPTION
Not ready.
JIRA: [BOM-1475](https://openedx.atlassian.net/browse/BOM-1475), [BOM-1476](https://openedx.atlassian.net/browse/BOM-1476)



OSCAR_HOMEPAGE is already set to dashboard. So I have now added a redirection. It now redirects authenticated users with staff access to ecommerce dashboard, while rest of users are redirected to LMS dashboard.
https://github.com/edx/ecommerce/blob/142cba95a981a7d0b8fdfe5d24d3783c9351fd98/ecommerce/settings/_oscar.py#L11