### PR TITLE
ENT-3084: Enable user to customize email subject for code assignment, remind and revoke email.

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -1369,6 +1369,7 @@ class CouponCodeAssignmentSerializer(serializers.Serializer):  # pylint: disable
         """Create OfferAssignment objects for each email and the available_assignments determined from validation."""
         emails = validated_data.get('emails')
         voucher_usage_type = validated_data.pop('voucher_usage_type')
+        subject = validated_data.pop('subject')
         greeting = validated_data.pop('greeting')
         closing = validated_data.pop('closing')
         available_assignments = validated_data.pop('available_assignments')
@@ -1391,7 +1392,9 @@ class CouponCodeAssignmentSerializer(serializers.Serializer):  # pylint: disable
                 # Start async email task. For MULTI_USE_PER_CUSTOMER, a single email is sent
                 email_code_pair = frozenset((new_offer_assignment.user_email, new_offer_assignment.code))
                 if email_code_pair not in emails_already_sent:
-                    self._trigger_email_sending_task(greeting, closing, new_offer_assignment, voucher_usage_type)
+                    self._trigger_email_sending_task(
+                        subject, greeting, closing, new_offer_assignment, voucher_usage_type
+                    )
                     emails_already_sent.add(email_code_pair)
         validated_data['offer_assignments'] = offer_assignments
         return validated_data
@@ -1404,6 +1407,7 @@ class CouponCodeAssignmentSerializer(serializers.Serializer):  # pylint: disable
         codes = attrs.get('codes')
         emails = attrs.get('emails')
         coupon = self.context.get('coupon')
+        subject = self.context.get('subject')
         greeting = self.context.get('greeting')
         closing = self.context.get('closing')
         available_assignments = {}
@@ -1472,11 +1476,12 @@ class CouponCodeAssignmentSerializer(serializers.Serializer):  # pylint: disable
         # Add available_assignments to the validated data so that we can perform the assignments in create.
         attrs['voucher_usage_type'] = voucher_usage_type
         attrs['available_assignments'] = available_assignments
+        attrs['subject'] = subject
         attrs['greeting'] = greeting
         attrs['closing'] = closing
         return attrs
 
-    def _trigger_email_sending_task(self, greeting, closing, assigned_offer, voucher_usage_type):
+    def _trigger_email_sending_task(self, subject, greeting, closing, assigned_offer, voucher_usage_type):
         """
         Schedule async task to send email to the learner who has been assigned the code.
         """
@@ -1487,6 +1492,7 @@ class CouponCodeAssignmentSerializer(serializers.Serializer):  # pylint: disable
         )
         try:
             send_assigned_offer_email(
+                subject=subject,
                 greeting=greeting,
                 closing=closing,
                 offer_assignment_id=assigned_offer.id,
@@ -1497,9 +1503,10 @@ class CouponCodeAssignmentSerializer(serializers.Serializer):  # pylint: disable
             )
         except Exception as exc:  # pylint: disable=broad-except
             logger.exception(
-                '[Offer Assignment] Email for offer_assignment_id: %d with greeting %r and closing %r raised '
-                'exception: %r',
+                '[Offer Assignment] Email for offer_assignment_id: %d with subject %r, '
+                'greeting %r and closing %r raised exception: %r',
                 assigned_offer.id,
+                subject,
                 greeting,
                 closing,
                 exc
@@ -1614,6 +1621,7 @@ class CouponCodeRevokeSerializer(CouponCodeMixin, serializers.Serializer):  # py
         offer_assignments = validated_data.get('offer_assignments')
         email = validated_data.get('email')
         code = validated_data.get('code')
+        subject = self.context.get('subject')
         greeting = self.context.get('greeting')
         closing = self.context.get('closing')
         detail = 'success'
@@ -1626,6 +1634,7 @@ class CouponCodeRevokeSerializer(CouponCodeMixin, serializers.Serializer):  # py
                 offer_assignment.save()
 
             send_revoked_offer_email(
+                subject=subject,
                 greeting=greeting,
                 closing=closing,
                 learner_email=email,
@@ -1633,7 +1642,7 @@ class CouponCodeRevokeSerializer(CouponCodeMixin, serializers.Serializer):  # py
             )
         except Exception as exc:  # pylint: disable=broad-except
             logger.exception('[Offer Revocation] Encountered error when revoking code %s for user %s with '
-                             'greeting %r and closing %r', code, email, greeting, closing)
+                             'subject %r, greeting %r and closing %r', code, email, subject, greeting, closing)
             detail = six.text_type(exc)
 
         validated_data['detail'] = detail
