### PR TITLE
REV-2365: remove pinned version for social-auth-core

### DIFF
--- a/requirements/pins.txt
+++ b/requirements/pins.txt
@@ -46,6 +46,3 @@ idna==2.7
 
 # TODO : Pinning this until we are sure there aren't any breaking changes, then we'll upgrade.
 celery<5.0.0
-
-# Latest version requires PyJWT>=2.0.0 but drf-jwt requires PyJWT[crypto]<2.0.0,>=1.5.2
-social-auth-core<4.0.3


### PR DESCRIPTION
## Description

Right now 'make upgrade' is blocked in ecommerce because of a requirements conflict for the **social-auth-core** package: 
- edx-ecommerce requires edx-auth-backends 
- in pins.txt, edx-ecommerce  requires us to keep social-auth-core<4.0.3
- this month edx-auth-backends started requiring social-auth-core>=4.1.0 (in common_constraints.txt)

'make upgrade' won't proceed because no version of social-auth-core is both <4.0.3 and >=4.1.0

This PR removes the pinned maximum version in pins.txt


## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
