### PR TITLE
feat: add user and group management commands 

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -308,6 +308,7 @@ DJANGO_APPS = [
     'csrf.apps.CsrfAppConfig',  # Enables frontend apps to retrieve CSRF tokens.
     'rules.apps.AutodiscoverRulesConfig',
     'xss_utils',
+    'edx_django_utils.user',
 ]
 
 # Apps specific to this project go here.


### PR DESCRIPTION
<!--
Add user and group management commands from edx-django-utils.

-->

## Description

The pull request adds `edx_django_utils.user` as a django app. `edx_django_utils.user` contains user and group management commands.

## Supporting information

See [ADR (decision record)](https://edx.readthedocs.io/projects/edx-django-utils/en/latest/decisions/0005-user-and-group-management-commands.html) for more details.

## Testing instructions

To test this PR in devstack, update edx-django-utils to >=4.3.0 and:

1. Use the management command to create group:

```
./manage.py manage_group waffle_admin --permissions waffle:flag:add_flag waffle:flag:change_flag waffle:flag:delete_flag waffle:sample:add_sample waffle:sample:change_sample waffle:sample:delete_sample waffle:switch:add_switch waffle:switch:change_switch waffle:switch:delete_switch
```

2. Add user to the group:

```
./manage.py manage_user staff staff@example.com --groups waffle_admin  --superuser --staff
```
Verify that the user and group have been successfully added via django admin.


## Other information

This PR depends on edx-django-utils >= 4.3.0.
