### PR TITLE
Bumped ecommerce-worker to 0.7.5

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -56,7 +56,7 @@ edx-django-release-util==0.4.4  # via -r requirements/base.in
 edx-django-sites-extensions==2.5.1  # via -r requirements/base.in
 edx-django-utils==3.5.0   # via -r requirements/base.in, django-config-models, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/base.in, edx-rbac
-edx-ecommerce-worker==0.7.4  # via -r requirements/base.in
+edx-ecommerce-worker==0.7.5  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/base.in
 edx-rest-api-client==1.9.2  # via -c requirements/pins.txt, -r requirements/base.in, edx-ecommerce-worker

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -66,7 +66,7 @@ edx-django-release-util==0.4.4  # via -r requirements/test.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/test.txt
 edx-django-utils==3.5.0   # via -r requirements/test.txt, django-config-models, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/test.txt, edx-rbac
-edx-ecommerce-worker==0.7.4  # via -r requirements/test.txt
+edx-ecommerce-worker==0.7.5  # via -r requirements/test.txt
 edx-i18n-tools==0.5.3     # via -r requirements/test.txt
 edx-opaque-keys==2.1.1    # via -r requirements/test.txt, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -58,7 +58,7 @@ edx-django-release-util==0.4.4  # via -r requirements/base.in
 edx-django-sites-extensions==2.5.1  # via -r requirements/base.in
 edx-django-utils==3.5.0   # via -r requirements/base.in, django-config-models, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/base.in, edx-rbac
-edx-ecommerce-worker==0.7.4  # via -r requirements/base.in
+edx-ecommerce-worker==0.7.5  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/base.in
 edx-rest-api-client==1.9.2  # via -c requirements/pins.txt, -r requirements/base.in, edx-ecommerce-worker

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -62,7 +62,7 @@ edx-django-release-util==0.4.4  # via -r requirements/base.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/base.txt
 edx-django-utils==3.5.0   # via -r requirements/base.txt, django-config-models, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/base.txt, edx-rbac
-edx-ecommerce-worker==0.7.4  # via -r requirements/base.txt
+edx-ecommerce-worker==0.7.5  # via -r requirements/base.txt
 edx-i18n-tools==0.5.3     # via -r requirements/test.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.3.2           # via -r requirements/base.txt


### PR DESCRIPTION
Bumping ecommerce-worker to 0.7.5 to incorporate recent
changes, fixing the sending of offer limit emails

ENT-3280