### PR TITLE
temp: add title to segment traits

### DIFF
--- a/ecommerce/extensions/checkout/signals.py
+++ b/ecommerce/extensions/checkout/signals.py
@@ -53,6 +53,9 @@ def track_completed_order(sender, order=None, **kwargs):  # pylint: disable=unus
                 'price': float(line.line_price_excl_tax),
                 'quantity': int(line.quantity),
                 'category': line.product.get_product_class().name,
+                # TODO: DENG-797: remove the the `title` once we are no longer forwarding
+                # these events to Hubspot.
+                'title': line.product.title,
             } for line in order.lines.all()
         ],
     }

--- a/ecommerce/extensions/checkout/tests/test_signals.py
+++ b/ecommerce/extensions/checkout/tests/test_signals.py
@@ -238,6 +238,7 @@ class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
                     'price': float(line.line_price_excl_tax),
                     'quantity': line.quantity,
                     'category': line.product.get_product_class().name,
+                    'title': line.product.title,
                 } for line in order.lines.all()
             ],
         }


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## edX Internal Developers are expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories)

## Description

The human-readable title for each purchased course is used in Hubspot to filter user data for marketing purposes. However, the data currently being sent through segment does not contain this field. I originally thought this data was included in the event data we send to Sailthru (and along to Hubspot), but it does not appear to be the case. We only send course id and marketing URL. It seems Sailthru does some sort of custom lookup to other edX services to resolve the course title.

I am attempting to add the missing field it in this pull request, although I am not fully confident it will work. I reviewed the tests using this method and it looks like it might result in the field ultimately containing the id of the course, not the display name of it. My intention is to merge this, review the event traffic in segment, and then revert this if it is not useful. Either way, this is only an addition to the event payload, not a removal or manipulation of an existing field, so it should have no impact on downstream uses of these events outside of Hubspot. 

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
