### PR TITLE
Fix transition to enterprise-catalog call

### DIFF
--- a/ecommerce/enterprise/tests/mixins.py
+++ b/ecommerce/enterprise/tests/mixins.py
@@ -483,7 +483,7 @@ class EnterpriseServiceMockMixin:
 
     def mock_catalog_contains_course_runs(self, course_run_ids, enterprise_customer_uuid, api_url,
                                           enterprise_customer_catalog_uuid=None, contains_content=True,
-                                          raise_exception=False):
+                                          raise_exception=False, catalog_resource='enterprise_catalogs'):
         self.mock_access_token_response()
         query_params = urlencode({'course_run_ids': course_run_ids}, True)
         body = raise_timeout if raise_exception else json.dumps({'contains_content_items': contains_content})
@@ -500,8 +500,9 @@ class EnterpriseServiceMockMixin:
         if enterprise_customer_catalog_uuid:
             httpretty.register_uri(
                 method=httpretty.GET,
-                uri='{}enterprise_catalogs/{}/contains_content_items/?{}'.format(
+                uri='{}{}/{}/contains_content_items/?{}'.format(
                     api_url,
+                    catalog_resource,
                     enterprise_customer_catalog_uuid,
                     query_params
                 ),

--- a/ecommerce/enterprise/tests/test_api.py
+++ b/ecommerce/enterprise/tests/test_api.py
@@ -150,6 +150,7 @@ class EnterpriseAPITests(EnterpriseServiceMockMixin, DiscoveryTestMixin, TestCas
                 self.site.siteconfiguration.enterprise_catalog_api_url,
                 enterprise_customer_catalog_uuid=enterprise_customer_catalog_uuid,
                 contains_content=expected,
+                catalog_resource='enterprise-catalogs',
             )
 
             self._assert_contains_course_runs(expected, [self.course_run.id], 'fake-uuid',


### PR DESCRIPTION
Correct the resource name for enterprise catalogs in the new service.
This was a change that was missed as most of the old enterprise api
urls use the standard hyphenated patterns EXCEPT for
enterprise_catalogs. Additionally, apparently the waffle flag was not
yet active when tested but it is active now.