### PR TITLE
Adding parameter to forward of params to enterprise data sharing consent url 

### DIFF
--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -29,7 +29,8 @@ from ecommerce.enterprise.utils import (
     get_enterprise_course_consent_url,
     get_enterprise_customer_consent_failed_context_data,
     get_enterprise_customer_data_sharing_consent_token,
-    get_enterprise_customer_from_voucher
+    get_enterprise_customer_from_voucher,
+    parse_consent_params
 )
 from ecommerce.extensions.api import exceptions
 from ecommerce.extensions.basket.utils import get_payment_microfrontend_or_basket_url, prepare_basket
@@ -249,7 +250,8 @@ class CouponRedeemView(EdxOrderPlacementMixin, APIView):
                     consent_token,
                     product.course.id,
                     enterprise_customer['id'],
-                    failure_url=failure_url
+                    failure_url=failure_url,
+                    consent_url_param_dict=parse_consent_params(request),
                 )
                 return HttpResponseRedirect(redirect_url)
 

--- a/ecommerce/enterprise/tests/test_utils.py
+++ b/ecommerce/enterprise/tests/test_utils.py
@@ -6,6 +6,7 @@ import ddt
 import httpretty
 from django.conf import settings
 from django.http.response import HttpResponse
+from django.test import RequestFactory
 from edx_django_utils.cache import TieredCache
 from mock import patch
 from oscar.core.loading import get_class
@@ -27,6 +28,7 @@ from ecommerce.enterprise.utils import (
     get_enterprise_customers,
     get_enterprise_id_for_current_request_user_from_jwt,
     get_or_create_enterprise_customer_user,
+    parse_consent_params,
     set_enterprise_customer_cookie,
     update_paginated_response
 )
@@ -385,3 +387,17 @@ class EnterpriseUtilsTests(EnterpriseServiceMockMixin, TestCase):
         enterprise_customer.return_value = {'sender_alias': sender_alias}
         sender_alias = get_enterprise_customer_sender_alias('some-site', 'uuid')
         assert sender_alias == expected_sender_alias
+
+    def test_parse_consent_params(self):
+        """
+        Verify that "parse_consent_params" util works as expected.
+        """
+
+        mock_request = RequestFactory().get(
+            '/any?consent_url_param_string=left_sidebar_text_override%3D')
+        parsed = parse_consent_params(mock_request)
+        self.assertDictEqual(parsed, {'left_sidebar_text_override': ''})
+
+        mock_request2 = RequestFactory().get('/any')
+        parsed = parse_consent_params(mock_request2)
+        assert parsed is None

--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -589,7 +589,7 @@ def get_enterprise_customer_from_enterprise_offer(basket):
 
 def parse_consent_params(request):
     """
-    Parse out parameters from an ecommerce request that 
+    Parse out parameters from an ecommerce request that
     need to be forwarded back to the consent page in a redirect.
 
     Returns:

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -38,7 +38,8 @@ from ecommerce.enterprise.utils import (
     enterprise_customer_user_needs_consent,
     get_enterprise_customer_from_enterprise_offer,
     get_enterprise_customer_from_voucher,
-    has_enterprise_offer
+    has_enterprise_offer,
+    parse_consent_params
 )
 from ecommerce.extensions.analytics.utils import (
     prepare_analytics_data,
@@ -234,7 +235,8 @@ class BasketLogicMixin:
                 redirect_url = construct_enterprise_course_consent_url(
                     self.request,
                     product.course.id,
-                    enterprise_custmer_uuid
+                    enterprise_custmer_uuid,
+                    consent_url_param_dict=parse_consent_params(self.request)
                 )
                 raise RedirectException(
                     response=HttpResponseRedirect(redirect_url)


### PR DESCRIPTION
For use with https://github.com/edx/frontend-app-learner-portal-enterprise/pull/238 to solve ENT-4276.

## Description

This adds an optional parameter to calls into ecommerce that allows passed through, url encoded parameters to get attached as query parameters when ecommerce redirects to Enterprise's Data Sharing Consent page.  This should only affect learners attempting to enroll in a course from the Enterprise Learner Portal. This work supports the Learner Portal with Codes feature (currently a feature flagged effort)

## Supporting information

See JIRA Issue ENT-4276 for details. 

## Testing instructions

This change is tested by using the Enterprise Learner Portal MFE to hit a configured ecommerce endpoint to redeem an Enterprise associated code, ensuring that the 'consent_url_param_string=' parameter has been populated via the change in https://github.com/edx/frontend-app-learner-portal-enterprise/pull/238.  Acceptance criteria are when the redirected url (send to the LMS edx-enterprise endpoint at /enterprise/grant_data_sharing_permissions) is redirected to with the encoded parameters as part of the newly created redirect URL.

Example URL hit in manual testing: 
http://localhost:18130/coupons/redeem/?code=2RLODGQ5ISYZZEF2&consent_url_param_string=left_sidebar_text_override%3D&failure_url=http%3A%2F%2Flocalhost%3A8734%2Ftest-enterprise%2Fsearch%3Fenrollment_failed%3Dtrue&next=http%3A%2F%2Flocalhost%3A18000%2Fcourses%2Fcourse-v1%3AedX%2Babolgercourse3%2B3T2020%2Fcourse&sku=A5D6253


