### PR TITLE
Revert "Added try-except to suppress refund error while we investigate"

### DIFF
--- a/e2e/test_payment.py
+++ b/e2e/test_payment.py
@@ -143,13 +143,7 @@ class TestSeatPayment:
         assert refund_ids != []
 
         for refund_id in refund_ids:
-            # [REV-2156] Cybersource refund errors are breaking e2e tests, quiet them for now while we investigate
-            # This try-except should be removed once the issue is resolved
-            try:
-                api.process_refund(refund_id, 'approve')
-            except Exception as e:  # pylint: disable=broad-except
-                log.warning('Exception while processing refund [%s]: [%r]', refund_id, e)
-
+            api.process_refund(refund_id, 'approve')
         return True
 
     def get_verified_seat(self, course_run):


### PR DESCRIPTION
Reverts edx/ecommerce#3361

Cybersource had a regression in their test environment, which they corrected when we brought it to their attention.  Returned the test to its previous state.