### PR TITLE
[REV-1311] download sdn csv file for fallback 

### DIFF
--- a/docs/decisions/0007-sdn-fallback.rst
+++ b/docs/decisions/0007-sdn-fallback.rst
@@ -29,6 +29,7 @@ Ecommerce is an exception/antipattern to this general approach; it doesn't use C
 Ecommerce-worker doesn't have access to the ecommerce database, so any database interaction with ecommerce needs to happen on the main ecommerce server machine. 
 
 Our workaround for cases like this is to do the work on a Jenkins machine (so Jenkins is both the scheduler and the worker). The download task is fairly lightweight, and impact is small if a run failed to complete. 
+(Other options would be adding a Celery integration to ecommerce so it could follow the pattern above, OR running the code in ecommerce-worker and calling ecommerce APIs to create/delete records, OR running the task on the ecommerce machine using an API call. Given the low complexity and low criticality of the download task, those options were less suitable than our typical workaround.)
 
 2. **Storing the data**
 

--- a/docs/decisions/0007-sdn-fallback.rst
+++ b/docs/decisions/0007-sdn-fallback.rst
@@ -4,7 +4,7 @@
 Status
 ------
 
-Accepted (August 2020)
+Accepted (September 2020)
 
 Context
 -------
@@ -21,6 +21,14 @@ Decision
 1. **Using the CSV as a fallback vs as a primary solution**
 
 We are only going to use the CSV when the API is down, not replace the API calls with the CSV. The reason is that the API is up the vast majority of the time and during that time we know the data is the most up to date, so the CSV makes more sense as a fallback rather than primary solution.
+
+1a. **Selection of which worker will run the task to download the CSV**
+
+As per OEP-0003, we generally use celery to run asynchronous tasks, with some scheduler (Jenkins, Kubernetes) if task runs periodically. 
+Ecommerce is an exception/antipattern to this general approach; it doesn't use Celery directly. Instead, we have a separate service called ecommerce-worker that has a Celery integration. 
+Ecommerce-worker doesn't have access to the ecommerce database, so any database interaction with ecommerce needs to happen on the main ecommerce server machine. 
+
+Our workaround for cases like this is to do the work on a Jenkins machine (so Jenkins is both the scheduler and the worker). The download task is fairly lightweight, and impact is small if a run failed to complete. 
 
 2. **Storing the data**
 

--- a/docs/decisions/0007-sdn-fallback.rst
+++ b/docs/decisions/0007-sdn-fallback.rst
@@ -24,7 +24,7 @@ We are only going to use the CSV when the API is down, not replace the API calls
 
 1a. **Selection of which worker will run the task to download the CSV**
 
-As per OEP-0003, we generally use celery to run asynchronous tasks, with some scheduler (Jenkins, Kubernetes) if task runs periodically. 
+As per OEP-0003, we generally use Celery to run asynchronous tasks, with some scheduler (Jenkins, Kubernetes) if task runs periodically. 
 Ecommerce is an exception/antipattern to this general approach; it doesn't use Celery directly. Instead, we have a separate service called ecommerce-worker that has a Celery integration. 
 Ecommerce-worker doesn't have access to the ecommerce database, so any database interaction with ecommerce needs to happen on the main ecommerce server machine. 
 

--- a/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
+++ b/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
@@ -31,11 +31,12 @@ class Command(BaseCommand):
 
         csv, csv_file_size_in_MB, csv_file_name = download_SDN_fallback_csv()
 
-        try:
-            assert csv_file_size_in_MB > threshold
+        file_has_eligible_size = csv_file_size_in_MB > threshold
+
+        if file_has_eligible_size:
+            print("[TEMP]: okay to import")
             # [placeholder] call the import for the csv here (REV-1310)
-        except:
+        else:
             logger.warning("CSV file download did not meet threshold")
             raise CommandError("CSV file download did not meet threshold")
-        finally:
-            os.remove(csv_file_name)
+        os.remove(csv_file_name)

--- a/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
+++ b/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
@@ -53,7 +53,7 @@ class Command(BaseCommand):
             file_size_in_MB = file_size_in_bytes / 10**6
 
             if file_size_in_MB > threshold:
-                print("[TEMP]: csv has eligible size, okay to import")
+                print("[TEMP]: CSV has eligible size, okay to import")
                 # ^ when import is ready (REV-1310), replace print statement with call to import with our csv
             else:
                 logger.warning("CSV file download did not meet threshold given: [%f]", threshold)

