### PR TITLE
Update Travis tests to use mysql5.7

### DIFF
--- a/.travis/docker-compose-travis.yml
+++ b/.travis/docker-compose-travis.yml
@@ -3,14 +3,11 @@ version: "2"
 
 services:
   db:
-    image: mysql:5.6.45
+    image: mysql:5.7
     container_name: db
     command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
     environment:
-      MYSQL_ROOT_PASSWORD: ""
-      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-      MYSQL_USER: "ecomm001"
-      MYSQL_PASSWORD: "password"
+      MYSQL_ROOT_PASSWORD: "password"
       MYSQL_DATABASE: "ecommerce"
   ecommerce:
     image: edxops/ecommerce:latest
@@ -33,7 +30,7 @@ services:
       DB_NAME: "ecommerce"
       DB_PASSWORD: "password"
       DB_PORT: "3306"
-      DB_USER: "ecomm001"
+      DB_USER: "root"
       DJANGO_SETTINGS_MODULE: "ecommerce.settings.test"
       JASMINE_HOSTNAME: "localhost"
       JASMINE_WEB_DRIVER: "FirefoxHeadless"


### PR DESCRIPTION
This PR is based off of the work done in https://github.com/edx/course-discovery/pull/2760/files

The switch to use the root user was done because according to mysql docs, the USER/PASSWORD/DATABASE combo grants that user full access to the named database, but does not say anything about other databases.

I believe the tests try to make additional test databases during test setup. For some reason, mysql 5.6 was allowing this so we just switched to using the root user for the tests, since they can make new databases fine.

https://dev.mysql.com/doc/refman/5.6/en/docker-mysql-more-topics.html
https://dev.mysql.com/doc/refman/5.7/en/docker-mysql-more-topics.html

We don't think this will affect staging or prod, and is limited to just travis, because mysql users permissions are managed via Ansible rather than via environment variables.

We also considered two options that may be worth doing in the future:
1: Using a top level `docker-compose.yml` file and creating a `docker-compose.travis.yml` file like https://github.com/edx/credentials/pull/839/files does to see if that makes tests pass.
2: Removing the docker compose file and relying on a native mysql instance in Tavis to simplify the tests. This is also what we currently have in the cookie cutter: https://github.com/edx/edx-cookiecutters/blob/master/cookiecutter-django-ida/%7B%7Bcookiecutter.repo_name%7D%7D/.travis.yml