### PR TITLE
[REV-1312] remove transaction.atomic to fix processor response segment event bug

### DIFF
--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -335,16 +335,15 @@ class CybersourceOrderCompletionView(EdxOrderPlacementMixin):
                     self.transaction_id,
                 )
 
-            # Explicitly delimit operations which will be rolled back if an exception occurs.
-            with transaction.atomic():
-                with self.log_payment_exceptions(
-                        basket,
-                        self.order_number,
-                        self.transaction_id,
-                        ppr,
-                        order_completion_message.get("message")
-                ):
-                    self.handle_payment(order_completion_message, basket)
+            # Don't make this an atomic transaction; rolled back transactions prevent track_segment_event from firing.
+            with self.log_payment_exceptions(
+                    basket,
+                    self.order_number,
+                    self.transaction_id,
+                    ppr,
+                    order_completion_message.get("message")
+            ):
+                self.handle_payment(order_completion_message, basket)
 
         except Exception as exception:  # pylint: disable=bare-except
             if getattr(exception, 'unlogged', True):


### PR DESCRIPTION
When payment fails at Cybersource (GatewayError), we're not logging any 'Payment Processor Response' Segment event. (These are only successfully firing when the payment was successful).

This was because track_segment_event returns its function transaction.on_commit(and payment processor exception rolled back the transaction). We confirmed with Cale that the block in question doesn't need to be atomic, so we're removing the with transaction.atomic():. 

Relevant Jira ticket:
https://openedx.atlassian.net/browse/REV-1312