### PR TITLE
[REV-1311] SDN download updates

### DIFF
--- a/docs/decisions/0007-sdn-fallback.rst
+++ b/docs/decisions/0007-sdn-fallback.rst
@@ -28,7 +28,7 @@ As per OEP-0003, we generally use Celery to run asynchronous tasks, with some sc
 Ecommerce is an exception/antipattern to this general approach; it doesn't use Celery directly. Instead, we have a separate service called ecommerce-worker that has a Celery integration. 
 Ecommerce-worker doesn't have access to the ecommerce database, so any database interaction with ecommerce needs to happen on the main ecommerce server machine. 
 
-Our workaround for cases like this is to do the work on a Jenkins machine (so Jenkins is both the scheduler and the worker). The download task is fairly lightweight, and impact is small if a run failed to complete. 
+Our workaround for cases like this is to do the work on a Jenkins machine (so Jenkins is both the scheduler and the worker). The download task is fairly lightweight, and impact is small if a run fails to complete. 
 (Other options would be adding a Celery integration to ecommerce so it could follow the pattern above, OR running the code in ecommerce-worker and calling ecommerce APIs to create/delete records, OR running the task on the ecommerce machine using an API call. Given the low complexity and low criticality of the download task, those options were less suitable than our typical workaround.)
 
 2. **Storing the data**

--- a/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
+++ b/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
 
         with requests.Session() as s:
             try:
-                download = s.get(url, timeout = timeout)
+                download = s.get(url, timeout=timeout)
                 status_code = download.status_code
             except Timeout as e:
                 logger.warning("SDN DOWNLOAD FAILURE: Timeout occurred trying to download SDN csv. Timeout threshold (in seconds): %s", timeout)

--- a/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
+++ b/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
                 download = s.get(url, timeout=timeout)
                 status_code = download.status_code
             except Timeout as e:
-                logger.warning("SDN DOWNLOAD FAILURE: Timeout occurred trying to download SDN csv. Timeout threshold (in seconds): %s", timeout)
+                logger.warning("SDN DOWNLOAD FAILURE: Timeout occurred trying to download SDN csv. Timeout threshold (in seconds): %s", timeout)  # pylint: disable=line-too-long
                 raise
             except Exception as e:  # pylint: disable=broad-except
                 logger.warning("SDN DOWNLOAD FAILURE: Exception occurred: [%s]", e)

--- a/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
+++ b/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
@@ -31,13 +31,14 @@ class Command(BaseCommand):
         # download the csv locally, to check size and pass along to import
         threshold = options['threshold']
         url = 'http://api.trade.gov/static/consolidated_screening_list/consolidated.csv'
+        timeout = settings.SDN_CHECK_REQUEST_TIMEOUT
 
         with requests.Session() as s:
             try:
-                download = s.get(url, timeout=settings.SDN_CHECK_REQUEST_TIMEOUT)
+                download = s.get(url, timeout = timeout)
                 status_code = download.status_code
             except Timeout as e:
-                logger.warning("SDN DOWNLOAD FAILURE: Timeout occurred trying to download SDN csv")
+                logger.warning("SDN DOWNLOAD FAILURE: Timeout occurred trying to download SDN csv. Timeout threshold (in seconds): %s", timeout)
                 raise
             except Exception as e:  # pylint: disable=broad-except
                 logger.warning("SDN DOWNLOAD FAILURE: Exception occurred: [%s]", e)

--- a/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
+++ b/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
@@ -107,7 +107,7 @@ class TestDownloadSndFallbackCommandExceptions(TestCase):
                 (
                     self.LOGGER_NAME,
                     'WARNING',
-                    "SDN DOWNLOAD FAILURE: Timeout occurred trying to download SDN csv. Timeout threshold (in seconds): 5"
+                    "SDN DOWNLOAD FAILURE: Timeout occurred trying to download SDN csv. Timeout threshold (in seconds): 5"  # pylint: disable=line-too-long
                 )
             )
 

--- a/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
+++ b/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
@@ -107,7 +107,7 @@ class TestDownloadSndFallbackCommandExceptions(TestCase):
                 (
                     self.LOGGER_NAME,
                     'WARNING',
-                    "SDN DOWNLOAD FAILURE: Timeout occurred trying to download SDN csv"
+                    "SDN DOWNLOAD FAILURE: Timeout occurred trying to download SDN csv. Timeout threshold (in seconds): 5"
                 )
             )
 

--- a/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
+++ b/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
@@ -1,8 +1,6 @@
 """
 Tests for Django management command to download csv for SDN fallback.
 """
-# import os
-# import tempfile
 import requests
 import responses
 from django.core.management import call_command

--- a/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
+++ b/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
@@ -1,14 +1,20 @@
 """
 Tests for Django management command to download csv for SDN fallback.
 """
+# import os
+# import tempfile
+import requests
+import responses
 from django.core.management import call_command
-from django.core.management.base import CommandError
 from mock import patch
+from testfixtures import LogCapture
 
 from ecommerce.tests.testcases import TestCase
 
 
 class TestDownloadSndFallbackCommand(TestCase):
+
+    LOGGER_NAME = 'ecommerce.core.management.commands.populate_sdn_fallback_data_and_metadata'
 
     def setUp(self):
         class TestResponse:
