### PR TITLE
ENT-3114 | update offer_data only if there is any change.

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -460,14 +460,15 @@ class EnterpriseCouponViewSetRbacTests(
         self.get_response('POST', ENTERPRISE_COUPONS_LINK, self.data)
         coupon = Product.objects.get(title=self.data['title'])
 
-        self.get_response(
+        new_title = 'Updated Enterprise Coupon'
+        self.data.update({'title': new_title})
+        response = self.get_response(
             'PUT',
             reverse('api:v2:enterprise-coupons-detail', kwargs={'pk': coupon.id}),
-            data={
-                'title': 'Updated Enterprise Coupon',
-            }
+            data=self.data
         )
-        updated_coupon = Product.objects.get(title='Updated Enterprise Coupon')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        updated_coupon = Product.objects.get(title=new_title)
         self.assertEqual(coupon.id, updated_coupon.id)
 
     def test_update_non_ent_coupon(self):

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -270,19 +270,20 @@ class EnterpriseCouponViewSet(CouponViewSet):
         pass
 
     def is_offer_data_updated(self, benefit_value, enterprise_customer, enterprise_catalog, max_uses, email_domains):
-        """ Compares request data with the old coupon data to that there is any change related to offers."""
-        old_data = self.get_serializer(self.get_object()).data
-        old_benefit_value = old_data.get('benefit_value')
-        old_enterprise_customer = old_data.get('enterprise_customer', {}).get('id')
-        old_enterprise_catalog = old_data.get('enterprise_customer_catalog')
-        old_max_uses = old_data.get('max_uses')
-        old_email_domains = old_data.get('email_domains')
+        """ Compares request data with the existing coupon data to determine if the offer in voucher needs to be
+         updated."""
+        existing_data = self.get_serializer(self.get_object()).data
+        existing_benefit_value = existing_data.get('benefit_value')
+        existing_enterprise_customer = existing_data.get('enterprise_customer', {}).get('id')
+        existing_enterprise_catalog = existing_data.get('enterprise_customer_catalog')
+        existing_max_uses = existing_data.get('max_uses')
+        existing_email_domains = existing_data.get('email_domains')
 
-        if benefit_value == old_benefit_value \
-                and enterprise_customer == str(old_enterprise_customer) \
-                and enterprise_catalog == str(old_enterprise_catalog) \
-                and max_uses == old_max_uses \
-                and email_domains == old_email_domains:
+        if benefit_value == existing_benefit_value \
+                and enterprise_customer == str(existing_enterprise_customer) \
+                and enterprise_catalog == str(existing_enterprise_catalog) \
+                and max_uses == existing_max_uses \
+                and email_domains == existing_email_domains:
             # nothing changed related to the offers.
             return False
         return True
@@ -304,6 +305,7 @@ class EnterpriseCouponViewSet(CouponViewSet):
         if not self.is_offer_data_updated(
                 benefit_value, enterprise_customer, enterprise_catalog, max_uses, email_domains
         ):
+            # Offer data does not need to be updated for current request
             return
 
         coupon_was_migrated = False

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -5,7 +5,7 @@ import logging
 import django_filters
 import six
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import (
     Count,
     ExpressionWrapper,
@@ -33,7 +33,6 @@ from six.moves.urllib.parse import urlparse  # pylint: disable=import-error, ung
 from slumber.exceptions import SlumberHttpBaseException
 
 from ecommerce.core.constants import COUPON_PRODUCT_CLASS_NAME, DEFAULT_CATALOG_PAGE_SIZE
-from ecommerce.core.utils import log_message_and_raise_validation_error
 from ecommerce.coupons.utils import is_coupon_available
 from ecommerce.enterprise.utils import (
     get_enterprise_catalog,
@@ -270,6 +269,24 @@ class EnterpriseCouponViewSet(CouponViewSet):
         # Since enterprise coupons do not have ranges, we bypass the range update logic entirely.
         pass
 
+    def is_offer_data_updated(self, benefit_value, enterprise_customer, enterprise_catalog, max_uses, email_domains):
+        """ Compares request data with the old coupon data to that there is any change related to offers."""
+        old_data = self.get_serializer(self.get_object()).data
+        old_benefit_value = old_data.get('benefit_value')
+        old_enterprise_customer = old_data.get('enterprise_customer', {}).get('id')
+        old_enterprise_catalog = old_data.get('enterprise_customer_catalog')
+        old_max_uses = old_data.get('max_uses')
+        old_email_domains = old_data.get('email_domains')
+
+        if benefit_value == old_benefit_value \
+                and enterprise_customer == str(old_enterprise_customer) \
+                and enterprise_catalog == str(old_enterprise_catalog) \
+                and max_uses == old_max_uses \
+                and email_domains == old_email_domains:
+            # nothing changed related to the offers.
+            return False
+        return True
+
     def update_offer_data(self, request_data, vouchers, site):
         """
         Remove all offers from the vouchers and add a new offer
@@ -284,23 +301,13 @@ class EnterpriseCouponViewSet(CouponViewSet):
         max_uses = request_data.get('max_uses')
         email_domains = request_data.get('email_domains')
 
-        # Validate max_uses
-        if max_uses is not None:
-            if vouchers.first().usage == Voucher.SINGLE_USE:
-                log_message_and_raise_validation_error(
-                    'Failed to update Coupon. '
-                    'max_global_applications field cannot be set for voucher type [{voucher_type}].'.format(
-                        voucher_type=Voucher.SINGLE_USE
-                    ))
-            try:
-                max_uses = int(max_uses)
-                if max_uses < 1:
-                    raise ValueError
-            except ValueError:
-                raise ValidationError('max_global_applications field must be a positive number.')
+        if not self.is_offer_data_updated(
+                benefit_value, enterprise_customer, enterprise_catalog, max_uses, email_domains
+        ):
+            return
 
         coupon_was_migrated = False
-        for voucher in vouchers.all():
+        for voucher in vouchers:
             updated_enterprise_offer = update_voucher_with_enterprise_offer(
                 offer=voucher.enterprise_offer,
                 benefit_value=benefit_value,


### PR DESCRIPTION
While updating enterprise coupon
update offer_data only if there is any change related to the offer.
moved validation to the serializer.