### PR TITLE
BOM-2181 : Unpin social-auth-core

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -48,10 +48,10 @@ pytz
 requests
 rules
 sailthru-client==2.2.3
+social-auth-app-django
 sorl-thumbnail
 stripe==1.70.0
 unicodecsv
 xss-utils
 zeep
 
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,44 +9,44 @@ analytics-python==1.2.9   # via -r requirements/base.in
 appdirs==1.4.4            # via zeep
 argparse==1.4.0           # via unittest2
 asn1crypto==1.4.0         # via cybersource-rest-client-python
-attrs==20.2.0             # via jsonschema, zeep
-babel==2.8.0              # via django-oscar, django-phonenumber-field
+attrs==20.3.0             # via jsonschema, zeep
+babel==2.9.0              # via django-oscar, django-phonenumber-field
 bcrypt==3.2.0             # via cybersource-rest-client-python, paramiko
 billiard==3.6.3.0         # via celery
 bleach==3.2.1             # via -r requirements/base.in
 cached-property==1.5.2    # via zeep
 celery==4.4.7             # via -c requirements/pins.txt, edx-ecommerce-worker
-certifi==2020.6.20        # via cybersource-rest-client-python, requests
-cffi==1.14.3              # via bcrypt, cryptography, cybersource-rest-client-python, pynacl
-chardet==3.0.4            # via cybersource-rest-client-python, requests
+certifi==2020.12.5        # via cybersource-rest-client-python, requests
+cffi==1.14.4              # via bcrypt, cryptography, cybersource-rest-client-python, pynacl
+chardet==4.0.0            # via cybersource-rest-client-python, requests
 configparser==5.0.1       # via cybersource-rest-client-python
 coreapi==2.3.3            # via -r requirements/base.in, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
-coverage==5.3             # via cybersource-rest-client-python
+coverage==5.3.1           # via cybersource-rest-client-python
 crypto==1.4.1             # via cybersource-rest-client-python
-cryptography==3.2.1       # via cybersource-rest-client-python, paramiko, pyjwt, pyopenssl
+cryptography==3.3.1       # via cybersource-rest-client-python, paramiko, pyjwt, pyopenssl, social-auth-core
 cssselect==1.1.0          # via premailer
 cssutils==1.0.2           # via premailer
-cybersource-rest-client-python==0.0.21  # via -r requirements/base.in
+cybersource-rest-client-python==0.0.21  # via -c requirements/pins.txt, -r requirements/base.in
 datetime==4.3             # via cybersource-rest-client-python
 defusedxml==0.6.0         # via python3-openid, social-auth-core, zeep
 django-appconf==1.0.4     # via django-compressor
 django-compressor==2.4    # via -r requirements/base.in, django-libsass
 django-config-models==2.0.3  # via -r requirements/base.in
-django-cors-headers==3.5.0  # via -r requirements/base.in
+django-cors-headers==3.6.0  # via -r requirements/base.in
 django-crispy-forms==1.8.1  # via -r requirements/base.in
-django-crum==0.7.8        # via edx-django-utils, edx-rbac
-django-extensions==3.0.9  # via -r requirements/base.in
+django-crum==0.7.9        # via edx-django-utils, edx-rbac
+django-extensions==3.1.0  # via -r requirements/base.in
 django-extra-views==0.11.0  # via django-oscar
 django-filter==2.4.0      # via -r requirements/base.in
 django-haystack==2.8.1    # via django-oscar
 django-libsass==0.8       # via -r requirements/base.in
-django-model-utils==4.0.0  # via edx-rbac
+django-model-utils==4.1.1  # via edx-rbac
 django-oscar==2.0.4       # via -c requirements/pins.txt, -r requirements/base.in
 django-phonenumber-field==2.0.1  # via django-oscar
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-simple-history==2.12.0  # via -r requirements/base.in
-django-solo==1.1.3        # via -r requirements/base.in
+django-solo==1.1.5        # via -r requirements/base.in
 django-tables2==1.21.2    # via django-oscar
 django-threadlocals==0.10  # via -r requirements/base.in
 django-treebeard==4.3.1   # via django-oscar
@@ -55,13 +55,13 @@ django-widget-tweaks==1.4.8  # via django-oscar
 django==2.2.17            # via -r requirements/base.in, django-appconf, django-config-models, django-cors-headers, django-crum, django-extra-views, django-filter, django-haystack, django-model-utils, django-oscar, django-phonenumber-field, django-tables2, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition, xss-utils
 djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework-datatables==0.5.2  # via -r requirements/base.in
-djangorestframework==3.12.1  # via -r requirements/base.in, django-config-models, django-rest-swagger, djangorestframework-csv, djangorestframework-datatables, drf-extensions, drf-jwt, edx-drf-extensions, rest-condition
+djangorestframework==3.12.2  # via -r requirements/base.in, django-config-models, django-rest-swagger, djangorestframework-csv, djangorestframework-datatables, drf-extensions, drf-jwt, edx-drf-extensions, rest-condition
 drf-extensions==0.6.0     # via -r requirements/base.in
-drf-jwt==1.17.2           # via edx-drf-extensions
+drf-jwt==1.17.3           # via edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
 edx-django-sites-extensions==2.5.1  # via -r requirements/base.in
-edx-django-utils==3.11.0  # via -r requirements/base.in, django-config-models, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.13.0  # via -r requirements/base.in, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/base.in, edx-rbac
 edx-ecommerce-worker==1.1.3  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-drf-extensions
@@ -70,7 +70,7 @@ edx-rest-api-client==5.2.1  # via -r requirements/base.in, edx-ecommerce-worker
 enum34==1.1.10            # via cybersource-rest-client-python
 extras==1.0.0             # via cybersource-rest-client-python, python-subunit, testtools
 factory-boy==2.12.0       # via django-oscar
-faker==4.14.1             # via factory-boy
+faker==5.3.0              # via factory-boy
 fixtures==3.0.0           # via cybersource-rest-client-python, testtools
 funcsigs==1.0.2           # via cybersource-rest-client-python
 future==0.18.2            # via pyjwkest
@@ -85,37 +85,37 @@ kombu==4.6.11             # via celery
 libsass==0.9.2            # via -r requirements/base.in, django-libsass
 linecache2==1.0.0         # via cybersource-rest-client-python, traceback2
 logger==1.4               # via cybersource-rest-client-python
-lxml==4.6.1               # via premailer, zeep
+lxml==4.6.2               # via premailer, zeep
 markdown==2.6.9           # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
 mysqlclient==1.4.6        # via -r requirements/base.in
 naked==0.1.31             # via crypto, cybersource-rest-client-python
 ndg-httpsclient==0.5.1    # via -r requirements/base.in
-newrelic==5.22.1.152      # via -r requirements/base.in, edx-django-utils
+newrelic==5.24.0.153      # via -r requirements/base.in, edx-django-utils
 nose==1.3.7               # via cybersource-rest-client-python
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
-packaging==20.4           # via bleach
+packaging==20.8           # via bleach
 paramiko==2.7.2           # via cybersource-rest-client-python
 path.py==7.2              # via -r requirements/base.in
 paypalrestsdk==1.13.1     # via -r requirements/base.in
 pbr==5.5.1                # via cybersource-rest-client-python, fixtures, stevedore, testtools
-phonenumbers==8.12.12     # via django-oscar, django-phonenumber-field
-pillow==8.0.1             # via django-oscar
+phonenumbers==8.12.15     # via django-oscar, django-phonenumber-field
+pillow==8.1.0             # via django-oscar
 premailer==2.9.2          # via -r requirements/base.in
-psutil==5.7.3             # via edx-django-utils
+psutil==5.8.0             # via edx-django-utils
 purl==1.5                 # via django-oscar
 pyasn1==0.4.8             # via cybersource-rest-client-python, ndg-httpsclient, rsa, x509
 pycountry==17.1.8         # via -r requirements/base.in
 pycparser==2.20           # via cffi, cybersource-rest-client-python
 pycryptodome==3.9.9       # via cybersource-rest-client-python
 pycryptodomex==3.9.9      # via cybersource-rest-client-python, pyjwkest
-pygments==2.7.2           # via -r requirements/base.in
+pygments==2.7.3           # via -r requirements/base.in
 pyjwkest==1.4.2           # via edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via cybersource-rest-client-python, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pymongo==3.11.0           # via edx-opaque-keys
+pymongo==3.11.2           # via edx-opaque-keys
 pynacl==1.4.0             # via cybersource-rest-client-python, paramiko
-pyopenssl==19.1.0         # via cybersource-rest-client-python, ndg-httpsclient, paypalrestsdk
+pyopenssl==20.0.1         # via cybersource-rest-client-python, ndg-httpsclient, paypalrestsdk
 pyparsing==2.4.7          # via packaging
 pypi==2.1                 # via cybersource-rest-client-python
 pyrsistent==0.17.3        # via jsonschema
@@ -131,7 +131,7 @@ redis==3.5.3              # via edx-ecommerce-worker
 requests-file==1.5.1      # via zeep
 requests-oauthlib==1.3.0  # via social-auth-core
 requests-toolbelt==0.9.1  # via zeep
-requests==2.24.0          # via -r requirements/base.in, analytics-python, coreapi, cybersource-rest-client-python, edx-drf-extensions, edx-rest-api-client, naked, paypalrestsdk, pyjwkest, requests-file, requests-oauthlib, requests-toolbelt, sailthru-client, slumber, social-auth-core, stripe, zeep
+requests==2.25.1          # via -r requirements/base.in, analytics-python, coreapi, cybersource-rest-client-python, edx-drf-extensions, edx-rest-api-client, naked, paypalrestsdk, pyjwkest, requests-file, requests-oauthlib, requests-toolbelt, sailthru-client, slumber, social-auth-core, stripe, zeep
 rest-condition==1.0.3     # via edx-drf-extensions
 rjsmin==1.1.0             # via django-compressor
 rsa==4.6                  # via cybersource-rest-client-python
