### PR TITLE
chore: update pillow to 8.1.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -101,7 +101,7 @@ path.py==7.2              # via -r requirements/base.in
 paypalrestsdk==1.13.1     # via -r requirements/base.in
 pbr==5.5.1                # via cybersource-rest-client-python, fixtures, stevedore, testtools
 phonenumbers==8.12.16     # via django-oscar, django-phonenumber-field
-pillow==8.1.0             # via django-oscar
+pillow==8.1.2             # via django-oscar
 premailer==2.9.2          # via -r requirements/base.in
 psutil==5.8.0             # via edx-django-utils
 purl==1.5                 # via django-oscar

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -496,7 +496,7 @@ phonenumbers==8.12.16
     #   -r test.txt
     #   django-oscar
     #   django-phonenumber-field
-pillow==8.1.0
+pillow==8.1.2
     # via
     #   -r test.txt
     #   django-oscar

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -107,7 +107,7 @@ path.py==7.2              # via -r requirements/base.in
 paypalrestsdk==1.13.1     # via -r requirements/base.in
 pbr==5.5.1                # via cybersource-rest-client-python, fixtures, stevedore, testtools
 phonenumbers==8.12.16     # via django-oscar, django-phonenumber-field
-pillow==8.1.0             # via django-oscar
+pillow==8.1.2             # via django-oscar
 premailer==2.9.2          # via -r requirements/base.in
 psutil==5.8.0             # via edx-django-utils
 purl==1.5                 # via django-oscar

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -119,7 +119,7 @@ path.py==7.2              # via -r requirements/base.txt, edx-i18n-tools
 paypalrestsdk==1.13.1     # via -r requirements/base.txt
 pbr==5.5.1                # via -r requirements/base.txt, -r requirements/e2e.txt, cybersource-rest-client-python, fixtures, stevedore, testtools
 phonenumbers==8.12.16     # via -r requirements/base.txt, django-oscar, django-phonenumber-field
-pillow==8.1.0             # via -r requirements/base.txt, django-oscar
+pillow==8.1.2             # via -r requirements/base.txt, django-oscar
 pluggy==0.13.1            # via -r requirements/e2e.txt, -r requirements/tox.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
 premailer==2.9.2          # via -r requirements/base.txt


### PR DESCRIPTION
REV-2153: security advisory to update Pillow to 8.1.2: 
https://github.com/advisories/GHSA-95q3-8gr9-gm8w/dependabot?query=user:edx

## edX Internal Developers are expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories)


## Supporting information
https://openedx.atlassian.net/browse/REV-2153

## Testing instructions
- build tests pass
- I can complete an order in my local environment with this branch

