### PR TITLE
[REV-2078]: update stage offer id, rename variable

### DIFF
--- a/ecommerce/extensions/offer/models.py
+++ b/ecommerce/extensions/offer/models.py
@@ -137,8 +137,8 @@ class Benefit(AbstractBenefit):
             )
 
             #  REV-2078 logging for financial assistance coupons
-            coupon_ids_to_log = [53050]  # Stage coupon id to test with
-            if offer.id in coupon_ids_to_log:
+            offer_ids_to_log = [70649]  # Stage coupon id to test with
+            if offer.id in offer_ids_to_log:
                 logger.info('(REV-2078) checked _identify_uncached_product_identifiers for '
                             'Basket: [%s], Offer: [%s], User: [%s], course_run_ids: [%s], course_uuids: [%s],'
                             'applicable_lines: [%s]',
@@ -167,7 +167,7 @@ class Benefit(AbstractBenefit):
                     )
                     raise Exception('Failed to contact Discovery Service to retrieve offer catalog_range data.')
 
-                if offer.id in coupon_ids_to_log:
+                if offer.id in offer_ids_to_log:
                     logger.info('(REV-2078) Called Discovery Service for Basket: [%s], Offer: [%s], User: [%s],'
                                 'course_run_ids: [%s] or course_uuids: [%s], response: [%s]',
                                 basket.id,


### PR DESCRIPTION
To help with the issue where basket items are not qualifying for coupons as expected (REV-2078), we added some logging for specific offer IDs in PR 3321, starting with an id for a stage offer. 

- We had the wrong id in that PR, fixed here (53050->70649)
- I'm also fixing a confusing/wrong variable name: coupon_ids_to_log -> offer_ids_to_log