@@ -140,13 +140,13 @@ sailthru-client==2.2.3    # via -r requirements/base.in, edx-ecommerce-worker
 semantic-version==2.8.5   # via edx-drf-extensions
 shellescape==3.8.1        # via crypto, cybersource-rest-client-python
 simplejson==3.17.2        # via django-rest-swagger, sailthru-client
-six==1.15.0               # via analytics-python, bcrypt, bleach, cryptography, cybersource-rest-client-python, django-compressor, django-extra-views, django-simple-history, djangorestframework-csv, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-ecommerce-worker, edx-opaque-keys, edx-rbac, fixtures, isodate, jsonschema, libsass, packaging, paypalrestsdk, purl, pyjwkest, pynacl, pyopenssl, python-dateutil, requests-file, social-auth-app-django, social-auth-core, testtools, unittest2
+six==1.15.0               # via analytics-python, bcrypt, bleach, cryptography, cybersource-rest-client-python, django-compressor, django-extra-views, django-simple-history, djangorestframework-csv, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-ecommerce-worker, edx-opaque-keys, edx-rbac, fixtures, isodate, jsonschema, libsass, paypalrestsdk, purl, pyjwkest, pynacl, pyopenssl, python-dateutil, requests-file, social-auth-app-django, social-auth-core, testtools, unittest2
 slumber==0.7.1            # via edx-rest-api-client
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.in, edx-auth-backends
-social-auth-core==3.3.3   # via -c requirements/pins.txt, edx-auth-backends, social-auth-app-django
-sorl-thumbnail==12.6.3    # via -r requirements/base.in
+social-auth-app-django==4.0.0  # via -r requirements/base.in, edx-auth-backends
+social-auth-core==3.3.3   # via edx-auth-backends, social-auth-app-django
+sorl-thumbnail==12.7.0    # via -r requirements/base.in
 sqlparse==0.4.1           # via django
-stevedore==3.2.2          # via edx-django-utils, edx-opaque-keys
+stevedore==3.3.0          # via edx-django-utils, edx-opaque-keys
 stripe==1.70.0            # via -r requirements/base.in
 testtools==2.4.0          # via cybersource-rest-client-python, fixtures, python-subunit
 text-unidecode==1.3       # via faker
@@ -155,14 +155,14 @@ typing==3.7.4.3           # via cybersource-rest-client-python
 unicodecsv==0.14.1        # via -r requirements/base.in, djangorestframework-csv
 unittest2==1.1.0          # via testtools
 uritemplate==3.0.1        # via coreapi
-urllib3==1.25.11          # via -c requirements/pins.txt, cybersource-rest-client-python, requests
+urllib3==1.26.2           # via -c requirements/pins.txt, cybersource-rest-client-python, requests
 vine==1.3.0               # via amqp, celery
 webencodings==0.5.1       # via bleach
-wheel==0.35.1             # via cybersource-rest-client-python
+wheel==0.36.2             # via cybersource-rest-client-python
 x509==0.1                 # via cybersource-rest-client-python
 xss-utils==0.1.3          # via -r requirements/base.in
 zeep==4.0.0               # via -r requirements/base.in
-zope.interface==5.1.2     # via cybersource-rest-client-python, datetime
+zope.interface==5.2.0     # via cybersource-rest-client-python, datetime
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -143,7 +143,7 @@ simplejson==3.17.2        # via django-rest-swagger, sailthru-client
 six==1.15.0               # via analytics-python, bcrypt, bleach, cryptography, cybersource-rest-client-python, django-compressor, django-extra-views, django-simple-history, djangorestframework-csv, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-ecommerce-worker, edx-opaque-keys, edx-rbac, fixtures, isodate, jsonschema, libsass, packaging, paypalrestsdk, purl, pyjwkest, pynacl, pyopenssl, python-dateutil, requests-file, social-auth-app-django, social-auth-core, testtools, unittest2
 slumber==0.7.1            # via edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.in, edx-auth-backends
-social-auth-core==3.2.0   # via -c requirements/pins.txt, edx-auth-backends, social-auth-app-django
+social-auth-core==3.3.3   # via -c requirements/pins.txt, edx-auth-backends, social-auth-app-django
 sorl-thumbnail==12.6.3    # via -r requirements/base.in
 sqlparse==0.4.1           # via django
 stevedore==3.2.2          # via edx-django-utils, edx-opaque-keys

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -194,7 +194,7 @@ slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 smmap==3.0.4              # via gitdb
 snowballstemmer==2.0.0    # via -r requirements/docs.txt, sphinx
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/test.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
+social-auth-core==3.3.3   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
 sorl-thumbnail==12.6.3    # via -r requirements/test.txt
 soupsieve==2.0.1          # via -r requirements/test.txt, beautifulsoup4
 sphinx==1.5.3             # via -r requirements/docs.txt, edx-sphinx-theme

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,8 +11,8 @@ appdirs==1.4.4            # via -r requirements/test.txt, zeep
 argparse==1.4.0           # via -r requirements/test.txt, unittest2
 asn1crypto==1.4.0         # via -r requirements/test.txt, cybersource-rest-client-python
 astroid==2.3.3            # via -r requirements/test.txt, pylint
-attrs==20.2.0             # via -r requirements/test.txt, jsonschema, pytest, zeep
-babel==2.8.0              # via -r requirements/docs.txt, -r requirements/test.txt, django-oscar, django-phonenumber-field, sphinx
+attrs==20.3.0             # via -r requirements/test.txt, jsonschema, pytest, zeep
+babel==2.9.0              # via -r requirements/docs.txt, -r requirements/test.txt, django-oscar, django-phonenumber-field, sphinx
 bcrypt==3.2.0             # via -r requirements/test.txt, cybersource-rest-client-python, paramiko
 beautifulsoup4==4.9.3     # via -r requirements/test.txt, webtest
 billiard==3.6.3.0         # via -r requirements/test.txt, celery
@@ -20,15 +20,15 @@ bleach==3.2.1             # via -r requirements/test.txt
 bok-choy==1.1.1           # via -r requirements/test.txt
 cached-property==1.5.2    # via -r requirements/test.txt, zeep
 celery==4.4.7             # via -r requirements/test.txt, edx-ecommerce-worker
-certifi==2020.6.20        # via -r requirements/docs.txt, -r requirements/test.txt, cybersource-rest-client-python, requests
-cffi==1.14.3              # via -r requirements/test.txt, bcrypt, cryptography, cybersource-rest-client-python, pynacl
-chardet==3.0.4            # via -r requirements/docs.txt, -r requirements/test.txt, cybersource-rest-client-python, requests
+certifi==2020.12.5        # via -r requirements/docs.txt, -r requirements/test.txt, cybersource-rest-client-python, requests
+cffi==1.14.4              # via -r requirements/test.txt, bcrypt, cryptography, cybersource-rest-client-python, pynacl
+chardet==4.0.0            # via -r requirements/docs.txt, -r requirements/test.txt, cybersource-rest-client-python, requests
 configparser==5.0.1       # via -r requirements/test.txt, cybersource-rest-client-python
 coreapi==2.3.3            # via -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi
-coverage==5.3             # via -r requirements/test.txt, cybersource-rest-client-python, pytest-cov
+coverage==5.3.1           # via -r requirements/test.txt, cybersource-rest-client-python, pytest-cov
 crypto==1.4.1             # via -r requirements/test.txt, cybersource-rest-client-python
-cryptography==3.2.1       # via -r requirements/test.txt, cybersource-rest-client-python, paramiko, pyjwt, pyopenssl
+cryptography==3.3.1       # via -r requirements/test.txt, cybersource-rest-client-python, paramiko, pyjwt, pyopenssl, social-auth-core
 cssselect==1.1.0          # via -r requirements/test.txt, premailer
 cssutils==1.0.2           # via -r requirements/test.txt, premailer
 cybersource-rest-client-python==0.0.21  # via -r requirements/test.txt
@@ -39,21 +39,21 @@ diff-cover==4.0.1         # via -r requirements/test.txt
 django-appconf==1.0.4     # via -r requirements/test.txt, django-compressor
 django-compressor==2.4    # via -r requirements/test.txt, django-libsass
 django-config-models==2.0.3  # via -r requirements/test.txt
-django-cors-headers==3.5.0  # via -r requirements/test.txt
+django-cors-headers==3.6.0  # via -r requirements/test.txt
 django-crispy-forms==1.8.1  # via -r requirements/test.txt
-django-crum==0.7.8        # via -r requirements/test.txt, edx-django-utils, edx-rbac
-django-debug-toolbar==3.1.1  # via -r requirements/dev.in
-django-extensions==3.0.9  # via -r requirements/test.txt
+django-crum==0.7.9        # via -r requirements/test.txt, edx-django-utils, edx-rbac
+django-debug-toolbar==3.2  # via -r requirements/dev.in
+django-extensions==3.1.0  # via -r requirements/test.txt
 django-extra-views==0.11.0  # via -r requirements/test.txt, django-oscar
 django-filter==2.4.0      # via -r requirements/test.txt
 django-haystack==2.8.1    # via -r requirements/test.txt, django-oscar
 django-libsass==0.8       # via -r requirements/test.txt
-django-model-utils==4.0.0  # via -r requirements/test.txt, edx-rbac
+django-model-utils==4.1.1  # via -r requirements/test.txt, edx-rbac
 django-oscar==2.0.4       # via -r requirements/test.txt
 django-phonenumber-field==2.0.1  # via -r requirements/test.txt, django-oscar
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-simple-history==2.12.0  # via -r requirements/test.txt
-django-solo==1.1.3        # via -r requirements/test.txt
+django-solo==1.1.5        # via -r requirements/test.txt
 django-tables2==1.21.2    # via -r requirements/test.txt, django-oscar
 django-threadlocals==0.10  # via -r requirements/test.txt
 django-treebeard==4.3.1   # via -r requirements/test.txt, django-oscar
