### PR TITLE
fix: :pencil2: ENT-4396 fix typo in var name (ecommerce-worker) for enterprise…

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -63,7 +63,7 @@ edx-django-release-util==1.0.0  # via -r requirements/base.in
 edx-django-sites-extensions==3.0.0  # via -r requirements/base.in
 edx-django-utils==3.13.0  # via -r requirements/base.in, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.4.0  # via -r requirements/base.in, edx-rbac
-edx-ecommerce-worker==1.2.0  # via -r requirements/base.in
+edx-ecommerce-worker==1.3.0  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.3.4           # via -r requirements/base.in
 edx-rest-api-client==5.2.1  # via -r requirements/base.in, edx-ecommerce-worker

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -72,7 +72,7 @@ edx-django-release-util==1.0.0  # via -r requirements/test.txt
 edx-django-sites-extensions==3.0.0  # via -r requirements/test.txt
 edx-django-utils==3.13.0  # via -r requirements/test.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.4.0  # via -r requirements/test.txt, edx-rbac
-edx-ecommerce-worker==1.2.0  # via -r requirements/test.txt
+edx-ecommerce-worker==1.3.0  # via -r requirements/test.txt
 edx-i18n-tools==0.5.3     # via -r requirements/test.txt
 edx-opaque-keys==2.1.1    # via -r requirements/test.txt, edx-drf-extensions
 edx-rbac==1.3.4           # via -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -66,7 +66,7 @@ edx-django-release-util==1.0.0  # via -r requirements/base.in
 edx-django-sites-extensions==3.0.0  # via -r requirements/base.in
 edx-django-utils==3.13.0  # via -r requirements/base.in, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.4.0  # via -r requirements/base.in, edx-rbac
-edx-ecommerce-worker==1.2.0  # via -r requirements/base.in
+edx-ecommerce-worker==1.3.0  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.3.4           # via -r requirements/base.in
 edx-rest-api-client==5.2.1  # via -r requirements/base.in, edx-ecommerce-worker

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -68,7 +68,7 @@ edx-django-release-util==1.0.0  # via -r requirements/base.txt
 edx-django-sites-extensions==3.0.0  # via -r requirements/base.txt
 edx-django-utils==3.13.0  # via -r requirements/base.txt, -r requirements/e2e.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.4.0  # via -r requirements/base.txt, edx-rbac
-edx-ecommerce-worker==1.2.0  # via -r requirements/base.txt
+edx-ecommerce-worker==1.3.0  # via -r requirements/base.txt
 edx-i18n-tools==0.5.3     # via -r requirements/test.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.3.4           # via -r requirements/base.txt


### PR DESCRIPTION
… offer emails

base_enterprise_url var name is being fixed to correct email button links for enterprise users

ENT-4396

## edX Internal Developers are expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories)

## Description

pulls in release ecommerce-worker from https://github.com/edx/ecommerce-worker/pull/125

## Supporting information
JIRA: ENT-4396

## Testing instructions

I tested from Sailthru that template variables are correctly processed. The only thing missing is that we need to send correct template var name from ecommerce-worker, which this change will do. There are no other changes than var name fix for Offer assignment and Offer reminder emails for the `Enterprise portal email` Sailthru template.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
