### PR TITLE
[REV-2043] handle missing expiration date in user validation

### DIFF
--- a/ecommerce/core/exceptions.py
+++ b/ecommerce/core/exceptions.py
@@ -8,3 +8,7 @@ class SiteConfigurationError(Exception):
 
 class MissingLmsUserIdException(Exception):
     """Exception indicating the user is missing an LMS user id. """
+
+
+class UserVerificationExpirationIssueException(Exception):
+    """Exception indicating the user's verification has no expiration date. """

--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -25,7 +25,7 @@ from simple_history.models import HistoricalRecords
 from slumber.exceptions import HttpNotFoundError, SlumberBaseException
 
 from ecommerce.core.constants import ALL_ACCESS_CONTEXT, ALLOW_MISSING_LMS_USER_ID
-from ecommerce.core.exceptions import MissingLmsUserIdException
+from ecommerce.core.exceptions import MissingLmsUserIdException, UserVerificationExpirationIssueException
 from ecommerce.core.utils import log_message_and_raise_validation_error
 from ecommerce.extensions.payment.exceptions import ProcessorNotFoundError
 from ecommerce.extensions.payment.helpers import get_processor_class, get_processor_class_by_name
@@ -747,7 +747,7 @@ class User(AbstractUser):
                 expiration_datetime = response.get('expiration_datetime')
                 try:
                     cache_timeout = int((parse(expiration_datetime) - now()).total_seconds())
-                except Exception:   # pylint: disable=broad-except
+                except UserVerificationExpirationIssueException:
                     # There's a parser error exception happening, and we want to get info
                     log.exception(
                         'Checking verification failed when getting the cache timeout. Username: [%s] Expiration: [%s]',

--- a/ecommerce/core/tests/test_models.py
+++ b/ecommerce/core/tests/test_models.py
@@ -15,6 +15,7 @@ from requests.exceptions import ConnectionError as ReqConnectionError
 from social_django.models import UserSocialAuth
 from testfixtures import LogCapture
 
+# from ecommerce.core.exceptions import UserVerificationExpirationIssueException
 from ecommerce.core.models import (
     BusinessClient,
     EcommerceFeatureRole,
@@ -237,6 +238,12 @@ class UserTests(DiscoveryTestMixin, LmsApiMockMixin, TestCase):
 
         httpretty.disable()
         self.assertFalse(user.is_verified(self.site))
+
+    # def test_user_verification_expiration_date_issue(self):
+    #     """ Raise UserVerificationExpirationIssueException when no verification expiration date. """
+    #     user = self.create_user()
+    #     self.mock_verification_status_api(self.site, user, status=status_code, is_verified=is_verified)
+    #     self.assertEqual(user.is_verified(self.site), is_verified)
 
     def test_deactivation(self):
         """Verify the deactivation endpoint is called for the user."""

--- a/ecommerce/core/tests/test_models.py
+++ b/ecommerce/core/tests/test_models.py
@@ -15,7 +15,7 @@ from requests.exceptions import ConnectionError as ReqConnectionError
 from social_django.models import UserSocialAuth
 from testfixtures import LogCapture
 
-# from ecommerce.core.exceptions import UserVerificationExpirationIssueException
+from ecommerce.core.exceptions import UserVerificationExpirationIssueException
 from ecommerce.core.models import (
     BusinessClient,
     EcommerceFeatureRole,
@@ -239,11 +239,11 @@ class UserTests(DiscoveryTestMixin, LmsApiMockMixin, TestCase):
         httpretty.disable()
         self.assertFalse(user.is_verified(self.site))
 
-    # def test_user_verification_expiration_date_issue(self):
-    #     """ Raise UserVerificationExpirationIssueException when no verification expiration date. """
-    #     user = self.create_user()
-    #     self.mock_verification_status_api(self.site, user, status=status_code, is_verified=is_verified)
-    #     self.assertEqual(user.is_verified(self.site), is_verified)
+    def test_user_verification_expiration_date_issue(self):
+        """ Raise UserVerificationExpirationIssueException when no verification expiration date. """
+        with self.assertRaises(UserVerificationExpirationIssueException):
+            user = self.create_user()
+            self.mock_verification_status_api_no_expiration(self.site, user)
 
     def test_deactivation(self):
         """Verify the deactivation endpoint is called for the user."""

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -27,6 +27,7 @@ from threadlocals.threadlocals import set_thread_variable
 from waffle.models import Flag
 
 from ecommerce.core.constants import ALL_ACCESS_CONTEXT, SYSTEM_ENTERPRISE_ADMIN_ROLE, SYSTEM_ENTERPRISE_OPERATOR_ROLE
+from ecommerce.core.exceptions import UserVerificationExpirationIssueException
 from ecommerce.core.url_utils import get_lms_url
 from ecommerce.courses.models import Course
 from ecommerce.courses.utils import mode_for_product
@@ -458,6 +459,10 @@ class LmsApiMockMixin:
             body=json.dumps(verification_data),
             content_type=CONTENT_TYPE
         )
+
+    def mock_verification_status_api_no_expiration(self, site, user, status=200, is_verified=True):
+        """ Mock verification API endpoint. Raise exception if can't parse verification expiration date. """
+        raise UserVerificationExpirationIssueException
 
     def mock_deactivation_api(self, request, username, response):
         """ Mock deactivation API endpoint. """


### PR DESCRIPTION
Link to ticket: https://openedx.atlassian.net/browse/REV-2043

Support has reported an intermittent issue where a user gets a server error when clicking from their order history to receipt page. The error is raised when trying to parse the verification's expiration date (and it appears that it's missing for the user). 

This fix is to make the receipt page handle this case more gracefully. I've made these updates: 
- add custom exception (rather than previous 'Exception') in exceptions.py, and update models.py to raise that instead of Exception
- views.py: add a try/except/else around the problematic line, and only add the items to context if we actually got them back
- mixins.py: this file already has mock_verification_status_api, used by the other verification tests, so I've added mock_verification_status_api_no_expiration to return the exception for this problem case
- test_models.py: added test to call it