### PR TITLE
ENT3710 Add sender alias to use as from name in sailthru email templates

### DIFF
--- a/ecommerce/enterprise/constants.py
+++ b/ecommerce/enterprise/constants.py
@@ -9,3 +9,7 @@ USE_ROLE_BASED_ACCESS_CONTROL = 'use_role_based_access_control'
 
 # Waffle flag used to switch over ecommerce's usage of the enterprise catalog service
 USE_ENTERPRISE_CATALOG = 'use_enterprise_catalog'
+
+# Default Sender Alias used in Enterprise Customer Code Assign,Remind and Revoke Emails.
+
+SENDER_ALIAS = 'edX Support Team'

--- a/ecommerce/enterprise/tests/test_utils.py
+++ b/ecommerce/enterprise/tests/test_utils.py
@@ -22,6 +22,7 @@ from ecommerce.enterprise.utils import (
     get_enterprise_customer,
     get_enterprise_customer_catalogs,
     get_enterprise_customer_from_enterprise_offer,
+    get_enterprise_customer_sender_alias,
     get_enterprise_customer_uuid,
     get_enterprise_customers,
     get_enterprise_id_for_current_request_user_from_jwt,
@@ -370,3 +371,17 @@ class EnterpriseUtilsTests(EnterpriseServiceMockMixin, TestCase):
         Applicator().apply_offers(basket, [offer])
 
         self.assertIsNone(get_enterprise_customer_from_enterprise_offer(basket))
+
+    @patch('ecommerce.enterprise.utils.get_enterprise_customer')
+    @ddt.data(
+        ('edx', 'edx'),
+        ('', 'edX Support Team'),
+    )
+    @ddt.unpack
+    def test_get_enterprise_customer_sender_alias(self, sender_alias, expected_sender_alias, enterprise_customer):
+        """
+        Verify get_enterprise_customer_sender_alias returns enterprise sender alias if exists otherwise return default.
+        """
+        enterprise_customer.return_value = {'sender_alias': sender_alias}
+        sender_alias = get_enterprise_customer_sender_alias('some-site', 'uuid')
+        assert sender_alias == expected_sender_alias

--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -24,6 +24,7 @@ from slumber.exceptions import SlumberHttpBaseException
 
 from ecommerce.core.constants import SYSTEM_ENTERPRISE_LEARNER_ROLE
 from ecommerce.core.url_utils import absolute_url, get_lms_dashboard_url
+from ecommerce.enterprise.constants import SENDER_ALIAS
 from ecommerce.enterprise.exceptions import EnterpriseDoesNotExist
 from ecommerce.extensions.offer.models import OFFER_PRIORITY_ENTERPRISE
 
@@ -613,3 +614,31 @@ def convert_comma_separated_string_to_list(comma_separated_string):
     Convert the comma separated string to a valid list.
     """
     return list(set(item.strip() for item in comma_separated_string.split(",") if item.strip()))
+
+
+def get_enterprise_customer_sender_alias(site, enterprise_customer_uuid):
+    """
+    Return enterprise customer sender alias if the enterprise customer has sender alias otherwise send default alias.
+
+    Arguments:
+        site (Site): The site object.
+        enterprise_customer_uuid (Enterprise_customer): The enterprise_customer uuid.
+
+    Returns:
+        sender_alias: name if the enterprise_customer has a sender_alias, default otherwise.
+    """
+    sender_alias = ''
+    try:
+        enterprise_customer = get_enterprise_customer(site, enterprise_customer_uuid)
+        sender_alias = enterprise_customer['sender_alias']
+    except Exception as exc:  # pylint: disable=broad-except
+        logging.exception(
+            '[Enterprise Sender Alias Fetch Failure]. Customer: %s, Site: %s, Exception: %s',
+            enterprise_customer_uuid,
+            site,
+            exc
+        )
+
+    if not sender_alias:
+        sender_alias = SENDER_ALIAS
+    return sender_alias

--- a/ecommerce/extensions/api/tests/test_serializers.py
+++ b/ecommerce/extensions/api/tests/test_serializers.py
@@ -26,6 +26,7 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
     GREETING = 'Hello '
     CLOSING = ' Bye'
     BASE_ENTERPRISE_URL = 'https://bears.party'
+    SENDER_ALIAS = 'edx Support Team'
 
     def setUp(self):
         super(CouponCodeSerializerTests, self).setUp()
@@ -57,7 +58,8 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
             greeting=self.GREETING,
             closing=self.CLOSING,
             assigned_offer=self.offer_assignment,
-            voucher_usage_type=Voucher.MULTI_USE_PER_CUSTOMER
+            voucher_usage_type=Voucher.MULTI_USE_PER_CUSTOMER,
+            sender_alias=self.SENDER_ALIAS,
         )
         expected_expiration_date = self.coupon.attr.coupon_vouchers.vouchers.first().end_datetime
 
@@ -71,6 +73,7 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
         assert assign_email_args['code'] == self.offer_assignment.code
         assert assign_email_args['code_expiration_date'] == expected_expiration_date.strftime('%d %B, %Y %H:%M %Z')
         assert assign_email_args['base_enterprise_url'] == ''
+        assert assign_email_args['sender_alias'] == self.SENDER_ALIAS
 
     @mock.patch('ecommerce.extensions.api.serializers.send_assigned_offer_email')
     def test_send_assigned_offer_email_args_with_enterprise_url(self, mock_assign_email):
@@ -82,6 +85,7 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
             closing=self.CLOSING,
             assigned_offer=self.offer_assignment,
             voucher_usage_type=Voucher.MULTI_USE_PER_CUSTOMER,
+            sender_alias=self.SENDER_ALIAS,
             base_enterprise_url=self.BASE_ENTERPRISE_URL,
         )
         expected_expiration_date = self.coupon.attr.coupon_vouchers.vouchers.first().end_datetime
@@ -96,6 +100,7 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
         assert assign_email_args['code'] == self.offer_assignment.code
         assert assign_email_args['code_expiration_date'] == expected_expiration_date.strftime('%d %B, %Y %H:%M %Z')
         assert assign_email_args['base_enterprise_url'] == self.BASE_ENTERPRISE_URL
+        assert assign_email_args['sender_alias'] == self.SENDER_ALIAS
 
     @mock.patch('ecommerce.extensions.api.serializers.send_assigned_offer_reminder_email')
     def test_send_assigned_offer_reminder_email_args(self, mock_remind_email):
@@ -108,6 +113,7 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
             assigned_offer=self.offer_assignment,
             redeemed_offer_count=3,
             total_offer_count=5,
+            sender_alias=self.SENDER_ALIAS,
         )
         expected_expiration_date = self.coupon.attr.coupon_vouchers.vouchers.first().end_datetime
         mock_remind_email.assert_called_with(
@@ -118,7 +124,8 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
             code=self.offer_assignment.code,
             redeemed_offer_count=mock.ANY,
             total_offer_count=mock.ANY,
-            code_expiration_date=expected_expiration_date.strftime('%d %B, %Y %H:%M %Z')
+            code_expiration_date=expected_expiration_date.strftime('%d %B, %Y %H:%M %Z'),
+            sender_alias=self.SENDER_ALIAS
         )
 
     @mock.patch('ecommerce.extensions.api.serializers.send_assigned_offer_email')
@@ -147,7 +154,8 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
                 greeting=self.GREETING,
                 closing=self.CLOSING,
                 assigned_offer=self.offer_assignment,
-                voucher_usage_type=Voucher.MULTI_USE_PER_CUSTOMER
+                voucher_usage_type=Voucher.MULTI_USE_PER_CUSTOMER,
+                sender_alias=self.SENDER_ALIAS
             )
             log.check_present(*expected)
 
@@ -180,6 +188,7 @@ class CouponCodeSerializerTests(CouponMixin, TestCase):
                     assigned_offer=self.offer_assignment,
                     redeemed_offer_count=3,
                     total_offer_count=5,
+                    sender_alias=self.SENDER_ALIAS
                 )
         log.check_present(*expected)
 

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -705,6 +705,7 @@ class EnterpriseCouponViewSet(CouponViewSet):
                 'closing': closing,
                 'template_id': template_id,
                 'sender_id': sender_id,
+                'site': request.site
             }
         )
         if serializer.is_valid():
@@ -798,6 +799,7 @@ class EnterpriseCouponViewSet(CouponViewSet):
                 'closing': closing,
                 'template_id': template_id,
                 'sender_id': sender_id,
+                'site': request.site
             }
         )
         if serializer.is_valid():
@@ -861,6 +863,7 @@ class EnterpriseCouponViewSet(CouponViewSet):
                 'closing': closing,
                 'template_id': template_id,
                 'sender_id': sender_id,
+                'site': request.site,
             }
         )
         if serializer.is_valid():

--- a/ecommerce/extensions/offer/tests/test_utils.py
+++ b/ecommerce/extensions/offer/tests/test_utils.py
@@ -103,6 +103,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
                 'code_expiration_date': '2018-12-19'
             },
             None,
+            'sender alias',
             ''
         ),
         (
@@ -117,6 +118,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
                 'code_expiration_date': '2018-12-19'
             },
             None,
+            'sender alias',
             'https://bears.party'
         ),
     )
@@ -128,6 +130,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             closing,
             tokens,
             side_effect,
+            sender_alias,
             base_enterprise_url,
             mock_sailthru_task,
     ):
@@ -142,6 +145,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             tokens.get('code'),
             tokens.get('redemptions_remaining'),
             tokens.get('code_expiration_date'),
+            sender_alias,
             base_enterprise_url,
         )
         mock_sailthru_task.delay.assert_called_once_with(
@@ -149,6 +153,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             tokens.get('offer_assignment_id'),
             subject,
             mock.ANY,
+            sender_alias,
             None,
             base_enterprise_url,
         )
@@ -164,6 +169,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             'BearsOnly',
             1,
             '2020-12-19',
+            'sender alias'
         )
 
         mock_sailthru_task.delay.assert_called_once_with(
@@ -171,6 +177,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             42,
             "You have mail",
             mock.ANY,
+            'sender alias',
             None,
             '',
         )
@@ -181,6 +188,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             'subject',
             'hi',
             'bye',
+            'sender_alias',
             {
                 'learner_email': 'johndoe@unknown.com',
                 'code': 'GIL7RUEOU7VHBH7Q',
@@ -197,6 +205,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             subject,
             greeting,
             closing,
+            sender_alias,
             tokens,
             side_effect,
             mock_sailthru_task,
@@ -214,11 +223,13 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             tokens.get('redeemed_offer_count'),
             tokens.get('total_offer_count'),
             tokens.get('code_expiration_date'),
+            sender_alias,
         )
         mock_sailthru_task.delay.assert_called_once_with(
             tokens.get('learner_email'),
             subject,
-            mock.ANY
+            mock.ANY,
+            sender_alias
         )
 
     @mock.patch('ecommerce.extensions.offer.utils.send_offer_update_email')
@@ -227,6 +238,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             'subject',
             'hi',
             'bye',
+            'sender_alias',
             {
                 'learner_email': 'johndoe@unknown.com',
                 'code': 'GIL7RUEOU7VHBH7Q',
@@ -240,6 +252,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             subject,
             greeting,
             closing,
+            sender_alias,
             tokens,
             side_effect,
             mock_sailthru_task,
@@ -254,11 +267,13 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             closing,
             tokens.get('learner_email'),
             tokens.get('code'),
+            sender_alias,
         )
         mock_sailthru_task.delay.assert_called_once_with(
             tokens.get('learner_email'),
             subject,
-            mock.ANY
+            mock.ANY,
+            sender_alias
         )
 
     @ddt.data(

--- a/ecommerce/extensions/offer/utils.py
+++ b/ecommerce/extensions/offer/utils.py
@@ -160,6 +160,7 @@ def send_assigned_offer_email(
         code,
         redemptions_remaining,
         code_expiration_date,
+        sender_alias,
         base_enterprise_url=''):
     """
     Arguments:
@@ -194,7 +195,7 @@ def send_assigned_offer_email(
         logger.warning("Skipping Sailthru task 'send_offer_assignment_email' because DEBUG=true.")  # pragma: no cover
         return  # pragma: no cover
 
-    send_offer_assignment_email.delay(learner_email, offer_assignment_id, subject, email_body, None,
+    send_offer_assignment_email.delay(learner_email, offer_assignment_id, subject, email_body, sender_alias, None,
                                       base_enterprise_url)
 
 
@@ -203,7 +204,8 @@ def send_revoked_offer_email(
         greeting,
         closing,
         learner_email,
-        code
+        code,
+        sender_alias
 ):
     """
     Arguments:
@@ -224,7 +226,7 @@ def send_revoked_offer_email(
         CODE=code,
     )
     email_body = format_email(email_template, placeholder_dict, greeting, closing)
-    send_offer_update_email.delay(learner_email, subject, email_body)
+    send_offer_update_email.delay(learner_email, subject, email_body, sender_alias)
 
 
 def send_assigned_offer_reminder_email(
@@ -235,7 +237,8 @@ def send_assigned_offer_reminder_email(
         code,
         redeemed_offer_count,
         total_offer_count,
-        code_expiration_date):
+        code_expiration_date,
+        sender_alias):
     """
     Arguments:
         *subject*
@@ -254,6 +257,8 @@ def send_assigned_offer_reminder_email(
            Total number of offer assignments for this (code,email) pair
        *code_expiration_date*
            Date till code is valid.
+       *sender_alias*
+           Enterprise customer sender alias.
     """
     email_template = settings.OFFER_REMINDER_EMAIL_TEMPLATE
     placeholder_dict = SafeDict(
@@ -264,7 +269,7 @@ def send_assigned_offer_reminder_email(
         EXPIRATION_DATE=code_expiration_date
     )
     email_body = format_email(email_template, placeholder_dict, greeting, closing)
-    send_offer_update_email.delay(learner_email, subject, email_body)
+    send_offer_update_email.delay(learner_email, subject, email_body, sender_alias)
 
 
 def format_email(template, placeholder_dict, greeting, closing):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -63,7 +63,7 @@ edx-django-release-util==0.4.4  # via -r requirements/base.in
 edx-django-sites-extensions==2.5.1  # via -r requirements/base.in
 edx-django-utils==3.13.0  # via -r requirements/base.in, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/base.in, edx-rbac
-edx-ecommerce-worker==1.1.3  # via -r requirements/base.in
+edx-ecommerce-worker==1.1.5  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.3.3           # via -r requirements/base.in
 edx-rest-api-client==5.2.1  # via -r requirements/base.in, edx-ecommerce-worker

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -72,7 +72,7 @@ edx-django-release-util==0.4.4  # via -r requirements/test.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/test.txt
 edx-django-utils==3.13.0  # via -r requirements/test.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/test.txt, edx-rbac
-edx-ecommerce-worker==1.1.3  # via -r requirements/test.txt
+edx-ecommerce-worker==1.1.5  # via -r requirements/test.txt
 edx-i18n-tools==0.5.3     # via -r requirements/test.txt
 edx-opaque-keys==2.1.1    # via -r requirements/test.txt, edx-drf-extensions
 edx-rbac==1.3.3           # via -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -66,7 +66,7 @@ edx-django-release-util==0.4.4  # via -r requirements/base.in
 edx-django-sites-extensions==2.5.1  # via -r requirements/base.in
 edx-django-utils==3.13.0  # via -r requirements/base.in, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/base.in, edx-rbac
-edx-ecommerce-worker==1.1.3  # via -r requirements/base.in
+edx-ecommerce-worker==1.1.5  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.3.3           # via -r requirements/base.in
 edx-rest-api-client==5.2.1  # via -r requirements/base.in, edx-ecommerce-worker

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -68,7 +68,7 @@ edx-django-release-util==0.4.4  # via -r requirements/base.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/base.txt
 edx-django-utils==3.13.0  # via -r requirements/base.txt, -r requirements/e2e.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/base.txt, edx-rbac
-edx-ecommerce-worker==1.1.3  # via -r requirements/base.txt
+edx-ecommerce-worker==1.1.5  # via -r requirements/base.txt
 edx-i18n-tools==0.5.3     # via -r requirements/test.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.3.3           # via -r requirements/base.txt


### PR DESCRIPTION
[ENT3710](https://openedx.atlassian.net/browse/ENT-3710): Add sender alias to use as from name in Sailthru email templates

Here is another PR linked with it.
https://github.com/edx/ecommerce-worker/pull/113