### PR TITLE
[REV-1323] Remove accents from unicode characters where possible

### DIFF
--- a/docs/decisions/0007-sdn-fallback.rst
+++ b/docs/decisions/0007-sdn-fallback.rst
@@ -87,6 +87,11 @@ We intentionally tried to import all the rows from the csv regardless of whether
 For example, many rows do not have an address and our matching algorithm will never match records with no address. However, we chose to import those rows anyway and not run any input validation.
 The reasoning was that this would keep things clear and simple and decouple the import logic from the matching logic (in case the matching logic changed down the line). 
 
+10. **Transliterating unicode characters**
+We decided to transliterate unicode characters where possible for both addresses and names.
+Rationale:
+    - Names: Found an example where stripping an accents was necessary to get a match for a name
+    - Addresses: We did not see such an example for addresses because they are stored with the accented characters. However, we decided to strip the accents for both the input addresses and stored addresses, which will also work and would then behave more similarly to the names.
 
 Consequences
 ------------

--- a/ecommerce/extensions/payment/core/sdn.py
+++ b/ecommerce/extensions/payment/core/sdn.py
@@ -6,12 +6,8 @@ import io
 import logging
 import re
 import string
-<<<<<<< HEAD
-from datetime import datetime, timezone
-=======
 import unicodedata
-from datetime import datetime
->>>>>>> b6bdc83fa4... transliterate characters with accents
+from datetime import datetime, timezone
 from urllib.parse import urlencode
 
 # Changes part of REV-1209 - see https://github.com/edx/ecommerce/pull/3020
@@ -221,12 +217,14 @@ def process_text(text):
     """
     if len(text) == 0:
         return ''
+
+    # transliterate unicode characters into ascii
+    text = unicodedata.normalize('NFKD', text).encode('ascii', 'ignore').decode('ascii')
+    text = text.lower()
+
     # Strip non-alphanumeric characters from each word
     # Ignore order and word frequency
     text = set(filter(None, {word.strip(string.punctuation) for word in text.split()}))
-
-    text = unicodedata.normalize('NFKD', text).encode('ascii', 'ignore').decode('ascii')
-    text = text.lower()
 
     return text
 

--- a/ecommerce/extensions/payment/core/sdn.py
+++ b/ecommerce/extensions/payment/core/sdn.py
@@ -208,7 +208,10 @@ class SDNClient:
 
 
 def process_text(text):
-    """ Lowercase, remove non-alphanumeric characters, and ignore order and word frequency
+    """
+    Lowercase, remove non-alphanumeric characters, and ignore order and word frequency.
+    Attempts to transliterate unicode characters into ascii (such as accented characters into
+    non-accented characters).
 
     Args:
         text (str): names or addresses from the sdn list to be processed

--- a/ecommerce/extensions/payment/core/sdn.py
+++ b/ecommerce/extensions/payment/core/sdn.py
@@ -6,7 +6,12 @@ import io
 import logging
 import re
 import string
+<<<<<<< HEAD
 from datetime import datetime, timezone
+=======
+import unicodedata
+from datetime import datetime
+>>>>>>> b6bdc83fa4... transliterate characters with accents
 from urllib.parse import urlencode
 
 # Changes part of REV-1209 - see https://github.com/edx/ecommerce/pull/3020
@@ -213,10 +218,13 @@ def process_text(text):
     """
     if len(text) == 0:
         return ''
-    text = text.lower()
     # Strip non-alphanumeric characters from each word
     # Ignore order and word frequency
     text = set(filter(None, {word.strip(string.punctuation) for word in text.split()}))
+
+    text = unicodedata.normalize('NFKD', text).encode('ascii', 'ignore').decode('ascii')
+    text = text.lower()
+
     return text
 
 

