### PR TITLE
Revert "ENT-3666: Capture Newly Added Columns Data for Assign/Remind/Revoke emails"

### DIFF
--- a/ecommerce/enterprise/tests/test_conditions.py
+++ b/ecommerce/enterprise/tests/test_conditions.py
@@ -873,7 +873,6 @@ class AssignableEnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, Cou
         assert self.condition.is_satisfied(enterprise_offer, basket) is True
 
     @mock.patch('ecommerce.enterprise.conditions.crum.get_current_request')
-    @mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email', mock.Mock())
     @mock.patch.object(EnterpriseCustomerCondition, 'is_satisfied', mock.Mock(return_value=True))
     def test_is_satisfied_when_user_has_no_assignment(self, mock_request):
         """

--- a/ecommerce/extensions/api/tests/test_serializers.py
+++ b/ecommerce/extensions/api/tests/test_serializers.py
@@ -1,6 +1,5 @@
 import datetime
 from unittest import mock
-from uuid import uuid4
 
 from oscar.core.loading import get_model
 from testfixtures import LogCapture
@@ -202,13 +201,7 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
             ),
         ]
         with LogCapture(self.LOGGER_NAME) as log:
-            serializer.create(
-                validated_data={
-                    'sender_id': None,
-                    'template': None,
-                    'enterprise_customer_uuid': uuid4()
-                }
-            )
+            serializer.create(validated_data={})
             log.check_present(*expected)
 
     @mock.patch('ecommerce.extensions.api.serializers.send_revoked_offer_email')
@@ -219,9 +212,6 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
             'code': self.code,
             'email': self.email,
             'offer_assignments': self.offer_assignments,
-            'sender_id': None,
-            'template': None,
-            'enterprise_customer_uuid': uuid4()
         }
         context = {
             'coupon': self.coupon,

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -54,10 +54,13 @@ from ecommerce.extensions.catalogue.utils import (
     create_coupon_product_and_stockrecord
 )
 from ecommerce.extensions.offer.constants import (
+    ASSIGN,
     OFFER_ASSIGNED,
     OFFER_ASSIGNMENT_EMAIL_PENDING,
     OFFER_ASSIGNMENT_EMAIL_SUBJECT_LIMIT,
     OFFER_ASSIGNMENT_EMAIL_TEMPLATE_FIELD_LIMIT,
+    REMIND,
+    REVOKE,
     VOUCHER_IS_PRIVATE,
     VOUCHER_IS_PUBLIC,
     VOUCHER_NOT_ASSIGNED,
@@ -667,6 +670,10 @@ class EnterpriseCouponViewSet(CouponViewSet):
         if errors:
             raise DRFValidationError({'error': errors})
 
+    def _create_offer_assignment_email_sent_record(self, enterprise_customer, email_type, template=None):
+        """Saves the all email info to OfferAssignmentEmailSentRecord."""
+        OfferAssignmentEmailSentRecord.create_email_record(enterprise_customer, email_type, template)
+
     @action(detail=True, methods=['post'], permission_classes=[IsAuthenticated])
     @permission_required('enterprise.can_assign_coupon', fn=lambda request, pk: get_enterprise_from_product(pk))
     def assign(self, request, pk):  # pylint: disable=unused-argument
@@ -679,7 +686,8 @@ class EnterpriseCouponViewSet(CouponViewSet):
         greeting = request.data.pop('template_greeting', '')
         closing = request.data.pop('template_closing', '')
         template_id = request.data.pop('template_id', None)
-        sender_id = request.user.lms_user_id
+        template = OfferAssignmentEmailTemplates.get_template(template_id)
+        enterprise_customer = coupon.attr.enterprise_customer_uuid
 
         self._validate_email_fields(subject, greeting, closing)
 
@@ -690,12 +698,12 @@ class EnterpriseCouponViewSet(CouponViewSet):
                 'subject': subject,
                 'greeting': greeting,
                 'closing': closing,
-                'template_id': template_id,
-                'sender_id': sender_id,
             }
         )
         if serializer.is_valid():
             serializer.save()
+            # Create a record of the email sent
+            self._create_offer_assignment_email_sent_record(enterprise_customer, ASSIGN, template)
             return Response(serializer.data, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
@@ -766,7 +774,8 @@ class EnterpriseCouponViewSet(CouponViewSet):
         greeting = request.data.pop('template_greeting', '')
         closing = request.data.pop('template_closing', '')
         template_id = request.data.pop('template_id', None)
-        sender_id = request.user.lms_user_id
+        template = OfferAssignmentEmailTemplates.get_template(template_id)
+        enterprise_customer = coupon.attr.enterprise_customer_uuid
         self._validate_email_fields(subject, greeting, closing)
         assignments = request.data.get('assignments')
         serializer = CouponCodeRevokeSerializer(
@@ -777,17 +786,19 @@ class EnterpriseCouponViewSet(CouponViewSet):
                 'subject': subject,
                 'greeting': greeting,
                 'closing': closing,
-                'template_id': template_id,
-                'sender_id': sender_id,
             }
         )
         if serializer.is_valid():
             serializer.save()
+            # Create a record of the email sent
+            self._create_offer_assignment_email_sent_record(enterprise_customer, REVOKE, template)
+
             # unsubscribe user from receiving nudge emails
             CodeAssignmentNudgeEmails.unsubscribe_from_nudging(
                 map(lambda assignment: assignment['code'], assignments),
                 map(lambda assignment: assignment['email'], assignments)
             )
+
             return Response(serializer.data, status=status.HTTP_200_OK)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
@@ -804,7 +815,8 @@ class EnterpriseCouponViewSet(CouponViewSet):
         greeting = request.data.pop('template_greeting', '')
         closing = request.data.pop('template_closing', '')
         template_id = request.data.pop('template_id', None)
-        sender_id = request.user.lms_user_id
+        template = OfferAssignmentEmailTemplates.get_template(template_id)
+        enterprise_customer = coupon.attr.enterprise_customer_uuid
         self._validate_email_fields(subject, greeting, closing)
         if request.data.get('assignments'):
             assignments = request.data.get('assignments')
@@ -839,12 +851,12 @@ class EnterpriseCouponViewSet(CouponViewSet):
                 'subject': subject,
                 'greeting': greeting,
                 'closing': closing,
-                'template_id': template_id,
-                'sender_id': sender_id,
             }
         )
         if serializer.is_valid():
             serializer.save()
+            # Create a record of the email sent
+            self._create_offer_assignment_email_sent_record(enterprise_customer, REMIND, template)
             return Response(serializer.data, status=status.HTTP_200_OK)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
Reverts edx/ecommerce#3251

Looks like the recent shift to mysql 5.7 on `stage-ecommerce` now doesn't let the user make any changes in foreign keys. I'm guessing someone will have to grant the REFERENCES privileges. This is the error I'm getting on stage build 
`django.db.utils.OperationalError: (1142, "REFERENCES command denied to user 'migrate001'@'10.3.110.58' for table 'django_content_type'")`

https://stackoverflow.com/questions/41258971/mysql-impossible-to-use-references-on-mysql-5-7-but-was-working-on-5-0