### PR TITLE
[MST-567] Encode course_id passed into IDV workflow

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -1,7 +1,7 @@
 import datetime
 import hashlib
 import logging
-from urllib.parse import urljoin, urlsplit
+from urllib.parse import quote, urljoin, urlsplit
 
 import waffle
 from analytics import Client as SegmentClient
@@ -368,7 +368,7 @@ class SiteConfiguration(models.Model):
         """
         path = 'id-verification'
         if course_id:
-            path += '?course_id={}'.format(course_id)
+            path += '?course_id={}'.format(quote(str(course_id)))
 
         if self.account_microfrontend_url:
             return urljoin(self.account_microfrontend_url, path)

--- a/ecommerce/core/tests/test_models.py
+++ b/ecommerce/core/tests/test_models.py
@@ -1,6 +1,7 @@
 
 
 import json
+from urllib.parse import quote
 
 import ddt
 import httpretty
@@ -450,7 +451,7 @@ class SiteConfigurationTests(TestCase):
     def _validate_IDVerification_workflow_url(self, site_config, account_url, course_id):
         expected = None
         if course_id:
-            expected = account_url + '/id-verification?course_id={}'.format(course_id)
+            expected = account_url + '/id-verification?course_id={}'.format(quote(str(course_id)))
         else:
             expected = account_url + '/id-verification'
         self.assertEqual(
@@ -458,7 +459,7 @@ class SiteConfigurationTests(TestCase):
             expected
         )
 
-    @ddt.data(None, 'test_course_id')
+    @ddt.data(None, 'course-v1:edX+DemoX+Demo_Course')
     def test_IDVerification_workflow_url_configured(self, course_id):
         account_url = 'https://account.edx.org'
         site_config = SiteConfigurationFactory(
@@ -467,7 +468,7 @@ class SiteConfigurationTests(TestCase):
         self.assertEqual(site_config.account_microfrontend_url, account_url)
         self._validate_IDVerification_workflow_url(site_config, account_url, course_id)
 
-    @ddt.data(None, 'test_course_id')
+    @ddt.data(None, 'course-v1:edX+DemoX+Demo_Course')
     @override_settings(ACCOUNT_MICROFRONTEND_URL='https://test.edx.org')
     def test_IDVerification_workflow_url_settings_configured(self, course_id):
         account_url = 'https://test.edx.org'


### PR DESCRIPTION
[MST-567](https://openedx.atlassian.net/browse/MST-567)

Related to https://github.com/edx/edx-platform/pull/25845 and https://github.com/edx/frontend-app-account/pull/360

Without encoding the `course_id`, `+` symbols in the query string are parsed into spaces when passed to the front end. IE `course-v1:edX+DemoX+Demo_Course` becomes `course-v1:edX DemoX Demo_Course`, causing a 400 error when the user tries to submit their ID verification photos.