### PR TITLE
fix: AA-693: update script location

### DIFF
--- a/ecommerce/templates/edx/base.html
+++ b/ecommerce/templates/edx/base.html
@@ -29,6 +29,9 @@
         {% block stylesheets %}
         {% endblock %}
     {% endcompress %}
+    <script type="text/javascript">
+        var initModelData = {{ analytics_data|safe }};
+    </script>
 </head>
 <body>
 {% block skip_link %}
@@ -52,9 +55,6 @@
 {# Translation support for JavaScript strings. #}
 <script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
 
-<script type="text/javascript">
-    var initModelData = {{ analytics_data|safe }};
-</script>
 
 {% compress js %}
     <script src="{% static 'bower_components/requirejs/require.js' %}"></script>


### PR DESCRIPTION
We saw an issue where our analytics was not properly initializing and
I believe it might be possible the cause is because this script was
in the <body> and not the <head> and was being loaded too late.
This attempts to fix that situation