@@ -63,14 +63,14 @@ django-widget-tweaks==1.4.8  # via -r requirements/test.txt, django-oscar
 django==2.2.17            # via -r requirements/test.txt, django-appconf, django-config-models, django-cors-headers, django-crum, django-debug-toolbar, django-extra-views, django-filter, django-haystack, django-model-utils, django-oscar, django-phonenumber-field, django-tables2, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-rbac, jsonfield2, mock-django, pytest-django-ordering, rest-condition, xss-utils
 djangorestframework-csv==2.1.0  # via -r requirements/test.txt
 djangorestframework-datatables==0.5.2  # via -r requirements/test.txt
-djangorestframework==3.12.1  # via -r requirements/test.txt, django-config-models, django-rest-swagger, djangorestframework-csv, djangorestframework-datatables, drf-extensions, drf-jwt, edx-drf-extensions, rest-condition
+djangorestframework==3.12.2  # via -r requirements/test.txt, django-config-models, django-rest-swagger, djangorestframework-csv, djangorestframework-datatables, drf-extensions, drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via -r requirements/docs.txt, sphinx
 drf-extensions==0.6.0     # via -r requirements/test.txt
-drf-jwt==1.17.2           # via -r requirements/test.txt, edx-drf-extensions
+drf-jwt==1.17.3           # via -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/test.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/test.txt
-edx-django-utils==3.11.0  # via -r requirements/test.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.13.0  # via -r requirements/test.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/test.txt, edx-rbac
 edx-ecommerce-worker==1.1.3  # via -r requirements/test.txt
 edx-i18n-tools==0.5.3     # via -r requirements/test.txt
@@ -81,18 +81,18 @@ edx-sphinx-theme==1.0.2   # via -r requirements/docs.txt
 enum34==1.1.10            # via -r requirements/test.txt, cybersource-rest-client-python
 extras==1.0.0             # via -r requirements/test.txt, cybersource-rest-client-python, python-subunit, testtools
 factory-boy==2.12.0       # via -r requirements/test.txt, django-oscar
-faker==4.14.1             # via -r requirements/test.txt, factory-boy
+faker==5.3.0              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox
 fixtures==3.0.0           # via -r requirements/test.txt, cybersource-rest-client-python, testtools
 freezegun==1.0.0          # via -r requirements/test.txt
 funcsigs==1.0.2           # via -r requirements/test.txt, cybersource-rest-client-python
 future==0.18.2            # via -r requirements/test.txt, pyjwkest
 gitdb==4.0.5              # via gitpython
-gitpython==3.1.11         # via transifex-client
+gitpython==3.1.12         # via transifex-client
 httpretty==0.9.7          # via -r requirements/test.txt
 idna==2.7                 # via -r requirements/docs.txt, -r requirements/test.txt, cybersource-rest-client-python, requests
 imagesize==1.2.0          # via -r requirements/docs.txt, sphinx
-inflect==4.1.0            # via -r requirements/test.txt, jinja2-pluralize
+inflect==5.0.2            # via -r requirements/test.txt, jinja2-pluralize
 ipaddress==1.0.23         # via -r requirements/test.txt, cybersource-rest-client-python
 isodate==0.6.0            # via -r requirements/test.txt, zeep
 isort==4.3.21             # via -r requirements/test.txt, pylint
@@ -107,47 +107,47 @@ lazy==1.4                 # via -r requirements/test.txt, bok-choy
 libsass==0.9.2            # via -r requirements/test.txt, django-libsass
 linecache2==1.0.0         # via -r requirements/test.txt, cybersource-rest-client-python, traceback2
 logger==1.4               # via -r requirements/test.txt, cybersource-rest-client-python
-lxml==4.6.1               # via -r requirements/test.txt, premailer, zeep
+lxml==4.6.2               # via -r requirements/test.txt, premailer, zeep
 markdown==2.6.9           # via -r requirements/test.txt
 markupsafe==1.1.1         # via -r requirements/docs.txt, -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock-django==0.6.10       # via -r requirements/test.txt
-mock==4.0.2               # via -r requirements/test.txt, mock-django
+mock==4.0.3               # via -r requirements/test.txt, mock-django
 more-itertools==8.6.0     # via -r requirements/test.txt, pytest
 mysqlclient==1.4.6        # via -r requirements/test.txt
 naked==0.1.31             # via -r requirements/test.txt, crypto, cybersource-rest-client-python
 ndg-httpsclient==0.5.1    # via -r requirements/test.txt
-newrelic==5.22.1.152      # via -r requirements/test.txt, edx-django-utils
+newrelic==5.24.0.153      # via -r requirements/test.txt, edx-django-utils
 nose==1.3.7               # via -r requirements/test.txt, cybersource-rest-client-python
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
-packaging==20.4           # via -r requirements/test.txt, bleach, pytest, tox
+packaging==20.8           # via -r requirements/test.txt, bleach, pytest, tox
 paramiko==2.7.2           # via -r requirements/test.txt, cybersource-rest-client-python
 path.py==7.2              # via -r requirements/test.txt, edx-i18n-tools
 paypalrestsdk==1.13.1     # via -r requirements/test.txt
 pbr==5.5.1                # via -r requirements/test.txt, cybersource-rest-client-python, fixtures, stevedore, testtools
-phonenumbers==8.12.12     # via -r requirements/test.txt, django-oscar, django-phonenumber-field
-pillow==8.0.1             # via -r requirements/test.txt, django-oscar
+phonenumbers==8.12.15     # via -r requirements/test.txt, django-oscar, django-phonenumber-field
+pillow==8.1.0             # via -r requirements/test.txt, django-oscar
 pluggy==0.13.1            # via -r requirements/test.txt, diff-cover, pytest, tox
 polib==1.1.0              # via -r requirements/test.txt, edx-i18n-tools
 premailer==2.9.2          # via -r requirements/test.txt
-psutil==5.7.3             # via -r requirements/test.txt, edx-django-utils
+psutil==5.8.0             # via -r requirements/test.txt, edx-django-utils
 ptvsd==4.3.2              # via -r requirements/dev.in
 purl==1.5                 # via -r requirements/test.txt, django-oscar
-py==1.9.0                 # via -r requirements/test.txt, pytest, tox
+py==1.10.0                # via -r requirements/test.txt, pytest, tox
 pyasn1==0.4.8             # via -r requirements/test.txt, cybersource-rest-client-python, ndg-httpsclient, rsa, x509
 pycodestyle==2.6.0        # via -r requirements/test.txt
 pycountry==17.1.8         # via -r requirements/test.txt
 pycparser==2.20           # via -r requirements/test.txt, cffi, cybersource-rest-client-python
 pycryptodome==3.9.9       # via -r requirements/test.txt, cybersource-rest-client-python
 pycryptodomex==3.9.9      # via -r requirements/test.txt, cybersource-rest-client-python, pyjwkest
-pygments==2.7.2           # via -r requirements/docs.txt, -r requirements/test.txt, diff-cover, sphinx
+pygments==2.7.3           # via -r requirements/docs.txt, -r requirements/test.txt, diff-cover, sphinx
 pyjwkest==1.4.2           # via -r requirements/test.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/test.txt, cybersource-rest-client-python, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint==2.4.4             # via -r requirements/test.txt
-pymongo==3.11.0           # via -r requirements/test.txt, edx-opaque-keys
+pymongo==3.11.2           # via -r requirements/test.txt, edx-opaque-keys
 pynacl==1.4.0             # via -r requirements/test.txt, cybersource-rest-client-python, paramiko
-pyopenssl==19.1.0         # via -r requirements/test.txt, cybersource-rest-client-python, ndg-httpsclient, paypalrestsdk
+pyopenssl==20.0.1         # via -r requirements/test.txt, cybersource-rest-client-python, ndg-httpsclient, paypalrestsdk
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pypi==2.1                 # via -r requirements/test.txt, cybersource-rest-client-python
 pyrsistent==0.17.3        # via -r requirements/test.txt, jsonschema
@@ -155,9 +155,9 @@ pytest-base-url==1.4.2    # via -r requirements/test.txt, pytest-selenium
 pytest-cov==2.10.1        # via -r requirements/test.txt
 pytest-django-ordering==1.2.0  # via -r requirements/test.txt
 pytest-django==3.10.0     # via -r requirements/test.txt, pytest-django-ordering
-pytest-html==2.1.1        # via -r requirements/test.txt, pytest-selenium
-pytest-metadata==1.10.0   # via -r requirements/test.txt, pytest-html
-pytest-randomly==3.4.1    # via -r requirements/test.txt
+pytest-html==3.1.1        # via -r requirements/test.txt, pytest-selenium
+pytest-metadata==1.11.0   # via -r requirements/test.txt, pytest-html
+pytest-randomly==3.5.0    # via -r requirements/test.txt
 pytest-selenium==2.0.1    # via -r requirements/test.txt
 pytest-timeout==1.4.2     # via -r requirements/test.txt
 pytest-variables==1.9.0   # via -r requirements/test.txt, pytest-selenium
@@ -178,8 +178,8 @@ redis==3.5.3              # via -r requirements/test.txt, edx-ecommerce-worker
 requests-file==1.5.1      # via -r requirements/test.txt, zeep
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
 requests-toolbelt==0.9.1  # via -r requirements/test.txt, zeep
-requests==2.24.0          # via -r requirements/docs.txt, -r requirements/test.txt, analytics-python, coreapi, cybersource-rest-client-python, edx-drf-extensions, edx-rest-api-client, naked, paypalrestsdk, pyjwkest, pytest-base-url, pytest-selenium, requests-file, requests-oauthlib, requests-toolbelt, responses, sailthru-client, slumber, social-auth-core, sphinx, stripe, transifex-client, zeep
-responses==0.12.0         # via -r requirements/test.txt
+requests==2.25.1          # via -r requirements/docs.txt, -r requirements/test.txt, analytics-python, coreapi, cybersource-rest-client-python, edx-drf-extensions, edx-rest-api-client, naked, paypalrestsdk, pyjwkest, pytest-base-url, pytest-selenium, requests-file, requests-oauthlib, requests-toolbelt, responses, sailthru-client, slumber, social-auth-core, sphinx, stripe, transifex-client, zeep
+responses==0.12.1         # via -r requirements/test.txt
 rest-condition==1.0.3     # via -r requirements/test.txt, edx-drf-extensions
 rjsmin==1.1.0             # via -r requirements/test.txt, django-compressor
 rsa==4.6                  # via -r requirements/test.txt, cybersource-rest-client-python
