### PR TITLE
Usamasadiq/removing-six-I

### DIFF
--- a/e2e/test_hubspot_forms_submission.py
+++ b/e2e/test_hubspot_forms_submission.py
@@ -1,7 +1,8 @@
 
 
+from urllib.parse import urlencode
+
 import requests
-from six.moves.urllib.parse import urlencode
 
 from e2e.config import HUBSPOT_FORMS_API_URI, HUBSPOT_PORTAL_ID, HUBSPOT_SALES_LEAD_FORM_GUID
 

--- a/ecommerce/core/management/commands/sync_hubspot.py
+++ b/ecommerce/core/management/commands/sync_hubspot.py
@@ -15,7 +15,6 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db.models import Q
 from edx_rest_api_client.client import EdxRestApiClient
 from oscar.core.loading import get_class, get_model
-from six.moves import range
 from slumber.exceptions import HttpClientError, HttpServerError
 
 from ecommerce.extensions.fulfillment.status import ORDER

--- a/ecommerce/core/management/commands/tests/test_sync_hubspot.py
+++ b/ecommerce/core/management/commands/tests/test_sync_hubspot.py
@@ -4,10 +4,10 @@ Test the sync_hubspot management command
 
 
 from datetime import datetime, timedelta
+from io import StringIO
 
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from django.utils.six import StringIO
 from factory.django import get_model
 from mock import patch
 from slumber.exceptions import HttpClientError

--- a/ecommerce/core/management/commands/tests/test_verify_transactions.py
+++ b/ecommerce/core/management/commands/tests/test_verify_transactions.py
@@ -7,7 +7,6 @@ import datetime
 
 import ddt
 import pytz
-import six
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from oscar.core.loading import get_class, get_model
@@ -45,7 +44,7 @@ class VerifyTransactionsTest(TestCase):
         """ Test verify_transactions only examines the correct time window """
         with self.assertRaises(CommandError) as cm:
             call_command('verify_transactions')
-        exception = six.text_type(cm.exception)
+        exception = str(cm.exception)
         self.assertIn("The following orders are without payments", exception)
         self.assertIn(str(self.order.id), exception)
 
@@ -78,7 +77,7 @@ class VerifyTransactionsTest(TestCase):
         # self.order fixture should still have no payment
         with self.assertRaises(CommandError) as cm:
             call_command('verify_transactions')
-        exception = six.text_type(cm.exception)
+        exception = str(cm.exception)
         self.assertIn("The following orders are without payments", exception)
         self.assertIn(str(self.order.id), exception)
 
@@ -94,7 +93,7 @@ class VerifyTransactionsTest(TestCase):
 
         with self.assertRaises(CommandError) as cm:
             call_command('verify_transactions', '--threshold=0.2')
-        exception = six.text_type(cm.exception)
+        exception = str(cm.exception)
         self.assertIn("The following orders are without payments", exception)
         self.assertIn(str(self.order.id), exception)
 
@@ -132,7 +131,7 @@ class VerifyTransactionsTest(TestCase):
         """ Verify errors are thrown when there are valid product orders without payments """
         with self.assertRaises(CommandError) as cm:
             call_command('verify_transactions')
-        exception = six.text_type(cm.exception)
+        exception = str(cm.exception)
         self.assertIn("The following orders are without payments", exception)
         self.assertIn(str(self.order.id), exception)
 
@@ -164,7 +163,7 @@ class VerifyTransactionsTest(TestCase):
         payment2.save()
         with self.assertRaises(CommandError) as cm:
             call_command('verify_transactions')
-        exception = six.text_type(cm.exception)
+        exception = str(cm.exception)
         self.assertIn("The following orders had multiple payments", exception)
         self.assertIn(str(self.order.id), exception)
         self.assertIn(str(payment1.id), exception)
@@ -189,7 +188,7 @@ class VerifyTransactionsTest(TestCase):
         payment3.save()
         with self.assertRaises(CommandError) as cm:
             call_command('verify_transactions')
-        exception = six.text_type(cm.exception)
+        exception = str(cm.exception)
         self.assertIn("The following orders had multiple payments", exception)
         self.assertIn(str(self.order.id), exception)
         self.assertIn(str(payment1.id), exception)
@@ -206,7 +205,7 @@ class VerifyTransactionsTest(TestCase):
         payment.save()
         with self.assertRaises(CommandError) as cm:
             call_command('verify_transactions')
-        exception = six.text_type(cm.exception)
+        exception = str(cm.exception)
         self.assertIn("The following order totals mismatch payments received", exception)
         self.assertIn(str(self.order.id), exception)
         self.assertIn(str(payment.id), exception)
