### PR TITLE
[BB-3801] feat: install extra requirements in the tox environments

### DIFF
--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -1,0 +1,2 @@
+# If there are any Python packages you want to keep in your virtualenv beyond
+# those listed in the official requirements files, list them here.

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,7 @@ setenv =
     SELENIUM_BROWSER=firefox
 deps =
     -r{toxinidir}/requirements/test.txt
+    -r{toxinidir}/requirements/extra.txt
     django32: Django>=3.2,<3.3
 allowlist_externals =
     /bin/bash


### PR DESCRIPTION
This PR adds a `requirements/extra.txt` requirement file and configures `tox` to install them in its environments.

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Description

Extra requirements for ecommerce specified via the `ECOMMERCE_EXTRA_REQUIREMENTS` ansible variable in the `edx/configuration` repository do not get installed in the `tox` environments used to run the migrations (`make migrate`).

This is necessary when the extra requirements are added to

`INSTALLED_APPS` and hence have to be installed in the `tox` virtualenv
environments used for the various Django management commands.

This PR is related to and depends on https://github.com/edx/configuration/pull/6489

**Testing instructions**:


## Testing instructions

* Add some extra requirements (for example, `git+https://github.com/open-craft/ecommerce-hyperpay.git#egg=hyperpay-ecommerce`) to `requirements/extra.txt` and add them to `INSTALLED_APPS (for example, `hyperpay`).
* Run `make migrate` in as the `ecommerce` user in the ecommerce environment.
* Verify that the specified extra requirements are installed in the `tox` environment and the migration command completes successfully.

## Reviewers
- [ ] @kaizoku 
- [ ] edX reviewers (TBD)