--- a/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
+++ b/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
@@ -5,8 +5,8 @@ See docs/decisions/0007-sdn-fallback.rst for more details.
 """
 import logging
 import os
-import requests
 
+import requests
 from django.core.management.base import BaseCommand, CommandError
 
 logger = logging.getLogger(__name__)

--- a/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
+++ b/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
@@ -1,0 +1,41 @@
+"""
+Django management command to download SDN csv for use as fallback if the trade.gov API is down.
+
+"""
+import logging
+import os
+
+from django.core.management.base import BaseCommand, CommandError
+
+from ecommerce.extensions.payment.utils import download_SDN_fallback_csv
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = 'Management command to download csv for use as fallback for SDN check.'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--threshold',
+            metavar='N',
+            action='store',
+            type=float,
+            default=3,
+            help='File size MB threshold, under which we will not import it. Use default if argument not specified'
+        )
+
+    def handle(self, *args, **options):
+        # download the csv locally, to check size and pass along to import
+        threshold = options['threshold']
+
+        csv, csv_file_size_in_MB, csv_file_name = download_SDN_fallback_csv()
+
+        try:
+            assert csv_file_size_in_MB > threshold
+            # [placeholder] call the import for the csv here (REV-1310)
+        except:
+            logger.warning("CSV file download did not meet threshold")
+            raise CommandError("CSV file download did not meet threshold")
+        finally:
+            os.remove(csv_file_name)

--- a/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
+++ b/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
@@ -5,10 +5,9 @@ See docs/decisions/0007-sdn-fallback.rst for more details.
 """
 import logging
 import os
+import requests
 
 from django.core.management.base import BaseCommand, CommandError
-
-from ecommerce.extensions.payment.utils import download_SDN_fallback_csv
 
 logger = logging.getLogger(__name__)
 
@@ -25,17 +24,39 @@ class Command(BaseCommand):
             default=3,
             help='File size MB threshold, under which we will not import it. Use default if argument not specified'
         )
+        parser.add_argument(
+            '--url',
+            metavar='N',
+            action='store',
+            type=str,
+            default='http://api.trade.gov/static/consolidated_screening_list/consolidated.csv',
+            help='Url to call for SDN csv, default to trade.gov'
+        )
 
     def handle(self, *args, **options):
         # download the csv locally, to check size and pass along to import
         threshold = options['threshold']
+        url = options['url']
+        csv_file_name = 'temp_sdn_fallback.csv'
 
-        csv, csv_file_size_in_MB, csv_file_name = download_SDN_fallback_csv()
+        with requests.Session() as s:
+            try:
+                download = s.get(url)
+            except Exception as e:   # pylint: disable=broad-except
+                logger.warning("Exception occurred: [%s]", e)
+                raise CommandError("Exception occurred")
 
-        if csv_file_size_in_MB > threshold:
-            print("[TEMP]: csv has eligible size, okay to import")
-            # ^ when import is ready (REV-1310), replace print statement with call to import with our csv
-        else:
-            logger.warning("CSV file download did not meet threshold given: [%f]", threshold)
-            raise CommandError("CSV file download did not meet threshold")
-        os.remove(csv_file_name)
+            csv = open(csv_file_name, 'wb')
+            csv.write(download.content)
+            csv.close()
+            file_size_in_bytes = os.path.getsize(csv_file_name)
+            file_size_in_MB = file_size_in_bytes / 10**6
+
+            if file_size_in_MB > threshold:
+                print("[TEMP]: csv has eligible size, okay to import")
+                # ^ when import is ready (REV-1310), replace print statement with call to import with our csv
+            else:
+                logger.warning("CSV file download did not meet threshold given: [%f]", threshold)
+                raise CommandError("CSV file download did not meet threshold")
+            os.remove(csv_file_name)
+

--- a/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
+++ b/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
@@ -1,5 +1,6 @@
 """
 Django management command to download SDN csv for use as fallback if the trade.gov API is down.
+See docs/decisions/0007-sdn-fallback.rst for more details.
 
 """
 import logging
@@ -13,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = 'Management command to download csv for use as fallback for SDN check.'
+    help = 'Download the SDN csv from trade.gov, for use as fallback for when their SDN API is down.'
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
+++ b/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
@@ -57,6 +57,6 @@ class Command(BaseCommand):
                 # ^ when import is ready (REV-1310), replace print statement with call to import with our csv
             else:
                 logger.warning("CSV file download did not meet threshold given: [%f]", threshold)
