### PR TITLE
PCI-104 log processor request info

### DIFF
--- a/ecommerce/extensions/payment/processors/cybersource.py
+++ b/ecommerce/extensions/payment/processors/cybersource.py
@@ -916,6 +916,9 @@ class CybersourceREST(Cybersource):  # pragma: no cover
         requestObj = del_none(requestObj.__dict__)
         requestObj = json.dumps(requestObj)
 
+        # HACK: log the processor request into the processor response model for analyzing declines
+        self.record_processor_response(requestObj, transaction_id='[REQUEST]', basket=basket)
+
         api_instance = PaymentsApi(self.cybersource_api_config)
         payment_processor_response, _, _ = api_instance.create_payment(
             requestObj,

--- a/ecommerce/extensions/payment/processors/cybersource.py
+++ b/ecommerce/extensions/payment/processors/cybersource.py
@@ -914,14 +914,13 @@ class CybersourceREST(Cybersource):  # pragma: no cover
         )
 
         requestObj = del_none(requestObj.__dict__)
-        requestObj = json.dumps(requestObj)
 
         # HACK: log the processor request into the processor response model for analyzing declines
         self.record_processor_response(requestObj, transaction_id='[REQUEST]', basket=basket)
 
         api_instance = PaymentsApi(self.cybersource_api_config)
         payment_processor_response, _, _ = api_instance.create_payment(
-            requestObj,
+            json.dumps(requestObj),
             _request_timeout=(self.connect_timeout, self.read_timeout)
         )
 


### PR DESCRIPTION
Simple hack to stuff the REST request into the processor response model for analysis

Update: tested locally; request is logged to DB, linkable by `basket_id` and can be copied and pretty-printed with `jq`