### PR TITLE
ENT-2910 | Create a management command to refund duplicate

### DIFF
--- a/ecommerce/extensions/order/management/commands/create_refund_for_orders.py
+++ b/ecommerce/extensions/order/management/commands/create_refund_for_orders.py
@@ -1,19 +1,29 @@
 """
 This command generates refunds for orders.
+./manage.py create_refund_for_orders --order-numbers-file=order_numbers_file.txt
+./manage.py create_refund_for_orders --order-numbers-file=order_numbers_file.txt --refund-duplicate-only
+./manage.py create_refund_for_orders --order-numbers-file=order_numbers_file.txt --refund-duplicate-only  --no-commit
+./manage.py create_refund_for_orders --order-numbers-file=order_numbers_file.txt --refund-duplicate-only  --sleep-time=1
 """
 from __future__ import absolute_import, unicode_literals
 
 import logging
 import os
+import time
 
 from django.core.management import BaseCommand, CommandError
 from django.db.utils import IntegrityError
 from oscar.core.loading import get_model
+from requests import Timeout
+from slumber.exceptions import HttpServerError, SlumberBaseException
+
+from ecommerce.courses.utils import get_course_info_from_catalog
 
 logger = logging.getLogger(__name__)
 
 Order = get_model('order', 'Order')
 OrderLine = get_model('order', 'Line')
+Product = get_model('catalogue', 'Product')
 Refund = get_model('refund', 'Refund')
 
 
@@ -39,24 +49,75 @@ class Command(BaseCommand):
             help='Path of the file to read order numbers from.',
             type=str,
         )
+        parser.add_argument(
+            '--refund-duplicate-only',
+            action='store_true',
+            dest='refund_duplicate_only',
+            default=False,
+            help='Refund duplicate orders bought by the user via course entitlement form.',
+        )
+        parser.add_argument(
+            '--no-commit',
+            action='store_true',
+            dest='no_commit',
+            default=False,
+            help='Dry Run, print log messages without committing anything.',
+        )
+        parser.add_argument(
+            '--sleep-time',
+            action='store',
+            dest='sleep_time',
+            type=float,
+            default=0.0,
+            help='Sleep time in seconds after executing each order from file.'
+        )
 
     def handle(self, *args, **options):
         order_numbers_file = options[str('order_numbers_file')]
-        total_orders, failed_orders = 0, None
-        if order_numbers_file:
-            if not os.path.exists(order_numbers_file):
-                raise CommandError(
-                    'Pass the correct absolute path to order numbers file as --order-numbers-file argument.'
-                )
-            total_orders, failed_orders = self._create_refunds_from_file(order_numbers_file)
-        if failed_orders:
+        remove_duplicate_only = options['refund_duplicate_only']
+        should_commit = not options['no_commit']
+        sleep_time = options['sleep_time']
+
+        if not order_numbers_file or not os.path.exists(order_numbers_file):
+            raise CommandError(
+                'Pass the correct absolute path to order numbers file as --order-numbers-file argument.'
+            )
+        total_orders, failed_orders, skipped_orders = self._create_refunds_from_file(
+            order_numbers_file,
+            remove_duplicate_only,
+            should_commit,
+            sleep_time,
+        )
+        if failed_orders or skipped_orders:
             logger.error(
-                u'[Ecommerce Order Refund]: Completed refund generation. %d of %d failed. '
-                u'Failed orders: \n%s', len(failed_orders), total_orders, '\n'.join(failed_orders))
+                u'[Ecommerce Order Refund]: Completed refund generation. %d of %d failed and %d skipped.\n'
+                u'Failed orders: %s\n'
+                u'Skipped orders: %s\n',
+                len(failed_orders),
+                total_orders,
+                len(skipped_orders),
+                '\n'.join(failed_orders),
+                '\n'.join(skipped_orders),
+            )
         else:
             logger.info(u'[Ecommerce Order Refund] Generated refunds for the batch of %d orders.', total_orders)
 
