### PR TITLE
ENT-3068: Individually create offer assignment objects

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -1348,7 +1348,7 @@ class CouponCodeAssignmentSerializer(serializers.Serializer):  # pylint: disable
             offer = available_assignments[code]['offer']
             email = next(email_iterator) if voucher_usage_type == Voucher.MULTI_USE_PER_CUSTOMER else None
             for _ in range(available_assignments[code]['num_slots']):
-                new_offer_assignment = OfferAssignment(
+                new_offer_assignment = OfferAssignment.objects.create(
                     offer=offer,
                     code=code,
                     user_email=email or next(email_iterator),
@@ -1360,7 +1360,6 @@ class CouponCodeAssignmentSerializer(serializers.Serializer):  # pylint: disable
                 if email_code_pair not in emails_already_sent:
                     self._trigger_email_sending_task(greeting, closing, new_offer_assignment, voucher_usage_type)
                     emails_already_sent.add(email_code_pair)
-        OfferAssignment.objects.bulk_create(offer_assignments)
         validated_data['offer_assignments'] = offer_assignments
         return validated_data
 


### PR DESCRIPTION
Description: This PR reverts some of the optimisations done in https://github.com/edx/ecommerce/pull/3001. 
The assignments are now again individually created. This will ensure availability of the offer assignment id (PK AutoField) which is required to trigger the offer assignment email. In the current implementation, the id field is unavailable at the time of sending the email due to the bulk creation function.