### PR TITLE
REV-2226: update bower to 1.8.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -548,9 +548,9 @@
       }
     },
     "bower": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.4.tgz",
-      "integrity": "sha1-54dqB23rgTf30GUl3F6MZtuC8oo="
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.8.tgz",
+      "integrity": "sha512-1SrJnXnkP9soITHptSO+ahx3QKp3cVzn8poI6ujqc5SeOkg5iqM1pK9H+DSc2OQ8SnO0jC/NG4Ur/UIwy7574A=="
     },
     "brace-expansion": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "git://github.com/edx/ecommerce"
   },
   "dependencies": {
-    "bower": "1.8.4",
+    "bower": "1.8.8",
     "requirejs": "2.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
REV-2226: security advisory to update Bower to 1.8.8: 
https://github.com/edx/ecommerce/security/dependabot/package-lock.json/bower/open

## edX Internal Developers are expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories)


## Supporting information
https://openedx.atlassian.net/browse/REV-2226

## Testing instructions
- build tests pass
- I can complete an order in my local environment with this branch
