### PR TITLE
[REV-1341] Clean up SDNFallback fuzzy matching code

### DIFF
--- a/ecommerce/extensions/payment/core/sdn.py
+++ b/ecommerce/extensions/payment/core/sdn.py
@@ -12,10 +12,11 @@ import pycountry
 import requests
 from django.conf import settings
 from django.contrib.auth import logout
-from ecommerce.extensions.payment.exceptions import SDNFallbackDataEmptyError
-from ecommerce.extensions.payment.models import SDNCheckFailure, SDNFallbackData, SDNFallbackMetadata
 from oscar.core.loading import get_model
 from requests.exceptions import HTTPError, Timeout
+
+from ecommerce.extensions.payment.exceptions import SDNFallbackDataEmptyError
+from ecommerce.extensions.payment.models import SDNCheckFailure, SDNFallbackData, SDNFallbackMetadata
 
 logger = logging.getLogger(__name__)
 Basket = get_model('basket', 'Basket')

--- a/ecommerce/extensions/payment/core/sdn.py
+++ b/ecommerce/extensions/payment/core/sdn.py
@@ -1,5 +1,3 @@
-# Changes part of REV-1209 - see https://github.com/edx/ecommerce/pull/3020
-import copy
 import csv
 import hashlib
 import io
@@ -10,19 +8,14 @@ import unicodedata
 from datetime import datetime, timezone
 from urllib.parse import urlencode
 
-# Changes part of REV-1209 - see https://github.com/edx/ecommerce/pull/3020
-import crum
 import pycountry
 import requests
-# Changes part of REV-1209 - see https://github.com/edx/ecommerce/pull/3020
-import waffle
 from django.conf import settings
 from django.contrib.auth import logout
-from oscar.core.loading import get_model
-from requests.exceptions import HTTPError, Timeout
-
 from ecommerce.extensions.payment.exceptions import SDNFallbackDataEmptyError
 from ecommerce.extensions.payment.models import SDNCheckFailure, SDNFallbackData, SDNFallbackMetadata
+from oscar.core.loading import get_model
+from requests.exceptions import HTTPError, Timeout
 
 logger = logging.getLogger(__name__)
 Basket = get_model('basket', 'Basket')
@@ -115,55 +108,6 @@ class SDNClient:
         self.api_key = api_key
         self.sdn_list = sdn_list
 
-    # Changes part of REV-1209 - see https://github.com/edx/ecommerce/pull/3020
-    def make_testing_sdn_call(self, auth_header, first_check_response, params_dict):  # pragma: no cover
-        """
-        This is temporary code added as part of REV-1209.
-        The intent of this code is to compare the results of the SDN check
-        with fuzzy matching turned on and off.
-        Logs are included to help inform whether a threshold should be set
-        for the score that is included with the fuzzy match query results.
-        """
-        try:
-            if waffle.flag_is_active(crum.get_current_request(), 'make_second_sdn_check'):
-                second_check_dict = copy.deepcopy(params_dict)
-                first_check_results = first_check_response.json().get("results", [])
-                second_check_dict['fuzzy_name'] = 'true'
-                second_check_params = urlencode(second_check_dict)
-                sdn_check_url = '{api_url}?{params}'.format(
-                    api_url=self.api_url,
-                    params=second_check_params
-                )
-                second_check_response = requests.get(
-                    sdn_check_url,
-                    headers=auth_header,
-                    timeout=settings.SDN_CHECK_REQUEST_TIMEOUT
-                )
-                if second_check_response.status_code != 200:
-                    logger.warning(
-                        'Fuzzy SDN check error: status code [%d] message: [%s]',
-                        second_check_response.status_code, second_check_response.content
-                    )
-                second_check_results = second_check_response.json().get("results", [])
-                if second_check_results:
-                    top_score = max(r.get("score", -1) for r in second_check_results)
-                    if first_check_results:
-                        logger.info(
-                            'Regular SDN check: match. Fuzzy SDN check: match. Fuzzy match top score: [%s]',
-                            top_score
-                        )
-                    else:
-                        logger.info(
-                            'Regular SDN check: no match. Fuzzy SDN check: match. Fuzzy match top score: [%s]',
-                            top_score
-                        )
-                elif first_check_results:
-                    logger.info('Regular SDN check: match. Fuzzy SDN check: no match.')
-        except Exception as e:  # pylint:disable=broad-except
-            # Since this code is purely for testing purposes,
-            # we ensure any error would not interfere with the actual transaction.
-            logger.warning("Fuzzy SDN check error [%s]", str(e))
-
     def search(self, name, city, country):
         """
         Searches the OFAC list for an individual with the specified details.
@@ -179,7 +123,6 @@ class SDNClient:
         Returns:
             dict: SDN API response.
         """
-        # Changes part of REV-1209 - see https://github.com/edx/ecommerce/pull/3020
         params_dict = {
             'sources': self.sdn_list,
             'type': 'individual',
@@ -205,9 +148,6 @@ class SDNClient:
         except requests.exceptions.Timeout:
             logger.warning('Connection to US Treasury SDN API timed out for [%s].', name)
             raise
-
-        # Changes part of REV-1209 - see https://github.com/edx/ecommerce/pull/3020
-        self.make_testing_sdn_call(auth_header, response, params_dict)  # pragma: no cover
 
         if response.status_code != 200:
             logger.warning(


### PR DESCRIPTION
## What are we doing
Cleaning up code from the SDNFallback fuzzy matching analysis
Reverting https://github.com/edx/ecommerce/pull/3020/files (note that this code was moved in https://github.com/edx/ecommerce/pull/3152 so the diffs aren't going to be exact)

## Why are we doing this
Remove code that's no longer needed

## Additional things to do
-Remove the waffle flag (https://prod-edx-ecommerce-internal.edx.org/admin/waffle/flag/13/change/?_changelist_filters=q%3Dmake_second_sdn_check)

## Details:
- Keeping the variable extraction on https://github.com/edx/ecommerce/compare/jj-cleanup-sdn-stuff?expand=1#diff-59c8d902550a724ec07d258bb7af6987b01957324356b7005c67ffe5c9569990L182 unless anyone has strong feelings on this
