### PR TITLE
REV-2200: update program offer save logic to give more unique names

### DIFF
--- a/ecommerce/programs/forms.py
+++ b/ecommerce/programs/forms.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from datetime import datetime
 
 from django import forms
 from django.forms.utils import ErrorList
@@ -82,10 +83,12 @@ class ProgramOfferForm(forms.ModelForm):
     def save(self, commit=True):
         program_uuid = self.cleaned_data['program_uuid']
         site = self.request.site
+        current_date = str(datetime.today().strftime('%Y-%m-%d'))
 
         client = ProgramsApiClient(site.siteconfiguration.discovery_api_client, site.domain)
         program = client.get_program(program_uuid)
-        offer_name = _(u'Discount for the {program_title} {program_type} Program'.format(
+        offer_name = _(u'{current_date} Discount for the {program_title} {program_type} Program'.format(
+            current_date=current_date,
             program_title=program['title'],
             program_type=program['type']
         ))

--- a/ecommerce/programs/tests/test_forms.py
+++ b/ecommerce/programs/tests/test_forms.py
@@ -2,6 +2,7 @@
 
 
 import uuid
+from datetime import datetime
 
 import httpretty
 from oscar.core.loading import get_model
@@ -23,6 +24,7 @@ class ProgramOfferFormTests(ProgramTestMixin, TestCase):
             'program_uuid': uuid.uuid4(),
             'benefit_type': Benefit.PERCENTAGE,
             'benefit_value': 22,
+            'current_date': str(datetime.today().strftime('%Y-%m-%d')),
         }
         data.update(**kwargs)
         return data
@@ -83,8 +85,9 @@ class ProgramOfferFormTests(ProgramTestMixin, TestCase):
         form = ProgramOfferForm(request=self.request, data=data)
         form.is_valid()
         offer = form.save()
+        expected_name = data['current_date'] + ' Discount for the Test Program MicroMockers Program'
         self.assert_program_offer_conditions(offer, data['program_uuid'], data['benefit_value'], data['benefit_type'],
-                                             'Discount for the Test Program MicroMockers Program')
+                                             expected_name)
 
     @httpretty.activate
     def test_save_create_special_char_title(self):
@@ -96,8 +99,9 @@ class ProgramOfferFormTests(ProgramTestMixin, TestCase):
         form = ProgramOfferForm(request=self.request, data=data)
         form.is_valid()
         offer = form.save()
+        expected_name = data['current_date'] + ' Discount for the Spánish Program MicroMockers Program'
         self.assert_program_offer_conditions(offer, data['program_uuid'], data['benefit_value'], data['benefit_type'],
-                                             'Discount for the Spánish Program MicroMockers Program')
+                                             expected_name)
 
     @httpretty.activate
     def test_save_edit(self):
@@ -110,8 +114,9 @@ class ProgramOfferFormTests(ProgramTestMixin, TestCase):
         form.save()
 
         offer.refresh_from_db()
+        expected_name = data['current_date'] + ' Discount for the Test Program MicroMockers Program'
         self.assert_program_offer_conditions(offer, data['program_uuid'], data['benefit_value'], data['benefit_type'],
-                                             'Discount for the Test Program MicroMockers Program')
+                                             expected_name)
 
     @httpretty.activate
     def test_save_without_commit(self):
@@ -133,8 +138,9 @@ class ProgramOfferFormTests(ProgramTestMixin, TestCase):
         form = ProgramOfferForm(request=self.request, data=data)
         form.is_valid()
         offer = form.save()
+        expected_name = data['current_date'] + ' Discount for the Test Program MicroMockers Program'
         self.assert_program_offer_conditions(offer, data['program_uuid'], data['benefit_value'], data['benefit_type'],
-                                             'Discount for the Test Program MicroMockers Program')
+                                             expected_name)
 
     def test_create_when_conditional_offer_with_uuid_exists(self):
         """


### PR DESCRIPTION
## edX Internal Developers are expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories)


## Description

We received the following issue(s) where a project coordinator was unable to save a new offer for a program: 
https://openedx.atlassian.net/browse/CR-3619
https://openedx.atlassian.net/browse/REV-2200

The issue was that the offer name needs to be unique, and this is generated automatically when the offer is saved, using the program_title and program_type. This is problematic when a program is relaunched: we already have an offer for the same program_title and program_type, so a new one can't be created. 

I've updated the code to prepend the date during new offer creation, so instead of a name like 'Discount for the Video Game Design XSeries Program', it'll be '2021-06-30 Discount for the Video Game Design XSeries Program'

This offer_name is never shown to the learner, only visible to an admin viewing the order detail in the Oscar dashboard. 

## Testing instructions
- The affected tests are here:  `pytest ecommerce/programs/tests/test_forms.py `
- tested branch vs master locally, this way: 
1) choose active program you’ll replace, and edit its name
2) make a new active program with the original name of the old one, and grab its UUID
3) save an offer for this new UUID
Result: with master branch we're not allowed, but with this branch it uses a date in the name so we can save a new offer (once per day)