@@ -189,32 +189,32 @@ selenium==3.141.0         # via -r requirements/test.txt, bok-choy, pytest-selen
 semantic-version==2.8.5   # via -r requirements/test.txt, edx-drf-extensions
 shellescape==3.8.1        # via -r requirements/test.txt, crypto, cybersource-rest-client-python
 simplejson==3.17.2        # via -r requirements/test.txt, django-rest-swagger, sailthru-client
-six==1.15.0               # via -r requirements/docs.txt, -r requirements/test.txt, analytics-python, astroid, bcrypt, bleach, bok-choy, cryptography, cybersource-rest-client-python, django-compressor, django-extra-views, django-simple-history, djangorestframework-csv, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-ecommerce-worker, edx-i18n-tools, edx-opaque-keys, edx-rbac, edx-sphinx-theme, fixtures, httpretty, isodate, jsonschema, libsass, packaging, paypalrestsdk, purl, pyjwkest, pynacl, pyopenssl, python-dateutil, python-memcached, requests-file, responses, social-auth-app-django, social-auth-core, sphinx, tenacity, testtools, tox, transifex-client, unittest2, webtest
+six==1.15.0               # via -r requirements/docs.txt, -r requirements/test.txt, analytics-python, astroid, bcrypt, bleach, bok-choy, cryptography, cybersource-rest-client-python, django-compressor, django-extra-views, django-simple-history, djangorestframework-csv, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-ecommerce-worker, edx-i18n-tools, edx-opaque-keys, edx-rbac, edx-sphinx-theme, fixtures, httpretty, isodate, jsonschema, libsass, paypalrestsdk, purl, pyjwkest, pynacl, pyopenssl, python-dateutil, python-memcached, requests-file, responses, social-auth-app-django, social-auth-core, sphinx, tenacity, testtools, tox, transifex-client, unittest2, webtest
 slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 smmap==3.0.4              # via gitdb
 snowballstemmer==2.0.0    # via -r requirements/docs.txt, sphinx
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/test.txt, edx-auth-backends
+social-auth-app-django==4.0.0  # via -r requirements/test.txt, edx-auth-backends
 social-auth-core==3.3.3   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
-sorl-thumbnail==12.6.3    # via -r requirements/test.txt
-soupsieve==2.0.1          # via -r requirements/test.txt, beautifulsoup4
+sorl-thumbnail==12.7.0    # via -r requirements/test.txt
+soupsieve==2.1            # via -r requirements/test.txt, beautifulsoup4
 sphinx==1.5.3             # via -r requirements/docs.txt, edx-sphinx-theme
 sqlparse==0.4.1           # via -r requirements/test.txt, django, django-debug-toolbar
-stevedore==3.2.2          # via -r requirements/test.txt, edx-django-utils, edx-opaque-keys
+stevedore==3.3.0          # via -r requirements/test.txt, edx-django-utils, edx-opaque-keys
 stripe==1.70.0            # via -r requirements/test.txt
-tenacity==6.2.0           # via -r requirements/test.txt, pytest-selenium
-testfixtures==6.15.0      # via -r requirements/test.txt
+tenacity==6.3.1           # via -r requirements/test.txt, pytest-selenium
+testfixtures==6.17.0      # via -r requirements/test.txt
 testtools==2.4.0          # via -r requirements/test.txt, cybersource-rest-client-python, fixtures, python-subunit
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
 toml==0.10.2              # via -r requirements/test.txt, tox
 tox-battery==0.5.2        # via -r requirements/test.txt
 tox==3.14.6               # via -r requirements/test.txt, tox-battery
 traceback2==1.4.0         # via -r requirements/test.txt, cybersource-rest-client-python, testtools, unittest2
-transifex-client==0.14.1  # via -r requirements/dev.in
+transifex-client==0.14.2  # via -r requirements/dev.in
 typing==3.7.4.3           # via -r requirements/test.txt, cybersource-rest-client-python
 unicodecsv==0.14.1        # via -r requirements/test.txt, djangorestframework-csv
 unittest2==1.1.0          # via -r requirements/test.txt, testtools
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
-urllib3==1.25.11          # via -r requirements/docs.txt, -r requirements/test.txt, cybersource-rest-client-python, requests, responses, selenium, transifex-client
+urllib3==1.26.2           # via -r requirements/docs.txt, -r requirements/test.txt, cybersource-rest-client-python, requests, responses, selenium, transifex-client
 vine==1.3.0               # via -r requirements/test.txt, amqp, celery
 virtualenv==16.7.9        # via -r requirements/test.txt, tox
 waitress==1.4.4           # via -r requirements/test.txt, webtest
@@ -222,12 +222,12 @@ wcwidth==0.2.5            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via -r requirements/test.txt, bleach
 webob==1.8.6              # via -r requirements/test.txt, webtest
 webtest==2.0.35           # via -r requirements/test.txt, django-webtest
-wheel==0.35.1             # via -r requirements/test.txt, cybersource-rest-client-python
+wheel==0.36.2             # via -r requirements/test.txt, cybersource-rest-client-python
 wrapt==1.11.2             # via -r requirements/test.txt, astroid
 x509==0.1                 # via -r requirements/test.txt, cybersource-rest-client-python
 xss-utils==0.1.3          # via -r requirements/test.txt
 zeep==4.0.0               # via -r requirements/test.txt
-zope.interface==5.1.2     # via -r requirements/test.txt, cybersource-rest-client-python, datetime
+zope.interface==5.2.0     # via -r requirements/test.txt, cybersource-rest-client-python, datetime
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -5,19 +5,19 @@
 #    make upgrade
 #
 alabaster==0.7.12         # via sphinx
-babel==2.8.0              # via sphinx
-certifi==2020.6.20        # via requests
-chardet==3.0.4            # via requests
+babel==2.9.0              # via sphinx
+certifi==2020.12.5        # via requests
+chardet==4.0.0            # via requests
 docutils==0.16            # via sphinx
 edx-sphinx-theme==1.0.2   # via -r requirements/docs.in
 idna==2.7                 # via -c requirements/pins.txt, requests
 imagesize==1.2.0          # via sphinx
 jinja2==2.11.2            # via sphinx
 markupsafe==1.1.1         # via jinja2
-pygments==2.7.2           # via sphinx
+pygments==2.7.3           # via sphinx
 pytz==2016.10             # via -c requirements/pins.txt, babel
-requests==2.24.0          # via sphinx
+requests==2.25.1          # via sphinx
 six==1.15.0               # via edx-sphinx-theme, sphinx
 snowballstemmer==2.0.0    # via sphinx
 sphinx==1.5.3             # via -r requirements/docs.in, edx-sphinx-theme
-urllib3==1.25.11          # via -c requirements/pins.txt, requests
+urllib3==1.26.2           # via -c requirements/pins.txt, requests

--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -4,43 +4,43 @@
 #
 #    make upgrade
 #
-attrs==20.2.0             # via -c requirements/base.txt, pytest
-certifi==2020.6.20        # via -c requirements/base.txt, requests
-cffi==1.14.3              # via -c requirements/base.txt, cryptography
-chardet==3.0.4            # via -c requirements/base.txt, requests
-cryptography==3.2.1       # via -c requirements/base.txt, pyjwt
-django-crum==0.7.8        # via -c requirements/base.txt, edx-django-utils
+attrs==20.3.0             # via -c requirements/base.txt, pytest
+certifi==2020.12.5        # via -c requirements/base.txt, requests
+cffi==1.14.4              # via -c requirements/base.txt, cryptography
+chardet==4.0.0            # via -c requirements/base.txt, requests
+cryptography==3.3.1       # via -c requirements/base.txt, pyjwt
+django-crum==0.7.9        # via -c requirements/base.txt, edx-django-utils
 django-waffle==2.0.0      # via -c requirements/base.txt, edx-django-utils
 django==2.2.17            # via -c requirements/base.txt, django-crum, edx-django-utils
-edx-django-utils==3.11.0  # via -c requirements/base.txt, edx-rest-api-client
+edx-django-utils==3.13.0  # via -c requirements/base.txt, edx-rest-api-client
 edx-rest-api-client==5.2.1  # via -c requirements/base.txt, -r requirements/e2e.in
 idna==2.7                 # via -c requirements/base.txt, -c requirements/pins.txt, requests
 more-itertools==8.6.0     # via pytest
-newrelic==5.22.1.152      # via -c requirements/base.txt, edx-django-utils
-packaging==20.4           # via -c requirements/base.txt, pytest
+newrelic==5.24.0.153      # via -c requirements/base.txt, edx-django-utils
+packaging==20.8           # via -c requirements/base.txt, pytest
 pbr==5.5.1                # via -c requirements/base.txt, stevedore
 pluggy==0.13.1            # via pytest
-psutil==5.7.3             # via -c requirements/base.txt, edx-django-utils
-py==1.9.0                 # via pytest
+psutil==5.8.0             # via -c requirements/base.txt, edx-django-utils
+py==1.10.0                # via pytest
 pycparser==2.20           # via -c requirements/base.txt, cffi
 pyjwt[crypto]==1.7.1      # via -c requirements/base.txt, edx-rest-api-client
 pyparsing==2.4.7          # via -c requirements/base.txt, packaging
 pytest-base-url==1.4.2    # via pytest-selenium
