### PR TITLE
Revert "ENT-3084: Enable user to customize email subject for code assignment, remind and revoke email."

### DIFF
--- a/ecommerce/extensions/api/tests/test_serializers.py
+++ b/ecommerce/extensions/api/tests/test_serializers.py
@@ -23,7 +23,6 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
     """ Test for coupon code serializers. """
     LOGGER_NAME = 'ecommerce.extensions.api.serializers'
     TEMPLATE = 'Text {PARAM} is fun'
-    SUBJECT = 'Subject '
     GREETING = 'Hello '
     CLOSING = ' Bye'
 
@@ -53,7 +52,6 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
         """ Test that the code_expiration_date passed is equal to coupon batch end date """
         serializer = CouponCodeAssignmentSerializer(data=self.data, context={'coupon': self.coupon})
         serializer._trigger_email_sending_task(  # pylint: disable=protected-access
-            subject=self.SUBJECT,
             greeting=self.GREETING,
             closing=self.CLOSING,
             assigned_offer=self.offer_assignment,
@@ -61,7 +59,6 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
         )
         expected_expiration_date = self.coupon.attr.coupon_vouchers.vouchers.first().end_datetime
         mock_assign_email.assert_called_with(
-            subject=self.SUBJECT,
             greeting=self.GREETING,
             closing=self.CLOSING,
             offer_assignment_id=self.offer_assignment.id,
@@ -76,7 +73,6 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
         """ Test that the code_expiration_date passed is equal to coupon batch end date """
         serializer = CouponCodeRemindSerializer(data=self.data, context={'coupon': self.coupon})
         serializer._trigger_email_sending_task(  # pylint: disable=protected-access
-            subject=self.SUBJECT,
             greeting=self.GREETING,
             closing=self.CLOSING,
             assigned_offer=self.offer_assignment,
@@ -85,7 +81,6 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
         )
         expected_expiration_date = self.coupon.attr.coupon_vouchers.vouchers.first().end_datetime
         mock_remind_email.assert_called_with(
-            subject=self.SUBJECT,
             greeting=self.GREETING,
             closing=self.CLOSING,
             learner_email=self.offer_assignment.user_email,
@@ -104,10 +99,9 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
             (
                 self.LOGGER_NAME,
                 'ERROR',
-                '[Offer Assignment] Email for offer_assignment_id: {} with subject \'{}\', greeting \'{}\' and closing '
-                '\'{}\' raised exception: {}'.format(
+                '[Offer Assignment] Email for offer_assignment_id: {} with greeting \'{}\' and closing \'{}\' raised '
+                'exception: {}'.format(
                     self.offer_assignment.id,
-                    self.SUBJECT,
                     self.GREETING,
                     self.CLOSING,
                     repr(Exception('Ignore me - assignment'))
@@ -117,7 +111,6 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
 
         with LogCapture(self.LOGGER_NAME) as log:
             serializer._trigger_email_sending_task(  # pylint: disable=protected-access
-                subject=self.SUBJECT,
                 greeting=self.GREETING,
                 closing=self.CLOSING,
                 assigned_offer=self.offer_assignment,
@@ -134,10 +127,9 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
             (
                 self.LOGGER_NAME,
                 'ERROR',
-                '[Offer Reminder] Email for offer_assignment_id: {} with subject \'{}\', greeting \'{}\' '
-                'and closing \'{}\' raised exception: {}'.format(
+                '[Offer Reminder] Email for offer_assignment_id: {} with greeting \'{}\' and closing \'{}\' raised '
+                'exception: {}'.format(
                     self.offer_assignment.id,
-                    self.SUBJECT,
                     self.GREETING,
                     self.CLOSING,
                     repr(Exception('Ignore me - reminder'))
@@ -148,7 +140,6 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
         with self.assertRaises(Exception):
             with LogCapture(self.LOGGER_NAME) as log:
                 serializer._trigger_email_sending_task(  # pylint: disable=protected-access
-                    subject=self.SUBJECT,
                     greeting=self.GREETING,
                     closing=self.CLOSING,
                     assigned_offer=self.offer_assignment,
@@ -165,9 +156,8 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
             (
                 self.LOGGER_NAME,
                 'ERROR',
-                '[Offer Revocation] Encountered error when revoking code {} for user {} with subject {}, '
-                'greeting {} and closing {}'.format(
-                    None,
+                '[Offer Revocation] Encountered error when revoking code {} for user {} with greeting {} and '
+                'closing {}'.format(
                     None,
                     None,
                     None,
@@ -190,7 +180,6 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
         }
         context = {
             'coupon': self.coupon,
-            'subject': self.SUBJECT,
             'greeting': self.GREETING,
             'closing': self.CLOSING,
         }
@@ -200,11 +189,10 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
             (
                 self.LOGGER_NAME,
                 'ERROR',
-                '[Offer Revocation] Encountered error when revoking code {} for user {} with subject \'{}\', '
-                'greeting \'{}\' and closing \'{}\''.format(
+                '[Offer Revocation] Encountered error when revoking code {} for user {} with greeting \'{}\' and '
+                'closing \'{}\''.format(
                     self.code,
                     self.email,
-                    self.SUBJECT,
                     self.GREETING,
                     self.CLOSING,
                 )

--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -66,7 +66,6 @@ VoucherApplication = get_model('voucher', 'VoucherApplication')
 
 ENTERPRISE_COUPONS_LINK = reverse('api:v2:enterprise-coupons-list')
 OFFER_ASSIGNMENT_SUMMARY_LINK = reverse('api:v2:enterprise-offer-assignment-summary-list')
-TEMPLATE_SUBJECT = 'Test Subject '
 TEMPLATE_GREETING = 'hello there '
 TEMPLATE_CLOSING = ' kind regards'
 
@@ -567,7 +566,6 @@ class EnterpriseCouponViewSetRbacTests(
                     'emails': emails,
                     'codes': [voucher.code],
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING
                 }
@@ -629,7 +627,6 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': emails,
@@ -1792,7 +1789,6 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': emails
@@ -1832,7 +1828,6 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': emails,
@@ -1871,7 +1866,6 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': emails
@@ -1913,7 +1907,6 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': emails
@@ -1945,7 +1938,6 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': [email]
@@ -1974,7 +1966,6 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': [email]
@@ -2002,7 +1993,6 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': emails
@@ -2034,7 +2024,6 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': emails
@@ -2077,7 +2066,6 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': [email]
@@ -2120,7 +2108,6 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': [email]
@@ -2158,7 +2145,6 @@ class EnterpriseCouponViewSetRbacTests(
             '/api/v2/enterprise/coupons/{}/revoke/'.format(coupon_id),
             {
                 'template': 'Test template',
-                'template_subject': TEMPLATE_SUBJECT,
                 'template_greeting': TEMPLATE_GREETING,
                 'template_closing': TEMPLATE_CLOSING,
                 'assignments': {'email': email, 'code': 'RANDOMCODE'}
@@ -2181,7 +2167,6 @@ class EnterpriseCouponViewSetRbacTests(
             '/api/v2/enterprise/coupons/{}/revoke/'.format(coupon_id),
             {
                 'template': 'Test template',
-                'template_subject': TEMPLATE_SUBJECT,
                 'template_greeting': TEMPLATE_GREETING,
                 'template_closing': TEMPLATE_CLOSING,
                 'assignments': [{'email': email, 'code': 'RANDOMCODE'}]
@@ -2212,7 +2197,6 @@ class EnterpriseCouponViewSetRbacTests(
             '/api/v2/enterprise/coupons/{}/revoke/'.format(coupon_id),
             {
                 'template': 'Test template',
-                'template_subject': TEMPLATE_SUBJECT,
                 'template_greeting': TEMPLATE_GREETING,
                 'template_closing': TEMPLATE_CLOSING,
                 'assignments': [{'email': email, 'code': voucher.code}]
@@ -2242,7 +2226,6 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': [email]
@@ -2258,7 +2241,6 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/revoke/'.format(coupon_id),
                 {
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'assignments': [{'email': email, 'code': offer_assignment.code}]
@@ -2285,7 +2267,6 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': emails
@@ -2299,7 +2280,6 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/revoke/'.format(coupon_id),
                 {
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'assignments': [
@@ -2344,7 +2324,6 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': [email]
@@ -2378,7 +2357,6 @@ class EnterpriseCouponViewSetRbacTests(
             '/api/v2/enterprise/coupons/{}/remind/'.format(coupon_id),
             {
                 'template': 'Test template',
-                'template_subject': TEMPLATE_SUBJECT,
                 'template_greeting': TEMPLATE_GREETING,
                 'template_closing': TEMPLATE_CLOSING,
                 'assignments': [{'email': email, 'code': 'RANDOMCODE'}]
@@ -2408,7 +2386,6 @@ class EnterpriseCouponViewSetRbacTests(
             '/api/v2/enterprise/coupons/{}/remind/'.format(coupon_id),
             {
                 'template': 'Test template',
-                'template_subject': TEMPLATE_SUBJECT,
                 'template_greeting': TEMPLATE_GREETING,
                 'template_closing': TEMPLATE_CLOSING,
                 'assignments': [{'email': email, 'code': voucher.code}]
@@ -2438,7 +2415,6 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': [email]
@@ -2453,7 +2429,6 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/remind/'.format(coupon_id),
                 {
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'assignments': [{'email': email, 'code': offer_assignment.code}]
@@ -2477,7 +2452,6 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': emails
@@ -2491,7 +2465,6 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/remind/'.format(coupon_id),
                 {
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'assignments': [
@@ -2535,7 +2508,6 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/remind/'.format(coupon_id),
                 {
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'code_filter': VOUCHER_NOT_REDEEMED
@@ -2575,7 +2547,6 @@ class EnterpriseCouponViewSetRbacTests(
                 '/api/v2/enterprise/coupons/{}/remind/'.format(coupon_id),
                 {
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'code_filter': VOUCHER_PARTIAL_REDEEMED
@@ -2602,7 +2573,6 @@ class EnterpriseCouponViewSetRbacTests(
             '/api/v2/enterprise/coupons/{}/remind/'.format(coupon_id),
             {
                 'template': 'Test template',
-                'template_subject': TEMPLATE_SUBJECT,
                 'template_greeting': TEMPLATE_GREETING,
                 'template_closing': TEMPLATE_CLOSING,
             }
@@ -2623,7 +2593,6 @@ class EnterpriseCouponViewSetRbacTests(
             '/api/v2/enterprise/coupons/{}/remind/'.format(coupon_id),
             {
                 'template': 'Test template',
-                'template_subject': TEMPLATE_SUBJECT,
                 'template_greeting': TEMPLATE_GREETING,
                 'template_closing': TEMPLATE_CLOSING,
                 'code_filter': 'invalid-filter'
@@ -2663,7 +2632,6 @@ class EnterpriseCouponViewSetRbacTests(
             '/api/v2/enterprise/coupons/{}/{action}/'.format(coupon_id, action=action),
             {
                 'template': 'Test template',
-                'template_subject': TEMPLATE_SUBJECT,
                 'template_greeting': TEMPLATE_GREETING,
                 'template_closing': TEMPLATE_CLOSING,
                 'emails': ['test@edx.org']
@@ -2773,13 +2741,11 @@ class EnterpriseCouponViewSetRbacTests(
         coupon_id = coupon.json()['coupon_id']
 
         max_limit = OFFER_ASSIGNMENT_EMAIL_TEMPLATE_FIELD_LIMIT
-        email_subject_max_limit = OFFER_ASSIGNMENT_EMAIL_SUBJECT_LIMIT
         response = self.get_response(
             'POST',
             '/api/v2/enterprise/coupons/{}/{action}/'.format(coupon_id, action=action),
             {
                 'template': 'Test template',
-                'template_subject': 'S' * (email_subject_max_limit + 1),
                 'template_greeting': 'G' * (max_limit + 1),
                 'template_closing': 'C' * (max_limit + 1),
                 'emails': ['test@edx.org']
@@ -2788,7 +2754,6 @@ class EnterpriseCouponViewSetRbacTests(
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
             'error': {
-                'email_subject': 'Email subject must be {} characters or less'.format(email_subject_max_limit),
                 'email_greeting': 'Email greeting must be {} characters or less'.format(max_limit),
                 'email_closing': 'Email closing must be {} characters or less'.format(max_limit),
             }
@@ -2899,7 +2864,6 @@ class OfferAssignmentSummaryViewSetTests(
                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
                 {
                     'template': 'Test template',
-                    'template_subject': TEMPLATE_SUBJECT,
                     'template_greeting': TEMPLATE_GREETING,
                     'template_closing': TEMPLATE_CLOSING,
                     'emails': emails,

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -65,7 +65,6 @@ from ecommerce.extensions.catalogue.utils import (
 from ecommerce.extensions.offer.constants import (
     OFFER_ASSIGNED,
     OFFER_ASSIGNMENT_EMAIL_PENDING,
-    OFFER_ASSIGNMENT_EMAIL_SUBJECT_LIMIT,
     OFFER_ASSIGNMENT_EMAIL_TEMPLATE_FIELD_LIMIT,
     OFFER_ASSIGNMENT_REVOKED,
     OFFER_MAX_USES_DEFAULT,
@@ -673,17 +672,12 @@ class EnterpriseCouponViewSet(CouponViewSet):
         if not is_coupon_available(coupon):
             raise DRFValidationError({'error': message})
 
-    def _validate_email_fields(self, subject, greeting, closing):
+    def _validate_email_fields(self, greeting, closing):
         """
-        Raise ValidationError if subject, greeting and/or closing is above the allowed limit.
+        Raise ValidationError if greeting and/or closing is above the allowed limit.
         """
         errors = {}
         max_field_limit = OFFER_ASSIGNMENT_EMAIL_TEMPLATE_FIELD_LIMIT
-
-        if len(subject) > OFFER_ASSIGNMENT_EMAIL_SUBJECT_LIMIT:
-            errors['email_subject'] = 'Email subject must be {} characters or less'.format(
-                OFFER_ASSIGNMENT_EMAIL_SUBJECT_LIMIT
-            )
 
         if len(greeting) > max_field_limit:
             errors['email_greeting'] = 'Email greeting must be {} characters or less'.format(max_field_limit)
@@ -702,13 +696,12 @@ class EnterpriseCouponViewSet(CouponViewSet):
         """
         coupon = self.get_object()
         self._validate_coupon_availablity(coupon, 'Coupon is not available for code assignment')
-        subject = request.data.pop('template_subject', '')
         greeting = request.data.pop('template_greeting', '')
         closing = request.data.pop('template_closing', '')
-        self._validate_email_fields(subject, greeting, closing)
+        self._validate_email_fields(greeting, closing)
         serializer = CouponCodeAssignmentSerializer(
             data=request.data,
-            context={'coupon': coupon, 'subject': subject, 'greeting': greeting, 'closing': closing}
+            context={'coupon': coupon, 'greeting': greeting, 'closing': closing}
         )
         if serializer.is_valid():
             serializer.save()
@@ -723,14 +716,13 @@ class EnterpriseCouponViewSet(CouponViewSet):
         """
         coupon = self.get_object()
         self._validate_coupon_availablity(coupon, 'Coupon is not available for code revoke')
-        subject = request.data.pop('template_subject', '')
         greeting = request.data.pop('template_greeting', '')
         closing = request.data.pop('template_closing', '')
-        self._validate_email_fields(subject, greeting, closing)
+        self._validate_email_fields(greeting, closing)
         serializer = CouponCodeRevokeSerializer(
             data=request.data.get('assignments'),
             many=True,
-            context={'coupon': coupon, 'subject': subject, 'greeting': greeting, 'closing': closing}
+            context={'coupon': coupon, 'greeting': greeting, 'closing': closing}
         )
         if serializer.is_valid():
             serializer.save()
@@ -746,10 +738,9 @@ class EnterpriseCouponViewSet(CouponViewSet):
         """
         coupon = self.get_object()
         self._validate_coupon_availablity(coupon, 'Coupon is not available for code remind')
-        subject = request.data.pop('template_subject', '')
         greeting = request.data.pop('template_greeting', '')
         closing = request.data.pop('template_closing', '')
-        self._validate_email_fields(subject, greeting, closing)
+        self._validate_email_fields(greeting, closing)
         if request.data.get('assignments'):
             assignments = request.data.get('assignments')
         else:
@@ -778,7 +769,7 @@ class EnterpriseCouponViewSet(CouponViewSet):
         serializer = CouponCodeRemindSerializer(
             data=assignments,
             many=True,
-            context={'coupon': coupon, 'subject': subject, 'greeting': greeting, 'closing': closing}
+            context={'coupon': coupon, 'greeting': greeting, 'closing': closing}
         )
         if serializer.is_valid():
             serializer.save()

--- a/ecommerce/extensions/offer/tests/test_utils.py
+++ b/ecommerce/extensions/offer/tests/test_utils.py
@@ -92,7 +92,6 @@ class UtilTests(DiscoveryTestMixin, TestCase):
     @mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email')
     @ddt.data(
         (
-            'subject',
             'hi',
             'bye',
             {
@@ -108,7 +107,6 @@ class UtilTests(DiscoveryTestMixin, TestCase):
     @ddt.unpack
     def test_send_assigned_offer_email(
             self,
-            subject,
             greeting,
             closing,
             tokens,
@@ -116,9 +114,9 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             mock_sailthru_task,
     ):
         """ Test that the offer assignment email message is sent to async task. """
+        email_subject = settings.OFFER_ASSIGNMENT_EMAIL_SUBJECT
         mock_sailthru_task.delay.side_effect = side_effect
         send_assigned_offer_email(
-            subject,
             greeting,
             closing,
             tokens.get('offer_assignment_id'),
@@ -130,14 +128,13 @@ class UtilTests(DiscoveryTestMixin, TestCase):
         mock_sailthru_task.delay.assert_called_once_with(
             tokens.get('learner_email'),
             tokens.get('offer_assignment_id'),
-            subject,
+            email_subject,
             mock.ANY
         )
 
     @mock.patch('ecommerce.extensions.offer.utils.send_offer_update_email')
     @ddt.data(
         (
-            'subject',
             'hi',
             'bye',
             {
@@ -153,7 +150,6 @@ class UtilTests(DiscoveryTestMixin, TestCase):
     @ddt.unpack
     def test_send_assigned_offer_reminder_email(
             self,
-            subject,
             greeting,
             closing,
             tokens,
@@ -163,9 +159,9 @@ class UtilTests(DiscoveryTestMixin, TestCase):
         """
         Test that the offer assignment reminder email message is sent to the async task in ecommerce-worker.
         """
+        email_subject = settings.OFFER_REMINDER_EMAIL_SUBJECT
         mock_sailthru_task.delay.side_effect = side_effect
         send_assigned_offer_reminder_email(
-            subject,
             greeting,
             closing,
             tokens.get('learner_email'),
@@ -176,14 +172,13 @@ class UtilTests(DiscoveryTestMixin, TestCase):
         )
         mock_sailthru_task.delay.assert_called_once_with(
             tokens.get('learner_email'),
-            subject,
+            email_subject,
             mock.ANY
         )
 
     @mock.patch('ecommerce.extensions.offer.utils.send_offer_update_email')
     @ddt.data(
         (
-            'subject',
             'hi',
             'bye',
             {
@@ -196,7 +191,6 @@ class UtilTests(DiscoveryTestMixin, TestCase):
     @ddt.unpack
     def test_send_offer_revoked_email(
             self,
-            subject,
             greeting,
             closing,
             tokens,
@@ -206,9 +200,9 @@ class UtilTests(DiscoveryTestMixin, TestCase):
         """
         Test that the offer revocation email message is sent to the async task in ecommerce-worker.
         """
+        email_subject = settings.OFFER_REVOKE_EMAIL_SUBJECT
         mock_sailthru_task.delay.side_effect = side_effect
         send_revoked_offer_email(
-            subject,
             greeting,
             closing,
             tokens.get('learner_email'),
@@ -216,7 +210,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
         )
         mock_sailthru_task.delay.assert_called_once_with(
             tokens.get('learner_email'),
-            subject,
+            email_subject,
             mock.ANY
         )
 

--- a/ecommerce/extensions/offer/utils.py
+++ b/ecommerce/extensions/offer/utils.py
@@ -129,7 +129,6 @@ def get_redirect_to_email_confirmation_if_required(request, offer, product):
 
 
 def send_assigned_offer_email(
-        subject,
         greeting,
         closing,
         offer_assignment_id,
@@ -139,8 +138,6 @@ def send_assigned_offer_email(
         code_expiration_date):
     """
     Arguments:
-        *subject*
-            The email subject
         *email_greeting*
             The email greeting (prefix)
         *email_closing*
@@ -156,6 +153,8 @@ def send_assigned_offer_email(
         *code_expiration_date*
             Date till code is valid.
     """
+
+    email_subject = settings.OFFER_ASSIGNMENT_EMAIL_SUBJECT
     email_template = settings.OFFER_ASSIGNMENT_EMAIL_TEMPLATE
     placeholder_dict = SafeDict(
         REDEMPTIONS_REMAINING=redemptions_remaining,
@@ -164,11 +163,10 @@ def send_assigned_offer_email(
         EXPIRATION_DATE=code_expiration_date
     )
     email_body = format_email(email_template, placeholder_dict, greeting, closing)
-    send_offer_assignment_email.delay(learner_email, offer_assignment_id, subject, email_body)
+    send_offer_assignment_email.delay(learner_email, offer_assignment_id, email_subject, email_body)
 
 
 def send_revoked_offer_email(
-        subject,
         greeting,
         closing,
         learner_email,
@@ -176,8 +174,6 @@ def send_revoked_offer_email(
 ):
     """
     Arguments:
-        *subject*
-            The email subject
         *email_greeting*
             The email greeting (prefix)
         *email_closing*
@@ -187,17 +183,18 @@ def send_revoked_offer_email(
         *code*
             Code for the user.
     """
+
+    email_subject = settings.OFFER_REVOKE_EMAIL_SUBJECT
     email_template = settings.OFFER_REVOKE_EMAIL_TEMPLATE
     placeholder_dict = SafeDict(
         USER_EMAIL=learner_email,
         CODE=code,
     )
     email_body = format_email(email_template, placeholder_dict, greeting, closing)
-    send_offer_update_email.delay(learner_email, subject, email_body)
+    send_offer_update_email.delay(learner_email, email_subject, email_body)
 
 
 def send_assigned_offer_reminder_email(
-        subject,
         greeting,
         closing,
         learner_email,
@@ -207,8 +204,6 @@ def send_assigned_offer_reminder_email(
         code_expiration_date):
     """
     Arguments:
-        *subject*
-            The email subject
         *email_greeting*
             The email greeting (prefix)
         *email_closing*
@@ -224,6 +219,8 @@ def send_assigned_offer_reminder_email(
        *code_expiration_date*
            Date till code is valid.
     """
+
+    email_subject = settings.OFFER_REMINDER_EMAIL_SUBJECT
     email_template = settings.OFFER_REMINDER_EMAIL_TEMPLATE
     placeholder_dict = SafeDict(
         REDEEMED_OFFER_COUNT=redeemed_offer_count,
@@ -233,7 +230,7 @@ def send_assigned_offer_reminder_email(
         EXPIRATION_DATE=code_expiration_date
     )
     email_body = format_email(email_template, placeholder_dict, greeting, closing)
-    send_offer_update_email.delay(learner_email, subject, email_body)
+    send_offer_update_email.delay(learner_email, email_subject, email_body)
 
 
 def format_email(template, placeholder_dict, greeting, closing):

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -706,10 +706,12 @@ edX Login: {USER_EMAIL}
 Access Code: {CODE}
 Expiration Date: {EXPIRATION_DATE}
 '''
+OFFER_ASSIGNMENT_EMAIL_SUBJECT = 'New edX course assignment'
 
 OFFER_REVOKE_EMAIL_TEMPLATE = '''
 Your Learning Manager has revoked access code {CODE} and it is no longer assigned to your edX account {USER_EMAIL}.
 '''
+OFFER_REVOKE_EMAIL_SUBJECT = 'edX Course Assignment Revoked'
 
 OFFER_REMINDER_EMAIL_TEMPLATE = '''
 You have redeemed this code {REDEEMED_OFFER_COUNT} time(s) out of {TOTAL_OFFER_COUNT} available course redemptions.
@@ -718,6 +720,7 @@ edX Login: {USER_EMAIL}
 Access Code: {CODE}
 Expiration Date: {EXPIRATION_DATE}
 '''
+OFFER_REMINDER_EMAIL_SUBJECT = 'Reminder on edX course assignment'
 
 OFFER_ASSIGNMEN_EMAIL_TEMPLATE_BODY_MAP = {
     'assign': OFFER_ASSIGNMENT_EMAIL_TEMPLATE,


### PR DESCRIPTION
Reverts edx/ecommerce#3038

Reverting because we need to run the management command to populate the `subject` field for existing records.