### PR TITLE
Revert "Added Product IDs to receipt"

### DIFF
--- a/ecommerce/extensions/checkout/tests/test_views.py
+++ b/ecommerce/extensions/checkout/tests/test_views.py
@@ -236,9 +236,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.client.login(username=user.username, password=self.password)
         return self._get_receipt_response(order.number)
 
-    def _create_order_for_receipt(
-            self, user, credit=False, entitlement=False, id_verification_required=False, multiple_lines=False
-    ):
+    def _create_order_for_receipt(self, user, credit=False, entitlement=False, id_verification_required=False):
         """
         Helper function for creating an order and mocking verification status API response.
 
@@ -258,8 +256,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         return self.create_order(
             credit=credit,
             entitlement=entitlement,
-            id_verification_required=id_verification_required,
-            multiple_lines=multiple_lines,
+            id_verification_required=id_verification_required
         )
 
     def test_login_required_get_request(self):
@@ -431,18 +428,6 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertEqual(response.status_code, 200)
         order_value_string = 'data-total-amount="{}"'.format(order.total_incl_tax)
         self.assertContains(response, order_value_string)
-
-    @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
-    @httpretty.activate
-    def test_order_product_ids_available_for_tracking(self, mock_learner_data):
-        mock_learner_data.return_value = self.non_enterprise_learner_data
-        order = self._create_order_for_receipt(self.user, multiple_lines=True)
-        response = self._get_receipt_response(order.number)
-
-        self.assertEqual(response.status_code, 200)
-        expected_order_product_ids = ','.join(map(str, order.lines.values_list('product_id', flat=True)))
-        expected_order_product_ids_string = 'data-product-ids="{}"'.format(expected_order_product_ids)
-        self.assertContains(response, expected_order_product_ids_string)
 
     @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
     @httpretty.activate

--- a/ecommerce/extensions/checkout/views.py
+++ b/ecommerce/extensions/checkout/views.py
@@ -176,7 +176,6 @@ class ReceiptResponseView(ThankYouView):
     def get_context_data(self, **kwargs):  # pylint: disable=arguments-differ
         context = super(ReceiptResponseView, self).get_context_data(**kwargs)
         order = context[self.context_object_name]
-        context['order_product_ids'] = ','.join(map(str, order.lines.values_list('product_id', flat=True)))
         has_enrollment_code_product = False
         if order.basket:
             has_enrollment_code_product = any(

--- a/ecommerce/static/js/pages/receipt_page.js
+++ b/ecommerce/static/js/pages/receipt_page.js
@@ -37,12 +37,11 @@ define([
             };
         }
 
-        function trackPurchase(orderId, totalAmount, currency, productIds) {
+        function trackPurchase(orderId, totalAmount, currency) {
             window.analytics.track('Completed Purchase', {
                 orderId: orderId,
                 total: totalAmount,
-                currency: currency,
-                productIds: productIds
+                currency: currency
             });
         }
 
@@ -50,15 +49,14 @@ define([
             var $el = $('#receipt-container'),
                 currency = $el.data('currency'),
                 orderId = $el.data('order-id'),
-                totalAmount = $el.data('total-amount'),
-                productIds = $el.data('product-ids');
+                totalAmount = $el.data('total-amount');
 
             if ($el.data('back-button')) {
                 disableBackButton();
             }
 
             if (orderId) {
-                trackPurchase(orderId, totalAmount, currency, productIds);
+                trackPurchase(orderId, totalAmount, currency);
             }
         }
 

--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -36,8 +36,7 @@
        data-currency="{{ order.currency }}"
        data-order-id="{{ order.number }}"
        data-total-amount="{{ order.total_incl_tax | unlocalize }}"
-       data-back-button="{{ disable_back_button | default:0 }}"
-       data-product-ids="{{ order_product_ids }}"
+       data-back-button="{{ disable_back_button | default:0 }}">
        {% include 'oscar/partials/alert_messages.html' %}
 
       <h2 class="thank-you">{% trans "Thank you for your order!" as tmsg %}{{ tmsg | force_escape }}</h2>


### PR DESCRIPTION
Reverts edx/ecommerce#3350

We have noticed some issues with how the receipts page is rendered following this commit. We plan on reverting it for the time being until we can get it sorted out.