### PR TITLE
update logo and favicon to use django setting to allow for using a url

### DIFF
--- a/ecommerce/core/context_processors.py
+++ b/ecommerce/core/context_processors.py
@@ -1,6 +1,6 @@
 
 
-from ecommerce.core.url_utils import get_lms_dashboard_url, get_lms_url
+from ecommerce.core.url_utils import get_favicon_url, get_lms_dashboard_url, get_lms_url, get_logo_url
 
 
 def core(request):
@@ -12,5 +12,7 @@ def core(request):
         'lms_dashboard_url': get_lms_dashboard_url(),
         'platform_name': site.name,
         'support_url': site_configuration.payment_support_url,
+        'logo_url': get_logo_url(),
+        'favicon_url': get_favicon_url(),
         'optimizely_snippet_src': site_configuration.optimizely_snippet_src,
     }

--- a/ecommerce/core/tests/test_context_processors.py
+++ b/ecommerce/core/tests/test_context_processors.py
@@ -3,7 +3,7 @@
 from faker import Faker
 
 from ecommerce.core.context_processors import core
-from ecommerce.core.url_utils import get_lms_dashboard_url, get_lms_url
+from ecommerce.core.url_utils import get_favicon_url, get_lms_dashboard_url, get_lms_url, get_logo_url
 from ecommerce.tests.testcases import TestCase
 
 
@@ -20,6 +20,8 @@ class CoreContextProcessorTests(TestCase):
                 'lms_dashboard_url': get_lms_dashboard_url(),
                 'platform_name': self.site.name,
                 'support_url': site_configuration.payment_support_url,
+                'logo_url': get_logo_url(),
+                'favicon_url': get_favicon_url(),
                 'optimizely_snippet_src': site_configuration.optimizely_snippet_src,
             }
         )

--- a/ecommerce/core/tests/test_url_utils.py
+++ b/ecommerce/core/tests/test_url_utils.py
@@ -3,7 +3,7 @@
 import mock
 
 from ecommerce.core.exceptions import MissingRequestError
-from ecommerce.core.url_utils import get_ecommerce_url, get_lms_url
+from ecommerce.core.url_utils import get_ecommerce_url, get_favicon_url, get_lms_url, get_logo_url
 from ecommerce.tests.testcases import TestCase
 
 
@@ -17,3 +17,33 @@ class UrlUtilityTests(TestCase):
     def test_get_lms_url_with_no_current_request(self):
         with self.assertRaises(MissingRequestError):
             get_lms_url()
+
+    @mock.patch('django.conf.settings.LOGO_URL', None)
+    def test_get_logo_url_from_static_file(self):
+        """
+        If the django settings for the url are set to none, use the static asset
+        """
+        self.assertEqual(get_logo_url(), '/static/images/default-logo.png')
+
+    def test_get_logo_url_from_settings(self):
+        """
+        Use the django settings value for the logo url if set
+        """
+        fake_logo_url = 'https://logo_url.org/logo.svg'
+        with mock.patch('django.conf.settings.LOGO_URL', fake_logo_url):
+            self.assertEqual(get_logo_url(), fake_logo_url)
+
+    @mock.patch('django.conf.settings.FAVICON_URL', None)
+    def test_get_favicon_url_from_static_file(self):
+        """
+        If the django settings for the favicon url are set to none, use the static asset
+        """
+        self.assertEqual(get_favicon_url(), '/static/images/favicon.ico')
+
+    def test_get_favicon_url_from_settings(self):
+        """
+        Use the django settings value for the favicon url if set
+        """
+        fake_favicon_url = 'https://favicon_url.org/favicon.ico'
+        with mock.patch('django.conf.settings.FAVICON_URL', fake_favicon_url):
+            self.assertEqual(get_favicon_url(), fake_favicon_url)

--- a/ecommerce/core/url_utils.py
+++ b/ecommerce/core/url_utils.py
@@ -2,6 +2,8 @@
 
 import warnings
 
+from django.conf import settings
+from django.contrib.staticfiles.storage import staticfiles_storage
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from threadlocals.threadlocals import get_current_request
@@ -117,3 +119,39 @@ def absolute_url(request, reverse_string):
 
 def absolute_redirect(request, reverse_string):
     return HttpResponseRedirect(absolute_url(request, reverse_string))
