### PR TITLE
ENT-3967 Fix for devstack hanging

### DIFF
--- a/ecommerce/extensions/offer/utils.py
+++ b/ecommerce/extensions/offer/utils.py
@@ -191,7 +191,7 @@ def send_assigned_offer_email(
 
     if settings.DEBUG:  # pragma: no cover
         # Avoid breaking devstack when no such service is available.
-        logger.warning("Skipping Sailthru task for 'send_offer_assignment_email' because DEBUG=true.")  # pragma: no cover
+        logger.warning("Skipping Sailthru task 'send_offer_assignment_email' because DEBUG=true.")  # pragma: no cover
         return  # pragma: no cover
 
     send_offer_assignment_email.delay(learner_email, offer_assignment_id, subject, email_body, None,

--- a/ecommerce/extensions/offer/utils.py
+++ b/ecommerce/extensions/offer/utils.py
@@ -191,7 +191,7 @@ def send_assigned_offer_email(
 
     if settings.DEBUG:
         # Avoid breaking devstack when no such service is available.
-        logger.warning("settings.DEBUG is TRUE. Returning since in devstack no celery task is available for 'send_offer_assignment_email'. Skipping Sailthru email task.")
+        logger.warning("Skipping Sailthru task for 'send_offer_assignment_email' because DEBUG=true.")
         return
 
     send_offer_assignment_email.delay(learner_email, offer_assignment_id, subject, email_body, None,

--- a/ecommerce/extensions/offer/utils.py
+++ b/ecommerce/extensions/offer/utils.py
@@ -188,6 +188,12 @@ def send_assigned_offer_email(
         redemptions_remaining,
         code_expiration_date
     )
+
+    if settings.DEBUG:
+        # Avoid breaking devstack when no such service is available.
+        logger.warning("settings.DEBUG is TRUE. Returning since in devstack no celery task is available for 'send_offer_assignment_email'. Skipping Sailthru email task.")
+        return
+
     send_offer_assignment_email.delay(learner_email, offer_assignment_id, subject, email_body, None,
                                       base_enterprise_url)
 

--- a/ecommerce/extensions/offer/utils.py
+++ b/ecommerce/extensions/offer/utils.py
@@ -189,10 +189,10 @@ def send_assigned_offer_email(
         code_expiration_date
     )
 
-    if settings.DEBUG:
+    if settings.DEBUG:  # pragma: no cover
         # Avoid breaking devstack when no such service is available.
-        logger.warning("Skipping Sailthru task for 'send_offer_assignment_email' because DEBUG=true.")
-        return
+        logger.warning("Skipping Sailthru task for 'send_offer_assignment_email' because DEBUG=true.")  # pragma: no cover
+        return  # pragma: no cover
 
     send_offer_assignment_email.delay(learner_email, offer_assignment_id, subject, email_body, None,
                                       base_enterprise_url)


### PR DESCRIPTION
Fix allows devstack to test assigning codes in admin portal with bulk enrollment. Previous fix to this issue was  was having the developer comment out the line directly after the newly inserted check, which required institutional knowledge and has now cost 3 different developers a full dev day at different times. 