### PR TITLE
Usamasadiq/removing-six-IV

### DIFF
--- a/ecommerce/extensions/offer/management/commands/change_priority_of_offers.py
+++ b/ecommerce/extensions/offer/management/commands/change_priority_of_offers.py
@@ -8,7 +8,6 @@ import logging
 from django.core.management import BaseCommand
 from django.template.defaultfilters import pluralize
 from oscar.core.loading import get_model
-from six.moves import range
 
 from ecommerce.extensions.offer.models import OFFER_PRIORITY_VOUCHER
 from ecommerce.extensions.order.management.commands.prompt import query_yes_no

--- a/ecommerce/extensions/offer/management/commands/remove_partner_offers.py
+++ b/ecommerce/extensions/offer/management/commands/remove_partner_offers.py
@@ -10,7 +10,6 @@ from django.db.models import signals
 from django.template.defaultfilters import pluralize
 from oscar.apps.offer.signals import delete_unused_related_conditions_and_benefits
 from oscar.core.loading import get_model
-from six.moves import range
 
 from ecommerce.extensions.order.management.commands.prompt import query_yes_no
 

--- a/ecommerce/extensions/offer/management/commands/tests/test_change_priority_of_offers.py
+++ b/ecommerce/extensions/offer/management/commands/tests/test_change_priority_of_offers.py
@@ -5,7 +5,6 @@ from django.core.management import call_command
 from mock import patch
 from oscar.core.loading import get_model
 from oscar.test import factories
-from six.moves import range
 from testfixtures import LogCapture
 
 from ecommerce.tests.testcases import TestCase

--- a/ecommerce/extensions/offer/management/commands/tests/test_remove_partner_offers.py
+++ b/ecommerce/extensions/offer/management/commands/tests/test_remove_partner_offers.py
@@ -1,7 +1,6 @@
 
 
 import ddt
-import six
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from mock import patch
@@ -27,11 +26,8 @@ class RemovePartnerOffersTests(TestCase):
 
     def test_partner_required(self):
         """Test that command raises partner required error."""
-        if six.PY3:
-            err_msg = 'Error: the following arguments are required: --partner'
-        else:
-            err_msg = 'Error: argument --partner is required'
-        with six.assertRaisesRegex(self, CommandError, err_msg):
+        err_msg = 'Error: the following arguments are required: --partner'
+        with self.assertRaisesRegex(CommandError, err_msg):
             call_command('remove_partner_offers')
 
     def test_no_offer_found(self):

--- a/ecommerce/extensions/offer/models.py
+++ b/ecommerce/extensions/offer/models.py
@@ -3,7 +3,6 @@
 import logging
 import re
 
-import six
 from django.conf import settings
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
@@ -217,7 +216,7 @@ class ConditionalOffer(AbstractConditionalOffer):
     def clean_email_domains(self):
 
         if self.email_domains:
-            if not isinstance(self.email_domains, six.string_types):
+            if not isinstance(self.email_domains, str):
                 log_message_and_raise_validation_error(
                     'Failed to create ConditionalOffer. ConditionalOffer email domains must be of type string.'
                 )
@@ -259,7 +258,7 @@ class ConditionalOffer(AbstractConditionalOffer):
     def clean_max_global_applications(self):
         # enterprise offers have their own cleanup logic
         if self.priority != OFFER_PRIORITY_ENTERPRISE and self.max_global_applications is not None:
-            if not isinstance(self.max_global_applications, six.integer_types) or self.max_global_applications < 1:
+            if not isinstance(self.max_global_applications, int) or self.max_global_applications < 1:
                 log_message_and_raise_validation_error(
                     'Failed to create ConditionalOffer. max_global_applications field must be a positive number.'
                 )
@@ -345,7 +344,7 @@ class ConditionalOffer(AbstractConditionalOffer):
 
 
 def validate_credit_seat_type(course_seat_types):
-    if not isinstance(course_seat_types, six.string_types):
+    if not isinstance(course_seat_types, str):
         log_message_and_raise_validation_error('Failed to create Range. Credit seat types must be of type string.')
 
     course_seat_types_list = course_seat_types.split(',')

--- a/ecommerce/extensions/offer/tests/test_applicator.py
+++ b/ecommerce/extensions/offer/tests/test_applicator.py
@@ -6,7 +6,6 @@ import ddt
 import mock
 from oscar.core.loading import get_model
 from oscar.test import factories
-from six.moves import range
 
 from ecommerce.core.constants import SYSTEM_ENTERPRISE_LEARNER_ROLE
 from ecommerce.extensions.offer.applicator import Applicator

--- a/ecommerce/extensions/offer/tests/test_models.py
+++ b/ecommerce/extensions/offer/tests/test_models.py
@@ -5,7 +5,6 @@ from uuid import uuid4
 
 import ddt
 import httpretty
-import six
 from django.core.exceptions import ValidationError
 from edx_django_utils.cache import TieredCache
 from mock import patch
