### PR TITLE
[REV-2078] logging: replace offer ids with prod values

### DIFF
--- a/ecommerce/extensions/offer/models.py
+++ b/ecommerce/extensions/offer/models.py
@@ -137,12 +137,12 @@ class Benefit(AbstractBenefit):
             )
 
             #  REV-2078 logging for financial assistance coupons: recent 90% off coupons
-            coupon_ids_to_log = [55365, 55366, 55367, 55573, 55574, 55575, 55647, 55648, 55649, 55710,
-                                 55711, 55765, 55766, 55767, 55869, 55870, 55871, 56030, 56031, 56032,
-                                 56033, 56486, 56487, 56488, 56712, 56713, 56714, 61496, 61497, 61498,
-                                 62547, 63228, 63229, 63230, 63464, 63465, 63466, 65820, 65821, 65822,
-                                 66114, 66115, 66116, 66879, 66881, 66976, 67176, 67177, 67178]
-            if offer.id in coupon_ids_to_log:
+            offer_ids_to_log = [55365, 55366, 55367, 55573, 55574, 55575, 55647, 55648, 55649, 55710,
+                                55711, 55765, 55766, 55767, 55869, 55870, 55871, 56030, 56031, 56032,
+                                56033, 56486, 56487, 56488, 56712, 56713, 56714, 61496, 61497, 61498,
+                                62547, 63228, 63229, 63230, 63464, 63465, 63466, 65820, 65821, 65822,
+                                66114, 66115, 66116, 66879, 66881, 66976, 67176, 67177, 67178]
+            if offer.id in offer_ids_to_log:
                 logger.info('(REV-2078) checked _identify_uncached_product_identifiers for '
                             'Basket: [%s], Offer: [%s], User: [%s], course_run_ids: [%s], course_uuids: [%s],'
                             'applicable_lines: [%s]',
@@ -171,7 +171,7 @@ class Benefit(AbstractBenefit):
                     )
                     raise Exception('Failed to contact Discovery Service to retrieve offer catalog_range data.')
 
-                if offer.id in coupon_ids_to_log:
+                if offer.id in offer_ids_to_log:
                     logger.info('(REV-2078) Called Discovery Service for Basket: [%s], Offer: [%s], User: [%s],'
                                 'course_run_ids: [%s] or course_uuids: [%s], response: [%s]',
                                 basket.id,

--- a/ecommerce/extensions/offer/models.py
+++ b/ecommerce/extensions/offer/models.py
@@ -136,8 +136,12 @@ class Benefit(AbstractBenefit):
                 applicable_lines, site.domain, partner_code, query
             )
 
-            #  REV-2078 logging for financial assistance coupons
-            coupon_ids_to_log = [53050]  # Stage coupon id to test with
+            #  REV-2078 logging for financial assistance coupons: recent 90% off coupons
+            coupon_ids_to_log = [55365, 55366, 55367, 55573, 55574, 55575, 55647, 55648, 55649, 55710,
+                                 55711, 55765, 55766, 55767, 55869, 55870, 55871, 56030, 56031, 56032,
+                                 56033, 56486, 56487, 56488, 56712, 56713, 56714, 61496, 61497, 61498,
+                                 62547, 63228, 63229, 63230, 63464, 63465, 63466, 65820, 65821, 65822,
+                                 66114, 66115, 66116, 66879, 66881, 66976, 67176, 67177, 67178]
             if offer.id in coupon_ids_to_log:
                 logger.info('(REV-2078) checked _identify_uncached_product_identifiers for '
                             'Basket: [%s], Offer: [%s], User: [%s], course_run_ids: [%s], course_uuids: [%s],'


### PR DESCRIPTION
To help with the issue where basket items are not qualifying for coupons as expected (REV-2078), we added some logging for specific offer IDs in  [PR 3321](https://github.com/edx/ecommerce/pull/3321), an id from stage to start. 

After this testing is good, this PR is to (a) replace with the production offer ids where we want to start logging info, and (b) it also fixes a confusing/wrong variable name: coupon_ids_to_log -> offer_ids_to_log