### PR TITLE
Usamasadiq/removing-six-III

### DIFF
--- a/ecommerce/extensions/basket/management/commands/delete_ordered_baskets.py
+++ b/ecommerce/extensions/basket/management/commands/delete_ordered_baskets.py
@@ -10,7 +10,6 @@ import time
 from django.core.management import BaseCommand
 from django.db import transaction
 from oscar.core.loading import get_model
-from six.moves import range
 
 Basket = get_model('basket', 'Basket')
 

--- a/ecommerce/extensions/basket/tests/test_commands.py
+++ b/ecommerce/extensions/basket/tests/test_commands.py
@@ -1,11 +1,11 @@
 
 
+from io import StringIO
+
 from django.contrib.sites.models import Site
 from django.core.management import CommandError, call_command
-from django.utils.six import StringIO
 from oscar.core.loading import get_model
 from oscar.test import factories
-from six.moves import range
 
 from ecommerce.extensions.test.factories import create_order
 from ecommerce.invoice.models import Invoice

--- a/ecommerce/extensions/basket/tests/test_models.py
+++ b/ecommerce/extensions/basket/tests/test_models.py
@@ -3,7 +3,6 @@
 import itertools
 
 import mock
-import six
 from analytics import Client
 from edx_django_utils.cache import DEFAULT_REQUEST_CACHE
 from oscar.core.loading import get_class, get_model
@@ -45,7 +44,7 @@ class BasketTests(CatalogMixin, BasketMixin, TransactionTestCase):
             num_lines=basket.num_lines
         )
 
-        self.assertEqual(six.text_type(basket), expected)
+        self.assertEqual(str(basket), expected)
 
     def test_get_basket_without_existing_baskets(self):
         """ If the user has no existing baskets, the method should return a new one. """

--- a/ecommerce/extensions/basket/tests/test_views.py
+++ b/ecommerce/extensions/basket/tests/test_views.py
@@ -2,6 +2,8 @@
 
 import datetime
 import itertools
+import urllib.error
+import urllib.parse
 from contextlib import contextmanager
 from decimal import Decimal
 
@@ -9,9 +11,6 @@ import ddt
 import httpretty
 import mock
 import pytz
-import six.moves.urllib.error  # pylint: disable=import-error
-import six.moves.urllib.parse  # pylint: disable=import-error
-import six.moves.urllib.request  # pylint: disable=import-error
 from django.conf import settings
 from django.contrib.messages import get_messages
 from django.http import HttpResponseRedirect
