### PR TITLE
Pass base enterprise url to sailthru

### DIFF
--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -599,6 +599,7 @@ def construct_enterprise_course_consent_url(request, course_id, enterprise_custo
         'next': absolute_url(request, 'checkout:free-checkout'),
         'failure_url': failure_url,
     }
+
     redirect_url = '{base}?{params}'.format(
         base=site.siteconfiguration.enterprise_grant_data_sharing_url,
         params=urlencode(request_params)

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -666,10 +666,17 @@ class EnterpriseCouponViewSet(CouponViewSet):
         subject = request.data.pop('template_subject', '')
         greeting = request.data.pop('template_greeting', '')
         closing = request.data.pop('template_closing', '')
+
         self._validate_email_fields(subject, greeting, closing)
+
         serializer = CouponCodeAssignmentSerializer(
             data=request.data,
-            context={'coupon': coupon, 'subject': subject, 'greeting': greeting, 'closing': closing}
+            context={
+                'coupon': coupon,
+                'subject': subject,
+                'greeting': greeting,
+                'closing': closing,
+            }
         )
         if serializer.is_valid():
             serializer.save()

--- a/ecommerce/extensions/offer/tests/test_utils.py
+++ b/ecommerce/extensions/offer/tests/test_utils.py
@@ -103,6 +103,21 @@ class UtilTests(DiscoveryTestMixin, TestCase):
                 'code_expiration_date': '2018-12-19'
             },
             None,
+            ''
+        ),
+        (
+            'subject',
+            'hi',
+            'bye',
+            {
+                'offer_assignment_id': 555,
+                'learner_email': 'johndoe@unknown.com',
+                'code': 'GIL7RUEOU7VHBH7Q',
+                'redemptions_remaining': 10,
+                'code_expiration_date': '2018-12-19'
+            },
+            None,
+            'https://bears.party'
         ),
     )
     @ddt.unpack
@@ -113,6 +128,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             closing,
             tokens,
             side_effect,
+            base_enterprise_url,
             mock_sailthru_task,
     ):
         """ Test that the offer assignment email message is sent to async task. """
@@ -126,12 +142,35 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             tokens.get('code'),
             tokens.get('redemptions_remaining'),
             tokens.get('code_expiration_date'),
+            base_enterprise_url,
         )
         mock_sailthru_task.delay.assert_called_once_with(
             tokens.get('learner_email'),
             tokens.get('offer_assignment_id'),
             subject,
-            mock.ANY
+            mock.ANY,
+            base_enterprise_url,
+        )
+
+    @mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email')
+    def test_send_assigned_offer_email_without_base_ent_url(self, mock_sailthru_task):
+        send_assigned_offer_email(
+            "You have mail",
+            "you",
+            "KTHXBAI",
+            42,
+            "bears@bearparty.com",
+            'BearsOnly',
+            1,
+            '2020-12-19',
+        )
+
+        mock_sailthru_task.delay.assert_called_once_with(
+            "bears@bearparty.com",
+            42,
+            "You have mail",
+            mock.ANY,
+            '',
         )
 
     @mock.patch('ecommerce.extensions.offer.utils.send_offer_update_email')

--- a/ecommerce/extensions/offer/utils.py
+++ b/ecommerce/extensions/offer/utils.py
@@ -136,7 +136,8 @@ def send_assigned_offer_email(
         learner_email,
         code,
         redemptions_remaining,
-        code_expiration_date):
+        code_expiration_date,
+        base_enterprise_url=''):
     """
     Arguments:
         *subject*
@@ -164,7 +165,8 @@ def send_assigned_offer_email(
         EXPIRATION_DATE=code_expiration_date
     )
     email_body = format_email(email_template, placeholder_dict, greeting, closing)
-    send_offer_assignment_email.delay(learner_email, offer_assignment_id, subject, email_body)
+
+    send_offer_assignment_email.delay(learner_email, offer_assignment_id, subject, email_body, base_enterprise_url)
 
 
 def send_revoked_offer_email(


### PR DESCRIPTION
For use in an email template
base_enterprise_url is not required and has sensible defaults