### PR TITLE
REV-1338 Add shadow call to  SDNFallback

### DIFF
--- a/ecommerce/extensions/payment/exceptions.py
+++ b/ecommerce/extensions/payment/exceptions.py
@@ -58,3 +58,9 @@ class RedundantPaymentNotificationError(PaymentError):
 
 class ExcessivePaymentForOrderError(PaymentError):
     """ Raised when duplicate payment notification is detected with different transaction ID. """
+
+
+class SDNFallbackDataEmptyError(Exception):
+    """ Error for when we call checkSDNFallback and the data is not yet populated.
+    This data is populated by running: ./manage.py populate_sdn_fallback_data_and_metadata
+    See ecommerce ADR 0007-sdn-fallback for more info """

--- a/ecommerce/extensions/payment/tests/test_models.py
+++ b/ecommerce/extensions/payment/tests/test_models.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from django.core.exceptions import ValidationError
 from testfixtures import LogCapture
 
+from ecommerce.extensions.payment.exceptions import SDNFallbackDataEmptyError
 from ecommerce.extensions.payment.models import (
     EnterpriseContractMetadata,
     SDNCheckFailure,
@@ -310,3 +311,11 @@ class SDNFallbackDataTests(TestCase):
         filtered_records_isn = SDNFallbackData.get_current_records_and_filter_by_source_and_type(
             isn_source, "")
         self.assertEqual(len(filtered_records_isn), 1)
+
+    def test_get_current_records_and_filter_by_source_and_type_empty_data(self):
+        """ Verify that we raise the expected Exception if this is called before data is populated"""
+        sdn_source = "Specially Designated Nationals (SDN) - Treasury Department"
+        sdn_type = "Individual"
+
+        with self.assertRaises(SDNFallbackDataEmptyError):
+            SDNFallbackData.get_current_records_and_filter_by_source_and_type(sdn_source, sdn_type)

--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -30,7 +30,7 @@ from ecommerce.extensions.basket.utils import (
 )
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
 from ecommerce.extensions.checkout.utils import get_receipt_page_url
-from ecommerce.extensions.payment.core.sdn import checkSDN
+from ecommerce.extensions.payment.core.sdn import checkSDN, compare_SDNCheck_vs_fallback
 from ecommerce.extensions.payment.exceptions import (
     AuthorizationError,
     DuplicateReferenceNumber,
@@ -83,6 +83,8 @@ class CybersourceOrderInitiationView:
             data['first_name'] + ' ' + data['last_name'],
             data['city'],
             data['country'])
+
+        compare_SDNCheck_vs_fallback(request.basket.id, data, hit_count)
 
         if hit_count > 0:
             logger.info(


### PR DESCRIPTION
**Background:** 
Before using our new SDN csv fallback check as the fallback for when the SDN API is down, first we'd like to gather data on how consistently the two behave. Ticket REV-1338 is to add a 'shadow' call of checkSDNFallback and log the results for both, including the inputted name/city/country for investigation in the case that the SDN API returns a hit but our fallback does not (third case below). 

I've also added handling for the case where there is no fallback data populated (true for engineer local environments until they run the management command) so we log a message of throwing an exception. 

**Example output messages:** 
SDNFallback compare: MATCH. Results - SDN API: 0 hit(s); SDN Fallback match: False. Basket: 999
SDNFallback compare: MATCH. Results - SDN API: 1 hit(s); SDN Fallback match: True. Basket: 999
SDNFallback compare: MISMATCH. Results - SDN API: 0 hit(s); SDN Fallback match: True. Basket: 999
SDNFallback compare: MISMATCH. Results - SDN API: 1 hit(s); SDN Fallback match: False. Basket: 999

And additionally for that last problem case: 
Failed SDN match for first name: Sheikh Yusuf, last name: AASI, city: Beirut, country: LB

9/25 update: added improved exception handling based on feedback
9/29 update: refactored to clean up try/except/else
9/30 update: refactored to move comparison code into sdn.py instead of cybersource.py (so the code/tests can live together in the right place) and added tests for the logged output

Relevant ticket: https://openedx.atlassian.net/browse/REV-1338