@@ -147,7 +146,7 @@ class RangeTests(CouponMixin, DiscoveryTestMixin, DiscoveryMockMixin, TestCase):
             self.range.contains_product(seat)
 
         expected_exception_message = 'Unable to connect to Discovery Service for catalog contains endpoint.'
-        self.assertEqual(six.text_type(err.exception), expected_exception_message)
+        self.assertEqual(str(err.exception), expected_exception_message)
         # Verify that there only one call for the course discovery API for
         # checking if course exists in course runs against the course catalog.
         self._assert_num_requests(2)

--- a/ecommerce/extensions/offer/utils.py
+++ b/ecommerce/extensions/offer/utils.py
@@ -4,13 +4,13 @@
 import logging
 import string  # pylint: disable=W0402
 from decimal import Decimal
+from urllib.parse import urlencode
 
 import bleach
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 from ecommerce_worker.sailthru.v1.tasks import send_offer_assignment_email, send_offer_update_email
 from oscar.core.loading import get_model
-from six.moves.urllib.parse import urlencode
 
 from ecommerce.core.url_utils import absolute_redirect
 from ecommerce.extensions.checkout.utils import add_currency

--- a/ecommerce/extensions/order/conditions.py
+++ b/ecommerce/extensions/order/conditions.py
@@ -3,7 +3,6 @@
 import logging
 
 import crum
-import six
 from django.urls import reverse
 from oscar.core.loading import get_model
 
