### PR TITLE
Added Product IDs to receipt page (Fixed)

### DIFF
--- a/ecommerce/extensions/checkout/views.py
+++ b/ecommerce/extensions/checkout/views.py
@@ -176,6 +176,7 @@ class ReceiptResponseView(ThankYouView):
     def get_context_data(self, **kwargs):  # pylint: disable=arguments-differ
         context = super(ReceiptResponseView, self).get_context_data(**kwargs)
         order = context[self.context_object_name]
+        context['order_product_ids'] = ','.join(map(str, order.lines.values_list('product_id', flat=True)))
         has_enrollment_code_product = False
         if order.basket:
             has_enrollment_code_product = any(

--- a/ecommerce/static/js/pages/receipt_page.js
+++ b/ecommerce/static/js/pages/receipt_page.js
@@ -37,11 +37,12 @@ define([
             };
         }
 
-        function trackPurchase(orderId, totalAmount, currency) {
+        function trackPurchase(orderId, totalAmount, currency, productIds) {
             window.analytics.track('Completed Purchase', {
                 orderId: orderId,
                 total: totalAmount,
-                currency: currency
+                currency: currency,
+                productIds: productIds
             });
         }
 
@@ -49,14 +50,15 @@ define([
             var $el = $('#receipt-container'),
                 currency = $el.data('currency'),
                 orderId = $el.data('order-id'),
-                totalAmount = $el.data('total-amount');
+                totalAmount = $el.data('total-amount'),
+                productIds = $el.data('product-ids');
 
             if ($el.data('back-button')) {
                 disableBackButton();
             }
 
             if (orderId) {
-                trackPurchase(orderId, totalAmount, currency);
+                trackPurchase(orderId, totalAmount, currency, productIds);
             }
         }
 

--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -36,7 +36,8 @@
        data-currency="{{ order.currency }}"
        data-order-id="{{ order.number }}"
        data-total-amount="{{ order.total_incl_tax | unlocalize }}"
-       data-back-button="{{ disable_back_button | default:0 }}">
+       data-back-button="{{ disable_back_button | default:0 }}"
+       data-product-ids="{{ order_product_ids }}">
        {% include 'oscar/partials/alert_messages.html' %}
 
       <h2 class="thank-you">{% trans "Thank you for your order!" as tmsg %}{{ tmsg | force_escape }}</h2>


### PR DESCRIPTION
Re-submitting previous changelist for product IDs on the receipt
page, but fixes the missing '>' that broke the page with the earlier
commit.

ENT-4109

This changelist adds a new field to the data container built into the receipt page. This field will store a list of Product IDs of products purchased. This list is added to the "Completed Purchase" event that is generated when the receipt page is loaded. When the event is received, the product ID list is passed to a JS script managed in Google Tag Manager. That script sends the purchase information, including the product IDs to our enterprise customer Pearson.

Relevant links:
https://openedx.atlassian.net/browse/ENT-4109
https://openedx.atlassian.net/wiki/spaces/ENG/pages/2535194760/RCA+REV-2162+-+Receipt+Page+Lost+Formatting

## Testing instructions
1. Login to Google Tag Manager
2. Create a preview window to start a debugging session, using the receipt page to start
3. Confirm that the receipt page loads correctly
4. Follow up with Pearson to see that they receive the Product IDs from the Completed Purchase event sent by the page.
