### PR TITLE
Cleaned up REV-2142 logs, added better permanent logs

### DIFF
--- a/ecommerce/extensions/offer/models.py
+++ b/ecommerce/extensions/offer/models.py
@@ -176,9 +176,9 @@ class Benefit(AbstractBenefit):
                         applicable_lines.remove(metadata['line'])
 
             logger.info(
-                "Basket [%s] with offer [%s] has applicable lines: %s", 
-                basket.id, 
-                offer.id, 
+                "Basket [%s] with offer [%s] has applicable lines: %s",
+                basket.id,
+                offer.id,
                 applicable_lines
             )
             return [(line.product.stockrecords.first().price_excl_tax, line) for line in applicable_lines]

--- a/ecommerce/extensions/offer/models.py
+++ b/ecommerce/extensions/offer/models.py
@@ -130,40 +130,11 @@ class Benefit(AbstractBenefit):
             query = applicable_range.catalog_query
             applicable_lines = self._filter_for_paid_course_products(basket.all_lines(), applicable_range)
 
-            logger.info("(REV-2142) get_applicable_lines Basket: [%s], Offer: [%s]", basket.id, offer.id)
-            rev_2142_coupon_ids_to_log = [66492, 66502]  # REV-2142 Stage coupon ids to test with
-            rev_2142_basket_owners_to_log = [
-                'bjhstage', 'bjhstage2', 'bjhstage3', 'bjhstage4',
-                'bjh-prod', 'bjh-prod2', 'bjh-prod3', 'bjh-prod4',
-            ]
-            rev_2142_logging_enabled = (
-                offer.id in rev_2142_coupon_ids_to_log or
-                basket.owner.username in rev_2142_basket_owners_to_log
-            )
-            if rev_2142_logging_enabled:
-                logger.info("(REV-2142) initial applicable_lines: %s", str(applicable_lines))
-
             site = basket.site
             partner_code = site.siteconfiguration.partner.short_code
             course_run_ids, course_uuids, applicable_lines = self._identify_uncached_product_identifiers(
                 applicable_lines, site.domain, partner_code, query
             )
-
-            if rev_2142_logging_enabled:
-                logger.info(
-                    '(REV-2142) checked _identify_uncached_product_identifiers for '
-                    'Basket: [%s], Offer: [%s], User: [%s (%s)], course_run_ids: [%s], course_uuids: [%s],'
-                    'query: [%s]'
-                    'applicable_lines: [%s]',
-                    basket.id,
-                    offer.id,
-                    basket.owner.username,
-                    basket.owner.id,
-                    str(course_run_ids),
-                    str(course_uuids),
-                    str(query),
-                    str(applicable_lines)
-                )
 
             if course_run_ids or course_uuids:
                 # Hit Discovery Service to determine if remaining courses and runs are in the range.
@@ -183,12 +154,17 @@ class Benefit(AbstractBenefit):
                     )
                     raise Exception('Failed to contact Discovery Service to retrieve offer catalog_range data.')
 
+                logger.info(
+                    "Discovery Service results for basket: [%s], offer: [%s], query: '%s', response: %s",
+                    basket.id,
+                    offer.id,
+                    query,
+                    response,
+                )
+
                 # Cache range-state individually for each course or run identifier and remove lines not in the range.
                 for metadata in course_run_ids + course_uuids:
                     in_range = response[str(metadata['id'])]
-
-                    if rev_2142_logging_enabled:
-                        logger.info("(REV-2142) discovery response for id %s: %s", str(metadata['id']), str(in_range))
 
                     # Convert to int, because this is what memcached will return, and the request cache should return
                     # the same value.
@@ -197,12 +173,14 @@ class Benefit(AbstractBenefit):
                     TieredCache.set_all_tiers(metadata['cache_key'], in_range, settings.COURSES_API_CACHE_TIMEOUT)
 
                     if not in_range:
-                        if rev_2142_logging_enabled:
-                            logger.info("(REV-2142) Removing line from range: %s", str(metadata))
                         applicable_lines.remove(metadata['line'])
 
-            if rev_2142_logging_enabled:
-                logger.info("(REV-2142) Before returning, applicable_lines has: %s", str(applicable_lines))
+            logger.info(
+                "Basket [%s] with offer [%s] has applicable lines: %s", 
+                basket.id, 
+                offer.id, 
+                applicable_lines
+            )
             return [(line.product.stockrecords.first().price_excl_tax, line) for line in applicable_lines]
         return super(Benefit, self).get_applicable_lines(offer, basket, range=range)  # pylint: disable=bad-super-call
 


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## edX Internal Developers are expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories)

## Description

Cleaned up some temporary logging and added better permanent logging for diagnosing issues with coupon query lookups in the Discovery service; this should not have any other significant impact.

## Supporting information
[REV ticket for this cleanup work](https://openedx.atlassian.net/browse/REV-2290)

Prior investigation:
- [CR-3394: Coupons cannot be applied to courses with Enrollment End date passed](https://openedx.atlassian.net/browse/CR-3394)
- [REV-2142: Coupons cannot be applied to courses with Enrollment End date passed
](https://openedx.atlassian.net/browse/REV-2142)
- [VAN-632: Discovery `query_contains` sometimes returns `false` for upgradable courses past the enrollment end date](https://openedx.atlassian.net/browse/VAN-632)

## Testing instructions

Applying a coupon to a basket at checkout should result in the new logs in Splunk  detailing the coupon query and Discovery service results, and the line-items that it should apply to (actually completing the purchase should not be necessary.)

