### PR TITLE
ENT-3115: Change expiration date in code management emails to include date and timestamp

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -1483,7 +1483,7 @@ class CouponCodeAssignmentSerializer(serializers.Serializer):  # pylint: disable
                 learner_email=assigned_offer.user_email,
                 code=assigned_offer.code,
                 redemptions_remaining=redemptions_remaining,
-                code_expiration_date=code_expiration_date.strftime('%d %B, %Y')
+                code_expiration_date=code_expiration_date.strftime('%d %B, %Y %H:%M %Z')
             )
         except Exception as exc:  # pylint: disable=broad-except
             logger.exception(
@@ -1720,7 +1720,7 @@ class CouponCodeRemindSerializer(CouponCodeMixin, serializers.Serializer):  # py
                 code=assigned_offer.code,
                 redeemed_offer_count=redeemed_offer_count,
                 total_offer_count=total_offer_count,
-                code_expiration_date=code_expiration_date.strftime('%d %B, %Y')
+                code_expiration_date=code_expiration_date.strftime('%d %B, %Y %H:%M %Z')
             )
         except Exception as exc:  # pylint: disable=broad-except
             # Log the exception here to help diagnose any template issues, then raise it for backwards compatibility

--- a/ecommerce/extensions/api/tests/test_serializers.py
+++ b/ecommerce/extensions/api/tests/test_serializers.py
@@ -65,7 +65,7 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
             learner_email=self.offer_assignment.user_email,
             code=self.offer_assignment.code,
             redemptions_remaining=mock.ANY,
-            code_expiration_date=expected_expiration_date.strftime('%d %B, %Y')
+            code_expiration_date=expected_expiration_date.strftime('%d %B, %Y %H:%M %Z')
         )
 
     @mock.patch('ecommerce.extensions.api.serializers.send_assigned_offer_reminder_email')
@@ -87,7 +87,7 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
             code=self.offer_assignment.code,
             redeemed_offer_count=mock.ANY,
             total_offer_count=mock.ANY,
-            code_expiration_date=expected_expiration_date.strftime('%d %B, %Y')
+            code_expiration_date=expected_expiration_date.strftime('%d %B, %Y %H:%M %Z')
         )
 
     @mock.patch('ecommerce.extensions.api.serializers.send_assigned_offer_email')


### PR DESCRIPTION
Change expiration date in code management emails to include date and timestamp

**Current state**: code assignment/remind emails show the "DD MM, YYYY" string formatting of code expiration (example: 01 July, 2020)

**Expected state**: code assignment/remind emails show the ""DD MM, YYYY HH" string format of code expiration (example: 01 July, 2020 00:00 UTC).