### PR TITLE
ENT-3720: Added double tab character before new line characters in email body so that they appear correctly in outlook.

### DIFF
--- a/ecommerce/extensions/offer/tests/test_utils.py
+++ b/ecommerce/extensions/offer/tests/test_utils.py
@@ -318,13 +318,13 @@ class UtilTests(DiscoveryTestMixin, TestCase):
 
         # Compare strings, ignoring whitespace differences
         expected_email = """
-            hi {CODE} &lt;h1&gt;there&lt;/h1&gt;\n&nbsp;\n&nbsp;
-            Text\n&nbsp;
-            {DOES_NOT_EXIST} johndoe@unknown.com\n&nbsp;
-            code: GIL7RUEOU7VHBH7Q GIL7RUEOU7VHBH7Q\n&nbsp;
-            {}\n&nbsp;
-            { abc d }\n&nbsp;
-            More text.\n&nbsp;\n&nbsp;bye {CODE}, &lt;h3&gt;come back soon!&lt;/h3&gt;
+            hi {CODE} &lt;h1&gt;there&lt;/h1&gt;\t\t\n&nbsp;\t\t\n&nbsp;
+            Text\t\t\n&nbsp;
+            {DOES_NOT_EXIST} johndoe@unknown.com\t\t\n&nbsp;
+            code: GIL7RUEOU7VHBH7Q GIL7RUEOU7VHBH7Q\t\t\n&nbsp;
+            {}\t\t\n&nbsp;
+            { abc d }\t\t\n&nbsp;
+            More text.\t\t\n&nbsp;\t\t\n&nbsp;bye {CODE}, &lt;h3&gt;come back soon!&lt;/h3&gt;
             """
         self.assertEqual(email.split(), expected_email.split())
 
@@ -345,11 +345,11 @@ class UtilTests(DiscoveryTestMixin, TestCase):
 
         # Compare strings, ignoring whitespace differences
         expected_email = """
-            \n&nbsp; Text\n&nbsp;
-            {DOES_NOT_EXIST} johndoe2@unknown.com\n&nbsp;
-            code: ABC7RUEOU7VHBH7Q ABC7RUEOU7VHBH7Q\n&nbsp;
-            {}\n&nbsp;
-            { abc d }\n&nbsp;
-            More text.\n&nbsp;
+            \t\t\n&nbsp; Text\t\t\n&nbsp;
+            {DOES_NOT_EXIST} johndoe2@unknown.com\t\t\n&nbsp;
+            code: ABC7RUEOU7VHBH7Q ABC7RUEOU7VHBH7Q\t\t\n&nbsp;
+            {}\t\t\n&nbsp;
+            { abc d }\t\t\n&nbsp;
+            More text.\t\t\n&nbsp;
             """
         self.assertEqual(email.split(), expected_email.split())

--- a/ecommerce/extensions/offer/utils.py
+++ b/ecommerce/extensions/offer/utils.py
@@ -285,7 +285,7 @@ def format_email(template, placeholder_dict, greeting, closing):
     email_body = string.Formatter().vformat(template, SafeTuple(), placeholder_dict)
     # \n\n is being treated as single line except of two lines in HTML template,
     #  so separating them with &nbsp; tag to render them as expected.
-    return (greeting + email_body + closing).replace('\n', '\n&nbsp;')
+    return (greeting + email_body + closing).replace('\n', '\t\t\n&nbsp;')
 
 
 class SafeDict(dict):


### PR DESCRIPTION
**Jira Ticket:** [ENT-3720](https://openedx.atlassian.net/browse/ENT-3720)

__Description:__
Email is not being properly formatted in outlook, after some discovery, I found a solution to add some white spaces before newline character for it to take effect.