### PR TITLE
Fix send_offer_assignment_email call

### DIFF
--- a/ecommerce/extensions/offer/tests/test_utils.py
+++ b/ecommerce/extensions/offer/tests/test_utils.py
@@ -149,6 +149,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             tokens.get('offer_assignment_id'),
             subject,
             mock.ANY,
+            None,
             base_enterprise_url,
         )
 
@@ -170,6 +171,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             42,
             "You have mail",
             mock.ANY,
+            None,
             '',
         )
 

--- a/ecommerce/extensions/offer/utils.py
+++ b/ecommerce/extensions/offer/utils.py
@@ -166,7 +166,8 @@ def send_assigned_offer_email(
     )
     email_body = format_email(email_template, placeholder_dict, greeting, closing)
 
-    send_offer_assignment_email.delay(learner_email, offer_assignment_id, subject, email_body, base_enterprise_url)
+    send_offer_assignment_email.delay(learner_email, offer_assignment_id, subject, email_body, None,
+                                      base_enterprise_url)
 
 
 def send_revoked_offer_email(


### PR DESCRIPTION
base_enterprise_url was mistakenly being sent as site_code
Pass in site_code as none so that base_enterprise_url is passed correctly to ecommerce worker