### PR TITLE
suppress exception for missing expiration

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -754,7 +754,6 @@ class User(AbstractUser):
                         str(self.username),
                         str(expiration_datetime),
                     )
-                    raise
 
                 TieredCache.set_all_tiers(cache_key, verification, cache_timeout)
             return verification


### PR DESCRIPTION
Link to ticket: https://openedx.atlassian.net/browse/REV-2043

Support has reported an intermittent issue where a user gets a server error when clicking from their order history to receipt page. The error is raised when trying to parse the verification's expiration date (and it appears that it's missing for the user).

The approach in this PR is to remove the line that bubbles the exception up