### PR TITLE
ENT-2870 | optimized get_not_redeemed_usage method in a single query.

### DIFF
--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -414,9 +414,9 @@ class EnterpriseCouponViewSet(CouponViewSet):
         users_having_usages = VoucherApplication.objects.filter(
             voucher__in=vouchers).values_list('user__email', flat=True)
         return OfferAssignment.objects.filter(
-                code__in=vouchers.values_list('code', flat=True),
-                status__in=[OFFER_ASSIGNED, OFFER_ASSIGNMENT_EMAIL_PENDING],
-                user_email__in=users_having_usages
+            code__in=vouchers.values_list('code', flat=True),
+            status__in=[OFFER_ASSIGNED, OFFER_ASSIGNMENT_EMAIL_PENDING],
+            user_email__in=users_having_usages
         ).values('code', 'user_email').order_by('user_email').distinct()
 
     def _get_redeemed_usages(self, vouchers):

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -436,7 +436,6 @@ class EnterpriseCouponViewSet(CouponViewSet):
             user__email__in=unredeemed_voucher_assignments.values_list('user_email', flat=True)
         ).values('voucher__code', 'user__email').order_by('user__email').distinct()
 
-
     @action(detail=False, url_path=r'(?P<enterprise_id>.+)/search', permission_classes=[IsAuthenticated])
     @permission_required('enterprise.can_view_coupon', fn=lambda request, enterprise_id: enterprise_id)
     def search(self, request, enterprise_id):     # pylint: disable=unused-argument


### PR DESCRIPTION
all new 3 refactored methods are consuming calls ranging from 10 to 14.