### PR TITLE
Update LMSPublisher to not convert price to integer

### DIFF
--- a/ecommerce/courses/publishers.py
+++ b/ecommerce/courses/publishers.py
@@ -38,7 +38,7 @@ class LMSPublisher:
         return {
             'name': mode_for_product(seat),
             'currency': stock_record.price_currency,
-            'price': int(stock_record.price_excl_tax),
+            'price': float(stock_record.price_excl_tax),
             'sku': stock_record.partner_sku,
             'bulk_sku': bulk_sku,
             'expires': self.get_seat_expiration(seat),

--- a/ecommerce/courses/tests/test_publishers.py
+++ b/ecommerce/courses/tests/test_publishers.py
@@ -130,7 +130,7 @@ class LMSPublisherTests(DiscoveryTestMixin, TestCase):
         expected = {
             'name': 'verified',
             'currency': 'USD',
-            'price': int(stock_record.price_excl_tax),
+            'price': float(stock_record.price_excl_tax),
             'sku': stock_record.partner_sku,
             'bulk_sku': None,
             'expires': None,
@@ -162,7 +162,7 @@ class LMSPublisherTests(DiscoveryTestMixin, TestCase):
         expected = {
             'name': expected_mode,
             'currency': 'USD',
-            'price': int(stock_record.price_excl_tax),
+            'price': float(stock_record.price_excl_tax),
             'sku': stock_record.partner_sku,
             'bulk_sku': None,
             'expires': None,
@@ -178,7 +178,7 @@ class LMSPublisherTests(DiscoveryTestMixin, TestCase):
         expected = {
             'name': 'verified',
             'currency': 'USD',
-            'price': int(stock_record.price_excl_tax),
+            'price': float(stock_record.price_excl_tax),
             'sku': stock_record.partner_sku,
             'bulk_sku': ec_stock_record.partner_sku,
             'expires': None,


### PR DESCRIPTION
[REV-1632](https://openedx.atlassian.net/browse/REV-1632). 

Background: 
The `min_price` column in LMS `CourseMode` table takes integers, and should be updated to take decimals to match the price in ecommerce database, making the price across the learner pathway to purchase the same (49.99 vs. 49). 

This ticket covers:
Currently, ecommerce serializes the price as an `int` before sending a request to LMS - this ticket removes this conversion so that it's converted to a float instead, keeping the digits, then LMS will handle the conversion to the appropriate type it needs in the `CourseMode` table.  

In order to decrease the risk of breaking anything with migrations, this change will be divided into 5 steps across edx-platform and ecommerce:
1) Deploy LMS no.1 ([PR here](https://github.com/edx/edx-platform/pull/26508)):  make sure `min_price` can receive non-int.
2) Deploy ecommerce no.1 (**this PR**): change `LMSPublisher` to stop converting `min_price` to int.
3) Deploy LMS no.2 ([WIP PR here](https://github.com/edx/edx-platform/pull/26395)): add new column for price and make sure it's populated with the same `min_price`, and that `min_price` can receive a Decimal.
4) Deploy LMS no.3 : use new price column in Track Selection and Course Home pages. 
5) Deploy LMS no. 4 : remove original `min_price` column. 