@@ -91,7 +90,7 @@ class BasketAddItemsViewTests(CouponMixin, DiscoveryTestMixin, DiscoveryMockMixi
         self.catalog.stock_records.add(self.stock_record)
 
     def _get_response(self, product_skus, **url_params):
-        qs = six.moves.urllib.parse.urlencode({'sku': product_skus}, True)
+        qs = urllib.parse.urlencode({'sku': product_skus}, True)
         url = '{root}?{qs}'.format(root=self.path, qs=qs)
         for name, value in url_params.items():
             url += '&{}={}'.format(name, value)
@@ -966,7 +965,7 @@ class BasketSummaryViewTests(EnterpriseServiceMockMixin, DiscoveryTestMixin, Dis
         self.client.logout()
         response = self.client.get(self.path)
         expected_url = '{path}?next={next}'.format(path=reverse(settings.LOGIN_URL),
-                                                   next=six.moves.urllib.parse.quote(self.path))
+                                                   next=urllib.parse.quote(self.path))
         self.assertRedirects(response, expected_url, target_status_code=302)
 
     @ddt.data(
@@ -1309,7 +1308,7 @@ class VoucherAddMixin(LmsApiMockMixin, DiscoveryMockMixin):
     def _get_account_activation_view_response(self, keys, template_name):
         url = '{url}?{params}'.format(
             url=reverse('offers:email_confirmation'),
-            params=six.moves.urllib.parse.urlencode([('course_id', key) for key in keys])
+            params=urllib.parse.urlencode([('course_id', key) for key in keys])
         )
         with self.assertTemplateUsed(template_name):
             return self.client.get(url)

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -3,6 +3,7 @@
 import datetime
 import json
 import logging
+from urllib.parse import unquote, urlencode
 
 import newrelic.agent
 import pytz
@@ -13,7 +14,6 @@ from django.db import transaction
 from django.utils.translation import ugettext_lazy as _
 from oscar.apps.basket.signals import voucher_addition
 from oscar.core.loading import get_class, get_model
-from six.moves.urllib.parse import unquote, urlencode
 
 from ecommerce.core.url_utils import absolute_url
 from ecommerce.courses.utils import mode_for_product

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -3,13 +3,13 @@
 
 import logging
 import time
+import urllib
 from collections import OrderedDict
 from datetime import datetime
 from decimal import Decimal
 
 import dateutil.parser
 import newrelic.agent
-import six
 import waffle
 from django.http import HttpResponseBadRequest, HttpResponseRedirect
 from django.shortcuts import render
@@ -455,7 +455,7 @@ class BasketAddItemsView(BasketLogicMixin, APIView):
             return self._redirect_response_to_basket_or_payment(request, invalid_code)
 
         except BadRequestException as e:
-            return HttpResponseBadRequest(six.text_type(e))
+            return HttpResponseBadRequest(str(e))
         except RedirectException as e:
             return e.response
 
@@ -570,7 +570,7 @@ class BasketSummaryView(BasketLogicMixin, BasketView):
             context.update(payment_processors_data)
 
         context.update({
-            'formset_lines_data': list(six.moves.zip(formset, lines_data)),
+            'formset_lines_data': list(zip(formset, lines_data)),
             'homepage_url': get_lms_url(''),
             'min_seat_quantity': 1,
             'max_seat_quantity': 100,
@@ -599,7 +599,7 @@ class BasketSummaryView(BasketLogicMixin, BasketView):
             return {
                 'client_side_payment_processor': payment_processor,
                 'enable_client_side_checkout': True,
-                'months': list(six.moves.range(1, 13)),
+                'months': list(range(1, 13)),
                 'payment_form': PaymentForm(
                     user=self.request.user,
                     request=self.request,
@@ -608,7 +608,7 @@ class BasketSummaryView(BasketLogicMixin, BasketView):
                 ),
                 'paypal_enabled': 'paypal' in (p.NAME for p in payment_processors),
                 # Assumption is that the credit card duration is 15 years
-                'years': list(six.moves.range(current_year, current_year + 16)),
+                'years': list(range(current_year, current_year + 16)),
             }
         else:
             msg = 'Unable to load client-side payment processor [{processor}] for ' \
@@ -898,14 +898,14 @@ class VoucherAddLogicMixin:
             # the standard redemption flow, we kick the user out to the `redeem` flow.
             # This flow will handle any additional information that needs to be gathered
             # due to the fact that the voucher is attached to an Enterprise Customer.
-            params = six.moves.urllib.parse.urlencode(
+            params = urllib.parse.urlencode(
                 OrderedDict([
                     ('code', code),
                     ('sku', stock_record.partner_sku),
                     ('failure_url', self.request.build_absolute_uri(
                         '{path}?{params}'.format(
                             path=reverse('basket:summary'),
-                            params=six.moves.urllib.parse.urlencode(
+                            params=urllib.parse.urlencode(
                                 {
                                     CONSENT_FAILED_PARAM: code
                                 }

--- a/ecommerce/extensions/catalogue/management/commands/convert_course.py
+++ b/ecommerce/extensions/catalogue/management/commands/convert_course.py
@@ -2,12 +2,10 @@
 
 import logging
 
-import six  # pylint: disable=ungrouped-imports
 from django.core.management import BaseCommand
 from django.db import transaction
 from oscar.core.loading import get_model
 from oscar.test.utils import RequestFactory
-from six.moves import map
 from threadlocals.threadlocals import set_thread_variable
 
 from ecommerce.courses.models import Course
@@ -52,7 +50,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         self.options = options  # pylint: disable=attribute-defined-outside-init
-        course_ids = list(map(six.text_type, self.options.get('course_ids', [])))
+        course_ids = list(map(str, self.options.get('course_ids', [])))
 
         self.partner = Partner.objects.get(code__iexact=options['partner'])  # pylint: disable=attribute-defined-outside-init
         site = self.partner.default_site

--- a/ecommerce/extensions/catalogue/management/commands/migrate_course.py
+++ b/ecommerce/extensions/catalogue/management/commands/migrate_course.py
@@ -3,7 +3,6 @@
 import logging
 
 import requests
-import six
 import waffle
 from dateutil.parser import parse
 from django.conf import settings
@@ -113,7 +112,7 @@ class MigratedCourse:
         except Exception as e:  # pylint: disable=broad-except
             logger.warning(
                 'Calling Commerce API failed with: [%s]. Falling back to Course Structure API.',
-                six.text_type(e)
+                str(e)
             )
             course_name, course_verification_deadline = self._query_course_structure_api()
 
@@ -177,7 +176,7 @@ class Command(BaseCommand):
             return
 
         for course_id in course_ids:
-            course_id = six.text_type(course_id)
+            course_id = str(course_id)
             try:
                 with transaction.atomic():
                     migrated_course = MigratedCourse(course_id, site_domain)

--- a/ecommerce/extensions/catalogue/management/commands/tests/test_populate_enterprise_id_product_attribute.py
+++ b/ecommerce/extensions/catalogue/management/commands/tests/test_populate_enterprise_id_product_attribute.py
@@ -4,7 +4,6 @@ import uuid
 
 from django.core.management import call_command
 from oscar.core.loading import get_model
-from six.moves import range
 from testfixtures import LogCapture
 
 from ecommerce.coupons.tests.mixins import CouponMixin

--- a/ecommerce/extensions/catalogue/models.py
+++ b/ecommerce/extensions/catalogue/models.py
@@ -1,6 +1,5 @@
 
 
-import six
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.db import models
@@ -89,7 +88,7 @@ class Product(AbstractProduct):
 
     def save(self, *args, **kwargs):
         try:
-            if not isinstance(self.attr.note, six.string_types) and self.attr.note is not None:
+            if not isinstance(self.attr.note, str) and self.attr.note is not None:
                 log_message_and_raise_validation_error(
                     'Failed to create Product. Product note value must be of type string'
                 )

--- a/ecommerce/extensions/catalogue/tests/test_migrate_course.py
+++ b/ecommerce/extensions/catalogue/tests/test_migrate_course.py
@@ -5,15 +5,14 @@ import datetime
 import json
 import logging
 from decimal import Decimal
+from urllib.parse import urlparse
 
 import httpretty
 import mock
 import pytz
-import six  # pylint: disable=ungrouped-imports
 from django.core.management import call_command
 from django.test import override_settings
 from oscar.core.loading import get_model
-from six.moves.urllib.parse import urlparse
 from testfixtures import LogCapture
 
 from ecommerce.core.constants import ISO_8601_FORMAT
@@ -81,7 +80,7 @@ class CourseMigrationTestMixin(DiscoveryTestMixin):
         body = {
             'course_id': self.course_id,
             'course_modes': [{'slug': mode, 'min_price': price, 'expiration_datetime': EXPIRES_STRING} for
-                             mode, price in six.iteritems(self.prices)]
+                             mode, price in self.prices.items()]
         }
         httpretty.register_uri(httpretty.GET, self.enrollment_api_url, body=json.dumps(body), content_type=JSON)
 
@@ -187,7 +186,7 @@ class MigratedCourseTests(CourseMigrationTestMixin, TestCase):
             migrated_course = MigratedCourse(self.course_id, self.site.domain)
             migrated_course.load_from_lms()
         except Exception as ex:  # pylint: disable=broad-except
-            self.assertEqual(six.text_type(ex),
+            self.assertEqual(str(ex),
                              'Aborting migration. No name is available for {}.'.format(self.course_id))
 
         # Verify the Course Structure API was called.

--- a/ecommerce/extensions/catalogue/tests/test_update_course_seat_expire.py
+++ b/ecommerce/extensions/catalogue/tests/test_update_course_seat_expire.py
@@ -8,7 +8,6 @@ import logging
 import ddt
 import httpretty
 import mock
-import six
 from django.core.management import CommandError, call_command
 from pytz import UTC
 from slumber.exceptions import HttpClientError
@@ -41,7 +40,7 @@ class UpdateSeatExpireDateTests(DiscoveryTestMixin, TestCase):
             'pagination': {},
             'results': [
                 {
-                    'enrollment_end': six.text_type(self.expire_date),
+                    'enrollment_end': str(self.expire_date),
                     'course_id': self.course.id
                 },
             ],

--- a/ecommerce/extensions/catalogue/tests/test_utils.py
+++ b/ecommerce/extensions/catalogue/tests/test_utils.py
@@ -4,7 +4,6 @@
 from hashlib import md5
 
 import ddt
-import six
 from django.db.utils import IntegrityError
 from oscar.core.loading import get_model
 
@@ -98,7 +97,7 @@ class CouponUtilsTests(CouponMixin, DiscoveryTestMixin, TestCase):
         """Verify the method generates a SKU for a coupon."""
         coupon = self.create_coupon(partner=self.partner, catalog=self.catalog)
         _hash = ' '.join((
-            six.text_type(coupon.id),
+            str(coupon.id),
             str(self.partner.id)
         )).encode('utf-8')
 

--- a/ecommerce/extensions/catalogue/utils.py
+++ b/ecommerce/extensions/catalogue/utils.py
@@ -3,7 +3,6 @@
 import logging
 from hashlib import md5
 
-import six
 from django.conf import settings
 from django.db.utils import IntegrityError
 from oscar.core.loading import get_model
@@ -186,28 +185,28 @@ def generate_sku(product, partner):
 
     if product.is_coupon_product:
         _hash = ' '.join((
-            six.text_type(product.id),
-            six.text_type(partner.id)
+            str(product.id),
+            str(partner.id)
         )).encode('utf-8')
     elif product.is_enrollment_code_product:
         _hash = ' '.join((
             getattr(product.attr, 'course_key', ''),
             getattr(product.attr, 'seat_type', ''),
-            six.text_type(partner.id)
+            str(partner.id)
         )).encode('utf-8')
     elif product.is_seat_product:
         _hash = ' '.join((
             getattr(product.attr, 'certificate_type', ''),
-            six.text_type(product.attr.course_key),
-            six.text_type(product.attr.id_verification_required),
+            str(product.attr.course_key),
+            str(product.attr.id_verification_required),
             getattr(product.attr, 'credit_provider', ''),
-            six.text_type(partner.id)
+            str(partner.id)
         )).encode('utf-8')
     elif product.is_course_entitlement_product:
         _hash = ' '.join((
             getattr(product.attr, 'certificate_type', ''),
-            six.text_type(product.attr.UUID),
-            six.text_type(partner.id)
+            str(product.attr.UUID),
+            str(partner.id)
         )).encode('utf-8')
 
     else:

--- a/ecommerce/extensions/checkout/mixins.py
+++ b/ecommerce/extensions/checkout/mixins.py
@@ -4,15 +4,11 @@
 import abc
 import logging
 
-import six
 import waffle
 from django.db import transaction
 from ecommerce_worker.fulfillment.v1.tasks import fulfill_order
 from oscar.apps.checkout.mixins import OrderPlacementMixin
 from oscar.core.loading import get_class, get_model
-# Pylint will stop complaining about this when https://github.com/PyCQA/pylint/pull/2824
-# is released
-from six.moves import range  # pylint: disable=ungrouped-imports
 
 from ecommerce.core.models import BusinessClient
 from ecommerce.extensions.analytics.utils import audit_log, track_segment_event
@@ -42,7 +38,7 @@ Source = get_model('payment', 'Source')
 SourceType = get_model('payment', 'SourceType')
 
 
-class EdxOrderPlacementMixin(six.with_metaclass(abc.ABCMeta, OrderPlacementMixin)):
+class EdxOrderPlacementMixin(OrderPlacementMixin, metaclass=abc.ABCMeta):
     """ Mixin for edX-specific order placement. """
 
     # Instance of a payment processor with which to handle payment. Subclasses should set this value.

--- a/ecommerce/extensions/checkout/tests/test_views.py
+++ b/ecommerce/extensions/checkout/tests/test_views.py
@@ -1,12 +1,10 @@
 
 
 from decimal import Decimal
+from urllib import parse
 
 import ddt
 import httpretty
-import six.moves.urllib.error  # pylint: disable=import-error
-import six.moves.urllib.parse  # pylint: disable=import-error
-import six.moves.urllib.request  # pylint: disable=import-error
 from django.conf import settings
 from django.urls import reverse
 from mock import patch
@@ -266,7 +264,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.client.logout()
         response = self.client.get(self.path)
         expected_url = '{path}?next={next}'.format(path=reverse(settings.LOGIN_URL),
-                                                   next=six.moves.urllib.parse.quote(self.path))
+                                                   next=parse.quote(self.path))
         self.assertRedirects(response, expected_url, target_status_code=302)
 
     @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')

--- a/ecommerce/extensions/checkout/utils.py
+++ b/ecommerce/extensions/checkout/utils.py
@@ -1,10 +1,8 @@
 
 
 import logging
+from urllib import parse
 
-import six.moves.urllib.error  # pylint: disable=import-error
-import six.moves.urllib.parse  # pylint: disable=import-error
-import six.moves.urllib.request  # pylint: disable=import-error
 from babel.numbers import format_currency as default_format_currency
 from django.conf import settings
 from django.urls import reverse
@@ -55,7 +53,7 @@ def get_receipt_page_url(site_configuration, order_number=None, override_url=Non
     if disable_back_button:
         url_params['disable_back_button'] = int(disable_back_button)
     base_url = site_configuration.build_ecommerce_url(reverse('checkout:receipt'))
-    params = six.moves.urllib.parse.urlencode(url_params)
+    params = parse.urlencode(url_params)
 
     return '{base_url}{params}'.format(
         base_url=base_url,

--- a/ecommerce/extensions/dashboard/orders/tests.py
+++ b/ecommerce/extensions/dashboard/orders/tests.py
@@ -3,7 +3,6 @@
 import os
 from unittest import SkipTest, skipIf
 
-import six
 from bok_choy.browser import browser
 from django.contrib.messages import constants as MSG
 from django.test import override_settings
@@ -81,7 +80,7 @@ class OrderViewBrowserTestBase(LiveServerTestCase):
     def retry_fulfillment(self):
         """ Click the retry fulfillment button and wait for the AJAX call to finish. """
         button = self.selenium.find_element_by_css_selector(self.btn_selector)
-        self.assertEqual(six.text_type(self.order.number), button.get_attribute('data-order-number'))
+        self.assertEqual(str(self.order.number), button.get_attribute('data-order-number'))
         button.click()
 
         # Wait for the AJAX call to finish and display an alert

--- a/ecommerce/extensions/dashboard/orders/views.py
+++ b/ecommerce/extensions/dashboard/orders/views.py
@@ -1,6 +1,5 @@
 
 
-import six
 from django.contrib import messages
 from django.urls import reverse
 from django.utils.safestring import mark_safe
@@ -49,7 +48,7 @@ class OrderListView(FilterFieldsMixin, CoreOrderListView):
         # to the form constructor. This results in the form not being populated when re-rendered.
         self.form = self.form_class(self.request.GET)
         if self.form.is_valid():
-            for field, value in six.iteritems(self.form.cleaned_data):
+            for field, value in self.form.cleaned_data.items():
                 if value:
                     _filter = self.get_filter_fields().get(field)
 

--- a/ecommerce/extensions/dashboard/refunds/views.py
+++ b/ecommerce/extensions/dashboard/refunds/views.py
@@ -1,6 +1,5 @@
 
 
-import six
 from django.views.generic import DetailView, ListView
 from oscar.core.loading import get_class, get_model
 from oscar.views import sort_queryset
@@ -37,7 +36,7 @@ class RefundListView(FilterFieldsMixin, ListView):
 
         self.form = self.form_class(self.request.GET)
         if self.form.is_valid():
-            for field, value in six.iteritems(self.form.cleaned_data):
+            for field, value in self.form.cleaned_data.items():
                 if value:
                     # Check if the field has a custom query filter setup.
                     # If not, use a standard Django equals/match filter.

--- a/ecommerce/extensions/dashboard/views.py
+++ b/ecommerce/extensions/dashboard/views.py
@@ -1,6 +1,5 @@
 
 
-import six
 from oscar.apps.dashboard.views import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
 
@@ -63,7 +62,7 @@ class FilterFieldsMixin:
 
     def exposed_fields(self):
         """ Returns the dictionary of fields that will be immediately exposed to the user in the UI. """
-        return {field: details for (field, details) in six.iteritems(self.get_filter_fields()) if details['exposed']}
+        return {field: details for (field, details) in self.get_filter_fields().items() if details['exposed']}
 
     def get_context_data(self, **kwargs):
         context = super(FilterFieldsMixin, self).get_context_data(**kwargs)

--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -9,9 +9,9 @@ import abc
 import datetime
 import json
 import logging
+from urllib.parse import urlencode
 
 import requests
-import six
 import waffle
 from django.conf import settings
 from django.urls import reverse
@@ -20,7 +20,6 @@ from oscar.core.loading import get_model
 from requests.exceptions import ConnectionError as ReqConnectionError  # pylint: disable=ungrouped-imports
 from requests.exceptions import Timeout
 from rest_framework import status
-from six.moves.urllib.parse import urlencode
 
 from ecommerce.core.constants import (
     DONATIONS_FROM_CHECKOUT_TESTS_PRODUCT_TYPE_NAME,
@@ -57,7 +56,7 @@ StockRecord = get_model('partner', 'StockRecord')
 logger = logging.getLogger(__name__)
 
 
-class BaseFulfillmentModule(six.with_metaclass(abc.ABCMeta, object)):  # pragma: no cover
+class BaseFulfillmentModule(metaclass=abc.ABCMeta):  # pragma: no cover
     """
     Base FulfillmentModule class for containing Product specific fulfillment logic.
 
@@ -544,7 +543,7 @@ class EnrollmentCodeFulfillmentModule(BaseFulfillmentModule):
             _range.save()
 
             vouchers = create_vouchers(
-                name=six.text_type('Enrollment code voucher [{}]').format(line.product.title),
+                name=str('Enrollment code voucher [{}]').format(line.product.title),
                 benefit_type=Benefit.PERCENTAGE,
                 benefit_value=100,
                 catalog=coupon_catalog,

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -745,8 +745,6 @@ class EnrollmentCodeFulfillmentModuleTests(DiscoveryTestMixin, TestCase):
         generated_request_body = EnrollmentCodeFulfillmentModule().get_order_fulfillment_data_for_hubspot(order)
         self.assertCountEqual(expected_request_entries, generated_request_body.split('&'))
 
-        # assertCountEqual(self, expected_request_entries, generated_request_body.split('&'))
-
     def test_determine_if_enterprise_purchase_expect_true(self):
         """ Test for being able to retrieve 'purchased_behalf_of' attribute from Basket and the checkbox is checked. """
         self.add_required_attributes_to_basket(self.order, True)

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -5,6 +5,7 @@ import datetime
 import json
 import uuid
 from decimal import Decimal
+from urllib.parse import urlencode
 
 import ddt
 import httpretty
@@ -15,8 +16,6 @@ from oscar.core.loading import get_class, get_model
 from oscar.test import factories
 from requests.exceptions import ConnectionError as ReqConnectionError
 from requests.exceptions import Timeout
-from six import assertCountEqual
-from six.moves.urllib.parse import urlencode
 from testfixtures import LogCapture
 from waffle.testutils import override_switch
 
@@ -744,7 +743,9 @@ class EnrollmentCodeFulfillmentModuleTests(DiscoveryTestMixin, TestCase):
             customer_email_data,
         ]
         generated_request_body = EnrollmentCodeFulfillmentModule().get_order_fulfillment_data_for_hubspot(order)
-        assertCountEqual(self, expected_request_entries, generated_request_body.split('&'))
+        self.assertCountEqual(expected_request_entries, generated_request_body.split('&'))
+
+        # assertCountEqual(self, expected_request_entries, generated_request_body.split('&'))
 
     def test_determine_if_enterprise_purchase_expect_true(self):
         """ Test for being able to retrieve 'purchased_behalf_of' attribute from Basket and the checkbox is checked. """


### PR DESCRIPTION
**Issue:** [BOM-1713](https://openedx.atlassian.net/browse/BOM-1713)

### Description
- package `six` is used for making `python2&3` compatible code so it is not required after upgrading to `python3`.
- This is part 3 of the multiple PRs made for removing all the uses of package six completely. 