### PR TITLE
Disable cybersource logging for now

### DIFF
--- a/ecommerce/extensions/payment/processors/cybersource.py
+++ b/ecommerce/extensions/payment/processors/cybersource.py
@@ -162,6 +162,7 @@ class Cybersource(ApplePayMixin, BaseClientSidePaymentProcessor):
             'merchantid': self.merchant_id,
             'merchant_keyid': self.flex_shared_secret_key_id,
             'merchant_secretkey': self.flex_shared_secret_key,
+            "enable_log": False,
         }
 
     @property

--- a/ecommerce/extensions/payment/processors/cybersource.py
+++ b/ecommerce/extensions/payment/processors/cybersource.py
@@ -162,7 +162,7 @@ class Cybersource(ApplePayMixin, BaseClientSidePaymentProcessor):
             'merchantid': self.merchant_id,
             'merchant_keyid': self.flex_shared_secret_key_id,
             'merchant_secretkey': self.flex_shared_secret_key,
-            "enable_log": False,
+            'enable_log': False,
         }
 
     @property


### PR DESCRIPTION
We do not have write-access to the log directory, disable cybersource logging for now; I'm not currently able to test this change locally, but it just affects prod-like environments anyway.