### PR TITLE
Stop vending capture key from payment endpoint

### DIFF
--- a/ecommerce/extensions/basket/tests/test_views.py
+++ b/ecommerce/extensions/basket/tests/test_views.py
@@ -467,7 +467,6 @@ class PaymentApiResponseTestMixin(BasketLogicTestMixin):
                     u'title': title,
                 } for line in basket.lines.all()
             ],
-            'flex_microform_enabled': False,
         }
         if kwargs:
             expected_response.update(**kwargs)

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -646,7 +646,7 @@ class CaptureContextApiLogicMixin:  # pragma: no cover
             return
 
 
-class PaymentApiLogicMixin(BasketLogicMixin, CaptureContextApiLogicMixin):
+class PaymentApiLogicMixin(BasketLogicMixin):
     """
     Business logic for the various Payment APIs.
     """
@@ -698,7 +698,6 @@ class PaymentApiLogicMixin(BasketLogicMixin, CaptureContextApiLogicMixin):
         self._add_total_summary(response, context)
         self._add_offers(response)
         self._add_coupons(response, context)
-        self._add_capture_context(response)  # TODO: this is moving to its own endpoint
         return response
 
     def _add_products(self, response, lines_data):


### PR DESCRIPTION
WARNING: this will break the flex microform flow in the PayMFE until the new endpoint is plumbed in by https://github.com/edx/frontend-app-payment/pull/407