+                logger.warning("Response content was: [%s]", download.content)
                 raise CommandError("CSV file download did not meet threshold")
             os.remove(csv_file_name)
-

--- a/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
+++ b/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
@@ -31,11 +31,9 @@ class Command(BaseCommand):
 
         csv, csv_file_size_in_MB, csv_file_name = download_SDN_fallback_csv()
 
-        file_has_eligible_size = csv_file_size_in_MB > threshold
-
-        if file_has_eligible_size:
-            print("[TEMP]: okay to import")
-            # [placeholder] call the import for the csv here (REV-1310)
+        if csv_file_size_in_MB > threshold:
+            print("[TEMP]: csv has eligible size, okay to import")
+            # ^ when import is ready (REV-1310), replace print statement with call to import with our csv
         else:
             logger.warning("CSV file download did not meet threshold")
             raise CommandError("CSV file download did not meet threshold")

--- a/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
+++ b/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
@@ -35,6 +35,6 @@ class Command(BaseCommand):
             print("[TEMP]: csv has eligible size, okay to import")
             # ^ when import is ready (REV-1310), replace print statement with call to import with our csv
         else:
-            logger.warning("CSV file download did not meet threshold")
+            logger.warning("CSV file download did not meet threshold given: [%f]", threshold)
             raise CommandError("CSV file download did not meet threshold")
         os.remove(csv_file_name)

--- a/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
+++ b/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
@@ -17,7 +17,7 @@ class TestDownloadSndFallbackCommand(TestCase):
 
         #  mock response for csv download: just one row of the csv
         self.test_response = TestResponse(**{
-            'content': bytes('_id,source,entity_number,type,programs,name,title,addresses,federal_register_notice,start_date,end_date,standard_order,license_requirement,license_policy,call_sign,vessel_type,gross_tonnage,gross_registered_tonnage,vessel_flag,vessel_owner,remarks,source_list_url,alt_names,citizenships,dates_of_birth,nationalities,places_of_birth,source_information_url,ids\ne5a9eff64cec4a74ed5e9e93c2d851dc2d9132d2,Denied Persons List (DPL) - Bureau of Industry and Security,,,, ADRIAN MANUEL HERNANDEZ,,"3037 S. 69TH DRIVE, PHONEIX, AZ, 85043",82 F.R. 48792 10/20/2017,2017-10-16,2020-10-13,Y,,,,,,,,,FR NOTICE ADDED,http://bit.ly/1Qi5heF,,,,,,http://bit.ly/1iwxiF0', 'utf-8'), # pylint: disable=line-too-long
+            'content': bytes('_id,source,entity_number,type,programs,name,title,addresses,federal_register_notice,start_date,end_date,standard_order,license_requirement,license_policy,call_sign,vessel_type,gross_tonnage,gross_registered_tonnage,vessel_flag,vessel_owner,remarks,source_list_url,alt_names,citizenships,dates_of_birth,nationalities,places_of_birth,source_information_url,ids\ne5a9eff64cec4a74ed5e9e93c2d851dc2d9132d2,Denied Persons List (DPL) - Bureau of Industry and Security,,,, ADRIAN MANUEL HERNANDEZ,,"3037 S. 69TH DRIVE, PHONEIX, AZ, 85043",82 F.R. 48792 10/20/2017,2017-10-16,2020-10-13,Y,,,,,,,,,FR NOTICE ADDED,http://bit.ly/1Qi5heF,,,,,,http://bit.ly/1iwxiF0', 'utf-8'),  # pylint: disable=line-too-long
             'status_code': 200,
         })
 

--- a/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
+++ b/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
@@ -30,7 +30,7 @@ class TestDownloadSndFallbackCommand(TestCase):
         try:
             call_command('populate_sdn_fallback_data_and_metadata', '--threshold=0.0001')
         except CommandError as e:
-            self.fail("Failed download csv. {}".format(e))
+            self.fail("We expected to pass, but failed download csv. {}".format(e))
 
     @patch('requests.Session.get')
     def test_with_mock_fail(self, mock_response):
@@ -40,17 +40,4 @@ class TestDownloadSndFallbackCommand(TestCase):
 
         with self.assertRaises(CommandError) as cm:
             call_command('populate_sdn_fallback_data_and_metadata', '--threshold=1')
