### PR TITLE
ENT-3057 | updated _get_not_redeemed_usages() method

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -635,9 +635,9 @@ class EnterpriseCouponViewSetRbacTests(
     @ddt.data(
         {
             'voucher_type': Voucher.SINGLE_USE,
-            'quantity': 3,
+            'quantity': 4,
             'max_uses': None,
-            'code_assignments': {'user1@example.com': 1},
+            'code_assignments': {'user1@example.com': 1, 'user2@example.com': 3},
             'code_redemptions': {'user2@example.com': {'code': 2, 'num': 1}},
             'expected_responses': {
                 VOUCHER_NOT_ASSIGNED: [
@@ -646,6 +646,8 @@ class EnterpriseCouponViewSetRbacTests(
                 ],
                 VOUCHER_NOT_REDEEMED: [
                     {'code': 1, 'assigned_to': 'user1@example.com', 'redemptions': {'used': 0, 'total': 1},
+                     'assignment_date': '', 'last_reminder_date': '', 'revocation_date': ''},
+                    {'code': 3, 'assigned_to': 'user2@example.com', 'redemptions': {'used': 0, 'total': 1},
                      'assignment_date': '', 'last_reminder_date': '', 'revocation_date': ''}
                 ],
                 VOUCHER_PARTIAL_REDEEMED: [],

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -441,7 +441,7 @@ class EnterpriseCouponViewSet(CouponViewSet):
         prefetch_related_objects(vouchers, 'applications', 'offers', 'offers__condition', 'offers__offerassignment_set')
         not_redeemed_assignments = []
         for voucher in vouchers:
-            assignments = voucher.get_not_redeemed_assignment_ids
+            assignments = voucher.not_redeemed_assignment_ids
             if assignments:
                 not_redeemed_assignments.extend(assignments)
 

--- a/ecommerce/extensions/voucher/models.py
+++ b/ecommerce/extensions/voucher/models.py
@@ -136,7 +136,7 @@ class Voucher(AbstractVoucher):
         return self.calculate_available_slots(enterprise_offer.max_global_applications, num_assignments)
 
     @property
-    def get_not_redeemed_assignment_ids(self):
+    def not_redeemed_assignment_ids(self):
         """Returns offer assignments ids for the voucher that are available for redemption."""
         enterprise_offer = self.enterprise_offer
         # Assignment is only valid for Vouchers linked to an enterprise offer.

--- a/ecommerce/extensions/voucher/models.py
+++ b/ecommerce/extensions/voucher/models.py
@@ -135,6 +135,24 @@ class Voucher(AbstractVoucher):
 
         return self.calculate_available_slots(enterprise_offer.max_global_applications, num_assignments)
 
+    @property
+    def get_not_redeemed_assignment_ids(self):
+        """Returns offer assignments ids for the voucher that are available for redemption."""
+        enterprise_offer = self.enterprise_offer
+        # Assignment is only valid for Vouchers linked to an enterprise offer.
+        if not enterprise_offer:
+            return None
+        users_having_usages = self.applications.values_list('user__email', flat=True)
+
+        not_redeemed_assignments = []
+        for assignment in enterprise_offer.offerassignment_set.all():
+            if assignment.code == self.code \
+                    and assignment.status not in [OFFER_REDEEMED, OFFER_ASSIGNMENT_REVOKED] \
+                    and assignment.user_email not in users_having_usages:
+                not_redeemed_assignments.append(assignment.id)
+
+        return not_redeemed_assignments
+
     def calculate_available_slots(self, max_global_applications, num_assignments):
         """
         Calculate the number of available slots left for this voucher.

--- a/ecommerce/extensions/voucher/tests/test_models.py
+++ b/ecommerce/extensions/voucher/tests/test_models.py
@@ -131,6 +131,11 @@ class VoucherTests(TestCase):
         voucher = Voucher.objects.create(**self.data)
         assert not voucher.slots_available_for_assignment
 
+    def test_get_not_redeemed_assignment_ids_with_non_enterprise_offer(self):
+        """ Verify that a voucher with no enterprise offer returns none for get_not_redeemed_assignment_ids. """
+        voucher = Voucher.objects.create(**self.data)
+        assert not voucher.get_not_redeemed_assignment_ids
+
     @ddt.data(
         (Voucher.SINGLE_USE, 0, None, [], 1),
         (Voucher.MULTI_USE_PER_CUSTOMER, 0, 10, [], 10),

--- a/ecommerce/extensions/voucher/tests/test_models.py
+++ b/ecommerce/extensions/voucher/tests/test_models.py
@@ -131,10 +131,10 @@ class VoucherTests(TestCase):
         voucher = Voucher.objects.create(**self.data)
         assert not voucher.slots_available_for_assignment
 
-    def test_get_not_redeemed_assignment_ids_with_non_enterprise_offer(self):
-        """ Verify that a voucher with no enterprise offer returns none for get_not_redeemed_assignment_ids. """
+    def test_not_redeemed_assignment_ids_with_non_enterprise_offer(self):
+        """ Verify that a voucher with no enterprise offer returns none for not_redeemed_assignment_ids. """
         voucher = Voucher.objects.create(**self.data)
-        assert not voucher.get_not_redeemed_assignment_ids
+        assert not voucher.not_redeemed_assignment_ids
 
     @ddt.data(
         (Voucher.SINGLE_USE, 0, None, [], 1),


### PR DESCRIPTION
used pre_fetch related instead of a single query to fix corner cases.