### PR TITLE
ENT-4195: Updated email body to include templates when using Braze

### DIFF
--- a/ecommerce/core/constants.py
+++ b/ecommerce/core/constants.py
@@ -27,6 +27,9 @@ ENROLLMENT_CODE_PRODUCT_CLASS_NAME = 'Enrollment Code'
 ENROLLMENT_CODE_SWITCH = 'create_enrollment_codes'
 ENROLLMENT_CODE_SEAT_TYPES = ['verified', 'professional', 'no-id-professional']
 
+# Braze
+ENABLE_BRAZE = 'enable_braze'
+
 # Course Entitlement constant
 COURSE_ENTITLEMENT_PRODUCT_CLASS_NAME = 'Course Entitlement'
 

--- a/ecommerce/core/migrations/0063_braze_switch.py
+++ b/ecommerce/core/migrations/0063_braze_switch.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+
+from ecommerce.core.constants import ENABLE_BRAZE
+
+
+def create_switch(apps, schema_editor):
+    """Create the `enable_braze` switch if it does not already exist."""
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.update_or_create(name=ENABLE_BRAZE, defaults={'active': False})
+
+
+def delete_switch(apps, schema_editor):
+    """Delete the `enable_braze` switch."""
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.filter(name=ENABLE_BRAZE).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0062_siteconfiguration_account_microfrontend_url'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_switch, delete_switch),
+    ]

