### PR TITLE
intercept enrollment code fulfillment and make it do enterprise coupo…

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -401,8 +401,8 @@ class SiteConfiguration(models.Model):
         """
         key = 'siteconfiguration_access_token_{}'.format(self.id)
         access_token_cached_response = TieredCache.get_cached_response(key)
-        if access_token_cached_response.is_found:
-            return access_token_cached_response.value
+        # if access_token_cached_response.is_found:
+        #     return access_token_cached_response.value
 
         url = '{root}/access_token'.format(root=self.oauth2_provider_url)
         access_token, expiration_datetime = EdxRestApiClient.get_oauth_access_token(

--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -517,7 +517,6 @@ class EnrollmentCodeFulfillmentModule(BaseFulfillmentModule):
         api = get_enterprise_api_client(order.site)
         endpoint = getattr(api, 'enterprise-customer')
 
-        import pdb; pdb.set_trace()
         existing_customer_response = endpoint().get(slug=customer_slug)
         if existing_customer_response['results']:
             return existing_customer_response['results'][0]
@@ -571,6 +570,7 @@ class EnrollmentCodeFulfillmentModule(BaseFulfillmentModule):
                 line.partner,
                 order.total_excl_tax
             )
+            # TODO: Contract Discount Value - need this to not be null during code redemption.
             coupon_product.course_id = course_key
             coupon_product.save()
 

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -654,7 +654,7 @@ ENTERPRISE_SERVICE_URL = 'http://localhost:8000/enterprise/'
 # Cache enterprise response from Enterprise API.
 ENTERPRISE_API_CACHE_TIMEOUT = 300  # Value is in seconds
 
-ENTERPRISE_CATALOG_SERVICE_URL = 'http://localhost:18160/'
+ENTERPRISE_CATALOG_SERVICE_URL = 'http://enterprise.catalog.app:18160/'
 
 ENTERPRISE_LEARNER_PORTAL_HOSTNAME = os.environ.get('ENTERPRISE_LEARNER_PORTAL_HOSTNAME', 'localhost:8734')
 


### PR DESCRIPTION
…n stuff instead.

How to use:
* Find a local enrollment code SKU in your ecommerce service (or create one if none exist).
* Modify the hard-coded enterprise catalog UUIDs to match your local test data.
* Go to http://localhost:18130/basket/add/?sku=YOUR-SKU
* Fill out the form and submit.
* A new Enterprise Customer is created (or existing one, based on the org name provided in the form) automagically.
* A new enterprise coupon for the course and your enterprise will be created, payment/fulfillment should succeed.
* Go visit the enterprise admin portal at http://localhost:1991 and go to the Code Management screen.
* You should now be able to manage vouchers/codes for the coupon that was just created when you checked-out.