### PR TITLE
Implement SDNFallback if SDN API is down

### DIFF
--- a/ecommerce/extensions/payment/core/sdn.py
+++ b/ecommerce/extensions/payment/core/sdn.py
@@ -62,6 +62,7 @@ def checkSDN(request, name, city, country):
         except (HTTPError, Timeout):
             # If the SDN API endpoint is down or times out
             # the user is allowed to make the purchase.
+            # test
             pass
 
     return hit_count

--- a/ecommerce/extensions/payment/core/sdn.py
+++ b/ecommerce/extensions/payment/core/sdn.py
@@ -68,7 +68,7 @@ def checkSDN(request, name, city, country):
                 city,
                 country
             )
-            if SDNFallback_hit > 0:
+            if SDNFallback_hit:
                 logger.info('SDNFallback match found for name: %s, city: %s, country: %s ', name, city, country)
                 sdn_check.deactivate_user(
                     basket,

--- a/ecommerce/extensions/payment/core/sdn.py
+++ b/ecommerce/extensions/payment/core/sdn.py
@@ -49,12 +49,13 @@ def checkSDN(request, name, city, country):
         )
         try:
             response = sdn_check.search(name, city, country)
-        except (HTTPError, Timeout):
+        except (HTTPError, Timeout) as e:
             # If the SDN API endpoint is down or times out
-            # checkSDNFallback will be called. If it finds a match
+            # checkSDNFallback will be called. If it finds a hit
             # the user will be blocked from making a purchase.
             logger.info(
-                'SDNCheck: SDN API call received an error/timeout. SDNFallback function called for basket [%d].',
+                'SDNCheck: SDN API call received an error: %s. SDNFallback function called for basket %d.',
+                str(e),
                 basket.id
             )
             sdn_fallback_hit_count = checkSDNFallback(

--- a/ecommerce/extensions/payment/core/sdn.py
+++ b/ecommerce/extensions/payment/core/sdn.py
@@ -61,9 +61,23 @@ def checkSDN(request, name, city, country):
                 logout(request)
         except (HTTPError, Timeout):
             # If the SDN API endpoint is down or times out
-            # the user is allowed to make the purchase.
-            # test
-            pass
+            # checkSDNFallback will be called. If it finds a match
+            # the user will be blocked from making a purchase.
+            SDNFallback_hit = checkSDNFallback(
+                name,
+                city,
+                country
+            )
+            if SDNFallback_hit > 0:
+                logger.info('SDNFallback match found for name: %s, city: %s, country: %s ', name, city, country)
+                sdn_check.deactivate_user(
+                    basket,
+                    name,
+                    city,
+                    country,
+                    response
+                )
+                logout(request)
 
     return hit_count
 


### PR DESCRIPTION
[REV-1538](https://openedx.atlassian.net/browse/REV-1538). 

After a positive analysis of our SDNFallback ([here](https://openedx.atlassian.net/browse/REV-1342)), the backup should be implemented.

When the government's SDN API is down or there is a timeout, our SDNFallback should be used to determine if there is a match and the user should be blocked from making a purchase. 

Currently, if it's down/timeout, there is no check and the user is able to make a purchase. 

Edit: we will keep the shadow analysis for longer to capture 1 month worth of data.  