--- a/ecommerce/extensions/payment/core/tests/test_sdn.py
+++ b/ecommerce/extensions/payment/core/tests/test_sdn.py
@@ -303,8 +303,7 @@ Joshuafort, MD 72104, TH",,,,,,,,,,,,,,https://banks-bender.com/,Michael Anderso
         ('!f!o!o! !B!A!R!', {'f!o!o', 'b!a!r'}),
         ('!foo! !BAR! !BAR! !foo!', {'foo', 'bar'}),
         ('Renée Noël François Ruairí Jokūbas KŠthe Nuñez',
-            {'nunez', 'renee', 'noel', 'francois', 'ruairi', 'jokubas', 'ksthe'}
-        ),
+            {'nunez', 'renee', 'noel', 'francois', 'ruairi', 'jokubas', 'ksthe'}),
         ('Carl Patiño Jr.', {'carl', 'patino', 'jr'}),
         ('Avenida João XVII Santa Fé New Mexico', {'avenida', 'joao', 'xvii', 'santa', 'fe', 'new', 'mexico'})
     )

--- a/ecommerce/extensions/payment/core/tests/test_sdn.py
+++ b/ecommerce/extensions/payment/core/tests/test_sdn.py
@@ -311,7 +311,7 @@ Joshuafort, MD 72104, TH",,,,,,,,,,,,,,https://banks-bender.com/,Michael Anderso
     def test_process_text(self, text, expected_output):
         """ Verify that processing text works as expected (this function is used for names and addresses) """
         output = process_text(text)
-        self.assertEqual(set(output), set(expected_output))
+        self.assertEqual(output, expected_output)
 
     @ddt.data(
         ('À Á Â Ã Ä Å à á â ã ä å', {'a'}),

--- a/ecommerce/extensions/payment/core/tests/test_sdn.py
+++ b/ecommerce/extensions/payment/core/tests/test_sdn.py
@@ -302,9 +302,37 @@ Joshuafort, MD 72104, TH",,,,,,,,,,,,,,https://banks-bender.com/,Michael Anderso
         ('!f!o!o! !B!A!R!', {'f!o!o', 'b!a!r'}),
         ('!f!o!o! !B!A!R!', {'f!o!o', 'b!a!r'}),
         ('!foo! !BAR! !BAR! !foo!', {'foo', 'bar'}),
+        ('Renée Noël Sørina François Ruairí Jokūbas KŠthe Øyvind Asbjørn Nuñez',
+            'nunez renee noel sorina francois ruairi jokubas ksthe oyvind asbjorn')
     )
     @ddt.unpack
     def test_process_text(self, text, expected_output):
         """ Verify that processing text works as expected (this function is used for names and addresses) """
+        output = process_text(text)
+        self.assertEqual(set(output), set(expected_output))
+
+    @ddt.data(
+        ('À Á Â Ã Ä Å', 'a a a a a a'),
+        ('à á â ã ä å', 'a a a a a a'),
+        ('È É Ê Ë', 'e e e e'),
+        ('è é ê ë ', 'e e e e'),
+        ('Ì Í Î Ï', 'i i i i'),
+        ('ì í î ï', 'i i i i'),
+        ('Ò Ó Ô Õ Ö', 'o o o o o'),
+        ('ò ó ô ö õ', 'o o o o o'),
+        ('ð ø', ' '),
+        ('Ù Ú Û Ü', 'u u u u'),
+        ('ù ú û ü', 'u u u u'),
+        ('Ý ý ÿ', 'y y y'),
+        ('Ç ç', 'c c'),
+        ('Ñ ñ', 'n n'),
+        # these cases are here to explicitly note that they are not  transliterated,
+        # not to exclude them from transliteration in the future
+        ('Ð Æ æ Ø Þ ß þ', '      '),
+        ('÷ § § ×   ¶ ¯ ¬', '        '),
+    )
+    @ddt.unpack
+    def test_process_text_unicode(self, text, expected_output):
+        """ Verify that characters with accents are transliterated correctly."""
         output = process_text(text)
         self.assertEqual(output, expected_output)