@@ -223,7 +222,7 @@ class VerifyTransactionsTest(TestCase):
         payment.save()
         with self.assertRaises(CommandError) as cm:
             call_command('verify_transactions', '--support')
-        exception = six.text_type(cm.exception)
+        exception = str(cm.exception)
         self.assertTrue(payment.amount != self.order.total_incl_tax)
         self.assertIn("There was a mismatch in the totals in the following order that require a refund", exception)
         self.assertIn("orders_mismatched_totals_support", exception)
@@ -247,7 +246,7 @@ class VerifyTransactionsTest(TestCase):
         refund.save()
         with self.assertRaises(CommandError) as cm:
             call_command('verify_transactions')
-        exception = six.text_type(cm.exception)
+        exception = str(cm.exception)
         self.assertIn("The following orders had excessive refunds", exception)
         self.assertIn(str(self.order.id), exception)
         self.assertIn(str(refund.id), exception)

--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -3,8 +3,8 @@
 import datetime
 import hashlib
 import logging
+from urllib.parse import urljoin, urlsplit
 
-import six  # pylint: disable=ungrouped-imports
 import waffle
 from analytics import Client as SegmentClient
 from dateutil.parser import parse
@@ -24,7 +24,6 @@ from jsonfield.fields import JSONField
 from requests.exceptions import ConnectionError as ReqConnectionError
 from requests.exceptions import Timeout
 from simple_history.models import HistoricalRecords
-from six.moves.urllib.parse import urljoin, urlsplit
 from slumber.exceptions import HttpNotFoundError, SlumberBaseException
 
 from ecommerce.core.constants import ALL_ACCESS_CONTEXT, ALLOW_MISSING_LMS_USER_ID
@@ -245,7 +244,7 @@ class SiteConfiguration(models.Model):
                     self.site.id,
                     name
                 )
