### PR TITLE
[REV-1442] Add success log when the script completes successfully

### DIFF
--- a/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
+++ b/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
@@ -63,6 +63,8 @@ class Command(BaseCommand):
                         if metadata_entry:
                             logger.info('SDNFallback: IMPORT SUCCESS: Imported SDN CSV. Metadata id %s',
                                         metadata_entry.id)
+
+                        logger.info('SDNFallback: DOWNLOAD SUCCESS: Successfully downloaded the SDN CSV.')
                         self.stdout.write(
                             self.style.SUCCESS(
                                 'SDNFallback: Imported SDN CSV into the SDNFallbackMetadata and SDNFallbackData models.'


### PR DESCRIPTION
# What did we do?
We added a success log to note when the script completes successfully.

# Why are we doing this?
So we have confirmation that the script completed successfully (regardless of whether the file was imported or downloaded). This will allow us to set the appropriate alerting + monitoring on the script.

# How did we test this?
Updated the unit test for successful download to check for the success logs.