-pytest-html==2.1.1        # via pytest-selenium
-pytest-metadata==1.10.0   # via pytest-html
-pytest-randomly==3.4.1    # via -r requirements/e2e.in
+pytest-html==3.1.1        # via pytest-selenium
+pytest-metadata==1.11.0   # via pytest-html
+pytest-randomly==3.5.0    # via -r requirements/e2e.in
 pytest-selenium==2.0.1    # via -r requirements/e2e.in
 pytest-timeout==1.4.2     # via -r requirements/e2e.in
 pytest-variables==1.9.0   # via pytest-selenium
 pytest==5.3.5             # via -c requirements/pins.txt, -r requirements/e2e.in, pytest-base-url, pytest-html, pytest-metadata, pytest-randomly, pytest-selenium, pytest-timeout, pytest-variables
 python-dotenv==0.15.0     # via -r requirements/e2e.in
 pytz==2016.10             # via -c requirements/base.txt, -c requirements/pins.txt, django
-requests==2.24.0          # via -c requirements/base.txt, edx-rest-api-client, pytest-base-url, pytest-selenium, slumber
+requests==2.25.1          # via -c requirements/base.txt, edx-rest-api-client, pytest-base-url, pytest-selenium, slumber
 selenium==3.141.0         # via -r requirements/e2e.in, pytest-selenium
-six==1.15.0               # via -c requirements/base.txt, cryptography, packaging, tenacity
+six==1.15.0               # via -c requirements/base.txt, cryptography, tenacity
 slumber==0.7.1            # via -c requirements/base.txt, edx-rest-api-client
 sqlparse==0.4.1           # via -c requirements/base.txt, django
-stevedore==3.2.2          # via -c requirements/base.txt, edx-django-utils
-tenacity==6.2.0           # via pytest-selenium
-urllib3==1.25.11          # via -c requirements/base.txt, -c requirements/pins.txt, requests, selenium
+stevedore==3.3.0          # via -c requirements/base.txt, edx-django-utils
+tenacity==6.3.1           # via pytest-selenium
+urllib3==1.26.2           # via -c requirements/base.txt, -c requirements/pins.txt, requests, selenium
 wcwidth==0.2.5            # via pytest

--- a/requirements/pins.txt
+++ b/requirements/pins.txt
@@ -8,6 +8,9 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
+# Tests failing in test_cybersouce.py on version 0.0.23
+cybersource-rest-client-python==0.0.21
+
 # Newer version introduces `No installed app with label 'communication'.`
 django-oscar<2.1
 

--- a/requirements/pins.txt
+++ b/requirements/pins.txt
@@ -39,11 +39,6 @@ pylint==2.4.4
 # need an update in configuration before this can be removed.
 pip-tools<5.0.0
 
-
-# The upgrade to 3.3.0 is what triggered users to lose superuser status; see ARCHBOM-1078 for details.
-social-auth-core==3.2.0
-
-
 # greater versions failing with extract-tranlsations step.
 tox==3.14.6
 tox-battery==0.5.2

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -151,7 +151,7 @@ simplejson==3.17.2        # via django-rest-swagger, sailthru-client
 six==1.15.0               # via analytics-python, bcrypt, bleach, cryptography, cybersource-rest-client-python, django-compressor, django-extra-views, django-simple-history, djangorestframework-csv, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-ecommerce-worker, edx-opaque-keys, edx-rbac, fixtures, isodate, jsonschema, libsass, packaging, paypalrestsdk, purl, pyjwkest, pynacl, pyopenssl, python-dateutil, python-memcached, requests-file, social-auth-app-django, social-auth-core, testtools, unittest2
 slumber==0.7.1            # via edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.in, edx-auth-backends
-social-auth-core==3.2.0   # via -c requirements/pins.txt, edx-auth-backends, social-auth-app-django
+social-auth-core==3.3.3   # via -c requirements/pins.txt, edx-auth-backends, social-auth-app-django
 sorl-thumbnail==12.6.3    # via -r requirements/base.in
 sqlparse==0.4.1           # via django
 stevedore==3.2.2          # via edx-django-utils, edx-opaque-keys

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -9,47 +9,47 @@ analytics-python==1.2.9   # via -r requirements/base.in
 appdirs==1.4.4            # via zeep
 argparse==1.4.0           # via unittest2
 asn1crypto==1.4.0         # via cybersource-rest-client-python
-attrs==20.2.0             # via jsonschema, zeep
-babel==2.8.0              # via django-oscar, django-phonenumber-field
+attrs==20.3.0             # via jsonschema, zeep
+babel==2.9.0              # via django-oscar, django-phonenumber-field
 bcrypt==3.2.0             # via cybersource-rest-client-python, paramiko
 billiard==3.6.3.0         # via celery
 bleach==3.2.1             # via -r requirements/base.in
-boto3==1.16.11            # via django-ses
-botocore==1.19.11         # via boto3, s3transfer
+boto3==1.16.50            # via django-ses
+botocore==1.19.50         # via boto3, s3transfer
 cached-property==1.5.2    # via zeep
 celery==4.4.7             # via -c requirements/pins.txt, edx-ecommerce-worker
-certifi==2020.6.20        # via cybersource-rest-client-python, requests
-cffi==1.14.3              # via bcrypt, cryptography, cybersource-rest-client-python, pynacl
-chardet==3.0.4            # via cybersource-rest-client-python, requests
+certifi==2020.12.5        # via cybersource-rest-client-python, requests
+cffi==1.14.4              # via bcrypt, cryptography, cybersource-rest-client-python, pynacl
+chardet==4.0.0            # via cybersource-rest-client-python, requests
 configparser==5.0.1       # via cybersource-rest-client-python
 coreapi==2.3.3            # via -r requirements/base.in, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
-coverage==5.3             # via cybersource-rest-client-python
+coverage==5.3.1           # via cybersource-rest-client-python
 crypto==1.4.1             # via cybersource-rest-client-python
-cryptography==3.2.1       # via cybersource-rest-client-python, paramiko, pyjwt, pyopenssl
+cryptography==3.3.1       # via cybersource-rest-client-python, paramiko, pyjwt, pyopenssl, social-auth-core
 cssselect==1.1.0          # via premailer
 cssutils==1.0.2           # via premailer
-cybersource-rest-client-python==0.0.21  # via -r requirements/base.in
+cybersource-rest-client-python==0.0.21  # via -c requirements/pins.txt, -r requirements/base.in
 datetime==4.3             # via cybersource-rest-client-python
 defusedxml==0.6.0         # via python3-openid, social-auth-core, zeep
 django-appconf==1.0.4     # via django-compressor
 django-compressor==2.4    # via -r requirements/base.in, django-libsass
 django-config-models==2.0.3  # via -r requirements/base.in
-django-cors-headers==3.5.0  # via -r requirements/base.in
+django-cors-headers==3.6.0  # via -r requirements/base.in
 django-crispy-forms==1.8.1  # via -r requirements/base.in
-django-crum==0.7.8        # via edx-django-utils, edx-rbac
-django-extensions==3.0.9  # via -r requirements/base.in
+django-crum==0.7.9        # via edx-django-utils, edx-rbac
+django-extensions==3.1.0  # via -r requirements/base.in
 django-extra-views==0.11.0  # via django-oscar
 django-filter==2.4.0      # via -r requirements/base.in
 django-haystack==2.8.1    # via django-oscar
 django-libsass==0.8       # via -r requirements/base.in
-django-model-utils==4.0.0  # via edx-rbac
+django-model-utils==4.1.1  # via edx-rbac
 django-oscar==2.0.4       # via -c requirements/pins.txt, -r requirements/base.in
 django-phonenumber-field==2.0.1  # via django-oscar
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-ses==1.0.3         # via -r requirements/production.in
 django-simple-history==2.12.0  # via -r requirements/base.in
-django-solo==1.1.3        # via -r requirements/base.in
+django-solo==1.1.5        # via -r requirements/base.in
 django-tables2==1.21.2    # via django-oscar
 django-threadlocals==0.10  # via -r requirements/base.in
 django-treebeard==4.3.1   # via django-oscar
@@ -58,13 +58,13 @@ django-widget-tweaks==1.4.8  # via django-oscar
 django==2.2.17            # via -r requirements/base.in, django-appconf, django-config-models, django-cors-headers, django-crum, django-extra-views, django-filter, django-haystack, django-model-utils, django-oscar, django-phonenumber-field, django-ses, django-tables2, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-rbac, jsonfield2, rest-condition, xss-utils
 djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework-datatables==0.5.2  # via -r requirements/base.in
-djangorestframework==3.12.1  # via -r requirements/base.in, django-config-models, django-rest-swagger, djangorestframework-csv, djangorestframework-datatables, drf-extensions, drf-jwt, edx-drf-extensions, rest-condition
+djangorestframework==3.12.2  # via -r requirements/base.in, django-config-models, django-rest-swagger, djangorestframework-csv, djangorestframework-datatables, drf-extensions, drf-jwt, edx-drf-extensions, rest-condition
 drf-extensions==0.6.0     # via -r requirements/base.in
-drf-jwt==1.17.2           # via edx-drf-extensions
+drf-jwt==1.17.3           # via edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
 edx-django-sites-extensions==2.5.1  # via -r requirements/base.in
-edx-django-utils==3.11.0  # via -r requirements/base.in, django-config-models, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.13.0  # via -r requirements/base.in, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/base.in, edx-rbac
 edx-ecommerce-worker==1.1.3  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-drf-extensions
@@ -73,7 +73,7 @@ edx-rest-api-client==5.2.1  # via -r requirements/base.in, edx-ecommerce-worker
 enum34==1.1.10            # via cybersource-rest-client-python
 extras==1.0.0             # via cybersource-rest-client-python, python-subunit, testtools
 factory-boy==2.12.0       # via django-oscar
-faker==4.14.1             # via factory-boy
+faker==5.3.0              # via factory-boy
 fixtures==3.0.0           # via cybersource-rest-client-python, testtools
 funcsigs==1.0.2           # via cybersource-rest-client-python
 future==0.18.2            # via django-ses, pyjwkest