--- a/ecommerce/extensions/payment/core/tests/test_sdn.py
+++ b/ecommerce/extensions/payment/core/tests/test_sdn.py
@@ -302,8 +302,11 @@ Joshuafort, MD 72104, TH",,,,,,,,,,,,,,https://banks-bender.com/,Michael Anderso
         ('!f!o!o! !B!A!R!', {'f!o!o', 'b!a!r'}),
         ('!f!o!o! !B!A!R!', {'f!o!o', 'b!a!r'}),
         ('!foo! !BAR! !BAR! !foo!', {'foo', 'bar'}),
-        ('Renée Noël Sørina François Ruairí Jokūbas KŠthe Øyvind Asbjørn Nuñez',
-            'nunez renee noel sorina francois ruairi jokubas ksthe oyvind asbjorn')
+        ('Renée Noël François Ruairí Jokūbas KŠthe Nuñez',
+            {'nunez', 'renee', 'noel', 'francois', 'ruairi', 'jokubas', 'ksthe'}
+        ),
+        ('Carl Patiño Jr.', {'carl', 'patino', 'jr'}),
+        ('Avenida João XVII Santa Fé New Mexico', {'avenida', 'joao', 'xvii', 'santa', 'fe', 'new', 'mexico'})
     )
     @ddt.unpack
     def test_process_text(self, text, expected_output):
@@ -312,24 +315,18 @@ Joshuafort, MD 72104, TH",,,,,,,,,,,,,,https://banks-bender.com/,Michael Anderso
         self.assertEqual(set(output), set(expected_output))
 
     @ddt.data(
-        ('À Á Â Ã Ä Å', 'a a a a a a'),
-        ('à á â ã ä å', 'a a a a a a'),
-        ('È É Ê Ë', 'e e e e'),
-        ('è é ê ë ', 'e e e e'),
-        ('Ì Í Î Ï', 'i i i i'),
-        ('ì í î ï', 'i i i i'),
-        ('Ò Ó Ô Õ Ö', 'o o o o o'),
-        ('ò ó ô ö õ', 'o o o o o'),
-        ('ð ø', ' '),
-        ('Ù Ú Û Ü', 'u u u u'),
-        ('ù ú û ü', 'u u u u'),
-        ('Ý ý ÿ', 'y y y'),
-        ('Ç ç', 'c c'),
-        ('Ñ ñ', 'n n'),
+        ('À Á Â Ã Ä Å à á â ã ä å', {'a'}),
+        ('È É Ê Ë è é ê ë', {'e'}),
+        ('Ì Í Î Ï ì í î ï', {'i'}),
+        ('Ò Ó Ô Õ Ö  ó ô ö õ', {'o'}),
+        ('Ù Ú Û Ü ù ú û ü', {'u'}),
+        ('Ý ý ÿ', {'y'}),
+        ('Ç ç', {'c'}),
+        ('Ñ ñ', {'n'}),
         # these cases are here to explicitly note that they are not  transliterated,
         # not to exclude them from transliteration in the future
-        ('Ð Æ æ Ø Þ ß þ', '      '),
-        ('÷ § § ×   ¶ ¯ ¬', '        '),
+        ('Ð Æ æ Ø Þ ß þ ð ø', set()),
+        ('÷ § § ×   ¶ ¯ ¬', set()),
     )
     @ddt.unpack
     def test_process_text_unicode(self, text, expected_output):


### PR DESCRIPTION
# What did we do?
Replace characters (in the name and address fields) that have accents with non-accented characters when importing the SDN fallback CSV.

# Why are we doing this?
To normalize the input SDN characters to make it easier to search + find matches

## Data
A recent SDN fallback CSV file contained some accented characters. Not all were in the fields that are expected to be used, but that's not an unreasonable assumption that it will happen at some point if the csv allows unicode characters.

Command
```
sed 's/\(.\)/\1\'$'\n/g' 'consolidated (1).csv' | sort | uniq -c | sort -nr
```

Counts of unicode characters in one csv
```
1943 §
  3 ó
   3 é
  1 ü
   1 ö
   1 õ
   1 ã
   1 á
   1 º
```

The cases in the unit test were found via searching the internet for unicode character tables + names with unicode characters in them.

# How did we test this?
Added unit tests