### PR TITLE
Suppress PII from receipt page

### DIFF
--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -40,7 +40,7 @@
           <div class="copy col-md-8">
             <div class="confirm-message">
               {% captureas link_start %}
-                <a href="mailto:{{ order.user.email }}">
+                <a data-hj-suppress href="mailto:{{ order.user.email }}">
               {% endcaptureas %}
               {% if has_enrollment_code_product %}
                   {% blocktrans trimmed asvar tmsg %}
@@ -59,7 +59,7 @@
             </div>
 
             {% if order.billing_address %}
-              <address class="billing-address">
+              <address data-hj-suppress class="billing-address">
                 {% for field in order.billing_address.active_address_fields %}
                   {{ field }}<br/>
                 {% endfor %}
@@ -73,7 +73,7 @@
               <dd>{{ order.number }}</dd>
               {% if payment_method %}
                 <dt>{% trans "Payment Method:" as tmsg %}{{ tmsg | force_escape }}</dt>
-                <dd>{{ payment_method }}</dd>
+                <dd data-hj-suppress>{{ payment_method }}</dd>
               {% endif %}
               <dt>{% trans "Order Date:" as tmsg %}{{ tmsg | force_escape }}</dt>
               <dd>{{ order.date_placed|date:"E d, Y" }}</dd>
@@ -121,7 +121,7 @@
 
                     {% if discount.voucher_code %}
                       {% with voucher=discount.voucher %}
-                        <span class="discount">{{ voucher.code }}</span>
+                        <span data-hj-suppress class="discount">{{ voucher.code }}</span>
                         <span class="discount">
                           {% filter force_escape %}
                             {% blocktrans trimmed with voucher_code=voucher.code voucher_discount_amount=voucher.benefit|benefit_discount %}

--- a/ecommerce/templates/edx/partials/_base_navbar.html
+++ b/ecommerce/templates/edx/partials/_base_navbar.html
@@ -19,7 +19,7 @@
       <ul class="nav navbar-nav navbar-right">
         {% if user.is_authenticated %}
           <li class="btn-group user-menu">
-            <button type="button" class="btn btn-default hidden-xs main-btn nav-button"
+            <button data-hj-suppress type="button" class="btn btn-default hidden-xs main-btn nav-button"
                     onclick="window.open('{{ lms_dashboard_url }}');">
               <i class="icon fa fa-home" aria-hidden="true"></i>
               <span class="sr-only">{% trans "Dashboard for:" as tmsg %}{{ tmsg | force_escape }}</span>


### PR DESCRIPTION
Suppressed following PII and sensitive information in ecommerce:
* Receipt Page
  * email address
  * billing address
  * learner payment method
  * voucher code
* Header
  * username

Ticket: [VAN-16](https://openedx.atlassian.net/browse/VAN-16)

-----


Hotjar is a behavior analytics tool that analyses website use, providing feedback through tools such as heatmaps, session recordings, and surveys. Before we enable hotjar we have to suppress all PII and sensitive information so that screen recorder doesn’t capture it. Adding a `data-hj-suppress` attribute around the sensitive data marks the field as suppressed for hotjar and shows asterisks instead of text.
<img width="733" alt="Screenshot 2020-09-16 at 10 03 02 AM" src="https://user-images.githubusercontent.com/40633976/93294490-10955080-f804-11ea-9d39-dff3458741fa.png">