-        self.assertEqual('CSV file download did not meet threshold', str(cm.exception))
-
-    def test_live_url_pass(self):
-        """ Test against the live url, with default threshold"""
-        try:
-            call_command('populate_sdn_fallback_data_and_metadata')
-        except CommandError as e:
-            self.fail("Failed download csv. {}".format(e))
-
-    def test_live_url_below_threshold(self):
-        """ Test against the live url, with threshold too high to clear """
-        with self.assertRaises(CommandError) as cm:
-            call_command('populate_sdn_fallback_data_and_metadata', '--threshold=7')
         self.assertEqual('CSV file download did not meet threshold', str(cm.exception))

--- a/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
+++ b/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
@@ -4,7 +4,6 @@ Tests for Django management command to download csv for SDN fallback.
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from mock import patch
-
 from ecommerce.tests.testcases import TestCase
 
 
@@ -29,11 +28,16 @@ class TestDownloadSndFallbackCommand(TestCase):
         call_command('populate_sdn_fallback_data_and_metadata', '--threshold=0.0001')
 
     @patch('requests.Session.get')
-    def test_with_mock_fail(self, mock_response):
+    def test_with_mock_fail_size(self, mock_response):
         """ Test using mock response from setup, using threshold it will NOT clear"""
 
         mock_response.return_value = self.test_response
-
         with self.assertRaises(CommandError) as cm:
             call_command('populate_sdn_fallback_data_and_metadata', '--threshold=1')
         self.assertEqual('CSV file download did not meet threshold', str(cm.exception))
+
+    def test_with_bad_url(self):
+        """ Test using bad url, where connection exception occurs"""
+        with self.assertRaises(CommandError) as cm:
+            call_command('populate_sdn_fallback_data_and_metadata', '--threshold=1', '--url=http://googasdfle.com')
+        self.assertEqual('Exception occurred', str(cm.exception))

--- a/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
+++ b/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
@@ -4,6 +4,7 @@ Tests for Django management command to download csv for SDN fallback.
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from mock import patch
+
 from ecommerce.tests.testcases import TestCase
 
 

--- a/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
+++ b/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
@@ -1,0 +1,56 @@
+"""
+Tests for Django management command to download csv for SDN fallback.
+"""
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from mock import patch
+
+from ecommerce.tests.testcases import TestCase
+
+
+class TestDownloadSndFallbackCommand(TestCase):
+
+    def setUp(self):
+        class TestResponse:
+            def __init__(self, **kwargs):
+                self.__dict__ = kwargs
+
+        #  mock response for csv download: just one row of the csv
+        self.test_response = TestResponse(**{
+            'content': bytes('_id,source,entity_number,type,programs,name,title,addresses,federal_register_notice,start_date,end_date,standard_order,license_requirement,license_policy,call_sign,vessel_type,gross_tonnage,gross_registered_tonnage,vessel_flag,vessel_owner,remarks,source_list_url,alt_names,citizenships,dates_of_birth,nationalities,places_of_birth,source_information_url,ids\ne5a9eff64cec4a74ed5e9e93c2d851dc2d9132d2,Denied Persons List (DPL) - Bureau of Industry and Security,,,, ADRIAN MANUEL HERNANDEZ,,"3037 S. 69TH DRIVE, PHONEIX, AZ, 85043",82 F.R. 48792 10/20/2017,2017-10-16,2020-10-13,Y,,,,,,,,,FR NOTICE ADDED,http://bit.ly/1Qi5heF,,,,,,http://bit.ly/1iwxiF0', 'utf-8'), # pylint: disable=line-too-long
+            'status_code': 200,
+        })
+
+    @patch('requests.Session.get')
+    def test_with_mock_pass(self, mock_response):
+        """ Test using mock response from setup, using threshold it will clear"""
+
+        mock_response.return_value = self.test_response
+
+        try:
+            call_command('populate_sdn_fallback_data_and_metadata', '--threshold=0.0001')
+        except CommandError as e:
+            self.fail("Failed download csv. {}".format(e))
+
+    @patch('requests.Session.get')
+    def test_with_mock_fail(self, mock_response):
+        """ Test using mock response from setup, using threshold it will NOT clear"""
+
+        mock_response.return_value = self.test_response
+
+        with self.assertRaises(CommandError) as cm:
+            call_command('populate_sdn_fallback_data_and_metadata', '--threshold=1')
+        self.assertEqual('CSV file download did not meet threshold', str(cm.exception))
+
+    def test_live_url_pass(self):
+        """ Test against the live url, with default threshold"""
+        try:
+            call_command('populate_sdn_fallback_data_and_metadata')
+        except CommandError as e:
+            self.fail("Failed download csv. {}".format(e))
+
+    def test_live_url_below_threshold(self):
+        """ Test against the live url, with threshold too high to clear """
+        with self.assertRaises(CommandError) as cm:
+            call_command('populate_sdn_fallback_data_and_metadata', '--threshold=7')
+        self.assertEqual('CSV file download did not meet threshold', str(cm.exception))

