### PR TITLE
feat: Add fields to purchase event to support Braze confirmation emails

### DIFF
--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -291,7 +291,8 @@ class BusinessIntelligenceMixin:
         completed order or refund.
         """
         self.assertEqual(
-            ['coupon', 'currency', 'discount', 'email', 'orderId', 'products', 'revenue', 'total'],
+            ['billingAddress', 'coupon', 'currency', 'discount', 'email', 'orderDate', 'orderId', 'products',
+             'revenue', 'subtotal', 'total'],
             sorted(event_payload.keys())
         )
         self.assertEqual(event_payload['orderId'], order_number)


### PR DESCRIPTION
Allow ecommerce to send confirmation emails by pushing the necessary data to Braze via the Segment event.

## Description

Learners are not currently getting emails from edX about their purchases, this should enable us to do that again.

## Supporting information

See REV-2353


## Testing instructions

Testing this fully requires access to Segment and Braze, but it's also possible to just view in Segment the events to see that the correct new data is being sent.
