### PR TITLE
Removing allow_tag for Django20 update

### DIFF
--- a/ecommerce/extensions/payment/admin.py
+++ b/ecommerce/extensions/payment/admin.py
@@ -36,8 +36,6 @@ class PaymentProcessorResponseAdmin(admin.ModelAdmin):
         # Use format_html() to escape user-provided inputs, avoiding an XSS vulnerability.
         return format_html('<br><br><pre>{}</pre>', pretty_response)
 
-    formatted_response.allow_tags = True
-
 
 @admin.register(SDNCheckFailure)
 class SDNCheckFailureAdmin(admin.ModelAdmin):


### PR DESCRIPTION
**Issue:** [BOM-1620](https://openedx.atlassian.net/browse/BOM-1620)

### Description
- Django20 removed support for `allow_tags`. 
   https://django.readthedocs.io/en/2.0.x/internals/deprecation.html