@@ -20,25 +26,91 @@ class TestDownloadSndFallbackCommand(TestCase):
             'content': bytes('_id,source,entity_number,type,programs,name,title,addresses,federal_register_notice,start_date,end_date,standard_order,license_requirement,license_policy,call_sign,vessel_type,gross_tonnage,gross_registered_tonnage,vessel_flag,vessel_owner,remarks,source_list_url,alt_names,citizenships,dates_of_birth,nationalities,places_of_birth,source_information_url,ids\ne5a9eff64cec4a74ed5e9e93c2d851dc2d9132d2,Denied Persons List (DPL) - Bureau of Industry and Security,,,, MICKEY MOUSE,,"123 S. TEST DRIVE, SCOTTSDALE, AZ, 85251",82 F.R. 48792 10/01/2017,2017-10-18,2020-10-15,Y,,,,,,,,,FR NOTICE ADDED,http://bit.ly/1Qi5heF,,,,,,http://bit.ly/1iwxiF0', 'utf-8'),  # pylint: disable=line-too-long
             'status_code': 200,
         })
+        self.test_response_500 = TestResponse(**{
+            'status_code': 500,
+        })
 
     @patch('requests.Session.get')
-    def test_with_mock_pass(self, mock_response):
+    def test_handle_pass(self, mock_response):
         """ Test using mock response from setup, using threshold it will clear"""
 
         mock_response.return_value = self.test_response
         call_command('populate_sdn_fallback_data_and_metadata', '--threshold=0.0001')
 
     @patch('requests.Session.get')
-    def test_with_mock_fail_size(self, mock_response):
+    def test_handle_fail_size(self, mock_response):
         """ Test using mock response from setup, using threshold it will NOT clear"""
 
         mock_response.return_value = self.test_response
-        with self.assertRaises(CommandError) as cm:
-            call_command('populate_sdn_fallback_data_and_metadata', '--threshold=1')
-        self.assertEqual('CSV file download did not meet threshold', str(cm.exception))
 
-    def test_with_bad_url(self):
-        """ Test using bad url, where connection exception occurs"""
-        with self.assertRaises(CommandError) as cm:
-            call_command('populate_sdn_fallback_data_and_metadata', '--threshold=1', '--url=http://googasdfle.com')
-        self.assertEqual('Exception occurred', str(cm.exception))
+        with LogCapture(self.LOGGER_NAME) as log:
+            with self.assertRaises(Exception) as e:
+                call_command('populate_sdn_fallback_data_and_metadata', '--threshold=1')
+
+            log.check(
+                (
+                    self.LOGGER_NAME,
+                    'WARNING',
+                    "SDN DOWNLOAD FAILURE: file too small! (0.000642 MB vs threshold of 1.0 MB)"
+                )
+            )
+        self.assertEqual('CSV file download did not meet threshold given', str(e.exception))
+
+    @patch('requests.Session.get')
+    def test_handle_500_response(self, mock_response):
+        """ Test using url for 500 error"""
+        mock_response.return_value = self.test_response_500
+        with LogCapture(self.LOGGER_NAME) as log:
+            with self.assertRaises(Exception) as e:
+                call_command('populate_sdn_fallback_data_and_metadata', '--threshold=1')
+
+            log.check(
+                (
+                    self.LOGGER_NAME,
+                    'WARNING',
+                    "SDN DOWNLOAD FAILURE: Status code was: [500]"
+                )
+            )
+        self.assertEqual("('CSV download url got an unsuccessful response code: ', 500)", str(e.exception))
+
+
+class TestDownloadSndFallbackCommandExceptions(TestCase):
+    LOGGER_NAME = 'ecommerce.core.management.commands.populate_sdn_fallback_data_and_metadata'
+    URL = 'http://api.trade.gov/static/consolidated_screening_list/consolidated.csv'
+    ERROR_MESSAGE = 'some foo error'
+
+    @responses.activate
+    def test_general_exception(self):
+        responses.add(responses.GET, self.URL, body=Exception(self.ERROR_MESSAGE))
+
+        with LogCapture(self.LOGGER_NAME) as log:
+            with self.assertRaises(Exception) as e:
+                call_command('populate_sdn_fallback_data_and_metadata')
+
+            log.check(
+                (
+                    self.LOGGER_NAME,
+                    'WARNING',
+                    "SDN DOWNLOAD FAILURE: Exception occurred: [%s]" % self.ERROR_MESSAGE
+                )
+            )
+
+        self.assertEqual(self.ERROR_MESSAGE, str(e.exception))
+
+    @responses.activate
+    def test_timeout_exception(self):
+        responses.add(responses.GET, self.URL, body=requests.exceptions.ConnectTimeout(self.ERROR_MESSAGE))
+
+        with LogCapture(self.LOGGER_NAME) as log:
+            with self.assertRaises(Exception) as e:
+                call_command('populate_sdn_fallback_data_and_metadata')
+
+            log.check(
+                (
+                    self.LOGGER_NAME,
+                    'WARNING',
+                    "SDN DOWNLOAD FAILURE: Timeout occurred trying to download SDN csv"
+                )
+            )
+
+        self.assertEqual(self.ERROR_MESSAGE, str(e.exception))


### PR DESCRIPTION
Additional improvements, most notably: 
- switching from CommandError to raising exceptions
- differentiating/testing for different error response codes
- removing the url parameter (this had only been added for tests), mocking the error code test, and removing 'broken url' test (not standard)
- tests for timeout and general Exception, since removing the url parameter (these are easy if you can pass it in, less sure how to mock that)
- update to use a tempfile object
- provide timeout value (missing in first pass)

See "Additional Updates" tab [here](https://docs.google.com/spreadsheets/d/1bKpTb_PbFs8UPHUxSRvH735wikaPhSgHTqDreNFrssw/edit#gid=1647259588) for full list

PR for original work: https://github.com/edx/ecommerce/pull/3128