### PR TITLE
Added links for internal devs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,8 @@ How To Contribute
 
 Contributions are welcome. Please read `How To Contribute <https://github.com/edx/edx-platform/blob/master/CONTRIBUTING.rst>`_ for details. Even though it was written with ``edx-platform`` in mind, these guidelines should be followed for Open edX code in general.
 
+Developers internal to edX should follow the guidance on `this page <https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories>`_ when working on ecommerce related projects, including this one.
+
 Reporting Security Issues
 -------------------------
 
@@ -34,3 +36,5 @@ Get Help
 --------
 
 Ask questions and discuss this project on `Slack <https://openedx.slack.com/messages/ecommerce/>`_ or in the `edx-code Google Group <https://groups.google.com/forum/#!forum/edx-code>`_.
+
+For troubleshooting the ecommerce e2e tests in edX's deployment process, `see this page <https://openedx.atlassian.net/wiki/spaces/RS/pages/2638381505/Ecommerce+e2e+Tests>`_


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## edX Internal Developers are expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories)

## Description

Added links for internal devs to the Purchase squad deployment guidance and e2e test troubleshooting docs to the README

## Supporting information

- [REV-2177: Update ecomm docs with information on build / e2e test failures](https://openedx.atlassian.net/browse/REV-2177)
- [RCA action items](https://openedx.atlassian.net/wiki/spaces/ENG/pages/2535194760/RCA+REV-2162+-+Receipt+Page+Lost+Formatting#Action-Items-(optional))
