### PR TITLE
[REV-1170] Redirect to payment mfe when static page submits an invalid coupon

### DIFF
--- a/ecommerce/extensions/basket/tests/test_views.py
+++ b/ecommerce/extensions/basket/tests/test_views.py
@@ -145,6 +145,16 @@ class BasketAddItemsViewTests(CouponMixin, DiscoveryTestMixin, DiscoveryMockMixi
         expected_url += '?utm_source=test'
         self.assertRedirects(response, expected_url, status_code=303, fetch_redirect_response=False)
 
+    def test_add_invalid_code_to_basket(self):
+        """
+        When the BasketAddItemsView receives an invalid code as a parameter, add a message to the url.
+        This message will be displayed on the payment page.
+        """
+        microfrontend_url = self.configure_redirect_to_microfrontend(True, True)
+        response = self._get_response(self.stock_record.partner_sku, code='invalidcode')
+        expected_url = microfrontend_url + '?message=Code%20invalidcode%20is%20invalid.'
+        self.assertRedirects(response, expected_url, status_code=303, fetch_redirect_response=False)
+
     def test_microfrontend_for_enrollment_code_seat(self):
         microfrontend_url = self.configure_redirect_to_microfrontend()
 

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -78,6 +78,14 @@ def add_utm_params_to_url(url, params):
 
 
 @newrelic.agent.function_trace()
+def add_invalid_code_message_to_url(url, code):
+    if code:
+        message = 'message=Code {code} is invalid.'.format(code=str(code))
+        url += '&' + message if '?' in url else '?' + message
+    return url
+
+
+@newrelic.agent.function_trace()
 def prepare_basket(request, products, voucher=None):
     """
     Create or get the basket, add products, apply a voucher, and record referral data.


### PR DESCRIPTION
applying an invalid coupon from the static page was throwing an uncaught exception
modifying this behavior to direct to the regular payment page instead
