### PR TITLE
Use the CybersourceREST processor_response.id as the transaction_id f…

### DIFF
--- a/ecommerce/extensions/payment/processors/cybersource.py
+++ b/ecommerce/extensions/payment/processors/cybersource.py
@@ -721,8 +721,7 @@ class CybersourceREST(Cybersource):  # pragma: no cover
                 request,
                 form_data,
             )
-            transaction_id = payment_processor_response.processor_information.transaction_id
-            return payment_processor_response, transaction_id
+            return payment_processor_response, payment_processor_response.id
         except ApiException as e:
             if e.body is None:
                 self.record_processor_response({


### PR DESCRIPTION
…or logging