### PR TITLE
Fix send_offer_assignment_email call

### DIFF
--- a/ecommerce/extensions/offer/tests/test_utils.py
+++ b/ecommerce/extensions/offer/tests/test_utils.py
@@ -149,7 +149,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             tokens.get('offer_assignment_id'),
             subject,
             mock.ANY,
-            base_enterprise_url,
+            base_enterprise_url=base_enterprise_url,
         )
 
     @mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email')
@@ -170,7 +170,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             42,
             "You have mail",
             mock.ANY,
-            '',
+            base_enterprise_url='',
         )
 
     @mock.patch('ecommerce.extensions.offer.utils.send_offer_update_email')

--- a/ecommerce/extensions/offer/utils.py
+++ b/ecommerce/extensions/offer/utils.py
@@ -165,8 +165,8 @@ def send_assigned_offer_email(
         EXPIRATION_DATE=code_expiration_date
     )
     email_body = format_email(email_template, placeholder_dict, greeting, closing)
-
-    send_offer_assignment_email.delay(learner_email, offer_assignment_id, subject, email_body, base_enterprise_url)
+    send_offer_assignment_email.delay(learner_email, offer_assignment_id, subject, email_body,
+                                      base_enterprise_url=base_enterprise_url)
 
 
 def send_revoked_offer_email(


### PR DESCRIPTION
base_enterprise_url was mistakenly being sent as site_code