### PR TITLE
BOM-2022 : Use django-ses with boto3

### DIFF
--- a/requirements/production.in
+++ b/requirements/production.in
@@ -1,7 +1,7 @@
 # Packages required in a production environment
 -r base.in
 
-django-ses==0.8.2
+django-ses
 gunicorn==19.7.1
 newrelic<5
 python-memcached==1.58

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -14,7 +14,8 @@ babel==2.8.0              # via django-oscar, django-phonenumber-field
 bcrypt==3.2.0             # via cybersource-rest-client-python, paramiko
 billiard==3.6.3.0         # via celery
 bleach==3.2.1             # via -r requirements/base.in
-boto==2.49.0              # via django-ses
+boto3==1.15.4             # via django-ses
+botocore==1.18.4          # via boto3, s3transfer
 cached-property==1.5.2    # via zeep
 celery==4.4.7             # via -c requirements/pins.txt, edx-ecommerce-worker
 certifi==2020.6.20        # via cybersource-rest-client-python, requests
@@ -46,7 +47,7 @@ django-model-utils==4.0.0  # via edx-rbac
 django-oscar==2.0.4       # via -c requirements/pins.txt, -r requirements/base.in
 django-phonenumber-field==2.0.1  # via django-oscar
 django-rest-swagger==2.2.0  # via -r requirements/base.in
-django-ses==0.8.2         # via -r requirements/production.in
+django-ses==1.0.3         # via -r requirements/production.in
 django-simple-history==2.11.0  # via -r requirements/base.in
 django-solo==1.1.3        # via -r requirements/base.in
 django-tables2==1.21.2    # via django-oscar
@@ -54,7 +55,7 @@ django-threadlocals==0.10  # via -r requirements/base.in
 django-treebeard==4.3.1   # via django-oscar
 django-waffle==2.0.0      # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
 django-widget-tweaks==1.4.8  # via django-oscar
-django==2.2.16            # via -r requirements/base.in, django-appconf, django-config-models, django-cors-headers, django-crum, django-extra-views, django-filter, django-haystack, django-model-utils, django-oscar, django-phonenumber-field, django-tables2, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition, xss-utils
+django==2.2.16            # via -r requirements/base.in, django-appconf, django-config-models, django-cors-headers, django-crum, django-extra-views, django-filter, django-haystack, django-model-utils, django-oscar, django-phonenumber-field, django-ses, django-tables2, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition, xss-utils
 djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework-datatables==0.5.2  # via -r requirements/base.in
 djangorestframework==3.11.1  # via -r requirements/base.in, django-config-models, django-rest-swagger, djangorestframework-csv, djangorestframework-datatables, drf-extensions, drf-jwt, edx-drf-extensions, rest-condition
@@ -75,13 +76,14 @@ factory-boy==2.12.0       # via django-oscar
 faker==4.1.3              # via factory-boy
 fixtures==3.0.0           # via cybersource-rest-client-python, testtools
 funcsigs==1.0.2           # via cybersource-rest-client-python
-future==0.18.2            # via pyjwkest
+future==0.18.2            # via django-ses, pyjwkest
 gunicorn==19.7.1          # via -r requirements/production.in
 idna==2.7                 # via -c requirements/pins.txt, cybersource-rest-client-python, requests
 ipaddress==1.0.23         # via cybersource-rest-client-python
 isodate==0.6.0            # via zeep
 itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via coreschema
+jmespath==0.10.0          # via boto3, botocore
 jsonfield2==3.0.3         # via -c requirements/pins.txt, -r requirements/base.in
 jsonschema==3.2.0         # via cybersource-rest-client-python
 kombu==4.6.11             # via celery
@@ -123,13 +125,13 @@ pyopenssl==19.1.0         # via cybersource-rest-client-python, ndg-httpsclient,
 pyparsing==2.4.7          # via packaging
 pypi==2.1                 # via cybersource-rest-client-python
 pyrsistent==0.17.3        # via jsonschema
-python-dateutil==2.8.1    # via -r requirements/base.in, analytics-python, edx-drf-extensions, faker
+python-dateutil==2.8.1    # via -r requirements/base.in, analytics-python, botocore, edx-drf-extensions, faker
 python-memcached==1.58    # via -r requirements/production.in
 python-mimeparse==1.6.0   # via cybersource-rest-client-python, testtools
 python-subunit==1.4.0     # via cybersource-rest-client-python
 python-toolbox==1.0.11    # via cybersource-rest-client-python
 python3-openid==3.2.0     # via -r requirements/base.in, social-auth-core
-pytz==2016.10             # via -c requirements/pins.txt, -r requirements/base.in, babel, celery, cybersource-rest-client-python, datetime, django, zeep
+pytz==2016.10             # via -c requirements/pins.txt, -r requirements/base.in, babel, celery, cybersource-rest-client-python, datetime, django, django-ses, zeep
 pyyaml==5.3.1             # via -r requirements/production.in, cybersource-rest-client-python, edx-django-release-util, naked
 rcssmin==1.0.6            # via django-compressor
 redis==3.5.3              # via -r requirements/production.in, edx-ecommerce-worker
@@ -140,6 +142,7 @@ rest-condition==1.0.3     # via edx-drf-extensions
 rjsmin==1.1.0             # via django-compressor
 rsa==4.6                  # via cybersource-rest-client-python
 rules==2.2                # via -r requirements/base.in
+s3transfer==0.3.3         # via boto3
 sailthru-client==2.2.3    # via -r requirements/base.in, edx-ecommerce-worker
 semantic-version==2.8.5   # via edx-drf-extensions
 shellescape==3.8.1        # via crypto, cybersource-rest-client-python
@@ -159,7 +162,7 @@ typing==3.7.4.3           # via cybersource-rest-client-python
 unicodecsv==0.14.1        # via -r requirements/base.in, djangorestframework-csv
 unittest2==1.1.0          # via testtools
 uritemplate==3.0.1        # via coreapi
-urllib3==1.25.10          # via -c requirements/pins.txt, cybersource-rest-client-python, requests
+urllib3==1.25.10          # via -c requirements/pins.txt, botocore, cybersource-rest-client-python, requests
 vine==1.3.0               # via amqp, celery
 webencodings==0.5.1       # via bleach
 wheel==0.35.1             # via cybersource-rest-client-python


### PR DESCRIPTION
Amazon's SES is making a change on October 1st that will cause any email sent to this service via the older boto package to fail so we are upgrading `django-ses` package as it is already using `boto3` to send emails since version 1.0.0 [[Reference](https://github.com/django-ses/django-ses/releases/tag/v1.0.0)]

Relevant JIRA : https://openedx.atlassian.net/browse/BOM-2022