### PR TITLE
ENT-4490 only fetch non expired codes based on voucher expiration date

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -3523,6 +3523,8 @@ class OfferAssignmentSummaryViewSetTests(
             enterprise_customer=self.enterprise_customer['id'],
             enterprise_customer_catalog='dddddddd-2c44-487b-9b6a-24eee973f9a4',
         )
+        self.assign_user_to_code(expired_coupon.id, [self.user.email], [])
+        self.assign_user_to_code(non_expired_coupon.id, [self.user.email], [])
 
         oa_expired_code = OfferAssignment.objects.get(
             user_email=self.user.email,
@@ -3533,9 +3535,6 @@ class OfferAssignmentSummaryViewSetTests(
             user_email=self.user.email,
             offer__vouchers__coupon_vouchers__coupon__id=non_expired_coupon.id
         ).code
-
-        self.assign_user_to_code(expired_coupon.id, [self.user.email], [])
-        self.assign_user_to_code(non_expired_coupon.id, [self.user.email], [])
 
         response = self.client.get(OFFER_ASSIGNMENT_SUMMARY_LINK + "?is_active=True&full_discount_only=True").json()
         assert response['count'] == 1

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -187,7 +187,6 @@ class OfferAssignmentSummaryViewSet(ModelViewSet):
 
         for offer_assignment in queryset:
             if offer_assignment.code not in offer_assignments_with_counts:
-                breakpoint()
                 # Note that we can get away with just dropping in the first
                 # offerAssignment object of particular code that we see
                 # because most of the data we are returning lives on related

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -886,7 +886,6 @@ class EnterpriseCouponViewSet(CouponViewSet):
                 for assignment in assignment_usages
             ]
 
-        logger.info("Base enterprise url for coupon reminder: %s", base_enterprise_url)
         serializer = CouponCodeRemindSerializer(
             data=assignments,
             many=True,

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -7,9 +7,9 @@ import django_filters
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q, prefetch_related_objects
-from django.utils.timezone import now
 from django.http import Http404
 from django.shortcuts import get_object_or_404
+from django.utils.timezone import now
 from edx_rbac.decorators import permission_required
 from edx_rbac.mixins import PermissionRequiredMixin
 from oscar.core.loading import get_model
@@ -155,6 +155,10 @@ class OfferAssignmentSummaryViewSet(ModelViewSet):
         Each dictionary contains one offerAssignment object, and the count of
         how many total offerAssignment objects the DB returned with the same
         code, as a way of "rolling up" offerAssignments a user has.
+
+        If `is_active` is in the request parameters, does not include codes that are:
+         - set to inactive state via attributes.code
+         - whose voucher expiration date has passed (compared to now())
         """
         queryset = OfferAssignment.objects.filter(
             user_email=self.request.user.email,
@@ -192,7 +196,6 @@ class OfferAssignmentSummaryViewSet(ModelViewSet):
                 # offerAssignment object of particular code that we see
                 # because most of the data we are returning lives on related
                 # objects that each of these offerAssignments share (e.g. the benefit)
-                # is_active flag should cause a filtering out of codes for expired vouchers
                 offer_assignments_with_counts[offer_assignment.code] = {
                     'count': 1,
                     'obj': offer_assignment,


### PR DESCRIPTION
when is_active is provided only return non expired codes. Expiration date is in the voucher's end_datetime field as per

https://django-oscar.readthedocs.io/en/2.0.4/_modules/oscar/apps/voucher/abstract_models.html#AbstractVoucher

# Testing notes

Created a coupon code in ecom locally http://localhost:18130/enterprise/coupons
Made the voucher expired by setting its end date to an earlier date than current date (2021-04-16 in my case)
assigned this code to a learner using the admin portal http://localhost:1991/test-enterprise
verified that learner portal at first fetches this coupon code as part of the `offer_assignment_summary` endpoint from ecom

After change

verified it no longer fetches this coupon code

In progress: while code is being reviewed, will run a generated query against staging read replica to ensure no ecom database issues 