### PR TITLE
ENT-4456: Added support for learner portal url in braze emails

### DIFF
--- a/ecommerce/extensions/offer/tests/test_utils.py
+++ b/ecommerce/extensions/offer/tests/test_utils.py
@@ -176,7 +176,8 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             },
             None,
             'sender alias',
-            ''
+            '',
+            'https://www.edx.org'
         ),
         (
             'subject',
@@ -191,6 +192,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             },
             None,
             'sender alias',
+            'https://bears.party',
             'https://bears.party'
         ),
     )
@@ -204,6 +206,7 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             side_effect,
             sender_alias,
             base_enterprise_url,
+            search_url,
             mock_sailthru_task,
     ):
         """ Test that the offer assignment email message is sent to async task. """
@@ -229,7 +232,8 @@ class UtilTests(DiscoveryTestMixin, TestCase):
             tokens.get('learner_email'),
             tokens.get('code'),
             tokens.get('redemptions_remaining'),
-            tokens.get('code_expiration_date')
+            tokens.get('code_expiration_date'),
+            search_url
         )
         mock_sailthru_task.delay.assert_called_once_with(
             tokens.get('learner_email'),

--- a/ecommerce/templates/coupons/offer_email.html
+++ b/ecommerce/templates/coupons/offer_email.html
@@ -94,7 +94,8 @@
 					<tr>
 						<td>
 						<p style="white-space: pre-line">{{body}}</p>
-						<a class="btn-style" href="https://edx.org/search"><font color="#ffffff"><b>Find a course</b></font> </a></td>
+						<a class="btn-style" href={{search_url}}><font color="#ffffff"><b>Find a course</b></font> </a>
+						</td>
 					</tr>
 				</tbody>
 			</table>


### PR DESCRIPTION
Description: This PR adds the learner portal search url to the "Find a Course" button in the coupon code emails sent via Braze. If the url is not available, the default edx.org/search url is used.