### PR TITLE
[BD-6] Run tests in python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,12 +55,12 @@ matrix:
       env:
         DJANGO_ENV=django22
         TESTNAME=quality-and-js
-        TARGETS="requirements.js check_translations_up_to_date validate_translations clean_static static quality validate_js check_keywords"
+        TARGETS="PYTHON_ENV=py38 requirements.js check_translations_up_to_date validate_translations clean_static static quality validate_js check_keywords"
     - python: 3.8
       env:
         DJANGO_ENV=django22
         TESTNAME=test-python
-        TARGETS="requirements.js clean_static static validate_python"
+        TARGETS="PYTHON_ENV=py38 requirements.js clean_static static validate_python"
       after_success:
         - pip install -U codecov
         - docker exec ecommerce_testing /edx/app/ecommerce/ecommerce/.travis/run_coverage.sh

--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,10 @@ production-requirements: requirements.js
 	pip install -r requirements.txt --exists-action w
 
 migrate: requirements.tox
-	tox -e $(PYTHON_ENV)-migrate
+	tox -e $(PYTHON_ENV)-${DJANGO_ENV_VAR}-migrate
 
 serve: requirements.tox
-	tox -e $(PYTHON_ENV)-serve
+	tox -e $(PYTHON_ENV)-${DJANGO_ENV_VAR}-serve
 
 clean:
 	find . -name '*.pyc' -delete
@@ -66,10 +66,10 @@ run_check_isort: requirements.tox
 	tox -e $(PYTHON_ENV)-check_isort
 
 run_isort: requirements.tox
-	tox -e $(PYTHON_ENV)-run_isort
+	tox -e $(PYTHON_ENV)-${DJANGO_ENV_VAR}-run_isort
 
 run_pycodestyle: requirements.tox
-	tox -e $(PYTHON_ENV)-pycodestyle
+	tox -e $(PYTHON_ENV)-${DJANGO_ENV_VAR}-pycodestyle
 
 run_pep8: run_pycodestyle
 
@@ -110,13 +110,13 @@ e2e: requirements.tox
 	tox -e $(PYTHON_ENV)-e2e
 
 extract_translations: requirements.tox
-	tox -e $(PYTHON_ENV)-extract_translations
+	tox -e $(PYTHON_ENV)-${DJANGO_ENV_VAR}-extract_translations
 
 dummy_translations: requirements.tox
-	tox -e $(PYTHON_ENV)-dummy_translations
+	tox -e $(PYTHON_ENV)-${DJANGO_ENV_VAR}-dummy_translations
 
 compile_translations: requirements.tox
-	tox -e $(PYTHON_ENV)-compile_translations
+	tox -e $(PYTHON_ENV)-${DJANGO_ENV_VAR}-compile_translations
 
 fake_translations: extract_translations dummy_translations compile_translations
 
@@ -130,13 +130,13 @@ update_translations: pull_translations fake_translations
 
 # extract_translations should be called before this command can detect changes
 detect_changed_source_translations: requirements.tox
-	tox -e $(PYTHON_ENV)-detect_changed_translations
+	tox -e $(PYTHON_ENV)-${DJANGO_ENV_VAR}-detect_changed_translations
 
 check_translations_up_to_date: fake_translations detect_changed_source_translations
 
 # Validate translations
 validate_translations: requirements.tox
-	tox -e $(PYTHON_ENV)-validate_translations
+	tox -e $(PYTHON_ENV)-${DJANGO_ENV_VAR}-validate_translations
 
 # Scan the Django models in all installed apps in this project for restricted field names
 check_keywords: requirements.tox

--- a/ecommerce/extensions/api/tests/test_serializers.py
+++ b/ecommerce/extensions/api/tests/test_serializers.py
@@ -100,10 +100,11 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
                 self.LOGGER_NAME,
                 'ERROR',
                 '[Offer Assignment] Email for offer_assignment_id: {} with greeting \'{}\' and closing \'{}\' raised '
-                'exception: Exception(\'Ignore me - assignment\',)'.format(
+                'exception: {}'.format(
                     self.offer_assignment.id,
                     self.GREETING,
                     self.CLOSING,
+                    repr(Exception('Ignore me - assignment'))
                 )
             ),
         ]
@@ -127,10 +128,11 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
                 self.LOGGER_NAME,
                 'ERROR',
                 '[Offer Reminder] Email for offer_assignment_id: {} with greeting \'{}\' and closing \'{}\' raised '
-                'exception: Exception(\'Ignore me - reminder\',)'.format(
+                'exception: {}'.format(
                     self.offer_assignment.id,
                     self.GREETING,
                     self.CLOSING,
+                    repr(Exception('Ignore me - reminder'))
                 )
             ),
         ]

--- a/ecommerce/extensions/api/v2/tests/views/test_assignmentemail.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_assignmentemail.py
@@ -13,6 +13,7 @@ from ecommerce.extensions.offer.constants import OFFER_ASSIGNED, OFFER_ASSIGNMEN
 from ecommerce.extensions.offer.models import OfferAssignment, OfferAssignmentEmailAttempt
 from ecommerce.extensions.test import factories
 from ecommerce.tests.testcases import TestCase
+from ecommerce.tests.utils import DoesNotExist
 
 
 @ddt.ddt
@@ -52,7 +53,7 @@ class AssignmentEmailStatusTests(TestCase):
                 'error': 'OfferAssignment matching query does not exist.'
             },
             ("[Offer Assignment] AssignmentEmailStatus update raised: "
-             "DoesNotExist('OfferAssignment matching query does not exist.',)"),
+             "{}".format(repr(DoesNotExist('OfferAssignment matching query does not exist.')))),
             500,
         ),
         (
@@ -85,7 +86,7 @@ class AssignmentEmailStatusTests(TestCase):
         requisite keys are not present in offer_assignment model
         """
         log_name = 'ecommerce.extensions.api.v2.views.assignmentemail'
-        with LogCapture(level=logging.INFO) as log:
+        with LogCapture(log_name, level=logging.INFO) as log:
             response = self.client.post(self.path, data=json.dumps(post_data), content_type='application/json')
         log.check_present(
             (log_name, 'ERROR', log_data),

--- a/ecommerce/tests/utils.py
+++ b/ecommerce/tests/utils.py
@@ -1,0 +1,11 @@
+"""
+Utils used in tests
+"""
+
+
+class DoesNotExist(Exception):
+    """
+    Exception used in the test to get the
+     representation of the DoesNotExist
+     exception raised by the django models.
+    """

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ testpaths = ecommerce
 envdir=
     # Use the same environment for all commands running under a specific python version
     py35: {toxworkdir}/py35
+    py38: {toxworkdir}/py38
 passenv =
     CONN_MAX_AGE
     DB_ENGINE
@@ -109,3 +110,10 @@ passenv =
 deps = -r requirements/e2e.txt
 commands=
     xvfb-run --server-args="-screen 0, 1600x1200x24" pytest e2e --html=log/html_report.html --junitxml=e2e/xunit.xml
+
+[testenv:py38-e2e]
+envdir = {toxworkdir}/{envname}
+passenv = {[testenv:py35-e2e]passenv}
+deps = {[testenv:py35-e2e]deps}
+commands = {[testenv:py35-e2e35-e2e35-e2e
+


### PR DESCRIPTION
Run and fix tests in python3.8.

This chages were done in order to pass the tests:

Specify version of django used in several tox commands like: validate_translations,  extract_translations, compile_translations... because in python 3.8 if that is not define it uses Django3.0 which is currently failing.

Change tests to use the right representation of the exception of the version of python (Changed in python 3.7) https://bugs.python.org/issue30399

