### PR TITLE
Revert "Revert "temp: add title to segment traits""

### DIFF
--- a/ecommerce/extensions/checkout/signals.py
+++ b/ecommerce/extensions/checkout/signals.py
@@ -53,6 +53,9 @@ def track_completed_order(sender, order=None, **kwargs):  # pylint: disable=unus
                 'price': float(line.line_price_excl_tax),
                 'quantity': int(line.quantity),
                 'category': line.product.get_product_class().name,
+                # TODO: DENG-797: remove the the `title` once we are no longer forwarding
+                # these events to Hubspot.
+                'title': line.product.title,
             } for line in order.lines.all()
         ],
     }

--- a/ecommerce/extensions/checkout/tests/test_signals.py
+++ b/ecommerce/extensions/checkout/tests/test_signals.py
@@ -238,6 +238,7 @@ class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
                     'price': float(line.line_price_excl_tax),
                     'quantity': line.quantity,
                     'category': line.product.get_product_class().name,
+                    'title': line.product.title,
                 } for line in order.lines.all()
             ],
         }


### PR DESCRIPTION
Reverts edx/ecommerce#3368

This [commit](https://github.com/edx/ecommerce/commit/641c66106f23e9e649381e2db4a4e608c93aeac3) was merged to master but not deployed for a bit, due to some failing e2e tests in the gocd pipeline. Once ecommerce was deployed again, an issue was found with the how the receipt page was rendered. We thought that this commit was the most recent one deployed to production and was causing the receipt page problems, so it was [reverted](https://github.com/edx/ecommerce/commit/8d415b1bb3a1c5e6f32d7b13430be38521ac2890). However, there was some confusion as to what had actually been deployed and we have since determined it was actually caused by this (https://github.com/edx/ecommerce/pull/3350), which we are going to revert. It was particularly confusing because both suspected commits were doing similar things: modifying segment events related to completing orders/purchases.

I am reverting the revert.