### PR TITLE
[BB-4552] feat: Add support for fixed rate in ecommerce

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_baskets.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_baskets.py
@@ -423,6 +423,19 @@ class BasketCalculateViewTests(ProgramTestMixin, ThrottlingMixin, TestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 401)
 
+    @override_settings(TAX_RATE=0.1)
+    def test_basket_calculate_with_tax_different_than_zero(self):
+        """ Verify that total value(including tax) uses the tax rate defined on settings(TAX_RATE) """
+        expected = {
+            'total_incl_tax_excl_discounts': Decimal("32.97"),
+            'total_incl_tax': Decimal("32.97"),
+            'currency': 'GBP'
+        }
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, expected)
+
     def test_basket_calculate_no_offers(self):
         """ Verify a successful basket calculation with no offers"""
 

--- a/ecommerce/extensions/partner/strategy.py
+++ b/ecommerce/extensions/partner/strategy.py
@@ -1,5 +1,8 @@
 
 
+from decimal import Decimal
+
+from django.conf import settings
 from django.utils import timezone
 from oscar.apps.partner import availability, strategy
 from oscar.core.loading import get_model
@@ -33,8 +36,19 @@ class CourseSeatAvailabilityPolicyMixin(strategy.StockRequired):
         return availability.Unavailable()
 
 
+class TaxStrategyMixin(strategy.FixedRateTax):
+    """
+    Tax strategy for e-commerce pricing.
+    Defaults to 0% tax, but allows setting a fixed tax rate through Django settings.
+    """
+
+    @property
+    def rate(self):
+        return Decimal(settings.TAX_RATE)
+
+
 class DefaultStrategy(strategy.UseFirstStockRecord, CourseSeatAvailabilityPolicyMixin,
-                      strategy.NoTax, strategy.Structured):
+                      TaxStrategyMixin, strategy.Structured):
     """ Default Strategy """
 
 

--- a/ecommerce/extensions/partner/tests/test_strategy.py
+++ b/ecommerce/extensions/partner/tests/test_strategy.py
@@ -1,10 +1,11 @@
 
 
 import datetime
+from decimal import Decimal
 
 import ddt
 import pytz
-from django.test import RequestFactory
+from django.test import RequestFactory, override_settings
 from oscar.apps.partner import availability
 
 from ecommerce.courses.tests.factories import CourseFactory
@@ -66,6 +67,11 @@ class DefaultStrategyTests(DiscoveryTestMixin, TestCase):
         stock_record = product.stockrecords.first()
         actual = strategy.availability_policy(product, stock_record)
         self.assertIsInstance(actual, available)
+
+    @override_settings(TAX_RATE="0.3")
+    def test_get_rate(self):
+        strategy = DefaultStrategy()
+        self.assertEqual(strategy.get_rate(None, None), Decimal("0.3"))
 
 
 class SelectorTests(TestCase):

--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -9,7 +9,6 @@ from django.http import JsonResponse
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext as _
 from edx_django_utils import monitoring as monitoring_utils
-from oscar.apps.partner import strategy
 from oscar.apps.payment.exceptions import GatewayError, PaymentError, TransactionDeclined, UserCancelled
 from oscar.core.loading import get_class, get_model
 from rest_framework import permissions, status
@@ -51,6 +50,7 @@ Order = get_model('order', 'Order')
 OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
 OrderTotalCalculator = get_class('checkout.calculators', 'OrderTotalCalculator')
 PaymentProcessorResponse = get_model('payment', 'PaymentProcessorResponse')
+Selector = get_class('partner.strategy', 'Selector')
 
 
 class CyberSourceProcessorMixin:
@@ -301,7 +301,7 @@ class CybersourceOrderCompletionView(EdxOrderPlacementMixin):
         try:
             basket_id = int(basket_id)
             basket = Basket.objects.get(id=basket_id)
