### PR TITLE
DISCO-1540: Force default id_verified for professional entitlements

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -479,16 +479,21 @@ class EntitlementProductHelper:
         if not uuid:
             raise Exception(_(u"You need to provide a course UUID to create Course Entitlements."))
 
-        # Extract arguments required for Seat creation, deserializing as necessary.
+        # Extract arguments required for Entitlement creation, deserializing as necessary.
         certificate_type = attrs.get('certificate_type')
         price = Decimal(product['price'])
+
+        # DISCO-1540 Temporarily force a default of id_verified=True for Professional entitlements
+        id_verified_default = certificate_type == 'professional'
+        id_verification_required = attrs.get('id_verification_required', id_verified_default)
 
         entitlement = create_or_update_course_entitlement(
             certificate_type,
             price,
             partner,
             uuid,
-            course.name
+            course.name,
+            id_verification_required=id_verification_required
         )
 
         # As a convenience to our caller, provide the SKU in the returned product serialization.


### PR DESCRIPTION
Enforce a default of id_verified=True for Professional entitlements, to align with the associated seats.  

This stops short of the steps done in draft PR #2743, which are:

- add this attr field to the API / serializer 
- align this value on parent and child entitlement products
- propagate changes to this and other attrs upon subsequent updates

This PR will avoid a current problem in LMS with mode mismatches among purchased entitlements and available course modes and should help confirm that PR #2743 (and it's associated [course-discovery PR](https://github.com/edx/course-discovery/pull/2356)) are the correct path forward.