@@ -70,7 +69,7 @@ class ManualEnrollmentOrderDiscountCondition(
         basket_id = basket.id
         offer_id = offer.id
         # extract product ids to log
-        product_ids = ', '.join([six.text_type(line.product.id) for line in basket.lines.all()])
+        product_ids = ', '.join([str(line.product.id) for line in basket.lines.all()])
         product_type = None
         product_cert = None
 

--- a/ecommerce/extensions/order/management/commands/create_fake_orders.py
+++ b/ecommerce/extensions/order/management/commands/create_fake_orders.py
@@ -5,7 +5,6 @@ import logging
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 from oscar.core.loading import get_class, get_model
-from six.moves import range
 
 from ecommerce.tests.factories import UserFactory
 

--- a/ecommerce/extensions/order/management/commands/prompt.py
+++ b/ecommerce/extensions/order/management/commands/prompt.py
@@ -2,8 +2,6 @@
 
 import sys
 
-from six import moves
-
 
 def query_yes_no(question, default="yes"):
     """Ask a yes/no question via raw_input() and return their answer.
@@ -28,7 +26,7 @@ def query_yes_no(question, default="yes"):
 
     while True:
         sys.stdout.write(question + prompt)
-        choice = moves.input().lower()
+        choice = input().lower()
         if default is not None and choice == '':
             return valid[default]
         if choice in valid:

--- a/ecommerce/extensions/order/management/commands/tests/test_prompt.py
+++ b/ecommerce/extensions/order/management/commands/tests/test_prompt.py
@@ -1,11 +1,10 @@
 
 
 import sys
+from io import StringIO
 
 import ddt
-from django.utils.six import StringIO
 from mock import patch
-from six import moves
 
 from ecommerce.tests.testcases import TestCase
 
@@ -27,12 +26,12 @@ class PromptTests(TestCase):
         """Test wrong user input."""
         out = StringIO()
         sys.stdout = out
-        with patch.object(moves, 'input', side_effect=['wrong', 'no']):
+        with patch('builtins.input', side_effect=['wrong', 'no']):
             query_yes_no(self.CONFIRMATION_PROMPT)
             output = out.getvalue().strip()
             self.assertIn("Please respond with one of the following (n, no, y, yes)", output)
 
-    @patch.object(moves, 'input')
+    @patch('builtins.input')
     @ddt.data(
         ('yes', True, 'no'), ('no', False, 'yes'), ('', True, 'yes'), ('yes', True, None)
     )

--- a/ecommerce/extensions/order/management/commands/tests/test_update_order_lines_partner.py
+++ b/ecommerce/extensions/order/management/commands/tests/test_update_order_lines_partner.py
@@ -1,7 +1,6 @@
 
 
 import ddt
-import six
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from mock import patch
@@ -24,15 +23,12 @@ class UpdateOrderLinePartnerTests(TestCase):
 
     def assert_error_log(self, error_msg, *args):
         """Helper to call command and assert error log."""
-        with six.assertRaisesRegex(self, CommandError, error_msg):
+        with self.assertRaisesRegex(CommandError, error_msg):
             call_command('update_order_lines_partner', *args)
 
     def test_partner_required(self):
         """Test that command raises partner required error."""
-        if six.PY3:
-            err_msg = 'Error: the following arguments are required: --partner'
-        else:
-            err_msg = 'Error: argument --partner is required'
+        err_msg = 'Error: the following arguments are required: --partner'
         self.assert_error_log(
             err_msg,
             'sku12345'

--- a/ecommerce/extensions/order/processing.py
+++ b/ecommerce/extensions/order/processing.py
@@ -6,7 +6,6 @@ errors explaining why fulfillment may fail.
 
 """
 from oscar.apps.order import exceptions, processing
-from six.moves import zip
 
 from ecommerce.extensions.fulfillment import api as fulfillment_api
 from ecommerce.extensions.fulfillment.status import LINE

--- a/ecommerce/extensions/refund/models.py
+++ b/ecommerce/extensions/refund/models.py
@@ -2,7 +2,6 @@
 
 import logging
 
-import six
 from django.conf import settings
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
@@ -61,7 +60,7 @@ class StatusMixin:
         self.save()
 
     def __str__(self):
-        return six.text_type(self.id)
+        return str(self.id)
 
 
 class Refund(StatusMixin, TimeStampedModel):

--- a/ecommerce/extensions/refund/tests/mixins.py
+++ b/ecommerce/extensions/refund/tests/mixins.py
@@ -5,7 +5,6 @@ from django.test import override_settings
 from mock_django import mock_signal_receiver
 from oscar.core.loading import get_class, get_model
 from oscar.test.factories import BasketFactory
-from six.moves import zip
 
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.entitlements.utils import create_or_update_course_entitlement

--- a/ecommerce/extensions/refund/tests/test_models.py
+++ b/ecommerce/extensions/refund/tests/test_models.py
@@ -5,7 +5,6 @@ from decimal import Decimal
 import ddt
 import httpretty
 import mock
-import six
 from django.conf import settings
 from oscar.apps.payment.exceptions import PaymentError
 from oscar.core.loading import get_class, get_model
@@ -45,14 +44,14 @@ class StatusTestsMixin:
     def test_available_statuses(self):
         """ Verify available_statuses() returns a list of statuses corresponding to the pipeline. """
 
-        for status, allowed_transitions in six.iteritems(self.pipeline):
+        for status, allowed_transitions in self.pipeline.items():
             instance = self._get_instance(status=status)
             self.assertEqual(instance.available_statuses(), allowed_transitions)
 
     def test_set_status_invalid_status(self):
         """ Verify attempts to set the status to an invalid value raise an exception. """
 
-        for status, valid_statuses in six.iteritems(self.pipeline):
+        for status, valid_statuses in self.pipeline.items():
             instance = self._get_instance(status=status)
 
             all_statuses = list(self.pipeline.keys())
@@ -66,7 +65,7 @@ class StatusTestsMixin:
     def test_set_status_valid_status(self):
         """ Verify status is updated when attempting to transition to a valid status. """
 
-        for status, valid_statuses in six.iteritems(self.pipeline):
+        for status, valid_statuses in self.pipeline.items():
             for new_status in valid_statuses:
                 instance = self._get_instance(status=status)
                 instance.set_status(new_status)

--- a/ecommerce/extensions/voucher/tests/test_utils.py
+++ b/ecommerce/extensions/voucher/tests/test_utils.py
@@ -21,7 +21,6 @@ from oscar.test.factories import (
     datetime,
     get_model
 )
-from six.moves import range
 
 from ecommerce.core.url_utils import get_ecommerce_url
 from ecommerce.coupons.tests.mixins import CouponMixin, DiscoveryMockMixin

--- a/ecommerce/extensions/voucher/utils.py
+++ b/ecommerce/extensions/voucher/utils.py
@@ -17,7 +17,6 @@ from edx_django_utils.cache import TieredCache
 from opaque_keys.edx.keys import CourseKey
 from oscar.core.loading import get_model
 from oscar.templatetags.currency_filters import currency
-from six.moves import range
 
 from ecommerce.core.url_utils import get_ecommerce_url
 from ecommerce.core.utils import log_message_and_raise_validation_error

--- a/ecommerce/extensions/voucher/views.py
+++ b/ecommerce/extensions/voucher/views.py
@@ -3,7 +3,6 @@
 import csv
 import logging
 
-import six
 from django.http import HttpResponse
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _
@@ -29,7 +28,7 @@ class CouponReportCSVView(StaffOnlyMixin, View):
         Generate coupon report for vouchers associated with the coupon.
         """
         coupon = Product.objects.get(id=coupon_id)
-        filename = _("Coupon Report for {coupon_name}").format(coupon_name=six.text_type(coupon))
+        filename = _("Coupon Report for {coupon_name}").format(coupon_name=str(coupon))
         coupons_vouchers = CouponVouchers.objects.filter(coupon=coupon)
 
         filename = "{}.csv".format(slugify(filename))


### PR DESCRIPTION
**Issue:** [BOM-1713](https://openedx.atlassian.net/browse/BOM-1713)

### Description
- package `six` is used for making `python2&3` compatible code so it is not required after upgrading to `python3`.
- This is part 4 of the multiple PRs made for removing all the uses of package six completely. 