### PR TITLE
fix: add jsonfield support for Django 3.2

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -31,7 +31,7 @@ edx-ecommerce-worker
 edx-opaque-keys
 edx-rbac
 edx-rest-api-client
-jsonfield2
+jsonfield
 libsass==0.9.2
 markdown==2.6.9
 mysqlclient<1.5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -164,7 +164,7 @@ django==2.2.23
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-rbac
-    #   jsonfield2
+    #   jsonfield
     #   rest-condition
     #   xss-utils
 djangorestframework-csv==2.1.1
@@ -246,7 +246,7 @@ itypes==1.2.0
     # via coreapi
 jinja2==3.0.1
     # via coreschema
-jsonfield2==3.0.3
+jsonfield==3.1.0
     # via
     #   -c requirements/pins.txt
     #   -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -244,7 +244,7 @@ django==2.2.23
     #   edx-drf-extensions
     #   edx-i18n-tools
     #   edx-rbac
-    #   jsonfield2
+    #   jsonfield
     #   mock-django
     #   pytest-django-ordering
     #   rest-condition
@@ -395,7 +395,7 @@ jinja2==3.0.1
     #   diff-cover
     #   jinja2-pluralize
     #   sphinx
-jsonfield2==3.0.3
+jsonfield==3.1.0
     # via -r requirements/test.txt
 jsonschema==3.2.0
     # via

--- a/requirements/pins.txt
+++ b/requirements/pins.txt
@@ -17,9 +17,6 @@ django-oscar<2.1
 # causing tests failures
 httpretty==0.9.7
 
-# jsonfield2 > 3.0.3 dropped support for python 3.5
-jsonfield2<=3.0.3
-
 # 5.4 introduces test order problems that need to be resolved.
 pytest<5.4.0
 pytest-django<4.0 # Newer versions require pytest >= 5.4.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -173,7 +173,7 @@ django==2.2.23
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-rbac
-    #   jsonfield2
+    #   jsonfield
     #   rest-condition
     #   xss-utils
 djangorestframework-csv==2.1.1
@@ -263,7 +263,7 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
-jsonfield2==3.0.3
+jsonfield==3.1.0
     # via
     #   -c requirements/pins.txt
     #   -r requirements/base.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -242,7 +242,7 @@ django-widget-tweaks==1.4.8
     #   edx-drf-extensions
     #   edx-i18n-tools
     #   edx-rbac
-    #   jsonfield2
+    #   jsonfield
     #   mock-django
     #   pytest-django-ordering
     #   rest-condition
@@ -379,7 +379,7 @@ jinja2==3.0.1
     #   coreschema
     #   diff-cover
     #   jinja2-pluralize
-jsonfield2==3.0.3
+jsonfield==3.1.0
     # via
     #   -c requirements/pins.txt
     #   -r requirements/base.txt


### PR DESCRIPTION
## Add jsonfield support for Django 3.2

### Description

Solving issue https://github.com/edx/upgrades/issues/34
I changed `jsonfield2` to `jsonfield` because jsonfield 3.1.0 supports django 3.2, the test is here https://app.circleci.com/pipelines/github/MaferMazu/jsonfield?branch=mfmz%2Ffix-ci-and-test-django3.2 and it is the most updated version.
