### PR TITLE
Add enrollment_limit and bookings_limit for enterprise offers

### DIFF
--- a/ecommerce/enterprise/conditions.py
+++ b/ecommerce/enterprise/conditions.py
@@ -16,14 +16,51 @@ from ecommerce.enterprise.utils import get_enterprise_id_for_user
 from ecommerce.extensions.basket.utils import ENTERPRISE_CATALOG_ATTRIBUTE_TYPE
 from ecommerce.extensions.offer.constants import OFFER_ASSIGNMENT_REVOKED, OFFER_REDEEMED
 from ecommerce.extensions.offer.mixins import ConditionWithoutRangeMixin, SingleItemConsumptionConditionMixin
+from ecommerce.extensions.offer.models import OFFER_PRIORITY_ENTERPRISE
+from ecommerce.extensions.offer.utils import get_benefit_type, get_discount_value
 
 BasketAttribute = get_model('basket', 'BasketAttribute')
 BasketAttributeType = get_model('basket', 'BasketAttributeType')
+Benefit = get_model('offer', 'Benefit')
 Condition = get_model('offer', 'Condition')
 ConditionalOffer = get_model('offer', 'ConditionalOffer')
 OfferAssignment = get_model('offer', 'OfferAssignment')
+StockRecord = get_model('partner', 'StockRecord')
 Voucher = get_model('voucher', 'Voucher')
 logger = logging.getLogger(__name__)
+
+
+def is_offer_max_discount_available(basket, offer):
+    # no need to do anything if this is not an enterprise offer or `max_discount` is not set
+    if offer.priority != OFFER_PRIORITY_ENTERPRISE or offer.max_discount is None:
+        return True
+
+    # get course price
+    product = basket.lines.first().product
+    seat = product.course.seat_products.get(id=product.id)
+    stock_record = StockRecord.objects.get(product=seat, partner=product.course.partner)
+    course_price = stock_record.price_excl_tax
+
+    # calculate discount value that will be covered by the offer
+    benefit_type = get_benefit_type(offer.benefit)
+    benefit_value = float(offer.benefit.value)
+    if benefit_type == Benefit.PERCENTAGE:
+        discount_value = get_discount_value(benefit_value, float(course_price))
+    else:  # Benefit.FIXED
+        # There is a possibility that the discount value could be greater than the course price
+        # ie, discount value is $100, course price is $75, in this case the full price of the course will be covered
+        # and learner will owe $0 to checkout.
+        if benefit_value > course_price:
+            discount_value = course_price
+        else:
+            discount_value = benefit_value
+
+    # check if offer has discount available
+    new_total_discount = discount_value + offer.total_discount
+    if new_total_discount <= offer.max_discount:
+        return True
+
+    return False
 
 
 class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumptionConditionMixin, Condition):
@@ -137,6 +174,20 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
                            enterprise_customer,
                            enterprise_catalog,
                            courses_in_basket)
+            return False
+
+        if not is_offer_max_discount_available(basket, offer):
+            logger.warning(
+                '[Enterprise Offer Failure] Unable to apply enterprise offer because bookings limit is consumed.'
+                'User: %s, Offer: %s, Enterprise: %s, Catalog: %s, Courses: %s, BookingsLimit: %s, TotalDiscount: %s',
+                username,
+                offer.id,
+                enterprise_customer,
+                enterprise_catalog,
+                courses_in_basket,
+                offer.max_discount,
+                offer.total_discount,
+            )
             return False
 
         return True

--- a/ecommerce/extensions/offer/models.py
+++ b/ecommerce/extensions/offer/models.py
@@ -229,7 +229,8 @@ class ConditionalOffer(AbstractConditionalOffer):
                         log_message_and_raise_validation_error(error_message)
 
     def clean_max_global_applications(self):
-        if self.max_global_applications is not None:
+        # enterprise offers have their own cleanup logic
+        if self.priority != OFFER_PRIORITY_ENTERPRISE and self.max_global_applications is not None:
             if not isinstance(self.max_global_applications, six.integer_types) or self.max_global_applications < 1:
                 log_message_and_raise_validation_error(
                     'Failed to create ConditionalOffer. max_global_applications field must be a positive number.'


### PR DESCRIPTION
**Description:** Add `Enrollment Limit` and `Bookings Limit` for enterprise offers.
`Enrollment Limit:` The maximum number of enrollments that can redeem this offer.
`Bookings Limit:` The maximum USD dollar amount that can be redeemed by this offer.


**JIRA:** [ENT-2688](https://openedx.atlassian.net/browse/ENT-2688)

**Testing:**
This branch is deployed on sandbox. You can create/update enterprise offers to see how the new fields are working. Also enroll in a course and try to upgrade to verified to see how the offer limits works and also see in the oscar dashboard to see if offer is available or not an what limit is achieved. 

**Sandbox:** 
LMS: https://mammar.sandbox.edx.org/
Enterprise Offers: https://ecommerce-mammar.sandbox.edx.org/enterprise/offers/
Oscar Dashboard: https://ecommerce-mammar.sandbox.edx.org/dashboard/offers/

**Test Users:**
There are 20 enterprise learner available for testing. They are linked with Enterprise100(29806366-672e-4022-831a-a19ec83d34c9). Learner have emails with below format and their password is `edx`
```
enterprise100_learner_130@example.com, 
enterprise100_learner_131@example.com
.
.
.
enterprise100_learner_150@example.com
```

**Courses:**
- https://mammar.sandbox.edx.org/courses/course-v1:Ent1+Test1+2020/