### PR TITLE
Usamasadiq/removing-six-II

### DIFF
--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -2,15 +2,13 @@
 
 
 import datetime
+import urllib
 from decimal import Decimal
 
 import ddt
 import httpretty
 import mock
 import pytz
-import six.moves.urllib.error  # pylint: disable=import-error
-import six.moves.urllib.parse  # pylint: disable=import-error
-import six.moves.urllib.request  # pylint: disable=import-error
 from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.urls import reverse
@@ -58,7 +56,7 @@ ENTERPRISE_CUSTOMER_CATALOG = 'abc18838-adcb-41d5-abec-b28be5bfcc13'
 
 def format_url(base='', path='', params=None):
     if params:
-        return '{base}{path}?{params}'.format(base=base, path=path, params=six.moves.urllib.parse.urlencode(params))
+        return '{base}{path}?{params}'.format(base=base, path=path, params=urllib.parse.urlencode(params))
     return '{base}{path}'.format(base=base, path=path)
 
 
@@ -246,7 +244,7 @@ class CouponOfferViewTests(ApiMockMixin, CouponMixin, DiscoveryTestMixin, Enterp
         self.client.logout()
         url = self.prepare_url_for_credit_seat()
         response = self.client.get(url)
-        expected_url = '{path}?next={next}'.format(path=reverse('login'), next=six.moves.urllib.parse.quote(url))
+        expected_url = '{path}?next={next}'.format(path=reverse('login'), next=urllib.parse.quote(url))
         self.assertRedirects(response, expected_url, target_status_code=302)
 
     def test_credit_seat_response(self):
@@ -790,7 +788,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
 
     def assert_redirected_to_email_confirmation(self, response):
         expected_redirect_url = '/offers/email_confirmation/?{}'.format(
-            six.moves.urllib.parse.urlencode({'course_id': self.course.id})
+            urllib.parse.urlencode({'course_id': self.course.id})
         )
         self.assertIsInstance(response, HttpResponseRedirect)
         self.assertIn(expected_redirect_url, response.url)

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -2,7 +2,6 @@
 
 import logging
 
-import six
 import unicodecsv as csv
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -199,7 +198,7 @@ class CouponRedeemView(EdxOrderPlacementMixin, APIView):
         except EnterpriseDoesNotExist as e:
             # If an EnterpriseException is caught while pulling the EnterpriseCustomer, that means there's no
             # corresponding EnterpriseCustomer in the Enterprise service (which should never happen).
-            logger.exception(six.text_type(e))
+            logger.exception(str(e))
             return render(
                 request,
                 template_name,

--- a/ecommerce/courses/management/commands/create_enrollment_codes.py
+++ b/ecommerce/courses/management/commands/create_enrollment_codes.py
@@ -6,7 +6,6 @@ This command generates enrollment codes for courses.
 import logging
 import os
 
-import six
 from django.core.management import BaseCommand, CommandError
 
 from ecommerce.core.constants import ENROLLMENT_CODE_SEAT_TYPES
@@ -90,7 +89,7 @@ class Command(BaseCommand):
                     logger.error(
                         'Enrollment code generation failed for "%s" course. Because %s',
                         course.id,
-                        six.text_type(error),
+                        str(error),
                     )
                     failed_courses.append(course.id)
 
@@ -131,7 +130,7 @@ class Command(BaseCommand):
                     logger.error(
                         'Enrollment code generation failed for "%s" course. Because %s',
                         course.id,
-                        six.text_type(error),
+                        str(error),
                     )
                     failed_courses.append(course.id)
         return total_courses, failed_courses

--- a/ecommerce/courses/models.py
+++ b/ecommerce/courses/models.py
@@ -2,7 +2,6 @@
 
 import logging
 
-import six
 from django.conf import settings
 from django.db import models, transaction
 from django.db.models import Count, Q
@@ -45,7 +44,7 @@ class Course(models.Model):
     history = HistoricalRecords()
 
     def __unicode__(self):
-        return six.text_type(self.id)
+        return str(self.id)
 
     def _create_parent_seat(self):
         """ Create the parent seat product if it does not already exist. """
@@ -175,7 +174,7 @@ class Course(models.Model):
             Product:  The seat that has been created or updated.
         """
         certificate_type = certificate_type.lower()
-        course_id = six.text_type(self.id)
+        course_id = str(self.id)
 
         try:
             product_id = StockRecord.objects.get(partner_sku=sku, partner=self.partner).product_id

--- a/ecommerce/courses/publishers.py
+++ b/ecommerce/courses/publishers.py
@@ -3,7 +3,6 @@
 import json
 import logging
 
-import six
 from django.utils.translation import ugettext_lazy as _
 from edx_rest_api_client.exceptions import SlumberHttpBaseException
 from oscar.core.loading import get_model
@@ -131,7 +130,7 @@ class LMSPublisher:
         message = None
         try:
             data = json.loads(response)
-            if isinstance(data, six.string_types):
+            if isinstance(data, str):
                 message = data
             elif isinstance(data, dict) and data:
                 message = list(data.values())[0]

--- a/ecommerce/courses/tests/test_models.py
+++ b/ecommerce/courses/tests/test_models.py
@@ -2,7 +2,6 @@
 
 import ddt
 import mock
-import six
 from django.conf import settings
 from django.utils.timezone import now, timedelta
 from freezegun import freeze_time
@@ -28,7 +27,7 @@ class CourseTests(DiscoveryTestMixin, TestCase):
         """Verify the __unicode__ method returns the Course ID."""
         course_id = u'edx/Demo_Course/DemoX'
         course = CourseFactory(id=course_id, partner=self.partner)
-        self.assertEqual(six.text_type(course.id), course_id)
+        self.assertEqual(str(course.id), course_id)
 
     def test_seat_products(self):
         """
@@ -169,7 +168,7 @@ class CourseTests(DiscoveryTestMixin, TestCase):
         price = 10
 
         # Verify that the course can have multiple credit seats added to it
-        for credit_provider, credit_hours in six.iteritems(credit_data):
+        for credit_provider, credit_hours in credit_data.items():
             credit_seat = course.create_or_update_seat(
                 certificate_type,
                 id_verification_required,

--- a/ecommerce/enterprise/api.py
+++ b/ecommerce/enterprise/api.py
@@ -4,12 +4,12 @@ Methods for fetching enterprise API data.
 
 
 import logging
+from urllib.parse import urlencode
 
 from django.conf import settings
 from edx_django_utils.cache import TieredCache
 from requests.exceptions import ConnectionError as ReqConnectionError
 from requests.exceptions import Timeout
-from six.moves.urllib.parse import urlencode
 from slumber.exceptions import SlumberHttpBaseException
 
 from ecommerce.core.utils import get_cache_key

--- a/ecommerce/enterprise/tests/mixins.py
+++ b/ecommerce/enterprise/tests/mixins.py
@@ -1,6 +1,7 @@
 
 
 import json
+from urllib.parse import urlencode  # pylint: disable=import-error
 from uuid import uuid4
 
 import httpretty
@@ -8,7 +9,6 @@ import requests
 from django.conf import settings
 from oscar.core.loading import get_model
 from oscar.test import factories
-from six.moves.urllib.parse import urlencode  # pylint: disable=import-error
 
 from ecommerce.core.constants import COUPON_PRODUCT_CLASS_NAME
 from ecommerce.courses.tests.factories import CourseFactory

--- a/ecommerce/enterprise/tests/mixins.py
+++ b/ecommerce/enterprise/tests/mixins.py
@@ -1,7 +1,7 @@
 
 
 import json
-from urllib.parse import urlencode  # pylint: disable=import-error
+from urllib.parse import urlencode
 from uuid import uuid4
 
 import httpretty

--- a/ecommerce/enterprise/tests/test_conditions.py
+++ b/ecommerce/enterprise/tests/test_conditions.py
@@ -10,7 +10,6 @@ import mock
 from oscar.core.loading import get_model
 from oscar.test.factories import BasketFactory, OrderDiscountFactory, OrderFactory
 from requests.exceptions import ConnectionError as ReqConnectionError
-from six.moves import range, zip
 
 from ecommerce.coupons.tests.mixins import CouponMixin, DiscoveryMockMixin
 from ecommerce.courses.tests.factories import CourseFactory

--- a/ecommerce/enterprise/tests/test_migrate_enterprise_conditional_offers_command.py
+++ b/ecommerce/enterprise/tests/test_migrate_enterprise_conditional_offers_command.py
@@ -11,7 +11,6 @@ from oscar.test.factories import (
     RangeFactory,
     VoucherFactory
 )
-from six.moves import range
 
 from ecommerce.enterprise.management.commands.migrate_enterprise_conditional_offers import Command
 from ecommerce.programs.custom import get_model

--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -8,7 +8,7 @@ import hmac
 import logging
 from collections import OrderedDict
 from functools import reduce  # pylint: disable=redefined-builtin
-from urllib.parse import urlencode, urlparse  # pylint: disable=import-error
+from urllib.parse import urlencode, urlparse
 
 import crum
 import waffle

--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -8,9 +8,9 @@ import hmac
 import logging
 from collections import OrderedDict
 from functools import reduce  # pylint: disable=redefined-builtin
+from urllib.parse import urlencode, urlparse  # pylint: disable=import-error
 
 import crum
-import six  # pylint: disable=ungrouped-imports
 import waffle
 from django.conf import settings
 from django.urls import reverse
@@ -21,8 +21,6 @@ from edx_rest_framework_extensions.auth.jwt.cookies import get_decoded_jwt
 from oscar.core.loading import get_model
 from requests.exceptions import ConnectionError as ReqConnectionError
 from requests.exceptions import Timeout
-from six.moves.urllib.parse import urlparse  # pylint: disable=import-error
-from six.moves.urllib.parse import urlencode
 from slumber.exceptions import SlumberHttpBaseException
 
 from ecommerce.core.constants import SYSTEM_ENTERPRISE_LEARNER_ROLE
@@ -432,7 +430,7 @@ def get_enterprise_customer_data_sharing_consent_token(access_token, course_id, 
     Enterprise Customer combination.
     """
     consent_token_hmac = hmac.new(
-        six.text_type(access_token).encode('utf-8'),
+        str(access_token).encode('utf-8'),
         u'{course_id}_{enterprise_customer_uuid}'.format(
             course_id=course_id,
             enterprise_customer_uuid=enterprise_customer_uuid,

--- a/ecommerce/entitlements/utils.py
+++ b/ecommerce/entitlements/utils.py
@@ -2,7 +2,6 @@
 
 import logging
 
-import six
 from django.conf import settings
 from django.db.models import Q
 from oscar.core.loading import get_model
@@ -47,7 +46,7 @@ def get_entitlement(uuid, certificate_type):
     """ Get a Course Entitlement Product """
     uuid_query = Q(
         attributes__name='UUID',
-        attribute_values__value_text=six.text_type(uuid),
+        attribute_values__value_text=str(uuid),
     )
     certificate_type_query = Q(
         attributes__name='certificate_type',
@@ -59,7 +58,7 @@ def get_entitlement(uuid, certificate_type):
 def create_or_update_course_entitlement(certificate_type, price, partner, UUID, title, id_verification_required=False):
     """ Create or Update Course Entitlement Products """
     certificate_type = certificate_type.lower()
-    UUID = six.text_type(UUID)
+    UUID = str(UUID)
 
     try:
         parent_entitlement, __ = create_parent_course_entitlement(title, UUID)

--- a/ecommerce/extensions/analytics/utils.py
+++ b/ecommerce/extensions/analytics/utils.py
@@ -3,9 +3,9 @@
 import json
 import logging
 from functools import wraps
+from urllib.parse import urlunsplit
 
 from django.db import transaction
-from six.moves.urllib.parse import urlunsplit  # pylint: disable=import-error
 
 from ecommerce.courses.utils import mode_for_product
 

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -4,9 +4,9 @@
 import logging
 from collections import OrderedDict
 from decimal import Decimal
+from urllib.parse import urljoin
 
 import bleach
-import six  # pylint: disable=ungrouped-imports
 import waffle
 from dateutil.parser import parse
 from django.conf import settings
@@ -20,8 +20,6 @@ from oscar.core.loading import get_class, get_model
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 from rest_framework.settings import api_settings
-from six.moves import range
-from six.moves.urllib.parse import urljoin
 
 from ecommerce.core.constants import (
     COURSE_ENTITLEMENT_PRODUCT_CLASS_NAME,
@@ -642,8 +640,8 @@ class AtomicPublicationSerializer(serializers.Serializer):  # pylint: disable=ab
                 raise Exception(resp_message)
 
         except Exception as e:  # pylint: disable=broad-except
-            logger.exception(u'Failed to save and publish [%s]: [%s]', course_id, six.text_type(e))
-            return False, e, six.text_type(e)
+            logger.exception(u'Failed to save and publish [%s]: [%s]', course_id, str(e))
+            return False, e, str(e)
 
 
 class PartnerSerializer(serializers.ModelSerializer):
@@ -1643,7 +1641,7 @@ class CouponCodeRevokeSerializer(CouponCodeMixin, serializers.Serializer):  # py
         except Exception as exc:  # pylint: disable=broad-except
             logger.exception('[Offer Revocation] Encountered error when revoking code %s for user %s with '
                              'subject %r, greeting %r and closing %r', code, email, subject, greeting, closing)
-            detail = six.text_type(exc)
+            detail = str(exc)
 
         validated_data['detail'] = detail
         return validated_data
@@ -1701,7 +1699,7 @@ class CouponCodeRemindSerializer(CouponCodeMixin, serializers.Serializer):  # py
                 offer_assignment.save()
         except Exception as exc:  # pylint: disable=broad-except
             logger.exception('Encountered error during reminder email for code %s of user %s', code, email)
-            detail = six.text_type(exc)
+            detail = str(exc)
 
         validated_data['detail'] = detail
         return validated_data

--- a/ecommerce/extensions/api/tests/test_authentication.py
+++ b/ecommerce/extensions/api/tests/test_authentication.py
@@ -2,11 +2,11 @@
 
 
 import json
+from urllib.parse import urljoin
 
 import httpretty
 import mock
 from django.test import RequestFactory
-from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
 
 from ecommerce.extensions.api.authentication import BearerAuthentication
 from ecommerce.tests.testcases import TestCase

--- a/ecommerce/extensions/api/v2/tests/views/__init__.py
+++ b/ecommerce/extensions/api/v2/tests/views/__init__.py
@@ -1,6 +1,5 @@
 
 
-import six
 from django.test import RequestFactory
 from django.urls import reverse
 from oscar.core.loading import get_class, get_model
@@ -64,7 +63,7 @@ class ProductSerializerMixin:
             'id': product.id,
             'url': self.get_full_url(reverse('api:v2:product-detail', kwargs={'pk': product.id})),
             'structure': product.structure,
-            'product_class': six.text_type(product.get_product_class()),
+            'product_class': str(product.get_product_class()),
             'title': product.title,
             'expires': product.expires.strftime(ISO_8601_FORMAT) if product.expires else None,
             'attribute_values': attribute_values,
@@ -87,5 +86,5 @@ class ProductSerializerMixin:
             'product': stockrecord.product.id,
             'partner_sku': stockrecord.partner_sku,
             'price_currency': stockrecord.price_currency,
-            'price_excl_tax': six.text_type(stockrecord.price_excl_tax),
+            'price_excl_tax': str(stockrecord.price_excl_tax),
         }

--- a/ecommerce/extensions/api/v2/tests/views/test_baskets.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_baskets.py
@@ -3,13 +3,13 @@
 
 import datetime
 import json
+import urllib
 from collections import namedtuple
 from decimal import Decimal
 
 import ddt
 import httpretty
 import mock
-import six  # pylint: disable=ungrouped-imports
 from django.contrib.auth import get_user_model
 from django.test import override_settings
 from django.urls import reverse
@@ -18,7 +18,6 @@ from oscar.core.loading import get_model
 from oscar.test import factories
 from oscar.test.factories import BasketFactory
 from rest_framework.throttling import UserRateThrottle
-from six.moves import range
 from waffle.testutils import override_switch
 
 from ecommerce.core.constants import ALLOW_MISSING_LMS_USER_ID
@@ -974,7 +973,7 @@ class BasketCalculateViewTests(ProgramTestMixin, ThrottlingMixin, TestCase):
 
         """
         sku_list = [product.stockrecords.first().partner_sku for product in products]
-        qs = six.moves.urllib.parse.urlencode(
+        qs = urllib.parse.urlencode(
             {'sku': sku_list},
             True
         )

--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -10,7 +10,6 @@ import ddt
 import httpretty
 import mock
 import pytz
-import six
 from django.test import RequestFactory
 from django.urls import reverse
 from django.utils.timezone import now
@@ -76,11 +75,11 @@ class CouponViewSetTest(CouponMixin, DiscoveryTestMixin, TestCase):
             'benefit_type': Benefit.PERCENTAGE,
             'benefit_value': 100,
             'catalog': self.catalog,
-            'end_datetime': six.text_type(now() + datetime.timedelta(days=10)),
-            'enterprise_customer': {'id': six.text_type(uuid4())},
+            'end_datetime': str(now() + datetime.timedelta(days=10)),
+            'enterprise_customer': {'id': str(uuid4())},
             'code': '',
             'quantity': 2,
-            'start_datetime': six.text_type(now() - datetime.timedelta(days=1)),
+            'start_datetime': str(now() - datetime.timedelta(days=1)),
             'voucher_type': Voucher.ONCE_PER_CUSTOMER,
             'category': {'name': self.category.name},
             'note': None,
@@ -239,10 +238,10 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             'category': {'name': self.category.name},
             'client': 'TeštX',
             'code': '',
-            'end_datetime': six.text_type(now() + datetime.timedelta(days=10)),
+            'end_datetime': str(now() + datetime.timedelta(days=10)),
             'price': 100,
             'quantity': 2,
-            'start_datetime': six.text_type(now() - datetime.timedelta(days=10)),
+            'start_datetime': str(now() - datetime.timedelta(days=10)),
             'stock_record_ids': [seat.stockrecords.first().id, other_seat.stockrecords.first().id],
             'title': 'Tešt čoupon',
             'voucher_type': Voucher.SINGLE_USE,
@@ -322,8 +321,8 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             'benefit_value': benefit_value,
             'benefit_type': benefit_type
         })
-        enterprise_customer_id = six.text_type(uuid4())
-        enterprise_catalog_id = six.text_type(uuid4())
+        enterprise_customer_id = str(uuid4())
+        enterprise_catalog_id = str(uuid4())
         enterprise_name = 'test enterprise'
         response = self._create_enterprise_coupon(
             enterprise_customer_id,
@@ -516,15 +515,15 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         for voucher in vouchers:
             all_offers = voucher.offers.all()
             self.assertEqual(len(all_offers), 2)
-            self.assertEqual(six.text_type(all_offers[0].condition.range.enterprise_customer),
+            self.assertEqual(str(all_offers[0].condition.range.enterprise_customer),
                              enterprise_customer_id)
             self.assertEqual(
-                six.text_type(all_offers[0].condition.range.enterprise_customer_catalog),
+                str(all_offers[0].condition.range.enterprise_customer_catalog),
                 enterprise_catalog_id)
-            self.assertEqual(six.text_type(all_offers[1].condition.enterprise_customer_uuid),
+            self.assertEqual(str(all_offers[1].condition.enterprise_customer_uuid),
                              enterprise_customer_id)
             self.assertEqual(
-                six.text_type(all_offers[1].condition.enterprise_customer_catalog_uuid),
+                str(all_offers[1].condition.enterprise_customer_catalog_uuid),
                 enterprise_catalog_id)
             self.assertEqual(all_offers[1].condition.proxy_class,
                              class_path(AssignableEnterpriseCustomerCondition))
@@ -545,8 +544,8 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
 
     def test_create_enterprise_offers(self):
         """Test creating an enterprise coupon with the enterprise offers."""
-        enterprise_customer_id = six.text_type(uuid4())
-        enterprise_catalog_id = six.text_type(uuid4())
+        enterprise_customer_id = str(uuid4())
+        enterprise_catalog_id = str(uuid4())
         enterprise_name = 'test enterprise'
         response = self._create_enterprise_coupon(enterprise_customer_id, enterprise_catalog_id, enterprise_name)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -555,8 +554,8 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
 
     def test_update_enterprise_offers_regular_coupon(self):
         """Test updating a coupon to add enterprise data with the enterprise offers."""
-        enterprise_customer_id = six.text_type(uuid4())
-        enterprise_catalog_id = six.text_type(uuid4())
+        enterprise_customer_id = str(uuid4())
+        enterprise_catalog_id = str(uuid4())
         self.get_response(
             'PUT',
             reverse('api:v2:coupons-detail', kwargs={'pk': self.coupon.id}),
@@ -571,8 +570,8 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
 
     def test_update_enterprise_offers_enterprise_coupon(self):
         """Test updating an enterprise coupon with the enterprise offers."""
-        enterprise_customer_id = six.text_type(uuid4())
-        enterprise_catalog_id = six.text_type(uuid4())
+        enterprise_customer_id = str(uuid4())
+        enterprise_catalog_id = str(uuid4())
         enterprise_name = 'test enterprise'
         self._create_enterprise_coupon(
             enterprise_customer_id, enterprise_catalog_id, enterprise_name, ENTERPRISE_COUPONS_LINK
@@ -836,7 +835,7 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         # test EXPIRED
         data = {
             'id': self.coupon.id,
-            'end_datetime': six.text_type(now() - datetime.timedelta(days=1))
+            'end_datetime': str(now() - datetime.timedelta(days=1))
         }
         response_data = self.get_response_json(
             'PUT',
@@ -1152,7 +1151,7 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         """Verify create coupon with program uuid."""
         proxy_class = class_path(BENEFIT_MAP[self.data['benefit_type']])
         self.data.update({
-            'program_uuid': six.text_type(uuid4()),
+            'program_uuid': str(uuid4()),
             'title': 'Program Coupon',
             'stock_record_ids': []
         })
@@ -1167,7 +1166,7 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
 
     def test_update_coupon_with_program_uuid(self):
         """Verify update coupon program uuid."""
-        program_uuid = six.text_type(uuid4())
+        program_uuid = str(uuid4())
         proxy_class = class_path(BENEFIT_MAP[self.data['benefit_type']])
         self.data.update({
             'program_uuid': program_uuid,
@@ -1183,7 +1182,7 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         self.assertEqual(Benefit.objects.filter(proxy_class=proxy_class).count(), 1)
         self.assertEqual(Condition.objects.filter(program_uuid=self.data['program_uuid']).count(), 1)
 
-        edited_program_uuid = six.text_type(uuid4())
+        edited_program_uuid = str(uuid4())
         coupon = Product.objects.get(title=self.data['title'])
         response_data = self.get_response_json(
             'PUT',
@@ -1198,7 +1197,7 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
     def test_update_program_coupon_benefit_value(self):
         """Verify update benefit value for program coupon."""
         self.data.update({
-            'program_uuid': six.text_type(uuid4()),
+            'program_uuid': str(uuid4()),
             'title': 'Program Coupon',
             'stock_record_ids': []
         })
@@ -1218,7 +1217,7 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         """Verify that the coupon serializer returns benefit type for program coupons."""
         self.data.update({
             'benefit_type': benefit_type,
-            'program_uuid': six.text_type(uuid4()),
+            'program_uuid': str(uuid4()),
             'title': 'Test Program Coupon Benefit Type',
             'stock_record_ids': [],
         })
@@ -1243,8 +1242,8 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         metadata object attached to its attributes.
         """
 
-        enterprise_customer_id = six.text_type(uuid4())
-        enterprise_catalog_id = six.text_type(uuid4())
+        enterprise_customer_id = str(uuid4())
+        enterprise_catalog_id = str(uuid4())
         enterprise_name = 'test enterprise'
         response = self._create_enterprise_coupon(
             enterprise_customer_id,
@@ -1263,8 +1262,8 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         Verify an update of an existing coupon that has DOES have contract metadata
         successfully updates contract metadata object to the coupon's attributes.
         """
-        enterprise_customer_id = six.text_type(uuid4())
-        enterprise_catalog_id = six.text_type(uuid4())
+        enterprise_customer_id = str(uuid4())
+        enterprise_catalog_id = str(uuid4())
         enterprise_name = 'test enterprise'
         response = self._create_enterprise_coupon(
             enterprise_customer_id,

--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -11,7 +11,6 @@ import ddt
 import httpretty
 import mock
 import rules
-import six  # pylint: disable=ungrouped-imports
 from django.conf import settings
 from django.test import override_settings
 from django.urls import reverse
@@ -21,7 +20,6 @@ from django.utils.timezone import now
 from oscar.core.loading import get_model
 from oscar.test import factories
 from rest_framework import status
-from six.moves import range
 from slumber.exceptions import SlumberHttpBaseException
 
 from ecommerce.core.constants import (
@@ -303,8 +301,8 @@ class EnterpriseCouponViewSetRbacTests(
             'start_datetime': str(now() - datetime.timedelta(days=10)),
             'title': 'Tešt Enterprise čoupon',
             'voucher_type': Voucher.SINGLE_USE,
-            'enterprise_customer': {'name': 'test enterprise', 'id': six.text_type(uuid4())},
-            'enterprise_customer_catalog': six.text_type(uuid4()),
+            'enterprise_customer': {'name': 'test enterprise', 'id': str(uuid4())},
+            'enterprise_customer_catalog': str(uuid4()),
             'notify_email': 'batman@gotham.comics',
             'contract_discount_type': EnterpriseContractMetadata.PERCENTAGE,
             'contract_discount_value': '12.35',
@@ -774,15 +772,15 @@ class EnterpriseCouponViewSetRbacTests(
         vouchers = Product.objects.get(id=coupon_id).attr.coupon_vouchers.vouchers.all()
         codes = [voucher.code for voucher in vouchers]
 
-        for email, code_index in six.iteritems(code_assignments):
+        for email, code_index in code_assignments.items():
             self.assign_user_to_code(coupon_id, [email], [codes[code_index]])
 
-        for email, data in six.iteritems(code_redemptions):
+        for email, data in code_redemptions.items():
             redeeming_user = self.create_user(email=email)
             for _ in range(0, data['num']):
                 self.use_voucher(Voucher.objects.get(code=codes[data['code']]), redeeming_user)
 
-        for code_filter, expected_response in six.iteritems(expected_responses):
+        for code_filter, expected_response in expected_responses.items():
             response = self.get_response(
                 'GET',
                 '/api/v2/enterprise/coupons/{}/codes/?code_filter={}'.format(coupon_id, code_filter)
@@ -1759,7 +1757,7 @@ class EnterpriseCouponViewSetRbacTests(
         )
 
         # Verify that we get correct results.
-        for field, value in six.iteritems(expected_response):
+        for field, value in expected_response.items():
             if assignment_has_error and field == 'errors':
                 assignment_with_errors = OfferAssignment.objects.filter(status=OFFER_ASSIGNMENT_EMAIL_BOUNCED)
                 value = [
@@ -2810,7 +2808,7 @@ class OfferAssignmentSummaryViewSetTests(
         self.user = self.create_user(is_staff=True, email='test@example.com')
         self.client.login(username=self.user.username, password=self.password)
 
-        self.enterprise_customer = {'name': 'test enterprise', 'id': six.text_type(uuid4())}
+        self.enterprise_customer = {'name': 'test enterprise', 'id': str(uuid4())}
 
         self.course = CourseFactory(id='course-v1:test-org+course+run', partner=self.partner)
         self.verified_seat = self.course.create_or_update_seat('verified', False, 100)

--- a/ecommerce/extensions/api/v2/tests/views/test_orders.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_orders.py
@@ -8,7 +8,6 @@ import ddt
 import httpretty
 import mock
 import pytz
-import six
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.test import RequestFactory, override_settings
@@ -89,7 +88,7 @@ class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
 
         self.assertEqual(Order.objects.count(), 2)
         self.assertEqual(content['count'], 1)
-        self.assertEqual(content['results'][0]['number'], six.text_type(order.number))
+        self.assertEqual(content['results'][0]['number'], str(order.number))
 
         # Test ordering
         order_2 = create_order(site=self.site, user=self.user)
@@ -98,8 +97,8 @@ class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
         content = json.loads(response.content.decode('utf-8'))
 
         self.assertEqual(content['count'], 2)
-        self.assertEqual(content['results'][0]['number'], six.text_type(order_2.number))
-        self.assertEqual(content['results'][1]['number'], six.text_type(order.number))
+        self.assertEqual(content['results'][0]['number'], str(order_2.number))
+        self.assertEqual(content['results'][1]['number'], str(order.number))
 
     def test_with_other_users_orders(self):
         """ The view should only return orders for the authenticated users. """
@@ -112,7 +111,7 @@ class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
         response = self.client.get(self.path, HTTP_AUTHORIZATION=self.token)
         content = json.loads(response.content.decode('utf-8'))
         self.assertEqual(content['count'], 1)
-        self.assertEqual(content['results'][0]['number'], six.text_type(order.number))
+        self.assertEqual(content['results'][0]['number'], str(order.number))
 
     @ddt.unpack
     @ddt.data(
@@ -127,7 +126,7 @@ class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
         response = self.client.get(self.path, HTTP_AUTHORIZATION=self.generate_jwt_token_header(admin_user))
         content = json.loads(response.content.decode('utf-8'))
         self.assertEqual(content['count'], 1)
-        self.assertEqual(content['results'][0]['number'], six.text_type(order.number))
+        self.assertEqual(content['results'][0]['number'], str(order.number))
 
     def test_user_information(self):
         """ Make sure that the correct user information is returned. """
@@ -137,7 +136,7 @@ class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
         response = self.client.get(self.path, HTTP_AUTHORIZATION=self.generate_jwt_token_header(admin_user))
         content = json.loads(response.content.decode('utf-8'))
         self.assertEqual(content['count'], 1)
-        self.assertEqual(content['results'][0]['number'], six.text_type(order.number))
+        self.assertEqual(content['results'][0]['number'], str(order.number))
         self.assertEqual(content['results'][0]['user']['email'], admin_user.email)
         self.assertEqual(content['results'][0]['user']['username'], admin_user.username)
 
@@ -186,8 +185,8 @@ class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
 
         self.assertEqual(Order.objects.count(), 2)
         self.assertEqual(content['count'], 2)
-        self.assertEqual(content['results'][0]['number'], six.text_type(second_order.number))
-        self.assertEqual(content['results'][1]['number'], six.text_type(order.number))
+        self.assertEqual(content['results'][0]['number'], str(second_order.number))
+        self.assertEqual(content['results'][1]['number'], str(order.number))
 
         # Configure new site for same partner.
         domain = 'testserver.fake.internal'
@@ -211,8 +210,8 @@ class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
         content = json.loads(response.content.decode('utf-8'))
 
         self.assertEqual(content['count'], 2)
-        self.assertEqual(content['results'][0]['number'], six.text_type(second_order.number))
-        self.assertEqual(content['results'][1]['number'], six.text_type(order.number))
+        self.assertEqual(content['results'][0]['number'], str(second_order.number))
+        self.assertEqual(content['results'][1]['number'], str(order.number))
 
 
 @ddt.ddt
@@ -310,7 +309,7 @@ class OrderFulfillViewTests(TestCase):
 
         # Reload the order from the DB and check its status
         self.order = Order.objects.get(number=self.order.number)
-        self.assertEqual(six.text_type(self.order.number), response.data['number'])
+        self.assertEqual(str(self.order.number), response.data['number'])
         self.assertEqual(self.order.status, response.data['status'])
 
     def test_fulfillment_failed(self):

--- a/ecommerce/extensions/api/v2/tests/views/test_stockrecords.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_stockrecords.py
@@ -2,7 +2,6 @@
 
 import json
 
-import six
 from django.contrib.auth.models import Permission
 from django.urls import reverse
 from oscar.core.loading import get_model
@@ -87,7 +86,7 @@ class StockRecordViewSetTests(ProductSerializerMixin, DiscoveryTestMixin, Thrott
         self.assertEqual(response.status_code, 200)
 
         stockrecord = StockRecord.objects.get(id=self.stockrecord.id)
-        self.assertEqual(six.text_type(stockrecord.price_excl_tax), data['price_excl_tax'])
+        self.assertEqual(str(stockrecord.price_excl_tax), data['price_excl_tax'])
         self.assertEqual(stockrecord.price_currency, data['price_currency'])
 
     def test_update_without_permission(self):

--- a/ecommerce/extensions/api/v2/tests/views/test_user_management.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_user_management.py
@@ -5,7 +5,6 @@ import json
 import ddt
 import mock
 from django.urls import reverse
-from six.moves import range
 
 from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.testcases import TestCase

--- a/ecommerce/extensions/api/v2/tests/views/test_vouchers.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_vouchers.py
@@ -17,7 +17,6 @@ from requests.exceptions import ConnectionError as ReqConnectionError
 from requests.exceptions import Timeout
 from rest_framework import status
 from rest_framework.test import APIRequestFactory
-from six.moves import range
 from slumber.exceptions import SlumberBaseException
 
 from ecommerce.coupons.tests.mixins import CouponMixin, DiscoveryMockMixin

--- a/ecommerce/extensions/api/v2/views/baskets.py
+++ b/ecommerce/extensions/api/v2/views/baskets.py
@@ -4,7 +4,6 @@
 import logging
 import warnings
 
-import six
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import transaction
@@ -169,7 +168,7 @@ class BasketCreateView(EdxOrderPlacementMixin, generics.CreateAPIView):
                             product = data_api.get_product(sku)
                         except api_exceptions.ProductNotFoundError as error:
                             return self._report_bad_request(
-                                six.text_type(error),
+                                str(error),
                                 api_exceptions.PRODUCT_NOT_FOUND_USER_MESSAGE
                             )
                     else:
@@ -211,7 +210,7 @@ class BasketCreateView(EdxOrderPlacementMixin, generics.CreateAPIView):
                     payment_processor = get_processor_class_by_name(payment_processor_name)
                 except payment_exceptions.ProcessorNotFoundError as error:
                     return self._report_bad_request(
-                        six.text_type(error),
+                        str(error),
                         payment_exceptions.PROCESSOR_NOT_FOUND_USER_MESSAGE
                     )
             else:
@@ -222,7 +221,7 @@ class BasketCreateView(EdxOrderPlacementMixin, generics.CreateAPIView):
             except Exception as ex:  # pylint: disable=broad-except
                 basket.delete()
                 logger.exception('Failed to initiate checkout for Basket [%d]. The basket has been deleted.', basket_id)
-                return Response({'developer_message': six.text_type(ex)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+                return Response({'developer_message': str(ex)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         else:
             # Return a serialized basket, if checkout was not requested.
             response_data = self._generate_basic_response(basket)

--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -2,7 +2,6 @@
 
 import logging
 
-import six
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
@@ -204,7 +203,7 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
             try:
                 course_seat_types = prepare_course_seat_types(course_seat_types)
             except (AttributeError, TypeError) as exception:
-                validation_message = 'Invalid course seat types data: {}'.format(six.text_type(exception))
+                validation_message = 'Invalid course seat types data: {}'.format(str(exception))
                 raise ValidationError(validation_message)
 
         try:
@@ -431,7 +430,7 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
         if 'enterprise_customer_catalog' in request_data:
             range_data['enterprise_customer_catalog'] = request_data.get('enterprise_customer_catalog') or None
 
-        for attr, value in six.iteritems(range_data):
+        for attr, value in range_data.items():
             setattr(voucher_range, attr, value)
 
         voucher_range.save()

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -1,9 +1,9 @@
 
 
 import logging
+from urllib.parse import urlparse
 
 import django_filters
-import six
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import (
@@ -29,7 +29,6 @@ from rest_framework.exceptions import ValidationError as DRFValidationError
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet, ViewSet
-from six.moves.urllib.parse import urlparse  # pylint: disable=import-error, ungrouped-imports
 from slumber.exceptions import SlumberHttpBaseException
 
 from ecommerce.core.constants import COUPON_PRODUCT_CLASS_NAME, DEFAULT_CATALOG_PAGE_SIZE
@@ -136,7 +135,7 @@ class EnterpriseCustomerCatalogsViewSet(ViewSet):
                 exc
             )
             return Response(
-                {'error': 'Unable to retrieve enterprise catalog. Exception: {}'.format(six.text_type(exc))},
+                {'error': 'Unable to retrieve enterprise catalog. Exception: {}'.format(str(exc))},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
 

--- a/ecommerce/extensions/api/v2/views/vouchers.py
+++ b/ecommerce/extensions/api/v2/views/vouchers.py
@@ -2,6 +2,7 @@
 
 
 import logging
+from urllib.parse import urlparse
 
 import django_filters
 import pytz
@@ -16,7 +17,6 @@ from requests.exceptions import Timeout
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from six.moves.urllib.parse import urlparse
 from slumber.exceptions import SlumberBaseException
 
 from ecommerce.core.constants import DEFAULT_CATALOG_PAGE_SIZE


### PR DESCRIPTION
**Issue:** [BOM-1713](https://openedx.atlassian.net/browse/BOM-1713)

### Description
- package `six` is used for making `python2&3` compatible code so it is not required after upgrading to `python3`.
- This is part 2 of the multiple PRs made for removing all the uses of package six completely. 