-                raise ValidationError(six.text_type(exc))
+                raise ValidationError(str(exc))
 
     def _clean_client_side_payment_processor(self):
         """

--- a/ecommerce/core/tests/test_create_demo_data.py
+++ b/ecommerce/core/tests/test_create_demo_data.py
@@ -2,12 +2,12 @@
 
 import sys
 from datetime import datetime
+from io import StringIO
 
 import httpretty
 import mock
 import pytz
 from django.core.management import call_command
-from django.utils.six import StringIO
 
 from ecommerce.courses.models import Course
 from ecommerce.courses.tests.factories import CourseFactory

--- a/ecommerce/core/tests/test_generate_courses.py
+++ b/ecommerce/core/tests/test_generate_courses.py
@@ -6,7 +6,6 @@ import ddt
 import httpretty
 import mock
 from django.core.management import CommandError, call_command
-from six import assertRaisesRegex
 
 from ecommerce.courses.models import Course
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
@@ -20,7 +19,7 @@ class GenerateCoursesTests(DiscoveryTestMixin, TestCase):
         """
         Test that providing an invalid JSON object will raise the appropriate command error
         """
-        with assertRaisesRegex(self, CommandError, "Invalid JSON object"):
+        with self.assertRaisesRegex(CommandError, "Invalid JSON object"):
             arg = 'invalid_json'
             call_command("generate_courses", arg)
 
@@ -28,7 +27,7 @@ class GenerateCoursesTests(DiscoveryTestMixin, TestCase):
         """
         Test that missing the courses key will raise the appropriate command error
         """
-        with assertRaisesRegex(self, CommandError, "JSON object is missing courses list"):
+        with self.assertRaisesRegex(CommandError, "JSON object is missing courses list"):
             arg = ('{}')
             call_command("generate_courses", arg)
 

--- a/ecommerce/core/utils.py
+++ b/ecommerce/core/utils.py
@@ -1,12 +1,12 @@
 
 
 import logging
+from urllib.parse import parse_qs, urlparse
 
 import waffle
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from edx_django_utils.cache import get_cache_key as get_django_cache_key
-from six.moves.urllib.parse import parse_qs, urlparse
 
 logger = logging.getLogger(__name__)
 

--- a/ecommerce/programs/tests/mixins.py
+++ b/ecommerce/programs/tests/mixins.py
@@ -4,7 +4,6 @@ import json
 from decimal import Decimal
 
 import httpretty
-from six.moves import range
 
 from ecommerce.core.url_utils import get_lms_enrollment_api_url, get_lms_entitlement_api_url
 from ecommerce.courses.tests.factories import CourseFactory

--- a/ecommerce/referrals/tests/test_add_site_to_referrals.py
+++ b/ecommerce/referrals/tests/test_add_site_to_referrals.py
@@ -1,6 +1,7 @@
 
 
-import six
+from io import StringIO
+
 from django.core.management import CommandError, call_command
 
 from ecommerce.referrals.models import Referral
@@ -21,7 +22,7 @@ class AddSiteToReferralsCommandTests(TestCase):
         expected = queryset.count()
 
         # Call the command with dry-run flag
-        out = six.StringIO()
+        out = StringIO()
         call_command(self.command, site_id=self.site.id, commit=False, stdout=out)
 
         # Verify no referrals affected
@@ -46,7 +47,7 @@ class AddSiteToReferralsCommandTests(TestCase):
         self.assertEqual(queryset.count(), 0)
 
         # Call the command
-        out = six.StringIO()
+        out = StringIO()
         call_command(self.command, site_id=self.site.id, commit=True, stdout=out)
 
         # The referrals should be associated with the site

--- a/ecommerce/settings/local.py
+++ b/ecommerce/settings/local.py
@@ -1,8 +1,9 @@
 """Development settings and globals."""
 
 
+from urllib.parse import urljoin
+
 from corsheaders.defaults import default_headers as corsheaders_default_headers
-from six.moves.urllib.parse import urljoin
 
 from ecommerce.settings.base import *
 

--- a/ecommerce/settings/production.py
+++ b/ecommerce/settings/production.py
@@ -3,14 +3,13 @@
 
 import codecs
 from os import environ
+from urllib.parse import urljoin
 
-import six
 import yaml
 from corsheaders.defaults import default_headers as corsheaders_default_headers
 # Normally you should not import ANYTHING from Django directly
 # into your settings, but ImproperlyConfigured is an exception.
 from django.core.exceptions import ImproperlyConfigured
-from six.moves.urllib.parse import urljoin
 
 from ecommerce.settings.base import *
 
@@ -77,7 +76,7 @@ DB_OVERRIDES = dict(
     PORT=environ.get('DB_MIGRATION_PORT', DATABASES['default']['PORT']),
 )
 
-for override, value in six.iteritems(DB_OVERRIDES):
+for override, value in DB_OVERRIDES.items():
     DATABASES['default'][override] = value
 
 for key, value in LOGGING_ROOT_OVERRIDES.items():
@@ -99,8 +98,8 @@ for section, overrides in LOGGING_SUBSECTION_OVERRIDES.items():
 
 
 # PAYMENT PROCESSOR OVERRIDES
-for __, configs in six.iteritems(PAYMENT_PROCESSOR_CONFIG):
-    for __, config in six.iteritems(configs):
+for __, configs in PAYMENT_PROCESSOR_CONFIG.items():
+    for __, config in configs.items():
         config.update({
             'receipt_path': PAYMENT_PROCESSOR_RECEIPT_PATH,
             'cancel_checkout_path': PAYMENT_PROCESSOR_CANCEL_PATH,

--- a/ecommerce/settings/test.py
+++ b/ecommerce/settings/test.py
@@ -1,7 +1,8 @@
 
 
+from urllib.parse import urljoin
+
 from path import Path
-from six.moves.urllib.parse import urljoin
 
 from ecommerce.settings.base import *
 

--- a/ecommerce/theming/finders.py
+++ b/ecommerce/theming/finders.py
@@ -24,7 +24,6 @@ from collections import OrderedDict
 
 from django.contrib.staticfiles import utils
 from django.contrib.staticfiles.finders import BaseFinder
-from django.utils import six
 
 from ecommerce.theming.helpers import get_themes
 from ecommerce.theming.storage import ThemeStorage
@@ -67,7 +66,7 @@ class ThemeFilesFinder(BaseFinder):
         """
         List all files in all theme storages.
         """
-        for storage in six.itervalues(self.storages):
+        for storage in self.storages.values():
             if storage.exists(''):  # check if storage location exists
                 for path in utils.get_files(storage, ignore_patterns):
                     yield path, storage

--- a/ecommerce/theming/helpers.py
+++ b/ecommerce/theming/helpers.py
@@ -6,7 +6,6 @@
 import logging
 import os
 
-import six
 import waffle
 from django.conf import ImproperlyConfigured, settings
 from path import Path
@@ -154,7 +153,7 @@ def get_theme_base_dirs():
 
     if not isinstance(theme_dirs, list):
         raise ImproperlyConfigured("COMPREHENSIVE_THEME_DIRS must be a list.")
-    if not all([isinstance(theme_dir, six.string_types) for theme_dir in theme_dirs]):
+    if not all([isinstance(theme_dir, str) for theme_dir in theme_dirs]):
         raise ImproperlyConfigured("COMPREHENSIVE_THEME_DIRS must contain only strings.")
     if not all([theme_dir.startswith("/") for theme_dir in theme_dirs]):
         raise ImproperlyConfigured("COMPREHENSIVE_THEME_DIRS must contain only absolute paths to themes dirs.")

--- a/ecommerce/theming/management/commands/tests/test_update_assets.py
+++ b/ecommerce/theming/management/commands/tests/test_update_assets.py
@@ -3,7 +3,6 @@ Tests for Management commands of comprehensive theming.
 """
 
 
