### PR TITLE
BOM-2247 - Upgrade pip-tools

### DIFF
--- a/requirements/pins.txt
+++ b/requirements/pins.txt
@@ -38,10 +38,6 @@ virtualenv==16.7.9
 # removing this pin, then this pin can be removed.
 pylint==2.4.4
 
-# See https://openedx.atlassian.net/browse/BOM-2247 for details.
-# need an update in configuration before this can be removed.
-pip-tools<6.0
-
 # greater versions failing with extract-tranlsations step.
 tox==3.14.6
 tox-battery==0.5.2

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -6,10 +6,12 @@
 #
 click==8.0.1
     # via pip-tools
-pip-tools==5.5.0
-    # via
-    #   -c requirements/pins.txt
-    #   -r requirements/pip_tools.in
+pep517==0.10.0
+    # via pip-tools
+pip-tools==6.1.0
+    # via -r requirements/pip_tools.in
+toml==0.10.2
+    # via pep517
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
Now that we are have pinned pip to version 20.3.4 in configuration, which is compatible with the latest version of pip-tools according to this compatibility chart
https://github.com/jazzband/pip-tools/#versions-and-compatibility

So in this PR, we are upgrading the latest pip-tools.

Relevant JIRA: https://openedx.atlassian.net/browse/BOM-2247