### PR TITLE
BOM-2247: Upgrade pip-tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ requirements.js:
 	$(NODE_BIN)/bower install --allow-root
 
 requirements: requirements.js
+	pip3 install -r requirements/pip_tools.txt
 	pip3 install -r requirements/dev.txt --exists-action w
 
 requirements.tox:

--- a/requirements/pins.txt
+++ b/requirements/pins.txt
@@ -38,9 +38,9 @@ virtualenv==16.7.9
 # removing this pin, then this pin can be removed.
 pylint==2.4.4
 
-# See https://openedx.atlassian.net/browse/ARCHBOM-1141 for details.
+# See https://openedx.atlassian.net/browse/BOM-2247 for details.
 # need an update in configuration before this can be removed.
-pip-tools<5.0.0
+pip-tools==5.3.0
 
 # greater versions failing with extract-tranlsations step.
 tox==3.14.6

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -5,5 +5,8 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==4.5.1          # via -c requirements/pins.txt, -r requirements/pip_tools.in
+pip-tools==5.3.0          # via -c requirements/pins.txt, -r requirements/pip_tools.in
 six==1.15.0               # via pip-tools
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip


### PR DESCRIPTION
We are using `pip==20.0.2` in configuration, which is compatible with pip-tools up to version `5.3.0`.
The compatibility chart is available at https://github.com/jazzband/pip-tools/#versions-and-compatibility
See https://openedx.atlassian.net/browse/BOM-2247 for details.