### PR TITLE
Usamasadiq/removing-six-V

### DIFF
--- a/ecommerce/extensions/payment/constants.py
+++ b/ecommerce/extensions/payment/constants.py
@@ -1,7 +1,6 @@
 """Payment processor constants."""
 
 
-import six
 from django.utils.translation import ugettext_lazy as _
 
 CARD_TYPES = {
@@ -31,14 +30,14 @@ CARD_TYPES = {
     },
 }
 
-CARD_TYPE_CHOICES = ((key, value['display_name']) for key, value in six.iteritems(CARD_TYPES))
+CARD_TYPE_CHOICES = ((key, value['display_name']) for key, value in CARD_TYPES.items())
 
 # In Python 3.5 dicts aren't ordered so having this unsorted causes new migrations to happen on almost every
 # run of makemigrations. Sorting fixes that. This can be removed in Python 3.6+.
 CARD_TYPE_CHOICES = sorted(CARD_TYPE_CHOICES, key=lambda tup: tup[0])
 
 CYBERSOURCE_CARD_TYPE_MAP = {
-    value['cybersource_code']: key for key, value in six.iteritems(CARD_TYPES) if 'cybersource_code' in value
+    value['cybersource_code']: key for key, value in CARD_TYPES.items() if 'cybersource_code' in value
 }
 
 CLIENT_SIDE_CHECKOUT_FLAG_NAME = 'enable_client_side_checkout'
@@ -65,10 +64,10 @@ PAYPAL_LOCALES = {
 }
 
 APPLE_PAY_CYBERSOURCE_CARD_TYPE_MAP = {
-    value['apple_pay_network']: value['cybersource_code'] for value in six.itervalues(CARD_TYPES) if
+    value['apple_pay_network']: value['cybersource_code'] for value in CARD_TYPES.values() if
     'cybersource_code' in value
 }
 
 STRIPE_CARD_TYPE_MAP = {
-    value['stripe_brand']: key for key, value in six.iteritems(CARD_TYPES) if 'stripe_brand' in value
+    value['stripe_brand']: key for key, value in CARD_TYPES.items() if 'stripe_brand' in value
 }

--- a/ecommerce/extensions/payment/management/tests/test_paypal_profile.py
+++ b/ecommerce/extensions/payment/management/tests/test_paypal_profile.py
@@ -1,12 +1,12 @@
 
 
 import json
+from io import StringIO
 
 import ddt
 import mock
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from django.utils.six import StringIO
 
 from ecommerce.extensions.payment.models import PaypalWebProfile
 from ecommerce.tests.testcases import TestCase

--- a/ecommerce/extensions/payment/processors/__init__.py
+++ b/ecommerce/extensions/payment/processors/__init__.py
@@ -3,7 +3,6 @@
 import abc
 from collections import namedtuple
 
-import six
 import waffle
 from django.conf import settings
 from django.utils.functional import cached_property
@@ -15,7 +14,7 @@ HandledProcessorResponse = namedtuple('HandledProcessorResponse',
                                       ['transaction_id', 'total', 'currency', 'card_number', 'card_type'])
 
 
-class BasePaymentProcessor(six.with_metaclass(abc.ABCMeta, object)):  # pragma: no cover
+class BasePaymentProcessor(metaclass=abc.ABCMeta):  # pragma: no cover
     """Base payment processor class."""
 
     # NOTE: Ensure that, if passed to a Django template, Django does not attempt to instantiate this class
@@ -136,7 +135,7 @@ class BasePaymentProcessor(six.with_metaclass(abc.ABCMeta, object)):  # pragma: 
         return waffle.switch_is_active(settings.PAYMENT_PROCESSOR_SWITCH_PREFIX + cls.NAME)
 
 
-class BaseClientSidePaymentProcessor(six.with_metaclass(abc.ABCMeta, BasePaymentProcessor)):  # pylint: disable=abstract-method
+class BaseClientSidePaymentProcessor(BasePaymentProcessor, metaclass=abc.ABCMeta):  # pylint: disable=abstract-method
     """ Base class for client-side payment processors. """
 
     def get_template_name(self):

