### PR TITLE
[WIP] [REV-1312] Add try/except to troubleshoot case of missing Segment

### DIFF
--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -186,7 +186,6 @@ class CybersourceSubmitAPIView(APIView, CybersourceSubmitView):
         return super(CybersourceSubmitAPIView, self).post(request)
 
 
-
 class CybersourceOrderCompletionView(EdxOrderPlacementMixin):
     """
     A baseclass that includes error handling and financial reporting for orders placed via
@@ -341,7 +340,7 @@ class CybersourceOrderCompletionView(EdxOrderPlacementMixin):
             with self.log_payment_exceptions(
                     basket,
                     self.order_number,
-                        self.transaction_id,
+                    self.transaction_id,
                     ppr,
                     order_completion_message.get("message")
             ):

--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -186,6 +186,7 @@ class CybersourceSubmitAPIView(APIView, CybersourceSubmitView):
         return super(CybersourceSubmitAPIView, self).post(request)
 
 
+
 class CybersourceOrderCompletionView(EdxOrderPlacementMixin):
     """
     A baseclass that includes error handling and financial reporting for orders placed via

--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -336,15 +336,15 @@ class CybersourceOrderCompletionView(EdxOrderPlacementMixin):
                 )
 
             # Explicitly delimit operations which will be rolled back if an exception occurs.
-            with transaction.atomic():
-                with self.log_payment_exceptions(
-                        basket,
-                        self.order_number,
+            # with transaction.atomic():
+            with self.log_payment_exceptions(
+                    basket,
+                    self.order_number,
                         self.transaction_id,
-                        ppr,
-                        order_completion_message.get("message")
-                ):
-                    self.handle_payment(order_completion_message, basket)
+                    ppr,
+                    order_completion_message.get("message")
+            ):
+                self.handle_payment(order_completion_message, basket)
 
         except Exception as exception:  # pylint: disable=bare-except
             if getattr(exception, 'unlogged', True):


### PR DESCRIPTION
When payment fails at Cybersource (GatewayError), we're not logging any 'Payment Processor Response' Segment event. (These are only successfully firing when the payment was successful).

This branch is to add logging/error handling to find more clues about what's happening in this case.

Relevant Jira ticket:
https://openedx.atlassian.net/browse/REV-1312