### PR TITLE
Remove hotjar suppression from payment method

### DIFF
--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -73,7 +73,7 @@
               <dd>{{ order.number }}</dd>
               {% if payment_method %}
                 <dt>{% trans "Payment Method:" as tmsg %}{{ tmsg | force_escape }}</dt>
-                <dd data-hj-suppress>{{ payment_method }}</dd>
+                <dd>{{ payment_method }}</dd>
               {% endif %}
               <dt>{% trans "Order Date:" as tmsg %}{{ tmsg | force_escape }}</dt>
               <dd>{{ order.date_placed|date:"E d, Y" }}</dd>


### PR DESCRIPTION
After product review it is decided that we should not suppress payment method type as it will be a good data to know what is more frequently used method by the users. 

In this PR I remove the hotjar suppression attribute from payment method on receipt page.

Ticket: https://openedx.atlassian.net/browse/VAN-16
