### PR TITLE
[REV-2043] only parse verification expiration when it exists

### DIFF
--- a/ecommerce/core/tests/test_models.py
+++ b/ecommerce/core/tests/test_models.py
@@ -204,17 +204,20 @@ class UserTests(DiscoveryTestMixin, LmsApiMockMixin, TestCase):
         self.assertFalse(user.is_eligible_for_credit(course_key, site_config))
 
     @ddt.data(
-        (200, True, True),
-        (200, True, False),
-        (200, False, False),
-        (404, False, False)
+        (200, True),
+        (200, True, None),
+        (200, False),
+        (404, False)
     )
     @ddt.unpack
-    def test_user_verification_status(self, status_code, is_verified, has_expiration):
+    def test_user_verification_status(self, status_code, is_verified,
+                                      expiration=LmsApiMockMixin.get_default_expiration):
         """ Verify the method returns correct response. """
+        if callable(expiration):
+            expiration = expiration()
         user = self.create_user()
         self.mock_verification_status_api(self.site, user, status=status_code, is_verified=is_verified,
-                                          has_expiration=has_expiration)
+                                          expiration=expiration)
         self.assertEqual(user.is_verified(self.site), is_verified)
 
     def test_user_verification_connection_error(self):

--- a/ecommerce/core/tests/test_models.py
+++ b/ecommerce/core/tests/test_models.py
@@ -204,15 +204,17 @@ class UserTests(DiscoveryTestMixin, LmsApiMockMixin, TestCase):
         self.assertFalse(user.is_eligible_for_credit(course_key, site_config))
 
     @ddt.data(
-        (200, True),
-        (200, False),
-        (404, False)
+        (200, True, True),
+        (200, True, False),
+        (200, False, False),
+        (404, False, False)
     )
     @ddt.unpack
-    def test_user_verification_status(self, status_code, is_verified):
+    def test_user_verification_status(self, status_code, is_verified, has_expiration):
         """ Verify the method returns correct response. """
         user = self.create_user()
-        self.mock_verification_status_api(self.site, user, status=status_code, is_verified=is_verified)
+        self.mock_verification_status_api(self.site, user, status=status_code, is_verified=is_verified,
+                                          has_expiration=has_expiration)
         self.assertEqual(user.is_verified(self.site), is_verified)
 
     def test_user_verification_connection_error(self):

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -441,17 +441,19 @@ class LmsApiMockMixin:
         )
         httpretty.register_uri(httpretty.GET, url, body=json.dumps(eligibility_data), content_type=CONTENT_TYPE)
 
-    def mock_verification_status_api(self, site, user, status=200, is_verified=True, has_expiration=True):
+    @staticmethod
+    def get_default_expiration():
+        return (now() + datetime.timedelta(days=1)).isoformat()
+
+    def mock_verification_status_api(self, site, user, status=200, is_verified=True,
+                                     expiration=get_default_expiration.__func__):
         """ Mock verification API endpoint. Returns verification status data. """
 
-        if has_expiration:
-            expiration_value = (now() + datetime.timedelta(days=1)).isoformat()
-        else:
-            expiration_value = None
-
+        if callable(expiration):
+            expiration = expiration()
         verification_data = {
             'status': 'approved',
-            'expiration_datetime': expiration_value,
+            'expiration_datetime': expiration,
             'is_verified': is_verified
         }
         url = '{host}/accounts/{username}/verification_status/'.format(

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -441,11 +441,17 @@ class LmsApiMockMixin:
         )
         httpretty.register_uri(httpretty.GET, url, body=json.dumps(eligibility_data), content_type=CONTENT_TYPE)
 
-    def mock_verification_status_api(self, site, user, status=200, is_verified=True):
+    def mock_verification_status_api(self, site, user, status=200, is_verified=True, has_expiration=True):
         """ Mock verification API endpoint. Returns verification status data. """
+
+        if has_expiration:
+            expiration_value = (now() + datetime.timedelta(days=1)).isoformat()
+        else:
+            expiration_value = None
+
         verification_data = {
             'status': 'approved',
-            'expiration_datetime': (now() + datetime.timedelta(days=1)).isoformat(),
+            'expiration_datetime': expiration_value,
             'is_verified': is_verified
         }
         url = '{host}/accounts/{username}/verification_status/'.format(


### PR DESCRIPTION
Link to ticket: https://openedx.atlassian.net/browse/REV-2043

Support has reported an issue where verified users who are missing their verification expiration date get a server error when clicking from their order history to the receipt page. The error is raised when the code tries to parse that (missing) date. 

In this context, the verification expiration date is used to set how long we should cache the fact that the user is verified (so on subsequent page loads we only call the LMS endpoint if it's not already cached). 

Therefore we want to fix the code to only parse the verification expiration when it exists. Secondly, now that we've identified this possible use case (verified user who has no verification expiration date), we'll add a unit test so that the code can't be inadvertently broken later if someone's unaware of this case. 

Changes for this issue: 
1) Update the code to only try parsing the verification expiration date if it exists (models.py)
2) update the relevant test code to use expiration date value: 
- pass an argument for the expiration in both test_user_verification_status (test_models.py) and mock_verification_status_api (mixins.py)
- if no expiration value is passed, use new callable function (get_default_expiration) to set a default (defined in mixins.py)
- add this new case (validated user has expiration 'None') into ddt.data (test_models.py)


