### PR TITLE
send order complete properties in traits to hubspot

### DIFF
--- a/ecommerce/extensions/analytics/utils.py
+++ b/ecommerce/extensions/analytics/utils.py
@@ -128,7 +128,7 @@ def prepare_analytics_data(user, segment_key):
     return json.dumps(data)
 
 
-def track_segment_event(site, user, event, properties):
+def track_segment_event(site, user, event, properties, traits=None):
     """ Fire a tracking event via Segment.
 
     Args:
@@ -136,6 +136,8 @@ def track_segment_event(site, user, event, properties):
         user (User): User to which the event should be associated.
         event (str): Event name.
         properties (dict): Event properties.
+        traits (dict): Event traits, which will be included in the
+            `context` section of the event payload.
 
     Returns:
         (success, msg): Tuple indicating the success of enqueuing the event on the message queue.
@@ -172,6 +174,10 @@ def track_segment_event(site, user, event, properties):
             'url': page,
         }
     }
+
+    if traits:
+        context['traits'] = traits
+
     return transaction.on_commit(
         lambda: site.siteconfiguration.segment_client.track(user_tracking_id, event, properties,
                                                             context=context))

--- a/ecommerce/extensions/checkout/signals.py
+++ b/ecommerce/extensions/checkout/signals.py
@@ -91,7 +91,11 @@ def track_completed_order(sender, order=None, **kwargs):  # pylint: disable=unus
     except BasketAttribute.DoesNotExist:
         logger.info('There is no program or bundle associated with order number %s', order.number)
 
-    track_segment_event(order.site, order.user, 'Order Completed', properties)
+    # DENG-784: For segment events forwarded along to Hubspot, duplicate the `properties` section of
+    # the event payload into the `traits` section so that they can be received. This is a temporary
+    # fix until we implement this behavior outside of the ecommerce application.
+    # TODO: DENG-797: remove the properties duplication in the event traits.
+    track_segment_event(order.site, order.user, 'Order Completed', properties, traits=properties)
 
 
 @receiver(post_checkout, dispatch_uid='send_completed_order_email')

--- a/ecommerce/extensions/checkout/tests/test_mixins.py
+++ b/ecommerce/extensions/checkout/tests/test_mixins.py
@@ -167,7 +167,8 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin,
                 self.order.currency,
                 self.order.user.email,
                 self.order.total_excl_tax,
-                self.order.total_excl_tax        # value for revenue field is same as total.
+                self.order.total_excl_tax,        # value for revenue field is same as total.
+                check_traits=True,
             )
             logger.check_present(
                 (
@@ -258,7 +259,8 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin,
             self.order.currency,
             self.order.user.email,
             self.order.total_excl_tax,
-            self.order.total_excl_tax            # value for revenue field is same as total.
+            self.order.total_excl_tax,            # value for revenue field is same as total.
+            check_traits=True,
         )
 
     def test_order_no_lms_user_id(self, mock_track):
@@ -285,7 +287,8 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin,
             self.order.currency,
             self.order.user.email,
             self.order.total_excl_tax,
-            self.order.total_excl_tax  # value for revenue field is same as total.
+            self.order.total_excl_tax,  # value for revenue field is same as total.
+            check_traits=True,
         )
 
     def test_handle_successful_order_no_segment_key(self, mock_track):

--- a/ecommerce/extensions/checkout/tests/test_signals.py
+++ b/ecommerce/extensions/checkout/tests/test_signals.py
@@ -269,14 +269,14 @@ class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
             order = self.prepare_order('verified')
             track_completed_order(None, order)
             properties = self._generate_event_properties(order)
-            mock_track.assert_called_once_with(order.site, order.user, 'Order Completed', properties)
+            mock_track.assert_called_once_with(order.site, order.user, 'Order Completed', properties, traits=properties)
 
             # We should be able to fire events even if the product is not related to a course.
             mock_track.reset_mock()
             order = create_order()
             track_completed_order(None, order)
             properties = self._generate_event_properties(order)
-            mock_track.assert_called_once_with(order.site, order.user, 'Order Completed', properties)
+            mock_track.assert_called_once_with(order.site, order.user, 'Order Completed', properties, traits=properties)
 
     @mock.patch('ecommerce.extensions.checkout.signals.track_segment_event')
     def test_track_bundle_order(self, mock_track):
@@ -295,7 +295,7 @@ class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
             properties = self._generate_event_properties(
                 order, bundle_id=TEST_BUNDLE_ID, fullBundle=True
             )
-            mock_track.assert_called_once_with(order.site, order.user, 'Order Completed', properties)
+            mock_track.assert_called_once_with(order.site, order.user, 'Order Completed', properties, traits=properties)
 
         # Tracks a partial bundle order
         with mock.patch('ecommerce.extensions.checkout.signals.get_program',
@@ -303,7 +303,7 @@ class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
             mock_track.reset_mock()
             track_completed_order(None, order)
             properties = self._generate_event_properties(order, bundle_id=TEST_BUNDLE_ID)
-            mock_track.assert_called_once_with(order.site, order.user, 'Order Completed', properties)
+            mock_track.assert_called_once_with(order.site, order.user, 'Order Completed', properties, traits=properties)
 
     def test_track_completed_discounted_order_with_voucher(self):
         """ An event including coupon information should be sent to Segment"""
@@ -322,7 +322,7 @@ class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
             order = factories.create_order(basket=basket, user=self.user)
             track_completed_order(None, order)
             properties = self._generate_event_properties(order, voucher)
-            mock_track.assert_called_once_with(order.site, order.user, 'Order Completed', properties)
+            mock_track.assert_called_once_with(order.site, order.user, 'Order Completed', properties, traits=properties)
 
     def test_track_completed_discounted_order_with_voucher_with_offer(self):
         with mock.patch('ecommerce.extensions.checkout.signals.track_segment_event') as mock_track:
@@ -346,7 +346,7 @@ class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
             order = factories.create_order(basket=basket, user=self.user)
             track_completed_order(None, order)
             properties = self._generate_event_properties(order, voucher)
-            mock_track.assert_called_once_with(order.site, order.user, 'Order Completed', properties)
+            mock_track.assert_called_once_with(order.site, order.user, 'Order Completed', properties, traits=properties)
 
     def test_track_completed_discounted_order_with_offer(self):
         """ An event including a discount but no coupon should be sent to Segment"""
@@ -368,7 +368,7 @@ class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
             order = factories.create_order(basket=basket, user=self.user)
             track_completed_order(None, order)
             properties = self._generate_event_properties(order)
-            mock_track.assert_called_once_with(order.site, order.user, 'Order Completed', properties)
+            mock_track.assert_called_once_with(order.site, order.user, 'Order Completed', properties, traits=properties)
 
     def test_track_completed_coupon_order(self):
         """ Make sure we do not send GA events for Coupon orders """


### PR DESCRIPTION
We currently use Sailthru to send order completed event data along to Hubspot for marketing purposes. This will replace the Sailthru part with Segment. In order to do so, I needed to duplicate the event `properties` into the `context.traits` section, so that Hubspot can see them (see: https://segment.com/docs/connections/destinations/catalog/hubspot/#setting-contact-properties-on-track). We have created the necessary custom fields in Hubspot to receive this data.