-    def _create_refunds_from_file(self, order_numbers_file):
+    def _already_enrolled_in_course_entitlement(self, seat_product, user, site):
+        """
+        Check if the user is enrolled in course entitlement for given seat product.
+        :return: True if enrolled
+        """
+        course_uuid = get_course_info_from_catalog(site, seat_product)['course_uuid']
+        user_bought_product_ids = OrderLine.objects.filter(
+            order__in=user.orders.all()
+        ).values_list('product', flat=True)
+        return Product.objects.filter(
+            pk__in=user_bought_product_ids,
+            attributes__code='UUID',
+            attribute_values__value_text=course_uuid,
+        ).exists()
+
+    def _create_refunds_from_file(self, order_numbers_file, refund_duplicate_only, should_commit, sleep_time):
         """
         Generate refunds for the orders provided in the order numbers file.
 
@@ -68,6 +129,7 @@ class Command(BaseCommand):
             order numbers whose refunds could not be generated.
         """
         failed_orders = []
+        skipped_orders = []
 
         with open(order_numbers_file, 'r') as file_handler:
             order_numbers = file_handler.readlines()
@@ -77,12 +139,24 @@ class Command(BaseCommand):
                 try:
                     order_number = order_number.strip()
                     order = Order.objects.get(number=order_number)
-                    refund = Refund.create_with_lines(order, list(order.lines.all()))
-                    if refund is None:
-                        raise RefundError
-                except (Order.DoesNotExist, RefundError, IntegrityError) as e:
+
+                    if refund_duplicate_only:
+                        seat_product = order.lines.first().product
+                        if not self._already_enrolled_in_course_entitlement(seat_product, order.user, order.site):
+                            skipped_orders.append(order_number)
+                            continue
+                    if should_commit:
+                        refund = Refund.create_with_lines(order, list(order.lines.all()))
+                        if refund is None:
+                            raise RefundError
+                except (Order.DoesNotExist, RefundError, IntegrityError, SlumberBaseException, ConnectionError,
+                        Timeout, HttpServerError) as e:
                     failed_orders.append(order_number)
-                    logger.error(
+                    logger.exception(
                         u'[Ecommerce Order Refund] %d/%d '
-                        u'Failed to generate refund for %s. %s', index, total_orders, order_number, str(e))
-        return total_orders, failed_orders
+                        u'Failed to generate refund for %s. %s', index, total_orders, order_number, str(e)
+                    )
+                if sleep_time:
+                    logger.info(u'Sleeping for %s second/seconds', sleep_time)
+                    time.sleep(sleep_time)
+        return total_orders, failed_orders, skipped_orders

--- a/ecommerce/extensions/order/management/commands/tests/test_create_refund_for_orders.py
+++ b/ecommerce/extensions/order/management/commands/tests/test_create_refund_for_orders.py
@@ -2,14 +2,22 @@ from __future__ import absolute_import
 
 import json
 
+import ddt
+import httpretty
 from django.contrib.auth import get_user_model
 from django.core.management import CommandError, call_command
 from django.urls import reverse
+from faker import Factory as FakerFactory
 from oscar.core.loading import get_model
+from oscar.test import factories
 from rest_framework import status
+from testfixtures import LogCapture
 
+from ecommerce.coupons.tests.mixins import DiscoveryMockMixin
 from ecommerce.courses.tests.factories import CourseFactory
+from ecommerce.entitlements.utils import create_or_update_course_entitlement
 from ecommerce.extensions.refund.status import REFUND, REFUND_LINE
+from ecommerce.extensions.test.factories import create_order
 from ecommerce.tests.testcases import TestCase
 
 Order = get_model('order', 'Order')
@@ -17,8 +25,13 @@ OrderLine = get_model('order', 'Line')
 Refund = get_model('refund', 'Refund')
 User = get_user_model()
 
+FAKER = FakerFactory.create()
+LOGGER_NAME = 'ecommerce.extensions.order.management.commands.create_refund_for_orders'
 
