### PR TITLE
Add Product IDs to Completed Purchase

### DIFF
--- a/ecommerce/static/js/pages/receipt_page.js
+++ b/ecommerce/static/js/pages/receipt_page.js
@@ -37,11 +37,12 @@ define([
             };
         }
 
-        function trackPurchase(orderId, totalAmount, currency) {
+        function trackPurchase(orderId, totalAmount, currency, productIds) {
             window.analytics.track('Completed Purchase', {
                 orderId: orderId,
                 total: totalAmount,
-                currency: currency
+                currency: currency,
+                productIds: productIds
             });
         }
 
@@ -49,14 +50,15 @@ define([
             var $el = $('#receipt-container'),
                 currency = $el.data('currency'),
                 orderId = $el.data('order-id'),
-                totalAmount = $el.data('total-amount');
+                totalAmount = $el.data('total-amount'),
+                productIds = $el.data('product-ids');
 
             if ($el.data('back-button')) {
                 disableBackButton();
             }
 
             if (orderId) {
-                trackPurchase(orderId, totalAmount, currency);
+                trackPurchase(orderId, totalAmount, currency, productIds);
             }
         }
 

--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -38,7 +38,7 @@
        data-total-amount="{{ order.total_incl_tax | unlocalize }}"
        data-back-button="{{ disable_back_button | default:0 }}"
        data-product-ids="{% for line in order.lines %}
-                  order.line.sku  // TODO, concatenate into one string.
+                  line.sku  // TODO, concatenate into one string.
                 {% endfor %}"
   >
 

--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -37,7 +37,7 @@
        data-order-id="{{ order.number }}"
        data-total-amount="{{ order.total_incl_tax | unlocalize }}"
        data-back-button="{{ disable_back_button | default:0 }}"
-       data-product-ids="{% for line in order.lines %}
+       data-product-ids="{% for line in order.lines.all %}
                   line.sku  // TODO, concatenate into one string.
                 {% endfor %}"
   >

--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -36,7 +36,12 @@
        data-currency="{{ order.currency }}"
        data-order-id="{{ order.number }}"
        data-total-amount="{{ order.total_incl_tax | unlocalize }}"
-       data-back-button="{{ disable_back_button | default:0 }}">
+       data-back-button="{{ disable_back_button | default:0 }}"
+       data-product-ids="{% for line in order.lines %}
+                  order.line.sku  // TODO, concatenate into one string.
+                {% endfor %}"
+  >
+
        {% include 'oscar/partials/alert_messages.html' %}
 
       <h2 class="thank-you">{% trans "Thank you for your order!" as tmsg %}{{ tmsg | force_escape }}</h2>


### PR DESCRIPTION
Adds the product IDS from an order to the 'Completed Purchase' event
as a concantenated, comma-delimited string.
NOTE: this should NOT be checked in as is, since it contains pseudocode

ENT-4109