+
+
+def get_logo_url():
+    """
+    Return the url for the branded logo image to be used.
+
+    Preference of the logo should be,
+        Absolute url of brand Logo if defined in django settings
+        Relative default local image path
+
+    """
+    brand_logo_url = settings.LOGO_URL
+    default_local_path = 'images/default-logo.png'
+
+    if brand_logo_url:
+        return brand_logo_url
+
+    return staticfiles_storage.url(default_local_path)
+
+
+def get_favicon_url():
+    """
+    Return the url for the branded favicon image to be used.
+
+    Preference of the favicon should be,
+        Absolute url of brand favicon if defined in django settings
+        Relative default local image path
+
+    """
+    brand_favicon_url = settings.FAVICON_URL
+    default_local_path = 'images/favicon.ico'
+
+    if brand_favicon_url:
+        return brand_favicon_url
+
+    return staticfiles_storage.url(default_local_path)

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -821,3 +821,7 @@ ACCOUNT_MICROFRONTEND_URL = None
 
 # Awin advertiser id
 AWIN_ADVERTISER_ID = None
+
+################# Settings for brand logos. #################
+LOGO_URL = None
+FAVICON_URL = None

--- a/ecommerce/templates/edx/base.html
+++ b/ecommerce/templates/edx/base.html
@@ -8,7 +8,7 @@
 <!DOCTYPE html>
 <html lang={{ LANGUAGE_CODE }}>
 <head>
-    <link rel="shortcut icon" href="{% static 'images/favicon.ico' %}"/>
+    <link rel="shortcut icon" href="{{ favicon_url }}"/>
     <link rel="apple-touch-icon" href="{% static 'images/touch-icon.png' %}">
     <link rel="apple-touch-icon" sizes="120x120" href="{% static 'images/touch-icon-2x.png' %}">
     <link rel="apple-touch-icon" sizes="180x180" href="{% static 'images/touch-icon-3x.png' %}">

--- a/ecommerce/templates/edx/partials/_staff_navbar.html
+++ b/ecommerce/templates/edx/partials/_staff_navbar.html
@@ -5,22 +5,22 @@
 {% block navbar_brand %}
     {% if admin == "course" %}
         <a class="navbar-brand" href="{% url 'courses:app' '' %}">
-            <img class="navbar-brand-logo" alt="{{ platform_name }} logo" src="{% static 'images/default-logo.png' %}"/>
+            <img class="navbar-brand-logo" alt="{{ platform_name }} logo" src="{{ logo_url }}"/>
             <div class="navbar-brand-app">{% trans "E-Commerce Course Administration" as tmsg %}{{ tmsg | force_escape }}</div>
         </a>
     {% elif admin == "coupon" %}
         <a class="navbar-brand" href="{% url 'coupons:app' '' %}">
-            <img class="navbar-brand-logo" alt="{{ platform_name }} logo" src="{% static 'images/default-logo.png' %}"/>
+            <img class="navbar-brand-logo" alt="{{ platform_name }} logo" src="{{ logo_url }}"/>
             <div class="navbar-brand-app">{% trans "E-Commerce Coupon Administration" as tmsg %}{{ tmsg | force_escape }}</div>
         </a>
     {% elif admin == "program_offers" %}
         <a class="navbar-brand" href="{% url 'programs:offers:list' %}">
-            <img class="navbar-brand-logo" alt="{{ platform_name }} logo" src="{% static 'images/default-logo.png' %}"/>
+            <img class="navbar-brand-logo" alt="{{ platform_name }} logo" src="{{ logo_url }}"/>
             <div class="navbar-brand-app">{% trans "E-Commerce Program Offers Administration" as tmsg %}{{ tmsg | force_escape }}</div>
         </a>
     {% else %}
         <h1 class="navbar-brand">
-            <img class="navbar-brand-logo" alt="{{ platform_name }} logo" src="{% static 'images/default-logo.png' %}"/>
+            <img class="navbar-brand-logo" alt="{{ platform_name }} logo" src="{{ logo_url }}"/>
         </h1>
     {% endif %}
 {% endblock navbar_brand %}

--- a/ecommerce/templates/edx/partials/_student_navbar.html
+++ b/ecommerce/templates/edx/partials/_student_navbar.html
@@ -3,7 +3,7 @@
 
 {% block navbar_brand %}
     <h1 class="navbar-brand">
-        <img class="navbar-brand-logo" alt="{{ platform_name }} logo" src="{% static 'images/default-logo.png' %}"/>
+        <img class="navbar-brand-logo" alt="{{ platform_name }} logo" src="{{ logo_url }}"/>
     </h1>
 {% endblock navbar_brand %}
 


### PR DESCRIPTION
We need to change the logo and favicon to use a url rather than a static asset, so that the logo and favicon can be swapped to a new logo without redeployment. Here I am using a django setting in accordance to how it is being done in edx-platform.