--- a/ecommerce/extensions/payment/processors/cybersource.py
+++ b/ecommerce/extensions/payment/processors/cybersource.py
@@ -8,7 +8,6 @@ import logging
 import uuid
 from decimal import Decimal
 
-import six
 from django.conf import settings
 from django.urls import reverse
 from oscar.apps.payment.exceptions import GatewayError, TransactionDeclined, UserCancelled
@@ -399,7 +398,7 @@ class Cybersource(ApplePayMixin, BaseClientSidePaymentProcessor):
             }
             purchase_totals = {
                 'currency': currency,
-                'grandTotalAmount': six.text_type(amount),
+                'grandTotalAmount': str(amount),
             }
 
             response = client.service.runTransaction(

--- a/ecommerce/extensions/payment/processors/paypal.py
+++ b/ecommerce/extensions/payment/processors/paypal.py
@@ -5,17 +5,15 @@ import logging
 import re
 import uuid
 from decimal import Decimal
+from urllib.parse import urljoin
 
 import paypalrestsdk
-import six  # pylint: disable=ungrouped-imports
 import waffle
 from django.conf import settings
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import get_language
 from oscar.apps.payment.exceptions import GatewayError
-from six.moves import range
-from six.moves.urllib.parse import urljoin
 
 from ecommerce.core.url_utils import get_ecommerce_url
 from ecommerce.extensions.payment.constants import PAYPAL_LOCALES
@@ -155,7 +153,7 @@ class Paypal(BasePaymentProcessor):
             },
             'transactions': [{
                 'amount': {
-                    'total': six.text_type(basket.total_incl_tax),
+                    'total': str(basket.total_incl_tax),
                     'currency': basket.currency,
                 },
                 # Paypal allows us to send additional transaction related data in 'description' & 'custom' field
@@ -172,7 +170,7 @@ class Paypal(BasePaymentProcessor):
                             'name': middle_truncate(self.get_courseid_title(line), PAYPAL_FREE_FORM_FIELD_MAX_SIZE),
                             # PayPal requires that the sum of all the item prices (where price = price * quantity)
                             # equals to the total amount set in amount['total'].
-                            'price': six.text_type(line.line_price_incl_tax_incl_discounts / line.quantity),
+                            'price': str(line.line_price_incl_tax_incl_discounts / line.quantity),
                             'currency': line.stockrecord.price_currency,
                         }
                         for line in basket.all_lines()
@@ -379,7 +377,7 @@ class Paypal(BasePaymentProcessor):
 
             refund = sale.refund({
                 'amount': {
-                    'total': six.text_type(amount),
+                    'total': str(amount),
                     'currency': currency,
                 }
             })

--- a/ecommerce/extensions/payment/tests/mixins.py
+++ b/ecommerce/extensions/payment/tests/mixins.py
@@ -3,11 +3,11 @@
 import datetime
 import os
 from decimal import Decimal
+from urllib.parse import urljoin
 
 import ddt
 import mock
 import responses
-import six  # pylint: disable=ungrouped-imports
 from django.conf import settings
 from django.urls import reverse
 from factory.django import mute_signals
@@ -16,7 +16,6 @@ from oscar.apps.payment.exceptions import PaymentError, TransactionDeclined, Use
 from oscar.core.loading import get_class, get_model
 from oscar.test import factories
 from oscar.test.contextmanagers import mock_signal_receiver
-from six.moves.urllib.parse import urljoin
 from testfixtures import LogCapture
 
 from ecommerce.core.constants import ISO_8601_FORMAT
@@ -161,7 +160,7 @@ class CybersourceMixin(PaymentEventsMixin):
         """
         reason_code = kwargs.get('reason_code', '100')
         req_reference_number = kwargs.get('req_reference_number', basket.order_number)
-        total = six.text_type(basket.total_incl_tax)
+        total = str(basket.total_incl_tax)
         auth_amount = auth_amount or total
 
         notification = {
@@ -281,7 +280,7 @@ class CybersourceMixin(PaymentEventsMixin):
             'locale': settings.LANGUAGE_CODE,
             'transaction_type': 'sale',
             'reference_number': basket.order_number,
-            'amount': six.text_type(basket.total_incl_tax),
+            'amount': str(basket.total_incl_tax),
             'currency': basket.currency,
             'override_custom_receipt_page': basket.site.siteconfiguration.build_ecommerce_url(
                 reverse('cybersource:redirect')
@@ -858,7 +857,7 @@ class PaypalMixin:
         self.mock_api_response('/v1/oauth2/token', oauth2_response, rsps=rsps)
 
     def get_payment_creation_response_mock(self, basket, state=PAYMENT_CREATION_STATE, approval_url=APPROVAL_URL):
-        total = six.text_type(basket.total_incl_tax)
+        total = str(basket.total_incl_tax)
         payment_creation_response = {
             'create_time': '2015-05-04T18:18:27Z',
             'id': self.PAYMENT_ID,
@@ -896,7 +895,7 @@ class PaypalMixin:
                         {
                             'quantity': line.quantity,
                             'name': line.product.title,
-                            'price': six.text_type(line.line_price_incl_tax_incl_discounts / line.quantity),
+                            'price': str(line.line_price_incl_tax_incl_discounts / line.quantity),
                             'currency': line.stockrecord.price_currency,
                         }
                         for line in basket.all_lines()
@@ -951,7 +950,7 @@ class PaypalMixin:
     def mock_payment_execution_response(self, basket, state=PAYMENT_EXECUTION_STATE, payer_info=None):
         if payer_info is None:
             payer_info = self.PAYER_INFO
-        total = six.text_type(basket.total_incl_tax)
+        total = str(basket.total_incl_tax)
         payment_execution_response = {
             'create_time': '2015-05-04T15:55:27Z',
             'id': self.PAYMENT_ID,
@@ -981,7 +980,7 @@ class PaypalMixin:
                         {
                             'quantity': line.quantity,
                             'name': line.product.title,
-                            'price': six.text_type(line.line_price_incl_tax_incl_discounts / line.quantity),
+                            'price': str(line.line_price_incl_tax_incl_discounts / line.quantity),
                             'currency': line.stockrecord.price_currency,
                         }
                         for line in basket.all_lines()

--- a/ecommerce/extensions/payment/tests/processors/test_paypal.py
+++ b/ecommerce/extensions/payment/tests/processors/test_paypal.py
@@ -4,6 +4,7 @@
 
 import json
 import logging
+from urllib.parse import urljoin
 
 import ddt
 import mock
@@ -17,7 +18,6 @@ from factory.fuzzy import FuzzyInteger
 from oscar.apps.payment.exceptions import GatewayError
 from oscar.core.loading import get_model
 from paypalrestsdk.resource import Resource  # pylint:disable=ungrouped-imports
-from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
 from testfixtures import LogCapture
 
 from ecommerce.core.tests import toggle_switch

--- a/ecommerce/extensions/payment/tests/test_forms.py
+++ b/ecommerce/extensions/payment/tests/test_forms.py
@@ -4,7 +4,6 @@ import ddt
 import pycountry
 from oscar.core.loading import get_model
 from oscar.test import factories
-from six.moves import range
 from waffle.models import Switch
 
 from ecommerce.core.constants import ENROLLMENT_CODE_PRODUCT_CLASS_NAME, ENROLLMENT_CODE_SWITCH

--- a/ecommerce/extensions/payment/tests/test_models.py
+++ b/ecommerce/extensions/payment/tests/test_models.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-import six
 from django.core.exceptions import ValidationError
 
 from ecommerce.extensions.payment.models import EnterpriseContractMetadata, SDNCheckFailure
@@ -29,7 +28,7 @@ class SDNCheckFailureTests(TestCase):
             username=self.username
         )
 
-        self.assertEqual(six.text_type(basket), expected)
+        self.assertEqual(str(basket), expected)
 
 
 class EnterpriseContractMetadataTests(TestCase):

--- a/ecommerce/extensions/payment/tests/test_utils.py
+++ b/ecommerce/extensions/payment/tests/test_utils.py
@@ -3,15 +3,14 @@
 
 import json
 import time
+from urllib.parse import urlencode
 
 import httpretty
 import mock
-import six  # pylint: disable=ungrouped-imports
 from django.conf import settings
 from django.test import override_settings
 from oscar.test import factories
 from requests.exceptions import HTTPError, Timeout
-from six.moves.urllib.parse import urlencode
 
 from ecommerce.core.models import User
 from ecommerce.extensions.payment.models import SDNCheckFailure
@@ -69,8 +68,8 @@ class SDNCheckTests(TestCase):
             'sources': self.site_configuration.sdn_api_list,
             'api_key': self.sdn_api_key,
             'type': 'individual',
-            'name': six.text_type(self.name).encode('utf-8'),
-            'address': six.text_type(self.city).encode('utf-8'),
+            'name': str(self.name).encode('utf-8'),
+            'address': str(self.city).encode('utf-8'),
             'countries': self.country
         })
         sdn_check_url = '{api_url}?{params}'.format(

--- a/ecommerce/extensions/payment/utils.py
+++ b/ecommerce/extensions/payment/utils.py
@@ -2,11 +2,11 @@
 import copy
 import logging
 import re
+from urllib.parse import urlencode
 
 # Changes part of REV-1209 - see https://github.com/edx/ecommerce/pull/3020
 import crum
 import requests
-import six  # pylint: disable=ungrouped-imports
 # Changes part of REV-1209 - see https://github.com/edx/ecommerce/pull/3020
 import waffle
 from django.conf import settings
@@ -14,7 +14,6 @@ from django.contrib.auth import logout
 from django.utils.translation import ugettext_lazy as _
 from oscar.core.loading import get_model
 from requests.exceptions import HTTPError, Timeout
-from six.moves.urllib.parse import urlencode
 
 from ecommerce.core.constants import SEAT_PRODUCT_CLASS_NAME
 from ecommerce.extensions.analytics.utils import parse_tracking_context
@@ -256,10 +255,10 @@ class SDNClient:
         params_dict = {
             'sources': self.sdn_list,
             'type': 'individual',
-            'name': six.text_type(name).encode('utf-8'),
+            'name': str(name).encode('utf-8'),
             # We are using the city as the address parameter value as indicated in the documentation:
             # http://developer.trade.gov/consolidated-screening-list.html
-            'address': six.text_type(city).encode('utf-8'),
+            'address': str(city).encode('utf-8'),
             'countries': country
         }
         params = urlencode(params_dict)

--- a/ecommerce/extensions/payment/views/__init__.py
+++ b/ecommerce/extensions/payment/views/__init__.py
@@ -3,7 +3,6 @@
 import abc
 import logging
 
-import six
 from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
 from django.utils.decorators import method_decorator
@@ -89,7 +88,7 @@ class BasePaymentSubmitView(View):
             self.request.basket.id
         )
 
-        errors = {field: error[0] for field, error in six.iteritems(form.errors)}
+        errors = {field: error[0] for field, error in form.errors.items()}
         logger.debug(errors)
 
         data = {'field_errors': errors}

--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -3,7 +3,6 @@
 import logging
 
 import requests
-import six
 import waffle
 from django.contrib import messages
 from django.core.exceptions import ObjectDoesNotExist
@@ -124,7 +123,7 @@ class CybersourceSubmitView(BasePaymentSubmitView):
             'device_fingerprint_id': request.session.session_key or basket.order_number,
         }
 
-        for source, destination in six.iteritems(self.FIELD_MAPPINGS):
+        for source, destination in self.FIELD_MAPPINGS.items():
             extra_parameters[destination] = clean_field_value(data[source])
 
         parameters = Cybersource(self.request.site).get_transaction_parameters(

--- a/ecommerce/extensions/payment/views/paypal.py
+++ b/ecommerce/extensions/payment/views/paypal.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+from io import StringIO
 
 import waffle
 from django.core.exceptions import MultipleObjectsReturned
@@ -11,7 +12,6 @@ from django.db import transaction
 from django.http import Http404, HttpResponse, HttpResponseBadRequest
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
-from django.utils.six import StringIO
 from django.views.generic import View
 from edx_rest_api_client.client import EdxRestApiClient
 from edx_rest_api_client.exceptions import SlumberHttpBaseException

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -47,7 +47,6 @@ pytz
 requests
 rules
 sailthru-client==2.2.3
-six
 sorl-thumbnail
 stripe==1.70.0
 unicodecsv

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,7 +29,7 @@ django-config-models==2.0.2  # via -r requirements/base.in
 django-cors-headers==3.4.0  # via -r requirements/base.in
 django-crispy-forms==1.8.1  # via -r requirements/base.in
 django-crum==0.7.7        # via edx-rbac
-django-extensions==3.0.4  # via -r requirements/base.in
+django-extensions==3.0.5  # via -r requirements/base.in
 django-extra-views==0.11.0  # via django-oscar
 django-filter==2.3.0      # via -r requirements/base.in
 django-haystack==2.8.1    # via django-oscar
@@ -54,7 +54,7 @@ drf-jwt==1.16.2           # via edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
 edx-django-sites-extensions==2.5.1  # via -r requirements/base.in
-edx-django-utils==3.6.0   # via -r requirements/base.in, django-config-models, edx-drf-extensions
+edx-django-utils==3.7.3   # via -r requirements/base.in, django-config-models, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/base.in, edx-rbac
 edx-ecommerce-worker==0.7.5  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-drf-extensions
@@ -75,7 +75,7 @@ markdown==2.6.9           # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
 mysqlclient==1.4.6        # via -r requirements/base.in
 ndg-httpsclient==0.5.1    # via -r requirements/base.in
-newrelic==5.14.1.144      # via -r requirements/base.in, edx-django-utils
+newrelic==5.16.0.145      # via -r requirements/base.in, edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 packaging==20.4           # via bleach
@@ -85,7 +85,7 @@ pbr==5.4.5                # via stevedore
 phonenumbers==8.12.7      # via django-oscar, django-phonenumber-field
 pillow==7.2.0             # via django-oscar
 premailer==2.9.2          # via -r requirements/base.in
-psutil==1.2.1             # via edx-django-utils
+psutil==5.7.2             # via edx-django-utils
 purl==1.5                 # via django-oscar
 pyasn1==0.4.8             # via ndg-httpsclient
 pycountry==17.1.8         # via -r requirements/base.in
@@ -111,13 +111,13 @@ rules==2.2                # via -r requirements/base.in
 sailthru-client==2.2.3    # via -r requirements/base.in
 semantic-version==2.8.5   # via edx-drf-extensions
 simplejson==3.17.2        # via django-rest-swagger, sailthru-client
-six==1.15.0               # via -r requirements/base.in, analytics-python, bleach, cryptography, django-compressor, django-extra-views, django-simple-history, djangorestframework-csv, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, edx-rbac, isodate, libsass, packaging, paypalrestsdk, purl, pyjwkest, pyopenssl, python-dateutil, social-auth-app-django, social-auth-core, stevedore, zeep
+six==1.15.0               # via analytics-python, bleach, cryptography, django-compressor, django-extra-views, django-simple-history, djangorestframework-csv, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, edx-rbac, isodate, libsass, packaging, paypalrestsdk, purl, pyjwkest, pyopenssl, python-dateutil, social-auth-app-django, social-auth-core, stevedore, zeep
 slumber==0.7.1            # via edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.in, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/pins.txt, edx-auth-backends, social-auth-app-django
 sorl-thumbnail==12.6.3    # via -r requirements/base.in
 sqlparse==0.3.1           # via django
-stevedore==1.32.0         # via edx-opaque-keys
+stevedore==1.32.0         # via edx-django-utils, edx-opaque-keys
 stripe==1.70.0            # via -r requirements/base.in
 text-unidecode==1.3       # via faker
 unicodecsv==0.14.1        # via -r requirements/base.in, djangorestframework-csv

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -37,7 +37,7 @@ django-cors-headers==3.4.0  # via -r requirements/test.txt
 django-crispy-forms==1.8.1  # via -r requirements/test.txt
 django-crum==0.7.7        # via -r requirements/test.txt, edx-rbac
 django-debug-toolbar==2.2  # via -r requirements/dev.in
-django-extensions==3.0.4  # via -r requirements/test.txt
+django-extensions==3.0.5  # via -r requirements/test.txt
 django-extra-views==0.11.0  # via -r requirements/test.txt, django-oscar
 django-filter==2.3.0      # via -r requirements/test.txt
 django-haystack==2.8.1    # via -r requirements/test.txt, django-oscar
@@ -64,7 +64,7 @@ drf-jwt==1.16.2           # via -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/test.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/test.txt
-edx-django-utils==3.6.0   # via -r requirements/test.txt, django-config-models, edx-drf-extensions
+edx-django-utils==3.7.3   # via -r requirements/test.txt, django-config-models, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/test.txt, edx-rbac
 edx-ecommerce-worker==0.7.5  # via -r requirements/test.txt
 edx-i18n-tools==0.5.3     # via -r requirements/test.txt
@@ -103,7 +103,7 @@ mock==3.0.5               # via -r requirements/test.txt, mock-django
 more-itertools==8.4.0     # via -r requirements/test.txt, pytest
 mysqlclient==1.4.6        # via -r requirements/test.txt
 ndg-httpsclient==0.5.1    # via -r requirements/test.txt
-newrelic==5.14.1.144      # via -r requirements/test.txt, edx-django-utils
+newrelic==5.16.0.145      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 packaging==20.4           # via -r requirements/test.txt, bleach, pytest, tox
@@ -116,7 +116,7 @@ pillow==7.2.0             # via -r requirements/test.txt, django-oscar
 pluggy==0.13.1            # via -r requirements/test.txt, diff-cover, pytest, tox
 polib==1.1.0              # via -r requirements/test.txt, edx-i18n-tools
 premailer==2.9.2          # via -r requirements/test.txt
-psutil==1.2.1             # via -r requirements/test.txt, edx-django-utils
+psutil==5.7.2             # via -r requirements/test.txt, edx-django-utils
 ptvsd==4.3.2              # via -r requirements/dev.in
 purl==1.5                 # via -r requirements/test.txt, django-oscar
 py==1.9.0                 # via -r requirements/test.txt, pytest, tox
@@ -155,7 +155,7 @@ rcssmin==1.0.6            # via -r requirements/test.txt, django-compressor
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
 requests-toolbelt==0.9.1  # via -r requirements/test.txt, zeep
 requests==2.24.0          # via -r requirements/docs.txt, -r requirements/test.txt, analytics-python, coreapi, edx-drf-extensions, edx-rest-api-client, paypalrestsdk, pyjwkest, pytest-base-url, pytest-selenium, requests-oauthlib, requests-toolbelt, responses, sailthru-client, slumber, social-auth-core, sphinx, stripe, transifex-client, zeep
-responses==0.10.15        # via -r requirements/test.txt
+responses==0.10.16        # via -r requirements/test.txt
 rest-condition==1.0.3     # via -r requirements/test.txt, edx-drf-extensions
 rjsmin==1.1.0             # via -r requirements/test.txt, django-compressor
 rules==2.2                # via -r requirements/test.txt
@@ -173,7 +173,7 @@ sorl-thumbnail==12.6.3    # via -r requirements/test.txt
 soupsieve==2.0.1          # via -r requirements/test.txt, beautifulsoup4
 sphinx==1.5.3             # via -r requirements/docs.txt, edx-sphinx-theme
 sqlparse==0.3.1           # via -r requirements/test.txt, django, django-debug-toolbar
-stevedore==1.32.0         # via -r requirements/test.txt, edx-opaque-keys
+stevedore==1.32.0         # via -r requirements/test.txt, edx-django-utils, edx-opaque-keys
 stripe==1.70.0            # via -r requirements/test.txt
 testfixtures==6.14.1      # via -r requirements/test.txt
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
@@ -184,7 +184,7 @@ transifex-client==0.13.11  # via -r requirements/dev.in
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 unicodecsv==0.14.1        # via -r requirements/test.txt, djangorestframework-csv
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
-urllib3==1.25.10          # via -r requirements/docs.txt, -r requirements/test.txt, requests, selenium, transifex-client
+urllib3==1.25.10          # via -r requirements/docs.txt, -r requirements/test.txt, requests, responses, selenium, transifex-client
 virtualenv==16.7.9        # via -r requirements/test.txt, tox
 waitress==1.4.4           # via -r requirements/test.txt, webtest
 wcwidth==0.2.5            # via -r requirements/test.txt, pytest

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -30,7 +30,7 @@ django-config-models==2.0.2  # via -r requirements/base.in
 django-cors-headers==3.4.0  # via -r requirements/base.in
 django-crispy-forms==1.8.1  # via -r requirements/base.in
 django-crum==0.7.7        # via edx-rbac
-django-extensions==3.0.4  # via -r requirements/base.in
+django-extensions==3.0.5  # via -r requirements/base.in
 django-extra-views==0.11.0  # via django-oscar
 django-filter==2.3.0      # via -r requirements/base.in
 django-haystack==2.8.1    # via django-oscar
@@ -56,7 +56,7 @@ drf-jwt==1.16.2           # via edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
 edx-django-sites-extensions==2.5.1  # via -r requirements/base.in
-edx-django-utils==3.6.0   # via -r requirements/base.in, django-config-models, edx-drf-extensions
+edx-django-utils==3.7.3   # via -r requirements/base.in, django-config-models, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/base.in, edx-rbac
 edx-ecommerce-worker==0.7.5  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-drf-extensions
@@ -89,7 +89,7 @@ pbr==5.4.5                # via stevedore
 phonenumbers==8.12.7      # via django-oscar, django-phonenumber-field
 pillow==7.2.0             # via django-oscar
 premailer==2.9.2          # via -r requirements/base.in
-psutil==1.2.1             # via edx-django-utils
+psutil==5.7.2             # via edx-django-utils
 purl==1.5                 # via django-oscar
 pyasn1==0.4.8             # via ndg-httpsclient
 pycountry==17.1.8         # via -r requirements/base.in
@@ -117,13 +117,13 @@ rules==2.2                # via -r requirements/base.in
 sailthru-client==2.2.3    # via -r requirements/base.in
 semantic-version==2.8.5   # via edx-drf-extensions
 simplejson==3.17.2        # via django-rest-swagger, sailthru-client
-six==1.15.0               # via -r requirements/base.in, analytics-python, bleach, cryptography, django-compressor, django-extra-views, django-simple-history, djangorestframework-csv, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, edx-rbac, isodate, libsass, packaging, paypalrestsdk, purl, pyjwkest, pyopenssl, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, stevedore, zeep
+six==1.15.0               # via analytics-python, bleach, cryptography, django-compressor, django-extra-views, django-simple-history, djangorestframework-csv, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, edx-rbac, isodate, libsass, packaging, paypalrestsdk, purl, pyjwkest, pyopenssl, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, stevedore, zeep
 slumber==0.7.1            # via edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.in, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/pins.txt, edx-auth-backends, social-auth-app-django
 sorl-thumbnail==12.6.3    # via -r requirements/base.in
 sqlparse==0.3.1           # via django
-stevedore==1.32.0         # via edx-opaque-keys
+stevedore==1.32.0         # via edx-django-utils, edx-opaque-keys
 stripe==1.70.0            # via -r requirements/base.in
 text-unidecode==1.3       # via faker
 unicodecsv==0.14.1        # via -r requirements/base.in, djangorestframework-csv

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -35,7 +35,7 @@ django-config-models==2.0.2  # via -r requirements/base.txt
 django-cors-headers==3.4.0  # via -r requirements/base.txt
 django-crispy-forms==1.8.1  # via -r requirements/base.txt
 django-crum==0.7.7        # via -r requirements/base.txt, edx-rbac
-django-extensions==3.0.4  # via -r requirements/base.txt
+django-extensions==3.0.5  # via -r requirements/base.txt
 django-extra-views==0.11.0  # via -r requirements/base.txt, django-oscar
 django-filter==2.3.0      # via -r requirements/base.txt
 django-haystack==2.8.1    # via -r requirements/base.txt, django-oscar
@@ -60,7 +60,7 @@ drf-jwt==1.16.2           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/base.txt
-edx-django-utils==3.6.0   # via -r requirements/base.txt, django-config-models, edx-drf-extensions
+edx-django-utils==3.7.3   # via -r requirements/base.txt, django-config-models, edx-drf-extensions
 edx-drf-extensions==6.1.1  # via -r requirements/base.txt, edx-rbac
 edx-ecommerce-worker==0.7.5  # via -r requirements/base.txt
 edx-i18n-tools==0.5.3     # via -r requirements/test.in
@@ -95,7 +95,7 @@ mock==3.0.5               # via -r requirements/test.in, mock-django
 more-itertools==8.4.0     # via -r requirements/e2e.txt, pytest
 mysqlclient==1.4.6        # via -r requirements/base.txt
 ndg-httpsclient==0.5.1    # via -r requirements/base.txt
-newrelic==5.14.1.144      # via -r requirements/base.txt, edx-django-utils
+newrelic==5.16.0.145      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 packaging==20.4           # via -r requirements/base.txt, -r requirements/e2e.txt, -r requirements/tox.txt, bleach, pytest, tox
@@ -108,7 +108,7 @@ pillow==7.2.0             # via -r requirements/base.txt, django-oscar
 pluggy==0.13.1            # via -r requirements/e2e.txt, -r requirements/tox.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
 premailer==2.9.2          # via -r requirements/base.txt
-psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
+psutil==5.7.2             # via -r requirements/base.txt, edx-django-utils
 purl==1.5                 # via -r requirements/base.txt, django-oscar
 py==1.9.0                 # via -r requirements/e2e.txt, -r requirements/tox.txt, pytest, tox
 pyasn1==0.4.8             # via -r requirements/base.txt, ndg-httpsclient
@@ -144,7 +144,7 @@ rcssmin==1.0.6            # via -r requirements/base.txt, django-compressor
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests-toolbelt==0.9.1  # via -r requirements/base.txt, zeep
 requests==2.24.0          # via -r requirements/base.txt, -r requirements/e2e.txt, analytics-python, coreapi, edx-drf-extensions, edx-rest-api-client, paypalrestsdk, pyjwkest, pytest-base-url, pytest-selenium, requests-oauthlib, requests-toolbelt, responses, sailthru-client, slumber, social-auth-core, stripe, zeep
-responses==0.10.15        # via -r requirements/test.in
+responses==0.10.16        # via -r requirements/test.in
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 rjsmin==1.1.0             # via -r requirements/base.txt, django-compressor
 rules==2.2                # via -r requirements/base.txt
@@ -159,7 +159,7 @@ social-auth-core==3.2.0   # via -c requirements/pins.txt, -r requirements/base.t
 sorl-thumbnail==12.6.3    # via -r requirements/base.txt
 soupsieve==2.0.1          # via beautifulsoup4
 sqlparse==0.3.1           # via -r requirements/base.txt, django
-stevedore==1.32.0         # via -r requirements/base.txt, edx-opaque-keys
+stevedore==1.32.0         # via -r requirements/base.txt, edx-django-utils, edx-opaque-keys
 stripe==1.70.0            # via -r requirements/base.txt
 testfixtures==6.14.1      # via -r requirements/test.in
 text-unidecode==1.3       # via -r requirements/base.txt, faker
@@ -169,7 +169,7 @@ tox==3.14.6               # via -c requirements/pins.txt, -r requirements/tox.tx
 typed-ast==1.4.1          # via astroid
 unicodecsv==0.14.1        # via -r requirements/base.txt, djangorestframework-csv
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
-urllib3==1.25.10          # via -c requirements/pins.txt, -r requirements/base.txt, -r requirements/e2e.txt, requests, selenium
+urllib3==1.25.10          # via -c requirements/pins.txt, -r requirements/base.txt, -r requirements/e2e.txt, requests, responses, selenium
 virtualenv==16.7.9        # via -c requirements/pins.txt, -r requirements/tox.txt, tox
 waitress==1.4.4           # via webtest
 wcwidth==0.2.5            # via -r requirements/e2e.txt, pytest


### PR DESCRIPTION
**Issue:** [BOM-1713](https://openedx.atlassian.net/browse/BOM-1713)

### Description
- package `six` is used for making `python2&3` compatible code so it is not required after upgrading to `python3`.
- This is the final part of the multiple PRs made for removing all the uses of package six completely. 