-class CreateRefundForOrdersTests(TestCase):
+
+@httpretty.activate
+@ddt.ddt
+class CreateRefundForOrdersTests(DiscoveryMockMixin, TestCase):
     """
     Test the `create_refund_for_orders` command.
     """
@@ -128,6 +141,66 @@ class CreateRefundForOrdersTests(TestCase):
             refund = Refund.objects.get(order=order)
             self.assert_refund_matches_order(refund, order)
 
+    @ddt.data(True, False)
+    def test_create_refund_for_duplicate_orders_only(self, commit):
+        """
+        Test that refund is generated for manual enrollment orders only if having some duplicate enrollments.
+        """
+
+        orders = self.create_manual_order()
+        filename = 'orders_file.txt'
+        self.create_orders_file(orders, filename)
+
+        # create duplicate order having course_entitlement product
+        order_with_duplicate = orders[0]
+        order_without_duplicate = orders[1]
+
+        course_uuid = FAKER.uuid4()  # pylint: disable=no-member
+        order = Order.objects.get(number=order_with_duplicate['detail'])
+        course_entitlement = create_or_update_course_entitlement(
+            'verified', 100, order.partner, course_uuid, 'Course Entitlement'
+        )
+        basket = factories.BasketFactory(owner=order.user, site=order.site)
+        basket.add_product(course_entitlement, 1)
+        create_order(basket=basket, user=order.user)
+        self.mock_access_token_response()
+        self.mock_course_run_detail_endpoint(
+            self.course,
+            discovery_api_url=order.site.siteconfiguration.discovery_api_url,
+            course_run_info={
+                'course_uuid': course_uuid
+            }
+        )
+
+        self.assertFalse(Refund.objects.exists())
+        with LogCapture(LOGGER_NAME) as log_capture:
+            params = ['create_refund_for_orders', '--order-numbers-file={}'.format(filename), '--refund-duplicate-only',
+                      '--sleep-time=0.5']
+            if not commit:
+                params.append('--no-commit')
+            call_command(*params)
+            log_capture.check_present(
+                (LOGGER_NAME, 'INFO', 'Sleeping for 0.5 second/seconds'),
+            )
+            log_capture.check_present(
+                (
+                    LOGGER_NAME,
+                    'ERROR',
+                    '[Ecommerce Order Refund]: Completed refund generation. 0 of 2 failed and 1 skipped.\n'
+                    'Failed orders: \n'
+                    'Skipped orders: {}\n'.format(order_without_duplicate['detail']),
+                ),
+            )
+        if commit:
+            self.assertEqual(Refund.objects.count(), 1)
+
+            refund = Refund.objects.get(order=order)
+            self.assert_refund_matches_order(refund, order)
+            order = Order.objects.get(number=order_without_duplicate['detail'])
+            self.assertFalse(order.refunds.exists())
+        else:
+            self.assertEqual(Refund.objects.count(), 0)
+
     def test_invalid_file_path(self):
         """
         Verify command raises the CommandError for invalid file path.
@@ -135,13 +208,8 @@ class CreateRefundForOrdersTests(TestCase):
         with self.assertRaises(CommandError):
             call_command('create_refund_for_orders', '--order-numbers-file={}'.format("invalid/order_id/file/path"))
 
-    def test_no_file_path(self):
-        """
-        Verify command does not change the Refund state without a file.
-        """
-        self.assertFalse(Refund.objects.exists())
-        call_command('create_refund_for_orders')
-        self.assertFalse(Refund.objects.exists())
+        with self.assertRaises(CommandError):
+            call_command('create_refund_for_orders')
 
     def test_create_refund_order_does_not_exist(self):
         """


### PR DESCRIPTION
updated refund management command and added a param to refund new duplicate orders which users already have brought in the program

also added `--no-commit` argument in command to test command without saving anything.

We will provide a file with all order numbers that were created using manual order enrollments.
there are 5K order numbers

the input file has been attached in the ticket
https://openedx.atlassian.net/browse/ENT-2910