### PR TITLE
fix: bump edx-ecommerce-worker to 2.0.1 to fix celery

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -63,7 +63,7 @@ edx-django-release-util==1.0.0  # via -r requirements/base.in
 edx-django-sites-extensions==3.0.0  # via -r requirements/base.in
 edx-django-utils==3.13.0  # via -r requirements/base.in, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.4.0  # via -r requirements/base.in, edx-rbac
-edx-ecommerce-worker==2.0.0  # via -r requirements/base.in
+edx-ecommerce-worker==2.0.1  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.3.4           # via -r requirements/base.in
 edx-rest-api-client==5.2.1  # via -r requirements/base.in, edx-ecommerce-worker

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -284,7 +284,7 @@ edx-drf-extensions==6.4.0
     # via
     #   -r test.txt
     #   edx-rbac
-edx-ecommerce-worker==2.0.0
+edx-ecommerce-worker==2.0.1
     # via -r test.txt
 edx-i18n-tools==0.5.3
     # via -r test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -66,7 +66,7 @@ edx-django-release-util==1.0.0  # via -r requirements/base.in
 edx-django-sites-extensions==3.0.0  # via -r requirements/base.in
 edx-django-utils==3.13.0  # via -r requirements/base.in, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.4.0  # via -r requirements/base.in, edx-rbac
-edx-ecommerce-worker==2.0.0  # via -r requirements/base.in
+edx-ecommerce-worker==2.0.1  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.in, edx-drf-extensions
 edx-rbac==1.3.4           # via -r requirements/base.in
 edx-rest-api-client==5.2.1  # via -r requirements/base.in, edx-ecommerce-worker

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -68,7 +68,7 @@ edx-django-release-util==1.0.0  # via -r requirements/base.txt
 edx-django-sites-extensions==3.0.0  # via -r requirements/base.txt
 edx-django-utils==3.13.0  # via -r requirements/base.txt, -r requirements/e2e.txt, django-config-models, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.4.0  # via -r requirements/base.txt, edx-rbac
-edx-ecommerce-worker==2.0.0  # via -r requirements/base.txt
+edx-ecommerce-worker==2.0.1  # via -r requirements/base.txt
 edx-i18n-tools==0.5.3     # via -r requirements/test.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx-rbac==1.3.4           # via -r requirements/base.txt


### PR DESCRIPTION
## edX Internal Developers are expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories)