--- a/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
+++ b/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
@@ -26,11 +26,7 @@ class TestDownloadSndFallbackCommand(TestCase):
         """ Test using mock response from setup, using threshold it will clear"""
 
         mock_response.return_value = self.test_response
-
-        try:
-            call_command('populate_sdn_fallback_data_and_metadata', '--threshold=0.0001')
-        except CommandError as e:
-            self.fail("We expected to pass, but failed download csv. {}".format(e))
+        call_command('populate_sdn_fallback_data_and_metadata', '--threshold=0.0001')
 
     @patch('requests.Session.get')
     def test_with_mock_fail(self, mock_response):

--- a/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
+++ b/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
@@ -17,7 +17,7 @@ class TestDownloadSndFallbackCommand(TestCase):
 
         #  mock response for csv download: just one row of the csv
         self.test_response = TestResponse(**{
-            'content': bytes('_id,source,entity_number,type,programs,name,title,addresses,federal_register_notice,start_date,end_date,standard_order,license_requirement,license_policy,call_sign,vessel_type,gross_tonnage,gross_registered_tonnage,vessel_flag,vessel_owner,remarks,source_list_url,alt_names,citizenships,dates_of_birth,nationalities,places_of_birth,source_information_url,ids\ne5a9eff64cec4a74ed5e9e93c2d851dc2d9132d2,Denied Persons List (DPL) - Bureau of Industry and Security,,,, ADRIAN MANUEL HERNANDEZ,,"3037 S. 69TH DRIVE, PHONEIX, AZ, 85043",82 F.R. 48792 10/20/2017,2017-10-16,2020-10-13,Y,,,,,,,,,FR NOTICE ADDED,http://bit.ly/1Qi5heF,,,,,,http://bit.ly/1iwxiF0', 'utf-8'),  # pylint: disable=line-too-long
+            'content': bytes('_id,source,entity_number,type,programs,name,title,addresses,federal_register_notice,start_date,end_date,standard_order,license_requirement,license_policy,call_sign,vessel_type,gross_tonnage,gross_registered_tonnage,vessel_flag,vessel_owner,remarks,source_list_url,alt_names,citizenships,dates_of_birth,nationalities,places_of_birth,source_information_url,ids\ne5a9eff64cec4a74ed5e9e93c2d851dc2d9132d2,Denied Persons List (DPL) - Bureau of Industry and Security,,,, MICKEY MOUSE,,"123 S. TEST DRIVE, SCOTTSDALE, AZ, 85251",82 F.R. 48792 10/01/2017,2017-10-18,2020-10-15,Y,,,,,,,,,FR NOTICE ADDED,http://bit.ly/1Qi5heF,,,,,,http://bit.ly/1iwxiF0', 'utf-8'),  # pylint: disable=line-too-long
             'status_code': 200,
         })
 

--- a/ecommerce/extensions/payment/utils.py
+++ b/ecommerce/extensions/payment/utils.py
@@ -1,6 +1,7 @@
 # Changes part of REV-1209 - see https://github.com/edx/ecommerce/pull/3020
 import copy
 import logging
+import os
 import re
 from urllib.parse import urlencode
 
@@ -178,6 +179,24 @@ def checkSDN(request, name, city, country):
             pass
 
     return hit_count
+
+
+def download_SDN_fallback_csv():
+    """ Downloads csv for use as fallback for SDN check.'
+    """
+    url = 'http://api.trade.gov/static/consolidated_screening_list/consolidated.csv'
+    csv_file_name = 'temp_sdn_fallback.csv'
+
+    with requests.Session() as s:
+        download = s.get(url)
+
+    csv = open(csv_file_name, 'wb')
+    csv.write(download.content)
+    csv.close()
+    file_size_in_bytes = os.path.getsize(csv_file_name)
+    file_size_in_MB = file_size_in_bytes / 10**6
+
+    return csv, file_size_in_MB, csv_file_name
 
 
 class SDNClient:

--- a/ecommerce/extensions/payment/utils.py
+++ b/ecommerce/extensions/payment/utils.py
@@ -1,7 +1,6 @@
 # Changes part of REV-1209 - see https://github.com/edx/ecommerce/pull/3020
 import copy
 import logging