@@ -1672,6 +1681,7 @@ class CouponCodeRemindSerializer(CouponCodeMixin, serializers.Serializer):  # py
         code = validated_data.get('code')
         redeemed_offer_count = validated_data.get('redeemed_offer_count')
         total_offer_count = validated_data.get('total_offer_count')
+        subject = self.context.get('subject')
         greeting = self.context.get('greeting')
         closing = self.context.get('closing')
         detail = 'success'
@@ -1679,6 +1689,7 @@ class CouponCodeRemindSerializer(CouponCodeMixin, serializers.Serializer):  # py
 
         try:
             self._trigger_email_sending_task(
+                subject,
                 greeting,
                 closing,
                 offer_assignments.first(),
@@ -1716,7 +1727,9 @@ class CouponCodeRemindSerializer(CouponCodeMixin, serializers.Serializer):  # py
         attrs['total_offer_count'] = offer_assignments.count()
         return attrs
 
-    def _trigger_email_sending_task(self, greeting, closing, assigned_offer, redeemed_offer_count, total_offer_count):
+    def _trigger_email_sending_task(
+            self, subject, greeting, closing, assigned_offer, redeemed_offer_count, total_offer_count
+    ):
         """
         Schedule async task to send email to the learner who has been assigned the code.
         """
@@ -1724,6 +1737,7 @@ class CouponCodeRemindSerializer(CouponCodeMixin, serializers.Serializer):  # py
         code_expiration_date = retrieve_end_date(coupon)
         try:
             send_assigned_offer_reminder_email(
+                subject=subject,
                 greeting=greeting,
                 closing=closing,
                 learner_email=assigned_offer.user_email,
@@ -1735,9 +1749,10 @@ class CouponCodeRemindSerializer(CouponCodeMixin, serializers.Serializer):  # py
         except Exception as exc:  # pylint: disable=broad-except
             # Log the exception here to help diagnose any template issues, then raise it for backwards compatibility
             logger.exception(
-                '[Offer Reminder] Email for offer_assignment_id: %d with greeting %r and closing %r raised '
-                'exception: %r',
+                '[Offer Reminder] Email for offer_assignment_id: %d with subject %r, '
+                'greeting %r and closing %r raised exception: %r',
                 assigned_offer.id,
+                subject,
                 greeting,
                 closing,
                 exc

--- a/ecommerce/extensions/api/tests/test_serializers.py
+++ b/ecommerce/extensions/api/tests/test_serializers.py
@@ -23,6 +23,7 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
     """ Test for coupon code serializers. """
     LOGGER_NAME = 'ecommerce.extensions.api.serializers'
     TEMPLATE = 'Text {PARAM} is fun'
+    SUBJECT = 'Subject '
     GREETING = 'Hello '
     CLOSING = ' Bye'
 
@@ -52,6 +53,7 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
         """ Test that the code_expiration_date passed is equal to coupon batch end date """
         serializer = CouponCodeAssignmentSerializer(data=self.data, context={'coupon': self.coupon})
         serializer._trigger_email_sending_task(  # pylint: disable=protected-access
+            subject=self.SUBJECT,
             greeting=self.GREETING,
             closing=self.CLOSING,
             assigned_offer=self.offer_assignment,
@@ -59,6 +61,7 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
         )
         expected_expiration_date = self.coupon.attr.coupon_vouchers.vouchers.first().end_datetime
         mock_assign_email.assert_called_with(
+            subject=self.SUBJECT,
             greeting=self.GREETING,
             closing=self.CLOSING,
             offer_assignment_id=self.offer_assignment.id,
@@ -73,6 +76,7 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
         """ Test that the code_expiration_date passed is equal to coupon batch end date """
         serializer = CouponCodeRemindSerializer(data=self.data, context={'coupon': self.coupon})
         serializer._trigger_email_sending_task(  # pylint: disable=protected-access
+            subject=self.SUBJECT,
             greeting=self.GREETING,
             closing=self.CLOSING,
             assigned_offer=self.offer_assignment,
@@ -81,6 +85,7 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
         )
         expected_expiration_date = self.coupon.attr.coupon_vouchers.vouchers.first().end_datetime
         mock_remind_email.assert_called_with(
+            subject=self.SUBJECT,
             greeting=self.GREETING,
             closing=self.CLOSING,
             learner_email=self.offer_assignment.user_email,
@@ -99,9 +104,10 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
             (
                 self.LOGGER_NAME,
                 'ERROR',
-                '[Offer Assignment] Email for offer_assignment_id: {} with greeting \'{}\' and closing \'{}\' raised '
-                'exception: {}'.format(
+                '[Offer Assignment] Email for offer_assignment_id: {} with subject \'{}\', greeting \'{}\' and closing '
+                '\'{}\' raised exception: {}'.format(
                     self.offer_assignment.id,
+                    self.SUBJECT,
                     self.GREETING,
                     self.CLOSING,
                     repr(Exception('Ignore me - assignment'))
@@ -111,6 +117,7 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
 
         with LogCapture(self.LOGGER_NAME) as log:
             serializer._trigger_email_sending_task(  # pylint: disable=protected-access
+                subject=self.SUBJECT,
                 greeting=self.GREETING,
                 closing=self.CLOSING,
                 assigned_offer=self.offer_assignment,
@@ -127,9 +134,10 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
             (
                 self.LOGGER_NAME,
                 'ERROR',
-                '[Offer Reminder] Email for offer_assignment_id: {} with greeting \'{}\' and closing \'{}\' raised '
-                'exception: {}'.format(
+                '[Offer Reminder] Email for offer_assignment_id: {} with subject \'{}\', greeting \'{}\' '
+                'and closing \'{}\' raised exception: {}'.format(
                     self.offer_assignment.id,
+                    self.SUBJECT,
                     self.GREETING,
                     self.CLOSING,
                     repr(Exception('Ignore me - reminder'))
@@ -140,6 +148,7 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
         with self.assertRaises(Exception):
             with LogCapture(self.LOGGER_NAME) as log:
                 serializer._trigger_email_sending_task(  # pylint: disable=protected-access
+                    subject=self.SUBJECT,
                     greeting=self.GREETING,
                     closing=self.CLOSING,
                     assigned_offer=self.offer_assignment,
@@ -156,8 +165,9 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
             (
                 self.LOGGER_NAME,
                 'ERROR',
-                '[Offer Revocation] Encountered error when revoking code {} for user {} with greeting {} and '
-                'closing {}'.format(
+                '[Offer Revocation] Encountered error when revoking code {} for user {} with subject {}, '
+                'greeting {} and closing {}'.format(
+                    None,
                     None,
                     None,
                     None,
@@ -180,6 +190,7 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
         }
         context = {
             'coupon': self.coupon,
+            'subject': self.SUBJECT,
             'greeting': self.GREETING,
             'closing': self.CLOSING,
         }
@@ -189,10 +200,11 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
             (
                 self.LOGGER_NAME,
                 'ERROR',
-                '[Offer Revocation] Encountered error when revoking code {} for user {} with greeting \'{}\' and '
-                'closing \'{}\''.format(
+                '[Offer Revocation] Encountered error when revoking code {} for user {} with subject \'{}\', '
+                'greeting \'{}\' and closing \'{}\''.format(
                     self.code,
                     self.email,
+                    self.SUBJECT,
                     self.GREETING,
                     self.CLOSING,
                 )

--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -66,6 +66,7 @@ VoucherApplication = get_model('voucher', 'VoucherApplication')
 
 ENTERPRISE_COUPONS_LINK = reverse('api:v2:enterprise-coupons-list')
 OFFER_ASSIGNMENT_SUMMARY_LINK = reverse('api:v2:enterprise-offer-assignment-summary-list')
+TEMPLATE_SUBJECT = 'Test Subject '
 TEMPLATE_GREETING = 'hello there '
 TEMPLATE_CLOSING = ' kind regards'
 
@@ -566,6 +567,7 @@ class EnterpriseCouponViewSetRbacTests(
                     'emails': emails,
                     'codes': [voucher.code],
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING
                 }
@@ -627,6 +629,7 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': emails,
@@ -1789,6 +1792,7 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': emails
@@ -1828,6 +1832,7 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': emails,
@@ -1866,6 +1871,7 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': emails
@@ -1907,6 +1913,7 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': emails
@@ -1938,6 +1945,7 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': [email]
@@ -1966,6 +1974,7 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': [email]
@@ -1993,6 +2002,7 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': emails
@@ -2024,6 +2034,7 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': emails
@@ -2066,6 +2077,7 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': [email]
@@ -2108,6 +2120,7 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': [email]
@@ -2145,6 +2158,7 @@ class EnterpriseCouponViewSetRbacTests(
             '/api/v2/enterprise/coupons/{}/revoke/'.format(coupon_id),
             {
                 'template': 'Test template',
+                'template_subject': TEMPLATE_SUBJECT,
                 'template_greeting': TEMPLATE_GREETING,
                 'template_closing': TEMPLATE_CLOSING,
                 'assignments': {'email': email, 'code': 'RANDOMCODE'}
@@ -2167,6 +2181,7 @@ class EnterpriseCouponViewSetRbacTests(
             '/api/v2/enterprise/coupons/{}/revoke/'.format(coupon_id),
             {
                 'template': 'Test template',
+                'template_subject': TEMPLATE_SUBJECT,
                 'template_greeting': TEMPLATE_GREETING,
                 'template_closing': TEMPLATE_CLOSING,
                 'assignments': [{'email': email, 'code': 'RANDOMCODE'}]
@@ -2197,6 +2212,7 @@ class EnterpriseCouponViewSetRbacTests(
             '/api/v2/enterprise/coupons/{}/revoke/'.format(coupon_id),
             {
                 'template': 'Test template',
+                'template_subject': TEMPLATE_SUBJECT,
                 'template_greeting': TEMPLATE_GREETING,
                 'template_closing': TEMPLATE_CLOSING,
                 'assignments': [{'email': email, 'code': voucher.code}]
@@ -2226,6 +2242,7 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': [email]
@@ -2241,6 +2258,7 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/revoke/'.format(coupon_id),
                 {
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'assignments': [{'email': email, 'code': offer_assignment.code}]
@@ -2267,6 +2285,7 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': emails
@@ -2280,6 +2299,7 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/revoke/'.format(coupon_id),
                 {
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'assignments': [
@@ -2324,6 +2344,7 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': [email]
@@ -2357,6 +2378,7 @@ class EnterpriseCouponViewSetRbacTests(
             '/api/v2/enterprise/coupons/{}/remind/'.format(coupon_id),
             {
                 'template': 'Test template',
+                'template_subject': TEMPLATE_SUBJECT,
                 'template_greeting': TEMPLATE_GREETING,
                 'template_closing': TEMPLATE_CLOSING,
                 'assignments': [{'email': email, 'code': 'RANDOMCODE'}]
@@ -2386,6 +2408,7 @@ class EnterpriseCouponViewSetRbacTests(
             '/api/v2/enterprise/coupons/{}/remind/'.format(coupon_id),
             {
                 'template': 'Test template',
+                'template_subject': TEMPLATE_SUBJECT,
                 'template_greeting': TEMPLATE_GREETING,
                 'template_closing': TEMPLATE_CLOSING,
                 'assignments': [{'email': email, 'code': voucher.code}]
@@ -2415,6 +2438,7 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': [email]
@@ -2429,6 +2453,7 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/remind/'.format(coupon_id),
                 {
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'assignments': [{'email': email, 'code': offer_assignment.code}]
@@ -2452,6 +2477,7 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': emails
@@ -2465,6 +2491,7 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/remind/'.format(coupon_id),
                 {
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'assignments': [
@@ -2508,6 +2535,7 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/remind/'.format(coupon_id),
                 {
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'code_filter': VOUCHER_NOT_REDEEMED
@@ -2547,6 +2575,7 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/remind/'.format(coupon_id),
                 {
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'code_filter': VOUCHER_PARTIAL_REDEEMED
@@ -2573,6 +2602,7 @@ class EnterpriseCouponViewSetRbacTests(
             '/api/v2/enterprise/coupons/{}/remind/'.format(coupon_id),
             {
                 'template': 'Test template',
+                'template_subject': TEMPLATE_SUBJECT,
                 'template_greeting': TEMPLATE_GREETING,
                 'template_closing': TEMPLATE_CLOSING,
             }
@@ -2593,6 +2623,7 @@ class EnterpriseCouponViewSetRbacTests(
             '/api/v2/enterprise/coupons/{}/remind/'.format(coupon_id),
             {
                 'template': 'Test template',
+                'template_subject': TEMPLATE_SUBJECT,
                 'template_greeting': TEMPLATE_GREETING,
                 'template_closing': TEMPLATE_CLOSING,
                 'code_filter': 'invalid-filter'
@@ -2632,6 +2663,7 @@ class EnterpriseCouponViewSetRbacTests(
             '/api/v2/enterprise/coupons/{}/{action}/'.format(coupon_id, action=action),
             {
                 'template': 'Test template',
+                'template_subject': TEMPLATE_SUBJECT,
                 'template_greeting': TEMPLATE_GREETING,
                 'template_closing': TEMPLATE_CLOSING,
                 'emails': ['test@edx.org']
@@ -2741,11 +2773,13 @@ class EnterpriseCouponViewSetRbacTests(
         coupon_id = coupon.json()['coupon_id']
 
         max_limit = OFFER_ASSIGNMENT_EMAIL_TEMPLATE_FIELD_LIMIT
+        email_subject_max_limit = OFFER_ASSIGNMENT_EMAIL_SUBJECT_LIMIT
         response = self.get_response(
             'POST',
             '/api/v2/enterprise/coupons/{}/{action}/'.format(coupon_id, action=action),
             {
                 'template': 'Test template',
+                'template_subject': 'S' * (email_subject_max_limit + 1),
                 'template_greeting': 'G' * (max_limit + 1),
                 'template_closing': 'C' * (max_limit + 1),
                 'emails': ['test@edx.org']
@@ -2754,6 +2788,7 @@ class EnterpriseCouponViewSetRbacTests(
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
             'error': {
+                'email_subject': 'Email subject must be {} characters or less'.format(email_subject_max_limit),
                 'email_greeting': 'Email greeting must be {} characters or less'.format(max_limit),
                 'email_closing': 'Email closing must be {} characters or less'.format(max_limit),
             }
@@ -2864,6 +2899,7 @@ class OfferAssignmentSummaryViewSetTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
+                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': emails,

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -65,6 +65,7 @@ from ecommerce.extensions.catalogue.utils import (
 from ecommerce.extensions.offer.constants import (
     OFFER_ASSIGNED,
     OFFER_ASSIGNMENT_EMAIL_PENDING,
+    OFFER_ASSIGNMENT_EMAIL_SUBJECT_LIMIT,
     OFFER_ASSIGNMENT_EMAIL_TEMPLATE_FIELD_LIMIT,
     OFFER_ASSIGNMENT_REVOKED,
     OFFER_MAX_USES_DEFAULT,
@@ -672,12 +673,17 @@ class EnterpriseCouponViewSet(CouponViewSet):
         if not is_coupon_available(coupon):
             raise DRFValidationError({'error': message})
 
-    def _validate_email_fields(self, greeting, closing):
+    def _validate_email_fields(self, subject, greeting, closing):
         """
-        Raise ValidationError if greeting and/or closing is above the allowed limit.
+        Raise ValidationError if subject, greeting and/or closing is above the allowed limit.
         """
         errors = {}
         max_field_limit = OFFER_ASSIGNMENT_EMAIL_TEMPLATE_FIELD_LIMIT
+
+        if len(subject) > OFFER_ASSIGNMENT_EMAIL_SUBJECT_LIMIT:
+            errors['email_subject'] = 'Email subject must be {} characters or less'.format(
+                OFFER_ASSIGNMENT_EMAIL_SUBJECT_LIMIT
+            )
 
         if len(greeting) > max_field_limit:
             errors['email_greeting'] = 'Email greeting must be {} characters or less'.format(max_field_limit)
@@ -696,12 +702,13 @@ class EnterpriseCouponViewSet(CouponViewSet):
         """
         coupon = self.get_object()
         self._validate_coupon_availablity(coupon, 'Coupon is not available for code assignment')
+        subject = request.data.pop('template_subject', '')
         greeting = request.data.pop('template_greeting', '')
         closing = request.data.pop('template_closing', '')
-        self._validate_email_fields(greeting, closing)
+        self._validate_email_fields(subject, greeting, closing)
         serializer = CouponCodeAssignmentSerializer(
             data=request.data,
-            context={'coupon': coupon, 'greeting': greeting, 'closing': closing}
+            context={'coupon': coupon, 'subject': subject, 'greeting': greeting, 'closing': closing}
         )
         if serializer.is_valid():
             serializer.save()
@@ -716,13 +723,14 @@ class EnterpriseCouponViewSet(CouponViewSet):
         """
         coupon = self.get_object()
         self._validate_coupon_availablity(coupon, 'Coupon is not available for code revoke')
+        subject = request.data.pop('template_subject', '')
         greeting = request.data.pop('template_greeting', '')
         closing = request.data.pop('template_closing', '')
-        self._validate_email_fields(greeting, closing)
+        self._validate_email_fields(subject, greeting, closing)
         serializer = CouponCodeRevokeSerializer(
             data=request.data.get('assignments'),
             many=True,
-            context={'coupon': coupon, 'greeting': greeting, 'closing': closing}
+            context={'coupon': coupon, 'subject': subject, 'greeting': greeting, 'closing': closing}
         )
         if serializer.is_valid():
             serializer.save()
@@ -738,9 +746,10 @@ class EnterpriseCouponViewSet(CouponViewSet):
         """
         coupon = self.get_object()
         self._validate_coupon_availablity(coupon, 'Coupon is not available for code remind')
+        subject = request.data.pop('template_subject', '')
         greeting = request.data.pop('template_greeting', '')
         closing = request.data.pop('template_closing', '')
-        self._validate_email_fields(greeting, closing)
+        self._validate_email_fields(subject, greeting, closing)
         if request.data.get('assignments'):
             assignments = request.data.get('assignments')
         else:
@@ -769,7 +778,7 @@ class EnterpriseCouponViewSet(CouponViewSet):
         serializer = CouponCodeRemindSerializer(
             data=assignments,
             many=True,
-            context={'coupon': coupon, 'greeting': greeting, 'closing': closing}
+            context={'coupon': coupon, 'subject': subject, 'greeting': greeting, 'closing': closing}
         )
         if serializer.is_valid():
             serializer.save()

--- a/ecommerce/extensions/offer/tests/test_utils.py
+++ b/ecommerce/extensions/offer/tests/test_utils.py
@@ -92,6 +92,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
     @mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email')
     @ddt.data(
         (
+            'subject',
             'hi',
             'bye',
             {
@@ -107,6 +108,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
     @ddt.unpack
     def test_send_assigned_offer_email(
             self,
+            subject,
             greeting,
             closing,
             tokens,
@@ -114,9 +116,9 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             mock_sailthru_task,
     ):
         """ Test that the offer assignment email message is sent to async task. """
-        email_subject = settings.OFFER_ASSIGNMENT_EMAIL_SUBJECT
         mock_sailthru_task.delay.side_effect = side_effect
         send_assigned_offer_email(
+            subject,
             greeting,
             closing,
             tokens.get('offer_assignment_id'),
@@ -128,13 +130,14 @@ class UtilTests(DiscoveryTestMixin, TestCase):
         mock_sailthru_task.delay.assert_called_once_with(
             tokens.get('learner_email'),
             tokens.get('offer_assignment_id'),
-            email_subject,
+            subject,
             mock.ANY
         )
 
     @mock.patch('ecommerce.extensions.offer.utils.send_offer_update_email')
     @ddt.data(
         (
+            'subject',
             'hi',
             'bye',
             {
@@ -150,6 +153,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
     @ddt.unpack
     def test_send_assigned_offer_reminder_email(
             self,
+            subject,
             greeting,
             closing,
             tokens,
@@ -159,9 +163,9 @@ class UtilTests(DiscoveryTestMixin, TestCase):
         """
         Test that the offer assignment reminder email message is sent to the async task in ecommerce-worker.
         """
-        email_subject = settings.OFFER_REMINDER_EMAIL_SUBJECT
         mock_sailthru_task.delay.side_effect = side_effect
         send_assigned_offer_reminder_email(
+            subject,
             greeting,
             closing,
             tokens.get('learner_email'),
@@ -172,13 +176,14 @@ class UtilTests(DiscoveryTestMixin, TestCase):
         )
         mock_sailthru_task.delay.assert_called_once_with(
             tokens.get('learner_email'),
-            email_subject,
+            subject,
             mock.ANY
         )
 
     @mock.patch('ecommerce.extensions.offer.utils.send_offer_update_email')
     @ddt.data(
         (
+            'subject',
             'hi',
             'bye',
             {
@@ -191,6 +196,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
     @ddt.unpack
     def test_send_offer_revoked_email(
             self,
+            subject,
             greeting,
             closing,
             tokens,
@@ -200,9 +206,9 @@ class UtilTests(DiscoveryTestMixin, TestCase):
         """
         Test that the offer revocation email message is sent to the async task in ecommerce-worker.
         """
-        email_subject = settings.OFFER_REVOKE_EMAIL_SUBJECT
         mock_sailthru_task.delay.side_effect = side_effect
         send_revoked_offer_email(
+            subject,
             greeting,
             closing,
             tokens.get('learner_email'),
@@ -210,7 +216,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
         )
         mock_sailthru_task.delay.assert_called_once_with(
             tokens.get('learner_email'),
-            email_subject,
+            subject,
             mock.ANY
         )
 

--- a/ecommerce/extensions/offer/utils.py
+++ b/ecommerce/extensions/offer/utils.py
@@ -129,6 +129,7 @@ def get_redirect_to_email_confirmation_if_required(request, offer, product):
 
 
 def send_assigned_offer_email(
+        subject,
         greeting,
         closing,
         offer_assignment_id,
@@ -138,6 +139,8 @@ def send_assigned_offer_email(
         code_expiration_date):
     """
     Arguments:
+        *subject*
+            The email subject
         *email_greeting*
             The email greeting (prefix)
         *email_closing*
@@ -153,8 +156,6 @@ def send_assigned_offer_email(
         *code_expiration_date*
             Date till code is valid.
     """
-
-    email_subject = settings.OFFER_ASSIGNMENT_EMAIL_SUBJECT
     email_template = settings.OFFER_ASSIGNMENT_EMAIL_TEMPLATE
     placeholder_dict = SafeDict(
         REDEMPTIONS_REMAINING=redemptions_remaining,
@@ -163,10 +164,11 @@ def send_assigned_offer_email(
         EXPIRATION_DATE=code_expiration_date
     )
     email_body = format_email(email_template, placeholder_dict, greeting, closing)
-    send_offer_assignment_email.delay(learner_email, offer_assignment_id, email_subject, email_body)
+    send_offer_assignment_email.delay(learner_email, offer_assignment_id, subject, email_body)
 
 
 def send_revoked_offer_email(
+        subject,
         greeting,
         closing,
         learner_email,
@@ -174,6 +176,8 @@ def send_revoked_offer_email(
 ):
     """
     Arguments:
+        *subject*
+            The email subject
         *email_greeting*
             The email greeting (prefix)
         *email_closing*
@@ -183,18 +187,17 @@ def send_revoked_offer_email(
         *code*
             Code for the user.
     """
-
-    email_subject = settings.OFFER_REVOKE_EMAIL_SUBJECT
     email_template = settings.OFFER_REVOKE_EMAIL_TEMPLATE
     placeholder_dict = SafeDict(
         USER_EMAIL=learner_email,
         CODE=code,
     )
     email_body = format_email(email_template, placeholder_dict, greeting, closing)
-    send_offer_update_email.delay(learner_email, email_subject, email_body)
+    send_offer_update_email.delay(learner_email, subject, email_body)
 
 
 def send_assigned_offer_reminder_email(
+        subject,
         greeting,
         closing,
         learner_email,
@@ -204,6 +207,8 @@ def send_assigned_offer_reminder_email(
         code_expiration_date):
     """
     Arguments:
+        *subject*
+            The email subject
         *email_greeting*
             The email greeting (prefix)
         *email_closing*
@@ -219,8 +224,6 @@ def send_assigned_offer_reminder_email(
        *code_expiration_date*
            Date till code is valid.
     """
-
-    email_subject = settings.OFFER_REMINDER_EMAIL_SUBJECT
     email_template = settings.OFFER_REMINDER_EMAIL_TEMPLATE
     placeholder_dict = SafeDict(
         REDEEMED_OFFER_COUNT=redeemed_offer_count,
@@ -230,7 +233,7 @@ def send_assigned_offer_reminder_email(
         EXPIRATION_DATE=code_expiration_date
     )
     email_body = format_email(email_template, placeholder_dict, greeting, closing)
-    send_offer_update_email.delay(learner_email, email_subject, email_body)
+    send_offer_update_email.delay(learner_email, subject, email_body)
 
 
 def format_email(template, placeholder_dict, greeting, closing):

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -706,12 +706,10 @@ edX Login: {USER_EMAIL}
 Access Code: {CODE}
 Expiration Date: {EXPIRATION_DATE}
 '''
-OFFER_ASSIGNMENT_EMAIL_SUBJECT = 'New edX course assignment'
 
 OFFER_REVOKE_EMAIL_TEMPLATE = '''
 Your Learning Manager has revoked access code {CODE} and it is no longer assigned to your edX account {USER_EMAIL}.
 '''
-OFFER_REVOKE_EMAIL_SUBJECT = 'edX Course Assignment Revoked'
 
 OFFER_REMINDER_EMAIL_TEMPLATE = '''
 You have redeemed this code {REDEEMED_OFFER_COUNT} time(s) out of {TOTAL_OFFER_COUNT} available course redemptions.
@@ -720,7 +718,6 @@ edX Login: {USER_EMAIL}
 Access Code: {CODE}
 Expiration Date: {EXPIRATION_DATE}
 '''
-OFFER_REMINDER_EMAIL_SUBJECT = 'Reminder on edX course assignment'
 
 OFFER_ASSIGNMEN_EMAIL_TEMPLATE_BODY_MAP = {
     'assign': OFFER_ASSIGNMENT_EMAIL_TEMPLATE,


### PR DESCRIPTION
**JIRA Ticket:** [ENT-3084](https://openedx.atlassian.net/browse/ENT-3084)

**Description:**
"As an enterprise admin, I want to be able to change the subject line of the code assignment email I send."
Current State: Email subject lines for code assignment emails are set by edX, and cannot be changed.
Desired Future State: Email subjects lines can be edited, and saved, as part of a template under a "Customize Subject" field.