### PR TITLE
SE-2298 Allows setting default currency from environment

### DIFF
--- a/ecommerce/settings/production.py
+++ b/ecommerce/settings/production.py
@@ -96,6 +96,7 @@ for section, overrides in LOGGING_SUBSECTION_OVERRIDES.items():
                 LOGGING[section][key] = value
 
 
+OSCAR_DEFAULT_CURRENCY = environ.get('OSCAR_DEFAULT_CURRENCY', OSCAR_DEFAULT_CURRENCY)
 
 # PAYMENT PROCESSOR OVERRIDES
 for __, configs in PAYMENT_PROCESSOR_CONFIG.items():


### PR DESCRIPTION
(cherry picked from commit 5190470ee8a2a12611b36165f0934dad13f6b869)

This allows overriding the default currency in ecommerce. Useful for instances where the desired currency isn't USD. Originally tested and used at https://github.com/open-craft/ecommerce/pull/13

Relates to https://github.com/edx/configuration/pull/5757, which introduces the ansible variables to configure this.

**Jira tickets**: [OSPR-4408](https://openedx.atlassian.net/browse/OSPR-4408)

**Dependencies**: https://github.com/edx/configuration/pull/5757

**Sandbox URL**: TBD

**Merge deadline**: None

**Test instructions**:

See https://github.com/edx/configuration/pull/5757

**Reviewers**:

- [x] @pomegranited
- [x] edX reviewers TBD