### PR TITLE
REV-1237: prevent duplicate seats in basket

### DIFF
--- a/ecommerce/extensions/basket/tests/test_utils.py
+++ b/ecommerce/extensions/basket/tests/test_utils.py
@@ -25,7 +25,7 @@ from ecommerce.extensions.basket.utils import (
     add_utm_params_to_url,
     apply_voucher_on_basket_and_check_discount,
     attribute_cookie_data,
-    check_duplicate_seat_attempt,
+    is_duplicate_seat_attempt,
     get_basket_switch_data,
     get_payment_microfrontend_url_if_configured,
     prepare_basket
@@ -680,24 +680,24 @@ class BasketUtilsTests(DiscoveryTestMixin, BasketMixin, TestCase):
             basket = prepare_basket(self.request, [product1])  # try to add a duplicate seat
             self.assertEqual(basket.product_quantity(product1), 1)
 
-    def test_check_duplicate_seat_attempt__seats(self):
+    def test_is_duplicate_seat_attempt__seats(self):
         """ Verify we get a correct response for duplicate seat check (seats) """
         product_type_seat = ProductClass.objects.create(name='Seat')
         product1 = ProductFactory(stockrecords__partner__short_code='test1', product_class=product_type_seat)
         product2 = ProductFactory(stockrecords__partner__short_code='test2', product_class=product_type_seat)
         seat_basket = prepare_basket(self.request, [product1])
-        result_product1 = check_duplicate_seat_attempt(seat_basket, product1)
-        result_product2 = check_duplicate_seat_attempt(seat_basket, product2)
+        result_product1 = is_duplicate_seat_attempt(seat_basket, product1)
+        result_product2 = is_duplicate_seat_attempt(seat_basket, product2)
 
         self.assertTrue(result_product1)
         self.assertFalse(result_product2)
 
-    def test_check_duplicate_seat_attempt__enrollment_code(self):
+    def test_is_duplicate_seat_attempt__enrollment_code(self):
         """ Verify we get a correct response for duplicate seat check (false for Enrollment code)"""
         enrollment_class = ProductClass.objects.create(name='Enrollment Code')
         enrollment_product = ProductFactory(stockrecords__partner__short_code='test3', product_class=enrollment_class)
         basket_with_enrollment_code = prepare_basket(self.request, [enrollment_product])
-        result_product3 = check_duplicate_seat_attempt(basket_with_enrollment_code, enrollment_product)
+        result_product3 = is_duplicate_seat_attempt(basket_with_enrollment_code, enrollment_product)
 
         self.assertFalse(result_product3)
 

--- a/ecommerce/extensions/basket/tests/test_utils.py
+++ b/ecommerce/extensions/basket/tests/test_utils.py
@@ -27,7 +27,8 @@ from ecommerce.extensions.basket.utils import (
     attribute_cookie_data,
     get_basket_switch_data,
     get_payment_microfrontend_url_if_configured,
-    prepare_basket
+    prepare_basket, 
+    check_product_in_basket
 )
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
 from ecommerce.extensions.order.constants import DISABLE_REPEAT_ORDER_CHECK_SWITCH_NAME
@@ -670,6 +671,15 @@ class BasketUtilsTests(DiscoveryTestMixin, BasketMixin, TestCase):
             self.site_configuration.payment_microfrontend_url = payment_microfrontend_url
             self.assertEqual(get_payment_microfrontend_url_if_configured(self.request), expected_result)
 
+    def test_check_product_in_basket(self):
+        """ Verify we get a correct response for product in basket or not. """
+        product1 = ProductFactory(stockrecords__partner__short_code='test1')
+        product2 = ProductFactory(stockrecords__partner__short_code='test2')
+        basket = prepare_basket(self.request, [product1])
+        result_product1 = check_product_in_basket(basket, product1)
+        result_product2 = check_product_in_basket(basket, product2)
+        self.assertTrue(result_product1)
+        self.assertFalse(result_product2)
 
 class BasketUtilsTransactionTests(TransactionTestCase):
     def setUp(self):

--- a/ecommerce/extensions/basket/tests/test_utils.py
+++ b/ecommerce/extensions/basket/tests/test_utils.py
@@ -25,9 +25,9 @@ from ecommerce.extensions.basket.utils import (
     add_utm_params_to_url,
     apply_voucher_on_basket_and_check_discount,
     attribute_cookie_data,
-    is_duplicate_seat_attempt,
     get_basket_switch_data,
     get_payment_microfrontend_url_if_configured,
+    is_duplicate_seat_attempt,
     prepare_basket
 )
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -128,7 +128,7 @@ def prepare_basket(request, products, voucher=None):
     is_multi_product_basket = len(products) > 1
     for product in products:
         # Multiple clicks can try adding twice, return if product is seat already in basket
-        if check_duplicate_seat_attempt(basket, product):
+        if is_duplicate_seat_attempt(basket, product):
             logger.info(
                 'User [%s] repeated request to add [%s] seat of course [%s], will ignore',
                 request.user.username,
@@ -516,7 +516,7 @@ def apply_voucher_on_basket_and_check_discount(voucher, request, basket):
     return False, msg
 
 
-def check_duplicate_seat_attempt(basket, product):
+def is_duplicate_seat_attempt(basket, product):
     """
     Checks basket for duplicate seat product
 

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -127,7 +127,7 @@ def prepare_basket(request, products, voucher=None):
 
     is_multi_product_basket = len(products) > 1
     for product in products:
-        # Multiple clicks can try adding twice, return if already in basket
+        # Multiple clicks can try adding twice, return if product is seat already in basket
         if check_duplicate_seat_attempt(basket, product):
             logger.info(
                 'User [%s] repeated request to add [%s] seat of course [%s], will ignore',
@@ -521,16 +521,11 @@ def check_duplicate_seat_attempt(basket, product):
     Checks basket for duplicate seat product
 
     Args:
-        basket (Basket): basket object onto which we'll (potentially) add the new product, in prepare_basket
-        product (Product): product to search for in the basket (if it's a seat and it's already there, we don't want dupe)
+        basket (Basket): basket object onto which we'll (potentially) add the new product
+        product (Product): product to search for in the basket
     """
-    # This was added as a workaround for prepare_basket issue: for concurrent calls, basket.flush() only works the first time
-    # Subsequent calls were re-adding the product to the basket, incrementing the quantity, reflected in the total price
 
     product_type = product.get_product_class().name
-    found_product_quantity = basket.product_quantity(product)  
+    found_product_quantity = basket.product_quantity(product)
 
-    if product_type == 'Seat' and found_product_quantity:
-        return True
-    else:
-        return False
+    return bool(product_type == 'Seat' and found_product_quantity)

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -127,6 +127,17 @@ def prepare_basket(request, products, voucher=None):
 
     is_multi_product_basket = len(products) > 1
     for product in products:
+
+        # Multiple clicks can try adding twice, return if already in basket
+        if check_product_in_basket(basket, product):
+            logger.info(
+                'User [%s] repeated request to add [%s] seat of course [%s], will ignore',
+                request.user.username,
+                mode_for_product(product),
+                product.course_id
+            )
+            return basket
+
         if product.is_enrollment_code_product or \
                 not UserAlreadyPlacedOrder.user_already_placed_order(user=request.user,
                                                                      product=product, site=request.site):
@@ -504,3 +515,8 @@ def apply_voucher_on_basket_and_check_discount(voucher, request, basket):
     logger.info('Coupon Code [%s] is not valid for basket [%s]', voucher.code, basket.id)
     basket.clear_vouchers()
     return False, msg
+
+
+# will come back and check for seat (rather than bulk purchase)
+def check_product_in_basket(basket, product):
+    return basket.product_quantity(product)


### PR DESCRIPTION
We've seen a race condition where the quantity of seats for a course in the basket is more than 1 (with differing steps to reproduce). 

prepare_basket is only meant to have one instance of a seat (and calls basket.flush to make sure) but when we have multiple concurrent requests the flush doesn't work but the add_product does. I've added a check in prepare_basket to return if the requested product is already in the basket and is product type 'Seat' (so as not to interfere with bulk purchasing, aka 'Enrollment Code'), as well as tests for the new function, and three tests for prepare_basket to make sure we properly do NOT add a duplicate seat, and don't incorrectly reject a different seat or duplicate enrollment code. 

Relevant Jira ticket:
https://openedx.atlassian.net/browse/REV-1237