@@ -90,7 +90,7 @@ kombu==4.6.11             # via celery
 libsass==0.9.2            # via -r requirements/base.in, django-libsass
 linecache2==1.0.0         # via cybersource-rest-client-python, traceback2
 logger==1.4               # via cybersource-rest-client-python
-lxml==4.6.1               # via premailer, zeep
+lxml==4.6.2               # via premailer, zeep
 markdown==2.6.9           # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
 mysqlclient==1.4.6        # via -r requirements/base.in
@@ -101,27 +101,27 @@ nodeenv==1.1.1            # via -r requirements/production.in
 nose==1.3.7               # via cybersource-rest-client-python
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
-packaging==20.4           # via bleach
+packaging==20.8           # via bleach
 paramiko==2.7.2           # via cybersource-rest-client-python
 path.py==7.2              # via -r requirements/base.in
 paypalrestsdk==1.13.1     # via -r requirements/base.in
 pbr==5.5.1                # via cybersource-rest-client-python, fixtures, stevedore, testtools
-phonenumbers==8.12.12     # via django-oscar, django-phonenumber-field
-pillow==8.0.1             # via django-oscar
+phonenumbers==8.12.15     # via django-oscar, django-phonenumber-field
+pillow==8.1.0             # via django-oscar
 premailer==2.9.2          # via -r requirements/base.in
-psutil==5.7.3             # via edx-django-utils
+psutil==5.8.0             # via edx-django-utils
 purl==1.5                 # via django-oscar
 pyasn1==0.4.8             # via cybersource-rest-client-python, ndg-httpsclient, rsa, x509
 pycountry==17.1.8         # via -r requirements/base.in
 pycparser==2.20           # via cffi, cybersource-rest-client-python
 pycryptodome==3.9.9       # via cybersource-rest-client-python
 pycryptodomex==3.9.9      # via cybersource-rest-client-python, pyjwkest
-pygments==2.7.2           # via -r requirements/base.in
+pygments==2.7.3           # via -r requirements/base.in
 pyjwkest==1.4.2           # via edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via cybersource-rest-client-python, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pymongo==3.11.0           # via edx-opaque-keys
+pymongo==3.11.2           # via edx-opaque-keys
 pynacl==1.4.0             # via cybersource-rest-client-python, paramiko
-pyopenssl==19.1.0         # via cybersource-rest-client-python, ndg-httpsclient, paypalrestsdk
+pyopenssl==20.0.1         # via cybersource-rest-client-python, ndg-httpsclient, paypalrestsdk
 pyparsing==2.4.7          # via packaging
 pypi==2.1                 # via cybersource-rest-client-python
 pyrsistent==0.17.3        # via jsonschema
@@ -138,7 +138,7 @@ redis==3.5.3              # via -r requirements/production.in, edx-ecommerce-wor
 requests-file==1.5.1      # via zeep
 requests-oauthlib==1.3.0  # via social-auth-core
 requests-toolbelt==0.9.1  # via zeep
-requests==2.24.0          # via -r requirements/base.in, analytics-python, coreapi, cybersource-rest-client-python, edx-drf-extensions, edx-rest-api-client, naked, paypalrestsdk, pyjwkest, requests-file, requests-oauthlib, requests-toolbelt, sailthru-client, slumber, social-auth-core, stripe, zeep
+requests==2.25.1          # via -r requirements/base.in, analytics-python, coreapi, cybersource-rest-client-python, edx-drf-extensions, edx-rest-api-client, naked, paypalrestsdk, pyjwkest, requests-file, requests-oauthlib, requests-toolbelt, sailthru-client, slumber, social-auth-core, stripe, zeep
 rest-condition==1.0.3     # via edx-drf-extensions
 rjsmin==1.1.0             # via django-compressor
 rsa==4.6                  # via cybersource-rest-client-python
@@ -148,13 +148,13 @@ sailthru-client==2.2.3    # via -r requirements/base.in, edx-ecommerce-worker
 semantic-version==2.8.5   # via edx-drf-extensions
 shellescape==3.8.1        # via crypto, cybersource-rest-client-python
 simplejson==3.17.2        # via django-rest-swagger, sailthru-client
-six==1.15.0               # via analytics-python, bcrypt, bleach, cryptography, cybersource-rest-client-python, django-compressor, django-extra-views, django-simple-history, djangorestframework-csv, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-ecommerce-worker, edx-opaque-keys, edx-rbac, fixtures, isodate, jsonschema, libsass, packaging, paypalrestsdk, purl, pyjwkest, pynacl, pyopenssl, python-dateutil, python-memcached, requests-file, social-auth-app-django, social-auth-core, testtools, unittest2
+six==1.15.0               # via analytics-python, bcrypt, bleach, cryptography, cybersource-rest-client-python, django-compressor, django-extra-views, django-simple-history, djangorestframework-csv, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-ecommerce-worker, edx-opaque-keys, edx-rbac, fixtures, isodate, jsonschema, libsass, paypalrestsdk, purl, pyjwkest, pynacl, pyopenssl, python-dateutil, python-memcached, requests-file, social-auth-app-django, social-auth-core, testtools, unittest2
 slumber==0.7.1            # via edx-rest-api-client
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.in, edx-auth-backends
-social-auth-core==3.3.3   # via -c requirements/pins.txt, edx-auth-backends, social-auth-app-django
-sorl-thumbnail==12.6.3    # via -r requirements/base.in
+social-auth-app-django==4.0.0  # via -r requirements/base.in, edx-auth-backends
+social-auth-core==3.3.3   # via edx-auth-backends, social-auth-app-django
+sorl-thumbnail==12.7.0    # via -r requirements/base.in
 sqlparse==0.4.1           # via django
-stevedore==3.2.2          # via edx-django-utils, edx-opaque-keys
+stevedore==3.3.0          # via edx-django-utils, edx-opaque-keys
 stripe==1.70.0            # via -r requirements/base.in
 testtools==2.4.0          # via cybersource-rest-client-python, fixtures, python-subunit
 text-unidecode==1.3       # via faker
@@ -163,14 +163,14 @@ typing==3.7.4.3           # via cybersource-rest-client-python
 unicodecsv==0.14.1        # via -r requirements/base.in, djangorestframework-csv
 unittest2==1.1.0          # via testtools
 uritemplate==3.0.1        # via coreapi
-urllib3==1.25.11          # via -c requirements/pins.txt, botocore, cybersource-rest-client-python, requests
+urllib3==1.26.2           # via -c requirements/pins.txt, botocore, cybersource-rest-client-python, requests
 vine==1.3.0               # via amqp, celery
 webencodings==0.5.1       # via bleach
-wheel==0.35.1             # via cybersource-rest-client-python
+wheel==0.36.2             # via cybersource-rest-client-python
 x509==0.1                 # via cybersource-rest-client-python
 xss-utils==0.1.3          # via -r requirements/base.in
 zeep==4.0.0               # via -r requirements/base.in
-zope.interface==5.1.2     # via cybersource-rest-client-python, datetime
+zope.interface==5.2.0     # via cybersource-rest-client-python, datetime
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,8 +10,8 @@ appdirs==1.4.4            # via -r requirements/base.txt, zeep
 argparse==1.4.0           # via -r requirements/base.txt, unittest2
 asn1crypto==1.4.0         # via -r requirements/base.txt, cybersource-rest-client-python
 astroid==2.3.3            # via pylint
-attrs==20.2.0             # via -r requirements/base.txt, -r requirements/e2e.txt, jsonschema, pytest, zeep
-babel==2.8.0              # via -r requirements/base.txt, django-oscar, django-phonenumber-field
+attrs==20.3.0             # via -r requirements/base.txt, -r requirements/e2e.txt, jsonschema, pytest, zeep
+babel==2.9.0              # via -r requirements/base.txt, django-oscar, django-phonenumber-field
 bcrypt==3.2.0             # via -r requirements/base.txt, cybersource-rest-client-python, paramiko
 beautifulsoup4==4.9.3     # via webtest
 billiard==3.6.3.0         # via -r requirements/base.txt, celery
@@ -19,18 +19,18 @@ bleach==3.2.1             # via -r requirements/base.txt
 bok-choy==1.1.1           # via -r requirements/test.in
 cached-property==1.5.2    # via -r requirements/base.txt, zeep
 celery==4.4.7             # via -c requirements/pins.txt, -r requirements/base.txt, edx-ecommerce-worker
-certifi==2020.6.20        # via -r requirements/base.txt, -r requirements/e2e.txt, cybersource-rest-client-python, requests
-cffi==1.14.3              # via -r requirements/base.txt, -r requirements/e2e.txt, bcrypt, cryptography, cybersource-rest-client-python, pynacl
-chardet==3.0.4            # via -r requirements/base.txt, -r requirements/e2e.txt, cybersource-rest-client-python, requests
+certifi==2020.12.5        # via -r requirements/base.txt, -r requirements/e2e.txt, cybersource-rest-client-python, requests
+cffi==1.14.4              # via -r requirements/base.txt, -r requirements/e2e.txt, bcrypt, cryptography, cybersource-rest-client-python, pynacl
+chardet==4.0.0            # via -r requirements/base.txt, -r requirements/e2e.txt, cybersource-rest-client-python, requests
 configparser==5.0.1       # via -r requirements/base.txt, cybersource-rest-client-python
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-coverage==5.3             # via -r requirements/base.txt, -r requirements/test.in, cybersource-rest-client-python, pytest-cov
+coverage==5.3.1           # via -r requirements/base.txt, -r requirements/test.in, cybersource-rest-client-python, pytest-cov
 crypto==1.4.1             # via -r requirements/base.txt, cybersource-rest-client-python
-cryptography==3.2.1       # via -r requirements/base.txt, -r requirements/e2e.txt, cybersource-rest-client-python, paramiko, pyjwt, pyopenssl
+cryptography==3.3.1       # via -r requirements/base.txt, -r requirements/e2e.txt, cybersource-rest-client-python, paramiko, pyjwt, pyopenssl, social-auth-core
 cssselect==1.1.0          # via -r requirements/base.txt, premailer
 cssutils==1.0.2           # via -r requirements/base.txt, premailer
