### PR TITLE
ENT3709 Added enterprise customer sender alias which can be used in assign/remind/revoke emails

### DIFF
--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -85,7 +85,8 @@ def get_enterprise_customer(site, uuid):
         'enable_data_sharing_consent': response['enable_data_sharing_consent'],
         'enforce_data_sharing_consent': response['enforce_data_sharing_consent'],
         'contact_email': response.get('contact_email', ''),
-        'slug': response.get('slug')
+        'slug': response.get('slug'),
+        'sender_alias': response.get('sender_alias', ''),
     }
 
     TieredCache.set_all_tiers(


### PR DESCRIPTION
Added enterprise customer sender alias which can be used in assign/remind/revoke emails
This can be tested at the following URL. There should be a field named {sender_alias} in the response.
http://localhost:18000/enterprise/api/v1/enterprise-customer/{enterprise_customer_uuid}/
https://courses.stage.edx.org/enterprise/api/v1/enterprise-customer/beafadc5-69cc-48ce-a9a1-532067d9af0f/