-
 import re
 from urllib.parse import urlencode
 
@@ -180,32 +179,6 @@ def checkSDN(request, name, city, country):
 
     return hit_count
 
-
-# def download_SDN_fallback_csv():
-#     """ Downloads csv for use as fallback for SDN check.'
-
-#     Returns:
-#         the csv created locally, its size in MB, and its local filename
-#     """
-#     # url = 'http://api.trade.gov/static/consolidated_screening_list/consolidated.csv'
-#     url = 'http://gooasdfadsfgle.com'
-#     csv_file_name = 'temp_sdn_fallback.csv'
-
-#     with requests.Session() as s:
-#         download = s.get(url)
-
-#     print("download is: ", download)
-
-#     if (download.content): 
-#         csv = open(csv_file_name, 'wb')
-#         csv.write(download.content)
-#         csv.close()
-#         file_size_in_bytes = os.path.getsize(csv_file_name)
-#         file_size_in_MB = file_size_in_bytes / 10**6
-
-#         return csv, file_size_in_MB, csv_file_name
-#     else: 
-#         print("WE DIDN'T HAVE CONTENT")
 
 class SDNClient:
     """A utility class that handles SDN related operations."""

--- a/ecommerce/extensions/payment/utils.py
+++ b/ecommerce/extensions/payment/utils.py
@@ -1,7 +1,7 @@
 # Changes part of REV-1209 - see https://github.com/edx/ecommerce/pull/3020
 import copy
 import logging
-import os
+
 import re
 from urllib.parse import urlencode
 
@@ -181,26 +181,31 @@ def checkSDN(request, name, city, country):
     return hit_count
 
 
-def download_SDN_fallback_csv():
-    """ Downloads csv for use as fallback for SDN check.'
+# def download_SDN_fallback_csv():
+#     """ Downloads csv for use as fallback for SDN check.'
 
-    Returns:
-        the csv created locally, its size in MB, and its local filename
-    """
-    url = 'http://api.trade.gov/static/consolidated_screening_list/consolidated.csv'
-    csv_file_name = 'temp_sdn_fallback.csv'
+#     Returns:
+#         the csv created locally, its size in MB, and its local filename
+#     """
+#     # url = 'http://api.trade.gov/static/consolidated_screening_list/consolidated.csv'
+#     url = 'http://gooasdfadsfgle.com'
+#     csv_file_name = 'temp_sdn_fallback.csv'
 
-    with requests.Session() as s:
-        download = s.get(url)
+#     with requests.Session() as s:
+#         download = s.get(url)
 
-    csv = open(csv_file_name, 'wb')
-    csv.write(download.content)
-    csv.close()
-    file_size_in_bytes = os.path.getsize(csv_file_name)
-    file_size_in_MB = file_size_in_bytes / 10**6
+#     print("download is: ", download)
 
-    return csv, file_size_in_MB, csv_file_name
+#     if (download.content): 
+#         csv = open(csv_file_name, 'wb')
+#         csv.write(download.content)
+#         csv.close()
+#         file_size_in_bytes = os.path.getsize(csv_file_name)
+#         file_size_in_MB = file_size_in_bytes / 10**6
 
+#         return csv, file_size_in_MB, csv_file_name
+#     else: 
+#         print("WE DIDN'T HAVE CONTENT")
 
 class SDNClient:
     """A utility class that handles SDN related operations."""

--- a/ecommerce/extensions/payment/utils.py
+++ b/ecommerce/extensions/payment/utils.py
@@ -183,6 +183,9 @@ def checkSDN(request, name, city, country):
 
 def download_SDN_fallback_csv():
     """ Downloads csv for use as fallback for SDN check.'
+
+    Returns:
+        the csv created locally, its size in MB, and its local filename
     """
     url = 'http://api.trade.gov/static/consolidated_screening_list/consolidated.csv'
     csv_file_name = 'temp_sdn_fallback.csv'


### PR DESCRIPTION
As per REV-1311, we want to regularly download the "Consolidated Screening List" CSV from trade.gov. 

This is the ecommerce part of that: a management command to initiate the download and call import (coming in REV-1310) if the resulting file exceeds our minimum threshold size. 

Once this is all set, we'll update the edx-internal repo to add an hourly jenkins task to execute the management command: for stage and prod. 

https://openedx.atlassian.net/browse/REV-1311