### PR TITLE
[AA-715] Use course id instead of title in refund event

### DIFF
--- a/ecommerce/extensions/refund/signals.py
+++ b/ecommerce/extensions/refund/signals.py
@@ -22,7 +22,7 @@ def track_completed_refund(sender, refund=None, **kwargs):  # pylint: disable=un
                 'id': line.order_line.partner_sku,
                 'quantity': line.quantity,
                 'price': str(line.order_line.line_price_incl_tax),
-                'title': line.order_line.product.title,
+                'course_id': line.order_line.product.course_id,
             } for line in refund.lines.all()
         ],
     }

--- a/ecommerce/extensions/refund/tests/test_signals.py
+++ b/ecommerce/extensions/refund/tests/test_signals.py
@@ -54,7 +54,7 @@ class RefundTrackingTests(RefundTestMixin, TransactionTestCase):
                 'id': line.order_line.partner_sku,
                 'quantity': line.quantity,
                 'price': str(line.order_line.line_price_incl_tax),
-                'title': line.order_line.product.title,
+                'course_id': line.order_line.product.course_id,
             } for line in refund.lines.all()
         ]
         self.assertEqual(event_payload['products'], expected_products)


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## edX Internal Developers are expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories)

The line title in ecommerce included unnecessary info like the word Seat so we can use the course id to grab the standalone course title in braze using connected content
