### PR TITLE
Add default '' on hosted checkout page if no desription is given

### DIFF
--- a/ecommerce/templates/oscar/basket/partials/hosted_checkout_basket.html
+++ b/ecommerce/templates/oscar/basket/partials/hosted_checkout_basket.html
@@ -32,7 +32,7 @@
                         <div class="col-md-5 col-sm-12">
                             <p class="product-title">{{ line_data.product_title }} {% if line_data.course_key %}- {{ line_data.course_key.org }}
                                 ({{ line_data.course_key.run }}) {% endif %}</p>
-                            <p class="product-description">{{ line_data.product_description }}</p>
+                            <p class="product-description">{{ line_data.product_description|default_if_none:'' }}</p>
                         </div>
                         {% if line_data.enrollment_code %}
                             <div class="col-md-1 col-xs-12">


### PR DESCRIPTION
### Description
On client hosted checkout page, if no description is provided for the product, `None` is displayed. This PR is to provide a default `''` in that case

### Screenshot
#### Before
![image](https://user-images.githubusercontent.com/42166091/79110183-4cc70f80-7d93-11ea-80f5-7e7385ff82d0.png)

#### After
![image](https://user-images.githubusercontent.com/42166091/79110201-5b152b80-7d93-11ea-908f-635dd482894d.png)
