### PR TITLE
REV-2193: update ecommerce to use new ecommerce-worker version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -63,7 +63,7 @@ edx-django-release-util==1.0.0  # via -r requirements/base.in
 edx-django-sites-extensions==3.0.0  # via -r requirements/base.in
 edx-django-utils==3.13.0  # via -r requirements/base.in, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.4.0  # via -r requirements/base.in, edx-rbac
-edx-ecommerce-worker==1.3.2  # via -r requirements/base.in
+edx-ecommerce-worker==1.3.3  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.3.4           # via -r requirements/base.in
 edx-rest-api-client==5.2.1  # via -r requirements/base.in, edx-ecommerce-worker

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -72,7 +72,7 @@ edx-django-release-util==1.0.0  # via -r requirements/test.txt
 edx-django-sites-extensions==3.0.0  # via -r requirements/test.txt
 edx-django-utils==3.13.0  # via -r requirements/test.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.4.0  # via -r requirements/test.txt, edx-rbac
-edx-ecommerce-worker==1.3.2  # via -r requirements/test.txt
+edx-ecommerce-worker==1.3.3  # via -r requirements/test.txt
 edx-i18n-tools==0.5.3     # via -r requirements/test.txt
 edx-opaque-keys==2.1.1    # via -r requirements/test.txt, edx-drf-extensions
 edx-rbac==1.3.4           # via -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -66,7 +66,7 @@ edx-django-release-util==1.0.0  # via -r requirements/base.in
 edx-django-sites-extensions==3.0.0  # via -r requirements/base.in
 edx-django-utils==3.13.0  # via -r requirements/base.in, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.4.0  # via -r requirements/base.in, edx-rbac
-edx-ecommerce-worker==1.3.2  # via -r requirements/base.in
+edx-ecommerce-worker==1.3.3  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.3.4           # via -r requirements/base.in
 edx-rest-api-client==5.2.1  # via -r requirements/base.in, edx-ecommerce-worker

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -68,7 +68,7 @@ edx-django-release-util==1.0.0  # via -r requirements/base.txt
 edx-django-sites-extensions==3.0.0  # via -r requirements/base.txt
 edx-django-utils==3.13.0  # via -r requirements/base.txt, -r requirements/e2e.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.4.0  # via -r requirements/base.txt, edx-rbac
-edx-ecommerce-worker==1.3.2  # via -r requirements/base.txt
+edx-ecommerce-worker==1.3.3  # via -r requirements/base.txt
 edx-i18n-tools==0.5.3     # via -r requirements/test.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.3.4           # via -r requirements/base.txt


### PR DESCRIPTION
In REV-2193 we've made a new ecommerce-worker version to bump the py package version from 1.9.0 to 1.10.0. This PR updates ecommerce to use this new ecommerce-worker version

## Supporting information
https://openedx.atlassian.net/browse/REV-2193
