### PR TITLE
add warning that docs are out of date; update devstack link

### DIFF
--- a/docs/install_ecommerce.rst
+++ b/docs/install_ecommerce.rst
@@ -4,6 +4,10 @@
 Install and Start the E-Commerce Service
 ########################################
 
+.. warning::
+ This document is out of date regarding virtual environment configuration.
+ E-Commerce should be properly provisioned for you as part of Dockerized `devstack`_.
+
 To install and start the edX E-Commerce service, you must complete the
 following steps.
 
@@ -282,7 +286,7 @@ instead of ShoppingCart, follow these steps.
 #. Sign in to the Django administration console for your base URL. For example,
    ``http://{your_URL}/admin``.
 
-#. In the **Commerce** section, next to **Commerce configuration**, select **Add**. 
+#. In the **Commerce** section, next to **Commerce configuration**, select **Add**.
 
 #. Select **Enabled**.
 

--- a/docs/links/links.rst
+++ b/docs/links/links.rst
@@ -233,7 +233,7 @@
 .. _Communications API: http://django-oscar.readthedocs.org/en/latest/howto/how_to_customise_oscar_communications.html#communications-api
 .. _django-compressor: http://django-compressor.readthedocs.org/
 .. _RequireJS: http://requirejs.org/
-.. _devstack: https://github.com/edx/configuration/wiki/edX-Developer-Stack
+.. _devstack: https://github.com/edx/devstack
 .. _Testing in Django: https://docs.djangoproject.com/en/1.8/topics/testing/
 .. _Django sites framework: https://docs.djangoproject.com/en/1.8/ref/contrib/sites
 .. _Jasmine: http://jasmine.github.io/2.3/introduction.html


### PR DESCRIPTION
I ran through the installation doc seeing the note saying it was to be setup alongside devstack, but didn't realize it's actually already containerized in devstack.

In lieu of a full overhaul of the instructions here, I added a warning to indicate devstack should already have ecommerce [as a container] setup and thus the virtual environment configuration steps are unnecessary (I am not sure about the rest of the directions, which is why we're not completely overhauling the readme).