-import six
 from django.conf import settings
 from django.core.management import CommandError, call_command
 from django.test import override_settings
@@ -111,7 +110,7 @@ class TestUpdateAssets(TestCase):
         ]
 
         returned_dirs = get_sass_directories(themes=self.themes, system=True)
-        six.assertCountEqual(self, expected_directories, returned_dirs)
+        self.assertCountEqual(expected_directories, returned_dirs)
 
     def test_get_sass_directories_with_no_themes(self):
         """
@@ -127,7 +126,7 @@ class TestUpdateAssets(TestCase):
         ]
 
         returned_dirs = get_sass_directories(themes=[], system=True)
-        six.assertCountEqual(self, expected_directories, returned_dirs)
+        self.assertCountEqual(expected_directories, returned_dirs)
 
     def test_non_existent_sass_dir_error(self):
         """

--- a/ecommerce/theming/tests/test_core.py
+++ b/ecommerce/theming/tests/test_core.py
@@ -3,7 +3,6 @@ Comprehensive Theming tests for core functionality.
 """
 
 
-import six
 from django.conf import settings
 from django.test import override_settings
 from path import Path
@@ -31,7 +30,7 @@ class TestCore(TestCase):
 
         enable_theming()
 
-        six.assertCountEqual(self, expected_locale_paths, settings.LOCALE_PATHS)
+        self.assertCountEqual(expected_locale_paths, settings.LOCALE_PATHS)
 
     def test_enable_theming_red_theme(self):
         """

--- a/ecommerce/theming/tests/test_helpers.py
+++ b/ecommerce/theming/tests/test_helpers.py
@@ -3,7 +3,6 @@ Tests of comprehensive theming.
 """
 
 
-import six
 from django.conf import ImproperlyConfigured, settings
 from django.test import override_settings
 from mock import patch
@@ -37,7 +36,7 @@ class TestHelpers(TestCase):
             Theme('test-theme-3', 'test-theme-3', theme_dirs[1]),
         ]
         actual_themes = get_themes()
-        six.assertCountEqual(self, expected_themes, actual_themes)
+        self.assertCountEqual(expected_themes, actual_themes)
 
     def test_get_themes_with_theming_disabled(self):
         """
@@ -45,7 +44,7 @@ class TestHelpers(TestCase):
         """
         with override_settings(ENABLE_COMPREHENSIVE_THEMING=False):
             actual_themes = get_themes()
-            six.assertCountEqual(self, [], actual_themes)
+            self.assertCountEqual([], actual_themes)
 
     @with_comprehensive_theme('test-theme')
     def test_current_theme_path(self):
@@ -54,7 +53,7 @@ class TestHelpers(TestCase):
         """
         theme = get_current_theme()
         self.assertEqual(theme.path, settings.DJANGO_ROOT + "/tests/themes/test-theme")
-        self.assertIn(theme.path, six.text_type(theme))
+        self.assertIn(theme.path, str(theme))
 
     @with_comprehensive_theme('test-theme-2')
     def test_current_theme_path_2(self):
@@ -155,7 +154,7 @@ class TestHelpers(TestCase):
             themes_dir / "test-theme" / "templates" / "oscar",
         ]
         actual_theme_dirs = get_current_theme().template_dirs
-        six.assertCountEqual(self, expected_theme_dirs, actual_theme_dirs)
+        self.assertCountEqual(expected_theme_dirs, actual_theme_dirs)
 
     def test_get_all_theme_template_dirs(self):
         """
@@ -172,7 +171,7 @@ class TestHelpers(TestCase):
             themes_dirs[1] / "test-theme-3" / "templates" / "oscar",
         ]
         actual_theme_dirs = get_all_theme_template_dirs()
-        six.assertCountEqual(self, expected_theme_dirs, actual_theme_dirs)
+        self.assertCountEqual(expected_theme_dirs, actual_theme_dirs)
 
     def test_get_theme_base_dir(self):
         """


### PR DESCRIPTION
**Issue:** [BOM-1713](https://openedx.atlassian.net/browse/BOM-1713)

### Description
- package `six` is used for making `python2&3` compatible code so it is not required after upgrading to `python3`.
- This is part 1 of the multiple PRs made for removing all the uses of package six completely. 