-cybersource-rest-client-python==0.0.21  # via -r requirements/base.txt
+cybersource-rest-client-python==0.0.21  # via -c requirements/pins.txt, -r requirements/base.txt
 datetime==4.3             # via -r requirements/base.txt, cybersource-rest-client-python
 ddt==1.4.1                # via -r requirements/test.in
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core, zeep
@@ -38,20 +38,20 @@ diff-cover==4.0.1         # via -r requirements/test.in
 django-appconf==1.0.4     # via -r requirements/base.txt, django-compressor
 django-compressor==2.4    # via -r requirements/base.txt, django-libsass
 django-config-models==2.0.3  # via -r requirements/base.txt
-django-cors-headers==3.5.0  # via -r requirements/base.txt
+django-cors-headers==3.6.0  # via -r requirements/base.txt
 django-crispy-forms==1.8.1  # via -r requirements/base.txt
-django-crum==0.7.8        # via -r requirements/base.txt, -r requirements/e2e.txt, edx-django-utils, edx-rbac
-django-extensions==3.0.9  # via -r requirements/base.txt
+django-crum==0.7.9        # via -r requirements/base.txt, -r requirements/e2e.txt, edx-django-utils, edx-rbac
+django-extensions==3.1.0  # via -r requirements/base.txt
 django-extra-views==0.11.0  # via -r requirements/base.txt, django-oscar
 django-filter==2.4.0      # via -r requirements/base.txt
 django-haystack==2.8.1    # via -r requirements/base.txt, django-oscar
 django-libsass==0.8       # via -r requirements/base.txt
-django-model-utils==4.0.0  # via -r requirements/base.txt, edx-rbac
+django-model-utils==4.1.1  # via -r requirements/base.txt, edx-rbac
 django-oscar==2.0.4       # via -c requirements/pins.txt, -r requirements/base.txt
 django-phonenumber-field==2.0.1  # via -r requirements/base.txt, django-oscar
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-simple-history==2.12.0  # via -r requirements/base.txt
-django-solo==1.1.3        # via -r requirements/base.txt
+django-solo==1.1.5        # via -r requirements/base.txt
 django-tables2==1.21.2    # via -r requirements/base.txt, django-oscar
 django-threadlocals==0.10  # via -r requirements/base.txt
 django-treebeard==4.3.1   # via -r requirements/base.txt, django-oscar
@@ -60,13 +60,13 @@ django-webtest==1.9.7     # via -r requirements/test.in
 django-widget-tweaks==1.4.8  # via -r requirements/base.txt, django-oscar
 djangorestframework-csv==2.1.0  # via -r requirements/base.txt
 djangorestframework-datatables==0.5.2  # via -r requirements/base.txt
-djangorestframework==3.12.1  # via -r requirements/base.txt, django-config-models, django-rest-swagger, djangorestframework-csv, djangorestframework-datatables, drf-extensions, drf-jwt, edx-drf-extensions, rest-condition
+djangorestframework==3.12.2  # via -r requirements/base.txt, django-config-models, django-rest-swagger, djangorestframework-csv, djangorestframework-datatables, drf-extensions, drf-jwt, edx-drf-extensions, rest-condition
 drf-extensions==0.6.0     # via -r requirements/base.txt
-drf-jwt==1.17.2           # via -r requirements/base.txt, edx-drf-extensions
+drf-jwt==1.17.3           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/base.txt
-edx-django-utils==3.11.0  # via -r requirements/base.txt, -r requirements/e2e.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.13.0  # via -r requirements/base.txt, -r requirements/e2e.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/base.txt, edx-rbac
 edx-ecommerce-worker==1.1.3  # via -r requirements/base.txt
 edx-i18n-tools==0.5.3     # via -r requirements/test.in
@@ -76,7 +76,7 @@ edx-rest-api-client==5.2.1  # via -r requirements/base.txt, -r requirements/e2e.
 enum34==1.1.10            # via -r requirements/base.txt, cybersource-rest-client-python
 extras==1.0.0             # via -r requirements/base.txt, cybersource-rest-client-python, python-subunit, testtools
 factory-boy==2.12.0       # via -r requirements/base.txt, -r requirements/test.in, django-oscar
-faker==4.14.1             # via -r requirements/base.txt, factory-boy
+faker==5.3.0              # via -r requirements/base.txt, factory-boy
 filelock==3.0.12          # via -r requirements/tox.txt, tox
 fixtures==3.0.0           # via -r requirements/base.txt, cybersource-rest-client-python, testtools
 freezegun==1.0.0          # via -r requirements/test.in
@@ -84,7 +84,7 @@ funcsigs==1.0.2           # via -r requirements/base.txt, cybersource-rest-clien
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
 httpretty==0.9.7          # via -c requirements/pins.txt, -r requirements/test.in
 idna==2.7                 # via -c requirements/pins.txt, -r requirements/base.txt, -r requirements/e2e.txt, cybersource-rest-client-python, requests
-inflect==4.1.0            # via jinja2-pluralize
+inflect==5.0.2            # via jinja2-pluralize
 ipaddress==1.0.23         # via -r requirements/base.txt, cybersource-rest-client-python
 isodate==0.6.0            # via -r requirements/base.txt, zeep
 isort==4.3.21             # via -r requirements/test.in, pylint
@@ -99,46 +99,46 @@ lazy==1.4                 # via bok-choy
 libsass==0.9.2            # via -r requirements/base.txt, django-libsass
 linecache2==1.0.0         # via -r requirements/base.txt, cybersource-rest-client-python, traceback2
 logger==1.4               # via -r requirements/base.txt, cybersource-rest-client-python
-lxml==4.6.1               # via -r requirements/base.txt, -r requirements/test.in, premailer, zeep
+lxml==4.6.2               # via -r requirements/base.txt, -r requirements/test.in, premailer, zeep
 markdown==2.6.9           # via -r requirements/base.txt
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
 mock-django==0.6.10       # via -r requirements/test.in
-mock==4.0.2               # via -r requirements/test.in, mock-django
+mock==4.0.3               # via -r requirements/test.in, mock-django
 more-itertools==8.6.0     # via -r requirements/e2e.txt, pytest
 mysqlclient==1.4.6        # via -r requirements/base.txt
 naked==0.1.31             # via -r requirements/base.txt, crypto, cybersource-rest-client-python
 ndg-httpsclient==0.5.1    # via -r requirements/base.txt
-newrelic==5.22.1.152      # via -r requirements/base.txt, -r requirements/e2e.txt, edx-django-utils
+newrelic==5.24.0.153      # via -r requirements/base.txt, -r requirements/e2e.txt, edx-django-utils
 nose==1.3.7               # via -r requirements/base.txt, cybersource-rest-client-python
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
-packaging==20.4           # via -r requirements/base.txt, -r requirements/e2e.txt, -r requirements/tox.txt, bleach, pytest, tox
+packaging==20.8           # via -r requirements/base.txt, -r requirements/e2e.txt, -r requirements/tox.txt, bleach, pytest, tox
 paramiko==2.7.2           # via -r requirements/base.txt, cybersource-rest-client-python
 path.py==7.2              # via -r requirements/base.txt, edx-i18n-tools
 paypalrestsdk==1.13.1     # via -r requirements/base.txt
 pbr==5.5.1                # via -r requirements/base.txt, -r requirements/e2e.txt, cybersource-rest-client-python, fixtures, stevedore, testtools
-phonenumbers==8.12.12     # via -r requirements/base.txt, django-oscar, django-phonenumber-field
-pillow==8.0.1             # via -r requirements/base.txt, django-oscar
+phonenumbers==8.12.15     # via -r requirements/base.txt, django-oscar, django-phonenumber-field
+pillow==8.1.0             # via -r requirements/base.txt, django-oscar
 pluggy==0.13.1            # via -r requirements/e2e.txt, -r requirements/tox.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
 premailer==2.9.2          # via -r requirements/base.txt
-psutil==5.7.3             # via -r requirements/base.txt, -r requirements/e2e.txt, edx-django-utils
+psutil==5.8.0             # via -r requirements/base.txt, -r requirements/e2e.txt, edx-django-utils
 purl==1.5                 # via -r requirements/base.txt, django-oscar
-py==1.9.0                 # via -r requirements/e2e.txt, -r requirements/tox.txt, pytest, tox
+py==1.10.0                # via -r requirements/e2e.txt, -r requirements/tox.txt, pytest, tox
 pyasn1==0.4.8             # via -r requirements/base.txt, cybersource-rest-client-python, ndg-httpsclient, rsa, x509
 pycodestyle==2.6.0        # via -r requirements/test.in
 pycountry==17.1.8         # via -r requirements/base.txt
 pycparser==2.20           # via -r requirements/base.txt, -r requirements/e2e.txt, cffi, cybersource-rest-client-python
 pycryptodome==3.9.9       # via -r requirements/base.txt, cybersource-rest-client-python
 pycryptodomex==3.9.9      # via -r requirements/base.txt, cybersource-rest-client-python, pyjwkest
-pygments==2.7.2           # via -r requirements/base.txt, diff-cover
+pygments==2.7.3           # via -r requirements/base.txt, diff-cover
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, -r requirements/e2e.txt, cybersource-rest-client-python, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint==2.4.4             # via -c requirements/pins.txt, -r requirements/test.in
-pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys
+pymongo==3.11.2           # via -r requirements/base.txt, edx-opaque-keys
 pynacl==1.4.0             # via -r requirements/base.txt, cybersource-rest-client-python, paramiko
-pyopenssl==19.1.0         # via -r requirements/base.txt, cybersource-rest-client-python, ndg-httpsclient, paypalrestsdk
+pyopenssl==20.0.1         # via -r requirements/base.txt, cybersource-rest-client-python, ndg-httpsclient, paypalrestsdk
 pyparsing==2.4.7          # via -r requirements/base.txt, -r requirements/e2e.txt, -r requirements/tox.txt, packaging
 pypi==2.1                 # via -r requirements/base.txt, cybersource-rest-client-python
 pyrsistent==0.17.3        # via -r requirements/base.txt, jsonschema
