### PR TITLE
ENT-4661: calling the LMS API in bulk to load user data.

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -548,8 +548,8 @@ class User(AbstractUser):
         except Exception:  # pylint: disable=broad-except
             return None
 
-    @staticmethod
-    def get_lms_user_attribute_using_email(site, user_email, attribute='id'):
+    @classmethod
+    def get_lms_user_attribute_using_email(cls, site, user_email, attribute='id'):
         """Returns a lms_user attribute by query LMS using email address.
 
         Args:
@@ -562,14 +562,9 @@ class User(AbstractUser):
         """
         if user_email:
             try:
-                api = EdxRestApiClient(
-                    site.siteconfiguration.build_lms_url('/api/user/v1'),
-                    append_slash=False,
-                    jwt=site.siteconfiguration.access_token
-                )
-                response = api.accounts.get(email=user_email)
+                response = cls.get_bulk_lms_users_using_emails(site, [user_email])
                 return response[0][attribute]
-            except Exception:  # pylint: disable=broad-except
+            except (IndexError, KeyError):
                 log.exception('Failed to get attribute [%s] for email: [%s]', attribute, user_email)
         return None
 

--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -1247,8 +1247,11 @@ class EnterpriseCouponViewSetRbacTests(
 
         # Redeem a voucher without using the assignment endpoint
         self.use_voucher(coupon3.coupon_vouchers.first().vouchers.first(), self.user)
-
-        self.mock_accounts_api_using_email(self.request, self.user)
+        self.mock_bulk_lms_users_using_emails(self.request, [{
+            'id': self.user.lms_user_id,
+            'username': self.user.username,
+            'email': self.user.email}
+        ])
         self.mock_access_token_response()
         response = self.get_response(
             'GET',

--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -1248,7 +1248,7 @@ class EnterpriseCouponViewSetRbacTests(
         # Redeem a voucher without using the assignment endpoint
         self.use_voucher(coupon3.coupon_vouchers.first().vouchers.first(), self.user)
         self.mock_bulk_lms_users_using_emails(self.request, [{
-            'id': self.user.lms_user_id,
+            'lms_user_id': self.user.lms_user_id,
             'username': self.user.username,
             'email': self.user.email}
         ])

--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -1247,11 +1247,10 @@ class EnterpriseCouponViewSetRbacTests(
 
         # Redeem a voucher without using the assignment endpoint
         self.use_voucher(coupon3.coupon_vouchers.first().vouchers.first(), self.user)
-        self.mock_bulk_lms_users_using_emails(self.request, [{
-            'lms_user_id': self.user.lms_user_id,
-            'username': self.user.username,
-            'email': self.user.email}
-        ])
+        mock_users = [
+            {'lms_user_id': self.user.lms_user_id, 'username': self.user.username, 'email': self.user.email}
+        ]
+        self.mock_bulk_lms_users_using_emails(self.request, mock_users)
         self.mock_access_token_response()
         response = self.get_response(
             'GET',

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -727,7 +727,7 @@ class EnterpriseCouponViewSet(CouponViewSet):
         """
         Update assignments to add lms_user_id and username using email.
         """
-        emails = [assignment['user'] for assignment in assignments]
+        emails = [assignment['user']['email'] for assignment in assignments]
         lms_users = User.get_bulk_lms_users_using_emails(self.request.site, emails)
         for assignment in assignments:
             user = assignment['user']
@@ -768,7 +768,7 @@ class EnterpriseCouponViewSet(CouponViewSet):
             'sender_id': sender_id,
             'site': request.site
         }
-        serializer = CouponCodeAssignmentSerializer(data=request.data, context=context)
+        serializer = CouponCodeAssignmentSerializer(data=assignments, context=context)
         if serializer.is_valid():
             self.add_extra_user_info_in_users(assignments['users'])
             serializer = CouponCodeAssignmentSerializer(data=assignments, context=context)

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -441,24 +441,6 @@ class LmsApiMockMixin:
         body = json.dumps(data)
         httpretty.register_uri(httpretty.GET, url, body=body, content_type=CONTENT_TYPE)
 
-    def mock_accounts_api_using_email(self, request, user):
-        """ Mock the account LMS API endpoint for a user.
-
-        Args:
-            request (WSGIRequest): The request from which the host URL is constructed.
-            user(User): User to mock.
-        """
-        url = '{host}/accounts?email={email}'.format(
-            host=request.site.siteconfiguration.build_lms_url('/api/user/v1'),
-            email=user.email,
-        )
-        data = [{
-            'id': user.id,
-            'username': user.username,
-        }]
-        body = json.dumps(data)
-        httpretty.register_uri(httpretty.GET, url, body=body, content_type=CONTENT_TYPE)
-
     def mock_bulk_lms_users_using_emails(self, request, users):
         """ Mock the account Bulk LMS API endpoint for users.
 


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## edX Internal Developers are expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories)

## Description

Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?
Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
