### PR TITLE
ENT-3171: Optimized _get_not_redeemed_usages method

### DIFF
--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -449,7 +449,8 @@ class EnterpriseCouponViewSet(CouponViewSet):
         Returns a queryset containing unique code and user_email pairs from OfferAssignments.
         Only code and user_email pairs that have no corresponding VoucherApplication are returned.
         """
-        prefetch_related_objects(vouchers, 'applications', 'offers', 'offers__condition', 'offers__offerassignment_set')
+        prefetch_related_objects(vouchers, 'applications', 'applications__user', 'offers', 'offers__condition',
+                                 'offers__offerassignment_set')
         not_redeemed_assignments = []
         for voucher in vouchers:
             assignments = voucher.not_redeemed_assignment_ids

--- a/ecommerce/extensions/voucher/models.py
+++ b/ecommerce/extensions/voucher/models.py
@@ -142,7 +142,12 @@ class Voucher(AbstractVoucher):
         # Assignment is only valid for Vouchers linked to an enterprise offer.
         if not enterprise_offer:
             return None
-        users_having_usages = self.applications.values_list('user__email', flat=True)
+
+        # To filter out redeemed assignments of the given voucher
+        users_having_usages = []
+        for application in self.applications.all():
+            user_email = application.user.email
+            users_having_usages.append(user_email)
 
         not_redeemed_assignments = []
         for assignment in enterprise_offer.offerassignment_set.all():


### PR DESCRIPTION
**Results:** 

Tested on a batch of 2200 unredeemed coupons out of 5000. Query count now remains ineffective of the voucher and assignment count.

**Before optimisation**

Total Query Count = 1125
Total Time = Up to 2 seconds

**After optimisation:**

Total Query Count = 18
Total Time = 0.2 - 0.3 seconds