### PR TITLE
Revert "Fix dashboard URL on basket page"

### DIFF
--- a/ecommerce/templates/oscar/basket/basket.html
+++ b/ecommerce/templates/oscar/basket/basket.html
@@ -47,7 +47,7 @@
                         <div class="depth depth-2 message-error-content">
                             <h3>{% trans "Your basket is empty" as tmsg %}{{ tmsg | force_escape }}</h3>
                             {% blocktrans asvar tmsg %}
-                                If you attempted to make a purchase, you have not been charged. Return to your {link_start}{homepage_url}{link_middle}dashboard{link_end} to try
+                                If you attempted to make a purchase, you have not been charged. Return to your {link_start}{link_middle}{homepage_url}dashboard{link_end} to try
                                 again, or {link_start}{homepage_url}{link_middle}contact {platform_name} Support{link_end}.
                             {% endblocktrans %}
                             {% interpolate_html tmsg link_start='<a href="'|safe support_url=support_url|safe platform_name=platform_name|safe link_end='</a>'|safe homepage_url=homepage_url|safe link_middle='">'|safe %}


### PR DESCRIPTION
Reverts edx/ecommerce#3450

This is currently sitting undeployed on stage. Any commits that merge to master in ecommerce need to be deployed by the person/team that made the commit or an edX sponsor. This did not happen for this commit, and we are concerned about having unsponsored commits on stage but not prod. We want to make sure that stage is clean just in case we have a production issue that needs to be taken care of right away. Therefore, we are reverting this pr for now until we can connect with the original authors and arrange for it to be re-applied and deployed in a timely manner.

For more information for internal to edX stakeholders, see this confluence doc: https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories 