### PR TITLE
feat: Add program slug to cart viewed event

### DIFF
--- a/ecommerce/extensions/analytics/utils.py
+++ b/ecommerce/extensions/analytics/utils.py
@@ -239,20 +239,25 @@ def track_braze_event(user, event, properties):
 
     event_url = 'https://{url}/users/track'.format(url=getattr(settings, 'BRAZE_EVENT_REST_ENDPOINT'))
     headers = {'Authorization': 'Bearer ' + getattr(settings, 'BRAZE_API_KEY')}
-    response = requests.post(
-        event_url,
-        headers=headers,
-        json={
-            'events': [
-                {
-                    'external_id': user.lms_user_id_with_metric(usage='Braze event: ' + event),
-                    'name': event,
-                    'time': datetime.now(timezone.utc).isoformat(),
-                    'properties': properties
-                }
-            ]
-        }
-    )
+    try:
+        response = requests.post(
+            event_url,
+            headers=headers,
+            json={
+                'events': [
+                    {
+                        'external_id': user.lms_user_id_with_metric(usage='Braze event: ' + event),
+                        'name': event,
+                        'time': datetime.now(timezone.utc).isoformat(),
+                        'properties': properties
+                    }
+                ]
+            }
+        )
+    # Log out the exception since it could be a symptom we might want to look into.
+    except requests.exceptions.RequestException:
+        logger.exception('Failed to send event to Braze due to request exception.')
+        return
 
     try:
         response.raise_for_status()

--- a/ecommerce/extensions/basket/models.py
+++ b/ecommerce/extensions/basket/models.py
@@ -81,8 +81,8 @@ class Basket(AbstractBasket):
                     'total_price': self.total_excl_tax,
                     'quantity': self.lines.count(),
                 }
-                if program.get('type') and program.get('marketing_slug'):
-                    bundle_properties['marketing_slug'] = (program.get('type').lower() + '/' +
+                if program.get('type_attrs', {}).get('slug') and program.get('marketing_slug'):
+                    bundle_properties['marketing_slug'] = (program['type_attrs']['slug'] + '/' +
                                                            program.get('marketing_slug'))
                 track_segment_event(self.site, self.owner, 'edx.bi.ecommerce.basket.bundle_removed', bundle_properties)
             except BasketAttribute.DoesNotExist:

--- a/ecommerce/extensions/basket/tests/test_utils.py
+++ b/ecommerce/extensions/basket/tests/test_utils.py
@@ -386,7 +386,9 @@ class BasketUtilsTests(DiscoveryTestMixin, BasketMixin, TestCase):
         """
         product = ProductFactory()
         request = self.request
-        program_data = {'marketing_slug': 'program-slug', 'title': 'program title', 'type': 'MicroMasters'}
+        program_data = {
+            'marketing_slug': 'program-slug', 'title': 'program title', 'type_attrs': {'slug': 'micromasters'}
+        }
         with mock.patch('ecommerce.extensions.basket.utils.track_segment_event') as mock_track:
             basket = prepare_basket(request, [product])
             with self.assertRaises(BasketAttribute.DoesNotExist):
@@ -400,7 +402,7 @@ class BasketUtilsTests(DiscoveryTestMixin, BasketMixin, TestCase):
             properties = {
                 'bundle_id': TEST_BUNDLE_ID,
                 'cart_id': basket.id,
-                'marketing_slug': program_data['type'].lower() + '/' + program_data['marketing_slug'],
+                'marketing_slug': program_data['type_attrs']['slug'] + '/' + program_data['marketing_slug'],
                 'title': program_data['title'],
                 'total_price': basket.total_excl_tax,
                 'quantity': basket.lines.count(),
@@ -421,7 +423,9 @@ class BasketUtilsTests(DiscoveryTestMixin, BasketMixin, TestCase):
         basket = prepare_basket(request, [product], voucher)
         self.assertTrue(basket.vouchers.all())
         request.GET = {'bundle': TEST_BUNDLE_ID}
-        program_data = {'marketing_slug': 'program-slug', 'title': 'program title', 'type': 'micromasters'}
+        program_data = {
+            'marketing_slug': 'program-slug', 'title': 'program title', 'type_attrs': {'slug': 'micromasters'}
+        }
         with mock.patch('ecommerce.extensions.basket.utils.get_program', return_value=program_data):
             basket = prepare_basket(request, [product])
         self.assertFalse(basket.vouchers.all())
@@ -433,7 +437,9 @@ class BasketUtilsTests(DiscoveryTestMixin, BasketMixin, TestCase):
         product = ProductFactory(categories=[], stockrecords__partner__short_code='second')
         request = self.request
         request.GET = {'bundle': TEST_BUNDLE_ID}
-        program_data = {'marketing_slug': 'program-slug', 'title': 'program title', 'type': 'micromasters'}
+        program_data = {
+            'marketing_slug': 'program-slug', 'title': 'program title', 'type_attrs': {'slug': 'micromasters'}
+        }
         with mock.patch('ecommerce.extensions.basket.utils.get_program', return_value=program_data):
             basket = prepare_basket(request, [product])
 
@@ -448,7 +454,7 @@ class BasketUtilsTests(DiscoveryTestMixin, BasketMixin, TestCase):
                 prepare_basket(request, [product])
             properties = {
                 'bundle_id': TEST_BUNDLE_ID,
-                'marketing_slug': program_data['type'].lower() + '/' + program_data['marketing_slug'],
+                'marketing_slug': program_data['type_attrs']['slug'] + '/' + program_data['marketing_slug'],
                 'title': program_data['title'],
                 'total_price': basket.total_excl_tax,
                 'quantity': basket.lines.count(),

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -191,8 +191,8 @@ def prepare_basket(request, products, voucher=None):
             'total_price': basket.total_excl_tax,
             'quantity': basket.lines.count(),
         }
-        if program.get('type') and program.get('marketing_slug'):
-            bundle_properties['marketing_slug'] = program.get('type').lower() + '/' + program.get('marketing_slug')
+        if program.get('type_attrs', {}).get('slug') and program.get('marketing_slug'):
+            bundle_properties['marketing_slug'] = program['type_attrs']['slug'] + '/' + program.get('marketing_slug')
         track_segment_event(request.site, request.user, 'edx.bi.ecommerce.basket.bundle_added', bundle_properties)
 
     if len(products) == 1 and products[0].is_enrollment_code_product:

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -815,6 +815,8 @@ class PaymentApiView(PaymentApiLogicMixin, APIView):
         except BasketAttribute.DoesNotExist:
             # No reason to raise an error. Just means it's a single product and not a bundle
             bundle_id = None
+
+        product_slug = None
         # Now we can set fields based on if our basket contains a bundle or not
         if bundle_id:
             program = get_program(bundle_id, basket.site.siteconfiguration)
@@ -822,12 +824,14 @@ class PaymentApiView(PaymentApiLogicMixin, APIView):
                 bundle_variant = 'partial_bundle'
             else:
                 bundle_variant = 'full_bundle'
-            product_title = program.get('title')
             product_subject = program.get('subjects') and program.get('subjects')[0].get('slug')
+            if program.get('type_attrs', {}).get('slug') and program.get('marketing_slug'):
+                product_slug = program['type_attrs']['slug'] + '/' + program.get('marketing_slug')
+            product_title = program.get('title')
         else:
             bundle_variant = None
-            product_title = data['products'][0]['title']
             product_subject = data['products'][0]['subject']
+            product_title = data['products'][0]['title']
 
         return {
             'basket_discount': data['summary_discounts'],
@@ -842,8 +846,9 @@ class PaymentApiView(PaymentApiLogicMixin, APIView):
                 }
                 for product in data['products']
             ],
-            'product_title': product_title,
+            'product_slug': product_slug,
             'product_subject': product_subject,
+            'product_title': product_title,
         }
 
 


### PR DESCRIPTION
refactor: Switch to using type_attrs.slug to get the program type
slug as I noticed the slug was incorrect with professional certificate
in my first implementation ("professional certificate" instead of
"professional-certificate")

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## edX Internal Developers are expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories)

# This project is under merge-freeze until 26 April 2021, review by @revenue-team will be required until then.
## Description

Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?
Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