@@ -146,9 +146,9 @@ pytest-base-url==1.4.2    # via -r requirements/e2e.txt, pytest-selenium
 pytest-cov==2.10.1        # via -r requirements/test.in
 pytest-django-ordering==1.2.0  # via -r requirements/test.in
 pytest-django==3.10.0     # via -c requirements/pins.txt, -r requirements/test.in, pytest-django-ordering
-pytest-html==2.1.1        # via -r requirements/e2e.txt, pytest-selenium
-pytest-metadata==1.10.0   # via -r requirements/e2e.txt, pytest-html
-pytest-randomly==3.4.1    # via -r requirements/e2e.txt
+pytest-html==3.1.1        # via -r requirements/e2e.txt, pytest-selenium
+pytest-metadata==1.11.0   # via -r requirements/e2e.txt, pytest-html
+pytest-randomly==3.5.0    # via -r requirements/e2e.txt
 pytest-selenium==2.0.1    # via -r requirements/e2e.txt
 pytest-timeout==1.4.2     # via -r requirements/e2e.txt
 pytest-variables==1.9.0   # via -r requirements/e2e.txt, pytest-selenium
@@ -167,8 +167,8 @@ redis==3.5.3              # via -r requirements/base.txt, edx-ecommerce-worker
 requests-file==1.5.1      # via -r requirements/base.txt, zeep
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests-toolbelt==0.9.1  # via -r requirements/base.txt, zeep
-requests==2.24.0          # via -r requirements/base.txt, -r requirements/e2e.txt, analytics-python, coreapi, cybersource-rest-client-python, edx-drf-extensions, edx-rest-api-client, naked, paypalrestsdk, pyjwkest, pytest-base-url, pytest-selenium, requests-file, requests-oauthlib, requests-toolbelt, responses, sailthru-client, slumber, social-auth-core, stripe, zeep
-responses==0.12.0         # via -r requirements/test.in
+requests==2.25.1          # via -r requirements/base.txt, -r requirements/e2e.txt, analytics-python, coreapi, cybersource-rest-client-python, edx-drf-extensions, edx-rest-api-client, naked, paypalrestsdk, pyjwkest, pytest-base-url, pytest-selenium, requests-file, requests-oauthlib, requests-toolbelt, responses, sailthru-client, slumber, social-auth-core, stripe, zeep
+responses==0.12.1         # via -r requirements/test.in
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 rjsmin==1.1.0             # via -r requirements/base.txt, django-compressor
 rsa==4.6                  # via -r requirements/base.txt, cybersource-rest-client-python
@@ -178,17 +178,17 @@ selenium==3.141.0         # via -r requirements/e2e.txt, -r requirements/test.in
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
 shellescape==3.8.1        # via -r requirements/base.txt, crypto, cybersource-rest-client-python
 simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger, sailthru-client
-six==1.15.0               # via -r requirements/base.txt, -r requirements/e2e.txt, -r requirements/tox.txt, analytics-python, astroid, bcrypt, bleach, bok-choy, cryptography, cybersource-rest-client-python, django-compressor, django-extra-views, django-simple-history, djangorestframework-csv, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-ecommerce-worker, edx-i18n-tools, edx-opaque-keys, edx-rbac, fixtures, httpretty, isodate, jsonschema, libsass, packaging, paypalrestsdk, purl, pyjwkest, pynacl, pyopenssl, python-dateutil, python-memcached, requests-file, responses, social-auth-app-django, social-auth-core, tenacity, testtools, tox, unittest2, webtest
+six==1.15.0               # via -r requirements/base.txt, -r requirements/e2e.txt, -r requirements/tox.txt, analytics-python, astroid, bcrypt, bleach, bok-choy, cryptography, cybersource-rest-client-python, django-compressor, django-extra-views, django-simple-history, djangorestframework-csv, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-ecommerce-worker, edx-i18n-tools, edx-opaque-keys, edx-rbac, fixtures, httpretty, isodate, jsonschema, libsass, paypalrestsdk, purl, pyjwkest, pynacl, pyopenssl, python-dateutil, python-memcached, requests-file, responses, social-auth-app-django, social-auth-core, tenacity, testtools, tox, unittest2, webtest
 slumber==0.7.1            # via -r requirements/base.txt, -r requirements/e2e.txt, edx-rest-api-client
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.3.3   # via -c requirements/pins.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
-sorl-thumbnail==12.6.3    # via -r requirements/base.txt
-soupsieve==2.0.1          # via beautifulsoup4
+social-auth-app-django==4.0.0  # via -r requirements/base.txt, edx-auth-backends
+social-auth-core==3.3.3   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+sorl-thumbnail==12.7.0    # via -r requirements/base.txt
+soupsieve==2.1            # via beautifulsoup4
 sqlparse==0.4.1           # via -r requirements/base.txt, -r requirements/e2e.txt, django
-stevedore==3.2.2          # via -r requirements/base.txt, -r requirements/e2e.txt, edx-django-utils, edx-opaque-keys
+stevedore==3.3.0          # via -r requirements/base.txt, -r requirements/e2e.txt, edx-django-utils, edx-opaque-keys
 stripe==1.70.0            # via -r requirements/base.txt
-tenacity==6.2.0           # via -r requirements/e2e.txt, pytest-selenium
-testfixtures==6.15.0      # via -r requirements/test.in
+tenacity==6.3.1           # via -r requirements/e2e.txt, pytest-selenium
+testfixtures==6.17.0      # via -r requirements/test.in
 testtools==2.4.0          # via -r requirements/base.txt, cybersource-rest-client-python, fixtures, python-subunit
 text-unidecode==1.3       # via -r requirements/base.txt, faker
 toml==0.10.2              # via -r requirements/tox.txt, tox
@@ -199,7 +199,7 @@ typing==3.7.4.3           # via -r requirements/base.txt, cybersource-rest-clien
 unicodecsv==0.14.1        # via -r requirements/base.txt, djangorestframework-csv
 unittest2==1.1.0          # via -r requirements/base.txt, testtools
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
-urllib3==1.25.11          # via -c requirements/pins.txt, -r requirements/base.txt, -r requirements/e2e.txt, cybersource-rest-client-python, requests, responses, selenium
+urllib3==1.26.2           # via -c requirements/pins.txt, -r requirements/base.txt, -r requirements/e2e.txt, cybersource-rest-client-python, requests, responses, selenium
 vine==1.3.0               # via -r requirements/base.txt, amqp, celery
 virtualenv==16.7.9        # via -c requirements/pins.txt, -r requirements/tox.txt, tox
 waitress==1.4.4           # via webtest
@@ -207,12 +207,12 @@ wcwidth==0.2.5            # via -r requirements/e2e.txt, pytest
 webencodings==0.5.1       # via -r requirements/base.txt, bleach
 webob==1.8.6              # via webtest
 webtest==2.0.35           # via django-webtest
-wheel==0.35.1             # via -r requirements/base.txt, cybersource-rest-client-python
+wheel==0.36.2             # via -r requirements/base.txt, cybersource-rest-client-python
 wrapt==1.11.2             # via astroid
 x509==0.1                 # via -r requirements/base.txt, cybersource-rest-client-python
 xss-utils==0.1.3          # via -r requirements/base.txt
 zeep==4.0.0               # via -r requirements/base.txt
-zope.interface==5.1.2     # via -r requirements/base.txt, cybersource-rest-client-python, datetime
+zope.interface==5.2.0     # via -r requirements/base.txt, cybersource-rest-client-python, datetime
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -181,7 +181,7 @@ simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger, s
 six==1.15.0               # via -r requirements/base.txt, -r requirements/e2e.txt, -r requirements/tox.txt, analytics-python, astroid, bcrypt, bleach, bok-choy, cryptography, cybersource-rest-client-python, django-compressor, django-extra-views, django-simple-history, djangorestframework-csv, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-ecommerce-worker, edx-i18n-tools, edx-opaque-keys, edx-rbac, fixtures, httpretty, isodate, jsonschema, libsass, packaging, paypalrestsdk, purl, pyjwkest, pynacl, pyopenssl, python-dateutil, python-memcached, requests-file, responses, social-auth-app-django, social-auth-core, tenacity, testtools, tox, unittest2, webtest
 slumber==0.7.1            # via -r requirements/base.txt, -r requirements/e2e.txt, edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -c requirements/pins.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+social-auth-core==3.3.3   # via -c requirements/pins.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sorl-thumbnail==12.6.3    # via -r requirements/base.txt
 soupsieve==2.0.1          # via beautifulsoup4
 sqlparse==0.4.1           # via -r requirements/base.txt, -r requirements/e2e.txt, django

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -5,11 +5,11 @@
 #    make upgrade
 #
 filelock==3.0.12          # via tox
-packaging==20.4           # via tox
+packaging==20.8           # via tox
 pluggy==0.13.1            # via tox
-py==1.9.0                 # via tox
+py==1.10.0                # via tox
 pyparsing==2.4.7          # via packaging
-six==1.15.0               # via packaging, tox
+six==1.15.0               # via tox
 toml==0.10.2              # via tox
 tox-battery==0.5.2        # via -c requirements/pins.txt, -r requirements/tox.in
 tox==3.14.6               # via -c requirements/pins.txt, -r requirements/tox.in, tox-battery


### PR DESCRIPTION
The bug mentioned on [ARCHBOM-1078](https://openedx.atlassian.net/browse/ARCHBOM-1078) is fixed in `social-auth-core==3.3.3`, See [this comment](https://openedx.atlassian.net/browse/BOM-2094?focusedCommentId=514498) for details, now we are unpinning it wherever it was previously pinned due to that bug.
Relevant JIRA : https://openedx.atlassian.net/browse/BOM-2181