### PR TITLE
Add full discount option to offer assignment API

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -2956,6 +2956,41 @@ class OfferAssignmentSummaryViewSetTests(
             else:  # To test if response has something in it it shouldn't
                 assert False
 
+    def test_view_returns_appropriate_data_for_full_discount(self):
+        """
+        View should return the full discount data only for given user_email.
+        """
+        coupon4 = self.create_coupon(
+            max_uses=1,
+            quantity=1,
+            voucher_type=Voucher.MULTI_USE_PER_CUSTOMER,
+            benefit_type=Benefit.PERCENTAGE,
+            benefit_value=100.0,
+            enterprise_customer=self.enterprise_customer['id'],
+            enterprise_customer_catalog='dddddddd-2c44-487b-9b6a-24eee973f9a4',
+        )
+        self.assign_user_to_code(coupon4.id, [self.user.email], [])
+
+        oa_code = OfferAssignment.objects.get(
+            user_email=self.user.email,
+            offer__vouchers__coupon_vouchers__coupon__id=coupon4.id
+        ).code
+
+        response = self.client.get(OFFER_ASSIGNMENT_SUMMARY_LINK + "?full_discount_only=True").json()
+
+        # there are several coupons already assigned to this user, but only the one above is 100% off
+        assert response['count'] == 1
+        # To get the code to verify our response, filter using the coupon
+        # id these offerAssignments were created for
+        for result in response['results']:
+            if result['code'] == oa_code:
+                assert result['benefit_value'] == 100.0
+                assert result['usage_type'] == 'Percentage'
+                assert result['redemptions_remaining'] == 1
+                assert result['catalog'] == 'dddddddd-2c44-487b-9b6a-24eee973f9a4'
+            else:  # To test if response has something in it it shouldn't
+                assert False
+
 
 @ddt.ddt
 class OfferAssignmentEmailTemplatesViewSetTests(JwtMixin, TestCase):

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -170,6 +170,8 @@ class OfferAssignmentSummaryViewSet(ModelViewSet):
             'offer__condition',
         )
         offer_assignments_with_counts = {}
+        if self.request.query_params.get('full_discount_only'):
+            queryset = queryset.filter(offer__benefit__value=100.0)
         for offer_assignment in queryset:
             if offer_assignment.code not in offer_assignments_with_counts:
                 # Note that we can get away with just dropping in the first


### PR DESCRIPTION
For enterprise learner portal, allows users to see only their full discount offers

**For Testing/Review**
Create some 100% discounted coupons and some non-100% discounted coupons at
 http://localhost:18130/enterprise/coupons/
Note: _You must choose "Discount Code" from the "Code Type" dropdown to create a non-100% off coupon_

Assign Coupon to an enterprise user: 
http://localhost:1991/test-enterprise/admin/coupons

When signed in as an enterprise user with the above coupons,
Make a request to:
http://localhost:18130/api/v2/enterprise/offer_assignment_summary/?full_discount_only=True

(Or test with the frontend PR)