### PR TITLE
Revert "Set max_effected_items to null for new offers (#2960)"

### DIFF
--- a/ecommerce/extensions/api/v2/views/orders.py
+++ b/ecommerce/extensions/api/v2/views/orders.py
@@ -436,6 +436,7 @@ class ManualCourseEnrollmentOrderViewSet(EdxOrderPlacementMixin, ViewSet):
         benefit, _ = Benefit.objects.get_or_create(
             proxy_class=class_path(ManualEnrollmentOrderDiscountBenefit),
             value=100,
+            max_affected_items=1,
         )
 
         offer_kwargs = {

--- a/ecommerce/extensions/test/factories.py
+++ b/ecommerce/extensions/test/factories.py
@@ -273,6 +273,7 @@ class ManualEnrollmentOrderDiscountBenefitFactory(BenefitFactory):
     range = None
     type = ''
     value = 100
+    max_affected_items = 1
     proxy_class = class_path(ManualEnrollmentOrderDiscountBenefit)
 
 

--- a/ecommerce/extensions/voucher/tests/test_utils.py
+++ b/ecommerce/extensions/voucher/tests/test_utils.py
@@ -233,7 +233,6 @@ class UtilTests(CouponMixin, DiscoveryMockMixin, DiscoveryTestMixin, LmsApiMockM
         coupon_voucher.vouchers.add(*vouchers)
 
         self.assertEqual(voucher_offer.benefit.type, Benefit.PERCENTAGE)
-        self.assertEqual(voucher_offer.benefit.max_affected_items, None)
         self.assertEqual(voucher_offer.benefit.value, 100.00)
         self.assertEqual(voucher_offer.benefit.range.catalog, self.catalog)
         self.assertEqual(voucher_offer.email_domains, email_domains)

--- a/ecommerce/extensions/voucher/utils.py
+++ b/ecommerce/extensions/voucher/utils.py
@@ -416,6 +416,7 @@ def _get_or_create_offer(
                 range=product_range,
                 type=benefit_type,
                 value=Decimal(benefit_value),
+                max_affected_items=1,
             )
 
     except (TypeError, DecimalException):  # If the benefit_value parameter is not sent TypeError will be raised
@@ -470,6 +471,7 @@ def get_or_create_enterprise_offer(
     benefit, _ = Benefit.objects.get_or_create(
         proxy_class=class_path(ENTERPRISE_BENEFIT_MAP[benefit_type]),
         value=benefit_value,
+        max_affected_items=1,
     )
 
     offer_kwargs = {


### PR DESCRIPTION
This reverts commit 959090f1dc66ba6975b813bb65cde297a8c67d7d.

We believe this is resulting in the failure to create enterprise coupons, possibly any coupons, as described in: https://openedx.atlassian.net/browse/ENT-2935