--- a/ecommerce/templates/coupons/offer_email.html
+++ b/ecommerce/templates/coupons/offer_email.html
@@ -1,0 +1,238 @@
+<html xmlns='http://www.w3.org/1999/xhtml'>
+<head>
+    <meta http-equiv='Content-Type' content='text/html; charset=UTF-8'/>
+
+<title lang='en'>
+  
+  edX Email
+  
+</title>
+<meta name='viewport' content='width=device-width, initial-scale=1.0'/>
+<style>
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Roboto+Mono&display=swap');
+</style>
+<style>
+.btn-style {
+  	color: #ffffff;
+    text-decoration: none;
+    border-radius: 4px;
+    -webkit-border-radius: 4px;
+    -moz-border-radius: 4px;
+    background-color: #07223c;
+    border-top: 12px solid #07223c;
+    border-bottom: 12px solid #07223c;
+    border-right: 50px solid #07223c;
+    border-left: 50px solid #07223c;
+    display: inline-block;
+}
+</style>
+<style type='text/css'>
+    @media only screen and (min-device-width: 601px) {
+      .content {
+        width: 600px !important;
+      }
+    }
+
+    @-ms-viewport{
+      width: device-width;
+    }
+
+    /* Column Drop Layout Pattern CSS */
+    @media only screen and (max-width: 450px) {
+      td[class='col'] {
+        display: block;
+        width: 100%;
+        -moz-box-sizing: border-box;
+        -webkit-box-sizing: border-box;
+        box-sizing: border-box;
+        float: left;
+        text-align: left !important;
+        padding-bottom: 20px;
+      }
+    }
+</style>
+
+    </head>
+    <body>
+        
+<div lang='en' style='
+    display:none;
+    font-size:1px;
+    line-height:1px;
+    max-height:0px;
+    max-width:0px;
+    opacity:0;
+    overflow:hidden;
+    visibility:hidden;
+'>
+    
+</div>
+
+<img src='https://www.google-analytics.com/collect?cs=user_authn&ec=email&t=event&dh=courses.edx.org&cid=555&v=1&cc=2f2b9bef-da0d-463b-8bef-f2e1e7b655bf&cn=passwordreset&dp=%2Femail%2Fuser_authn%2Fpasswordreset%2F8ea4a455-1555-432e-806f-56e78adf3856%2F2f2b9bef-da0d-463b-8bef-f2e1e7b655bf&cm=email&tid=UA-35248639-2&ea=edx.bi.email.opened' alt='' role='presentation' aria-hidden='true' />
+
+<div bgcolor='#fbfaf9' lang='en' dir='ltr' style='
+    margin: 0;
+    padding: 0;
+    min-width: 100%;
+'>
+    <!-- Hack for outlook 2010, which wants to render everything in Times New Roman -->
+    <!--[if mso]>
+    <style type='text/css'>
+    body, table, td {font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif !important;}
+    </style>
+    <![endif]-->
+
+    <!--[if (gte mso 9)|(IE)]>
+    <table role='presentation' width='600' align='center' cellpadding='0' cellspacing='0' border='0'>
+    <tr>
+    <td>
+    <![endif]-->
+
+    <!-- CONTENT -->
+    <table class='content' role='presentation' align='center' cellpadding='0' cellspacing='0' border='0' bgcolor='#fbfaf9' width='100%' style='
+        font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
+        font-size: 1em;
+        line-height: 1.5;
+        max-width: 600px;
+        padding: 0 20px;
+    '>
+        <tr>
+            <!-- HEADER -->
+            <td class='header' style='
+                padding: 20px;
+            '>
+                
+                <table role='presentation' width='100%' align='left' border='0' cellpadding='0' cellspacing='0'>
+                    <tr>
+                        <td width='70'>
+                            <a href='https://www.edx.org?utm_content=2f2b9bef-da0d-463b-8bef-f2e1e7b655bf&utm_source=user_authn&utm_campaign=passwordreset&utm_medium=email'><img
+                                    src='https://edx-cdn.org/v3/prod/logo.png' width='auto'
+                                    height='40' alt='Go to edX Home Page'/></a>
+                        </td>
+                    </tr>
+                </table>
+                
+            </td>
+        </tr>
+
+        <tr>
+            <!-- MAIN -->
+            <td class='main' bgcolor='#ffffff' style='
+                padding: 30px 20px;
+                box-shadow: 0 1px 5px rgba(0,0,0,0.25);
+            '>
+                
+<table width='100%' align='left' border='0' cellpadding='0' cellspacing='0' role='presentation'>
+    <tr>
+        <td>
+            <p style='white-space: pre-line' >
+                
+				{{body}}
+            </p>    
+            <a href='https://edx.org/search' class='btn-style'>
+            <font color='#ffffff'><b>Find a course</b></font>
+            </a>
+            
+        </td>
+    </tr>
+</table>
+
+            </td>
+        </tr>
+
+        <tr>
+            <!-- FOOTER -->
+            <td class='footer' style='padding: 20px;'>
+                <table role='presentation' width='100%' align='left' border='0' cellpadding='0' cellspacing='0'>
+                    <tr>
+                        <td style='padding-bottom: 20px;'>
+                            <!-- SOCIAL -->
+                            <table role='presentation' align='left' border='0' border='0' cellpadding='0' cellspacing='0' width='210'>
+                                <tr>
+                                    
+                                        <td height='32' width='42'>
+                                            <a href='http://www.linkedin.com/company/edx'>
+                                                <img src='https://media.sailthru.com/595/1k1/8/o/599f354ec70cb.png'
+                                                     width='32' height='32' alt='edX on LinkedIn'/>
+                                            </a>
+                                        </td>
+                                    
+                                    
+                                        <td height='32' width='42'>
+                                            <a href='https://twitter.com/edXOnline'>
+                                                <img src='https://media.sailthru.com/595/1k1/8/o/599f354d9c26e.png'
+                                                     width='32' height='32' alt='edX on Twitter'/>
+                                            </a>
+                                        </td>
+                                    
+                                    
+                                        <td height='32' width='42'>
+                                            <a href='http://www.facebook.com/EdxOnline'>
+                                                <img src='https://media.sailthru.com/595/1k1/8/o/599f355052c8e.png'
+                                                     width='32' height='32' alt='edX on Facebook'/>
+                                            </a>
+                                        </td>
+                                    
+                                    
+                                    
+                                        <td height='32' width='42'>
+                                            <a href='http://www.reddit.com/r/edx'>
+                                                <img src='https://media.sailthru.com/595/1k1/8/o/599f354e326b9.png'
+                                                     width='32' height='32' alt='edX on Reddit'/>
+                                            </a>
+                                        </td>
+                                    
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    <tr>
+                        <!-- APP BUTTONS -->
+                        <td style='padding-bottom: 20px;'>
+                            
+                                <a href='https://itunes.apple.com/us/app/edx/id945480667?mt=8' style='text-decoration: none'>
+                                    <img src='https://media.sailthru.com/595/1k1/6/2/5931cfbba391b.png'
+                                         alt='Download the iOS app on the Apple Store'
+                                         width='136' height='50' style='margin-right: 10px'/>
+                                </a>
+                            
+                            
+                                <a href='https://play.google.com/store/apps/details?id=org.edx.mobile' style='text-decoration: none'>
+                                    <img src='https://media.sailthru.com/595/1k1/6/2/5931cf879a033.png'
+                                         alt='Download the Android app on the Google Play Store'
+                                         width='136' height='50'/>
+                                </a>
+                            
+                        </td>
+                    </tr>
+                    <tr>
+                        <!-- Actions -->
+                        <td style='padding-bottom: 20px;'>
+                            
+                        </td>
+                    </tr>
+                    <tr>
+                        <!-- COPYRIGHT -->
+                        <td>
+                            &copy; 2020 edX, All rights reserved.<br/>
+                            <br/>
+                            Our mailing address is:<br/>
+                            141 Portland St. Cambridge, MA 02139
+                        </td>
+                    </tr>
+                    
+                </table>
+            </td>
+        </tr>
+    </table>
+
+    <!--[if (gte mso 9)|(IE)]>
+    </td>
+    </tr>
+    </table>
+    <![endif]-->
+
+</div>
+    
+</body>
+</html>

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -63,7 +63,7 @@ edx-django-release-util==1.0.0  # via -r requirements/base.in
 edx-django-sites-extensions==3.0.0  # via -r requirements/base.in
 edx-django-utils==3.13.0  # via -r requirements/base.in, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.4.0  # via -r requirements/base.in, edx-rbac
