### PR TITLE
Add exec ed cert type

### DIFF
--- a/ecommerce/courses/utils.py
+++ b/ecommerce/courses/utils.py
@@ -133,6 +133,7 @@ def get_certificate_type_display_value(certificate_type):
         'honor': _('Honor'),
         'professional': _('Professional'),
         'verified': _('Verified'),
+        'executive-education': _('Executive Education')
     }
 
     if certificate_type not in display_values:


### PR DESCRIPTION
We are creating a new course type in LMS called "Executive Education". While this doesn't require much to be hardcoded, happily, the basket page does require this one dict to have the new cert type listed. Without this the basket fails to load. 