### PR TITLE
Update pytest.ini to set django settings as an option

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,7 @@ skipsdist=True
 envlist = {py35,py38}-django22-{static,pylint,tests,theme_static,check_keywords},{py35,py38}-{isort,pycodestyle,extract_translations,dummy_translations,compile_translations, detect_changed_translations,validate_translations}
 
 [pytest]
-DJANGO_SETTINGS_MODULE = ecommerce.settings.test
-addopts = --cov=ecommerce --cov-report term --cov-config=.coveragerc --no-cov-on-fail -p no:randomly
+addopts = --ds=ecommerce.settings.test --cov=ecommerce --cov-report term --cov-config=.coveragerc --no-cov-on-fail -p no:randomly
 testpaths = ecommerce
 
 [testenv]


### PR DESCRIPTION
There is a priority system for setting the django settings
variable (see https://pytest-django.readthedocs.io/en/latest/configuring_django.html#order-of-choosing-settings).
In short: command line option --ds, environment var DJANGO_SETTINGS_MODULE, then DJANGO_SETTINGS_MODULE option
listed in the configuration file (pytest.ini, tox.ini, etc.).
This change updates it so when you run pytest when shelled into the
container, you appropriately use the test settings file when you run pytest directly.

Normally when shelling in, we source the discovery_env file (/edx/app/discovery/ecommerce_env)
and that file sets the DJANGO_SETTINGS_MODULE environment variable to use
the devstack settings file.