-            basket.strategy = strategy.Default()
+            basket.strategy = Selector().strategy()
 
             Applicator().apply(basket, basket.owner, self.request)
             logger.info(

--- a/ecommerce/extensions/payment/views/paypal.py
+++ b/ecommerce/extensions/payment/views/paypal.py
@@ -12,7 +12,6 @@ from django.http import Http404, HttpResponse, HttpResponseBadRequest
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
 from django.views.generic import View
-from oscar.apps.partner import strategy
 from oscar.apps.payment.exceptions import PaymentError
 from oscar.core.loading import get_class, get_model
 
@@ -31,6 +30,7 @@ NoShippingRequired = get_class('shipping.methods', 'NoShippingRequired')
 OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
 OrderTotalCalculator = get_class('checkout.calculators', 'OrderTotalCalculator')
 PaymentProcessorResponse = get_model('payment', 'PaymentProcessorResponse')
+Selector = get_class('partner.strategy', 'Selector')
 
 
 class PaypalPaymentExecutionView(EdxOrderPlacementMixin, View):
@@ -65,7 +65,7 @@ class PaypalPaymentExecutionView(EdxOrderPlacementMixin, View):
                 processor_name=self.payment_processor.NAME,
                 transaction_id=payment_id
             ).basket
-            basket.strategy = strategy.Default()
+            basket.strategy = Selector().strategy()
 
             Applicator().apply(basket, basket.owner, self.request)
 

--- a/ecommerce/management/utils.py
+++ b/ecommerce/management/utils.py
@@ -3,7 +3,6 @@
 import logging
 
 from django.db.models import Q
-from oscar.apps.partner import strategy
 from oscar.core.loading import get_class, get_model
 
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
@@ -20,6 +19,7 @@ NoShippingRequired = get_class('shipping.methods', 'NoShippingRequired')
 Order = get_model('order', 'Order')
 OrderTotalCalculator = get_class('checkout.calculators', 'OrderTotalCalculator')
 ShippingEventType = get_model('order', 'ShippingEventType')
+Selector = get_class('partner.strategy', 'Selector')
 
 SHIPPING_EVENT_NAME = 'Shipped'
 
@@ -44,7 +44,7 @@ def refund_basket_transactions(site, basket_ids):
     failure_count = 0
 
     for basket in baskets:
-        basket.strategy = strategy.Default()
+        basket.strategy = Selector().strategy()
         Applicator().apply(basket, basket.owner, None)
 
         logger.info('Refunding transactions for basket [%d]...', basket.id)
@@ -140,7 +140,7 @@ class FulfillFrozenBaskets(EdxOrderPlacementMixin):
 
         # if no order exists we need to create a new order.
         if not order:
-            basket.strategy = strategy.Default()
+            basket.strategy = Selector().strategy(user=basket.owner)
 
             # Need to handle the case that applied voucher has been expired.
             # This will create the order  with out discount but subsequently

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -825,3 +825,6 @@ AWIN_ADVERTISER_ID = None
 ################# Settings for brand logos. #################
 LOGO_URL = None
 FAVICON_URL = None
+
+# Set a fixed tax rate for all products
+TAX_RATE = '0.0'


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## BB-4552: Add support for a fixed rate for all products in ecommerce

## Description

Ecommerce does not support tax rates for its payments(DefaultStrategy uses a NoTax strategy), this PR adds support for a fixed tax rate through a new django setting `TAX_RATE` that is applied to all products.
Also the default value for the `TAX_RATE` setting is 0.0, preserving the previous platform behaviour.

## Supporting information

Jira Issue: [BB-4552](https://tasks.opencraft.com/browse/BB-4552)

## Testing instructions

- Check that the added tests make sense and run without failure

- Change the `TAX_RATE` to a decimal value(like "0.3")
- Try to make a purchase(could be the certificate upgrade of the demo course)
- Verify that the total value displayed on basket and invoice includes the tax rate