-edx-ecommerce-worker==1.1.10  # via -r requirements/base.in
+edx-ecommerce-worker==1.1.11  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.3.4           # via -r requirements/base.in
 edx-rest-api-client==5.2.1  # via -r requirements/base.in, edx-ecommerce-worker

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -72,7 +72,7 @@ edx-django-release-util==1.0.0  # via -r requirements/test.txt
 edx-django-sites-extensions==3.0.0  # via -r requirements/test.txt
 edx-django-utils==3.13.0  # via -r requirements/test.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.4.0  # via -r requirements/test.txt, edx-rbac
-edx-ecommerce-worker==1.1.10  # via -r requirements/test.txt
+edx-ecommerce-worker==1.1.11  # via -r requirements/test.txt
 edx-i18n-tools==0.5.3     # via -r requirements/test.txt
 edx-opaque-keys==2.1.1    # via -r requirements/test.txt, edx-drf-extensions
 edx-rbac==1.3.4           # via -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -66,7 +66,7 @@ edx-django-release-util==1.0.0  # via -r requirements/base.in
 edx-django-sites-extensions==3.0.0  # via -r requirements/base.in
 edx-django-utils==3.13.0  # via -r requirements/base.in, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.4.0  # via -r requirements/base.in, edx-rbac
-edx-ecommerce-worker==1.1.10  # via -r requirements/base.in
+edx-ecommerce-worker==1.1.11  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.3.4           # via -r requirements/base.in
 edx-rest-api-client==5.2.1  # via -r requirements/base.in, edx-ecommerce-worker

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -68,7 +68,7 @@ edx-django-release-util==1.0.0  # via -r requirements/base.txt
 edx-django-sites-extensions==3.0.0  # via -r requirements/base.txt
 edx-django-utils==3.13.0  # via -r requirements/base.txt, -r requirements/e2e.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.4.0  # via -r requirements/base.txt, edx-rbac
-edx-ecommerce-worker==1.1.10  # via -r requirements/base.txt
+edx-ecommerce-worker==1.1.11  # via -r requirements/base.txt
 edx-i18n-tools==0.5.3     # via -r requirements/test.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.3.4           # via -r requirements/base.txt


### PR DESCRIPTION
## Description

This PR adds a switch to enable the external Braze messaging system. For this system, the template of the email is sent as part of message body in the API request. When the switch is active, the body of the email is augmented with the template.

## Supporting information

JIRA: https://openedx.atlassian.net/browse/ENT-4195

Email Format: 
![image](https://user-images.githubusercontent.com/34648393/110611304-e8821b00-81b0-11eb-8082-88939a92e15d.png)
