### PR TITLE
feat: Replace usages of `threadlocals` with local implementation WIP

### DIFF
--- a/ecommerce/core/url_utils.py
+++ b/ecommerce/core/url_utils.py
@@ -2,13 +2,13 @@
 
 import warnings
 
-from ecommerce.utils import get_current_request
 from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 
 from ecommerce.core.exceptions import MissingRequestError
+from ecommerce.utils import get_current_request
 
 
 def _get_site_configuration():

--- a/ecommerce/core/url_utils.py
+++ b/ecommerce/core/url_utils.py
@@ -2,7 +2,7 @@
 
 import warnings
 
-from crum import get_current_request
+from ecommerce.utils import get_current_request
 from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.http import HttpResponseRedirect

--- a/ecommerce/core/url_utils.py
+++ b/ecommerce/core/url_utils.py
@@ -2,11 +2,11 @@
 
 import warnings
 
+from crum import get_current_request
 from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.http import HttpResponseRedirect
 from django.urls import reverse
-from threadlocals.threadlocals import get_current_request
 
 from ecommerce.core.exceptions import MissingRequestError
 
@@ -18,7 +18,7 @@ def _get_site_configuration():
         This is a stopgap. Do NOT use this with any expectation that it will remain in place.
         This function WILL be removed.
     """
-    warnings.warn('Usage of _get_site_configuration and django-threadlocals is deprecated. '
+    warnings.warn('Usage of _get_site_configuration is deprecated. '
                   'Use the helper methods on the SiteConfiguration model.', DeprecationWarning)
 
     request = get_current_request()

--- a/ecommerce/enterprise/conditions.py
+++ b/ecommerce/enterprise/conditions.py
@@ -4,7 +4,6 @@ import logging
 from decimal import Decimal
 from uuid import UUID
 
-import crum
 from django.contrib import messages
 from django.db.models import Sum
 from django.utils.translation import ugettext as _
@@ -23,6 +22,7 @@ from ecommerce.extensions.offer.mixins import ConditionWithoutRangeMixin, Single
 from ecommerce.extensions.offer.models import OFFER_PRIORITY_ENTERPRISE
 from ecommerce.extensions.offer.utils import get_benefit_type, get_discount_value
 from ecommerce.extensions.refund.status import REFUND
+from ecommerce.utils import get_current_request
 
 BasketAttribute = get_model('basket', 'BasketAttribute')
 BasketAttributeType = get_model('basket', 'BasketAttributeType')
@@ -209,7 +209,7 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
                         'To redeem this coupon, you must first logout. When you log back in, '
                         'please select {new_enterprise} as your enterprise '
                         'and try again.').format(new_enterprise=enterprise_name_in_condition)
-                messages.warning(crum.get_current_request(), msg,)
+                messages.warning(get_current_request(), msg,)
 
             return False
 
@@ -358,7 +358,7 @@ class AssignableEnterpriseCustomerCondition(EnterpriseCustomerCondition):
             return True
 
         messages.warning(
-            crum.get_current_request(),
+            get_current_request(),
             _('This code is not valid with your email. '
               'Please login with the correct email assigned '
               'to the code or contact your Learning Manager '

--- a/ecommerce/enterprise/rules.py
+++ b/ecommerce/enterprise/rules.py
@@ -2,8 +2,6 @@
 Django rules for enterprise
 """
 
-
-import crum
 import rules
 from edx_rbac.utils import request_user_has_implicit_access_via_jwt, user_has_access_via_database
 # pylint: disable=no-name-in-module
@@ -12,6 +10,7 @@ from edx_rest_framework_extensions.auth.jwt.cookies import get_decoded_jwt
 
 from ecommerce.core.constants import ENTERPRISE_COUPON_ADMIN_ROLE
 from ecommerce.core.models import EcommerceFeatureRoleAssignment
+from ecommerce.utils import get_current_request
 
 
 @rules.predicate
@@ -21,7 +20,7 @@ def request_user_has_implicit_access(user, context):  # pylint: disable=unused-a
      Returns:
         boolean: whether the request user has access or not
     """
-    request = crum.get_current_request()
+    request = get_current_request()
     decoded_jwt = get_decoded_jwt(request) or get_decoded_jwt_from_auth(request)
     if not context:
         return False

--- a/ecommerce/enterprise/tests/test_conditions.py
+++ b/ecommerce/enterprise/tests/test_conditions.py
@@ -720,7 +720,7 @@ class AssignableEnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, Cou
                     assignment.status = OFFER_REDEEMED
                     assignment.save()
 
-    @mock.patch('ecommerce.enterprise.conditions.crum.get_current_request')
+    @mock.patch('ecommerce.enterprise.conditions.get_current_request')
     @mock.patch.object(EnterpriseCustomerCondition, 'is_satisfied', mock.Mock(return_value=True))
     @ddt.data(
         (0, 'test1@example.com', OFFER_ASSIGNMENT_EMAIL_PENDING, True),
@@ -747,7 +747,7 @@ class AssignableEnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, Cou
 
         assert self.condition.is_satisfied(enterprise_offer, basket) == condition_result
 
-    @mock.patch('ecommerce.enterprise.conditions.crum.get_current_request')
+    @mock.patch('ecommerce.enterprise.conditions.get_current_request')
     @mock.patch.object(EnterpriseCustomerCondition, 'is_satisfied', mock.Mock(return_value=True))
     def test_is_satisfied_with_different_users(self, mock_request):
         """
@@ -775,7 +775,7 @@ class AssignableEnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, Cou
 
         assert self.condition.is_satisfied(enterprise_offers[1], basket) is False
 
-    @mock.patch('ecommerce.enterprise.conditions.crum.get_current_request')
+    @mock.patch('ecommerce.enterprise.conditions.get_current_request')
     @mock.patch.object(EnterpriseCustomerCondition, 'is_satisfied', mock.Mock(return_value=True))
     @mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email', mock.Mock())
     @ddt.data(
@@ -930,7 +930,7 @@ class AssignableEnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, Cou
             self.assert_condition(voucher_type, assignments, True)
         self.assert_condition(voucher_type, wrong_assignments, False)
 
-    @mock.patch('ecommerce.enterprise.conditions.crum.get_current_request')
+    @mock.patch('ecommerce.enterprise.conditions.get_current_request')
     @mock.patch.object(EnterpriseCustomerCondition, 'is_satisfied', mock.Mock(return_value=True))
     def test_is_satisfied_when_owner_has_no_assignment(self, mock_request):
         """
@@ -957,7 +957,7 @@ class AssignableEnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, Cou
 
         assert self.condition.is_satisfied(enterprise_offer, basket) is True
 
-    @mock.patch('ecommerce.enterprise.conditions.crum.get_current_request')
+    @mock.patch('ecommerce.enterprise.conditions.get_current_request')
     @mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email', mock.Mock())
     @mock.patch.object(EnterpriseCustomerCondition, 'is_satisfied', mock.Mock(return_value=True))
     def test_is_satisfied_when_user_has_no_assignment(self, mock_request):
@@ -999,7 +999,7 @@ class AssignableEnterpriseCustomerConditionTests(EnterpriseServiceMockMixin, Cou
         # no redemption available
         self.assert_condition(voucher_type, user_with_no_assignment, False)
 
-    @mock.patch('ecommerce.enterprise.conditions.crum.get_current_request')
+    @mock.patch('ecommerce.enterprise.conditions.get_current_request')
     @mock.patch.object(EnterpriseCustomerCondition, 'is_satisfied', mock.Mock(return_value=True))
     @ddt.data(
         (0, True),

--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -10,7 +10,7 @@ from collections import OrderedDict
 from functools import reduce  # pylint: disable=redefined-builtin
 from urllib.parse import parse_qsl, urlencode, urlparse
 
-import crum
+from ecommerce.utils import get_current_request
 from django.conf import settings
 from django.urls import reverse
 from django.utils.translation import ugettext as _
@@ -560,7 +560,7 @@ def get_enterprise_catalog(site, enterprise_catalog, limit, page, endpoint_reque
 
 
 def get_enterprise_id_for_current_request_user_from_jwt():
-    request = crum.get_current_request()
+    request = get_current_request()
     decoded_jwt = get_decoded_jwt(request)
     if decoded_jwt:
         roles_claim = decoded_jwt.get('roles', [])

--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -10,7 +10,6 @@ from collections import OrderedDict
 from functools import reduce  # pylint: disable=redefined-builtin
 from urllib.parse import parse_qsl, urlencode, urlparse
 
-from ecommerce.utils import get_current_request
 from django.conf import settings
 from django.urls import reverse
 from django.utils.translation import ugettext as _
@@ -27,6 +26,7 @@ from ecommerce.core.url_utils import absolute_url, get_lms_dashboard_url
 from ecommerce.enterprise.constants import SENDER_ALIAS
 from ecommerce.enterprise.exceptions import EnterpriseDoesNotExist
 from ecommerce.extensions.offer.models import OFFER_PRIORITY_ENTERPRISE
+from ecommerce.utils import get_current_request
 
 ConditionalOffer = get_model('offer', 'ConditionalOffer')
 StockRecord = get_model('partner', 'StockRecord')

--- a/ecommerce/extensions/analytics/utils.py
+++ b/ecommerce/extensions/analytics/utils.py
@@ -160,7 +160,7 @@ def track_segment_event(site, user, event, properties, traits=None):
     # construct a URL, so that hostname can be sent to GA.
     # For now, send a dummy value for path.  Segment parses the URL and sends
     # the host and path separately. When needed, the path can be fetched by adding:
-    # request = crum.get_current_request()
+    # request = get_current_request()
     # if request:
     #     path = request.META.get('PATH_INFO')
     hostname = site.domain

--- a/ecommerce/extensions/catalogue/management/commands/convert_course.py
+++ b/ecommerce/extensions/catalogue/management/commands/convert_course.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from crum import set_current_request
+from ecommerce.utils import set_current_request
 from django.core.management import BaseCommand
 from django.db import transaction
 from oscar.core.loading import get_model

--- a/ecommerce/extensions/catalogue/management/commands/convert_course.py
+++ b/ecommerce/extensions/catalogue/management/commands/convert_course.py
@@ -2,7 +2,6 @@
 
 import logging
 
-from ecommerce.utils import set_current_request
 from django.core.management import BaseCommand
 from django.db import transaction
 from oscar.core.loading import get_model
@@ -10,6 +9,7 @@ from oscar.test.utils import RequestFactory
 
 from ecommerce.courses.models import Course
 from ecommerce.extensions.catalogue.utils import generate_sku
+from ecommerce.utils import set_current_request
 
 logger = logging.getLogger(__name__)
 Line = get_model('order', 'Line')

--- a/ecommerce/extensions/catalogue/management/commands/convert_course.py
+++ b/ecommerce/extensions/catalogue/management/commands/convert_course.py
@@ -2,11 +2,11 @@
 
 import logging
 
+from crum import set_current_request
 from django.core.management import BaseCommand
 from django.db import transaction
 from oscar.core.loading import get_model
 from oscar.test.utils import RequestFactory
-from threadlocals.threadlocals import set_thread_variable
 
 from ecommerce.courses.models import Course
 from ecommerce.extensions.catalogue.utils import generate_sku
@@ -132,4 +132,4 @@ class Command(BaseCommand):
         """
         request = RequestFactory()
         request.site = site
-        set_thread_variable('request', request)
+        set_current_request(request)

--- a/ecommerce/extensions/offer/dynamic_conditional_offer.py
+++ b/ecommerce/extensions/offer/dynamic_conditional_offer.py
@@ -15,7 +15,6 @@ from ecommerce.extensions.offer.mixins import (
 )
 from ecommerce.utils import get_current_request
 
-
 Condition = get_model('offer', 'Condition')
 PercentageDiscountBenefit = get_model('offer', 'PercentageDiscountBenefit')
 ZERO_DISCOUNT = get_class('offer.results', 'ZERO_DISCOUNT')

--- a/ecommerce/extensions/offer/dynamic_conditional_offer.py
+++ b/ecommerce/extensions/offer/dynamic_conditional_offer.py
@@ -2,7 +2,6 @@
 Dynamic conditional offers allow us to calculate discount percentages and whether a course and user are eligible
 for a discount elsewhere, and pass it in. We pass this information through a jwt on the request.
 """
-import crum
 import waffle
 from oscar.core.loading import get_class, get_model
 
@@ -14,6 +13,8 @@ from ecommerce.extensions.offer.mixins import (
     PercentageBenefitMixin,
     SingleItemConsumptionConditionMixin
 )
+from ecommerce.utils import get_current_request
+
 
 Condition = get_model('offer', 'Condition')
 PercentageDiscountBenefit = get_model('offer', 'PercentageDiscountBenefit')
@@ -21,7 +22,7 @@ ZERO_DISCOUNT = get_class('offer.results', 'ZERO_DISCOUNT')
 
 
 def get_decoded_jwt_discount_from_request():
-    request = crum.get_current_request()
+    request = get_current_request()
 
     # We use a get request for display on the basket page,
     # and we use a post request for submitting  payment.
@@ -64,7 +65,7 @@ class DynamicPercentageDiscountBenefit(BenefitWithoutRangeMixin, PercentageDisco
         We haven't plumbed the discount_percent all the way through, so we will get the discount
         percent from the request.
         """
-        if not waffle.flag_is_active(crum.get_current_request(), DYNAMIC_DISCOUNT_FLAG):
+        if not waffle.flag_is_active(get_current_request(), DYNAMIC_DISCOUNT_FLAG):
             return ZERO_DISCOUNT
         percent = self.benefit_class_value
         if percent:
@@ -94,7 +95,7 @@ class DynamicDiscountCondition(ConditionWithoutRangeMixin, SingleItemConsumption
         We haven't plumbed the condition all the way through, so we will get the discount condition from the request
         here.
         """
-        if not waffle.flag_is_active(crum.get_current_request(), DYNAMIC_DISCOUNT_FLAG):
+        if not waffle.flag_is_active(get_current_request(), DYNAMIC_DISCOUNT_FLAG):
             return False
 
         if basket.num_items > 1:

--- a/ecommerce/extensions/offer/models.py
+++ b/ecommerce/extensions/offer/models.py
@@ -3,7 +3,7 @@ import datetime
 import logging
 import re
 
-from crum import get_current_request
+from ecommerce.utils import get_current_request
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey

--- a/ecommerce/extensions/offer/models.py
+++ b/ecommerce/extensions/offer/models.py
@@ -3,7 +3,6 @@ import datetime
 import logging
 import re
 
-from ecommerce.utils import get_current_request
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
@@ -41,6 +40,7 @@ from ecommerce.extensions.offer.constants import (
     SENDER_CATEGORY_TYPES
 )
 from ecommerce.extensions.offer.utils import format_assigned_offer_email
+from ecommerce.utils import get_current_request
 
 OFFER_PRIORITY_ENTERPRISE = 10
 OFFER_PRIORITY_VOUCHER = 20

--- a/ecommerce/extensions/offer/models.py
+++ b/ecommerce/extensions/offer/models.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import re
 
+from crum import get_current_request
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
@@ -25,7 +26,6 @@ from requests.exceptions import ConnectionError as ReqConnectionError
 from requests.exceptions import Timeout
 from simple_history.models import HistoricalRecords
 from slumber.exceptions import SlumberBaseException
-from threadlocals.threadlocals import get_current_request
 
 from ecommerce.core.utils import get_cache_key, log_message_and_raise_validation_error
 from ecommerce.extensions.offer.constants import (

--- a/ecommerce/extensions/offer/tests/test_dynamic_conditional_offer.py
+++ b/ecommerce/extensions/offer/tests/test_dynamic_conditional_offer.py
@@ -42,7 +42,7 @@ class DynamicPercentageDiscountBenefitTests(BenefitTestMixin, TestCase):
     name_format = 'dynamic_discount_benefit'
 
     @override_flag(DYNAMIC_DISCOUNT_FLAG, active=True)
-    @patch('crum.get_current_request')
+    @patch('ecommerce.utils.get_current_request')
     @patch('ecommerce.extensions.offer.dynamic_conditional_offer.jwt_decode_handler',
            side_effect=_mock_jwt_decode_handler)
     @patch('ecommerce.enterprise.utils.get_decoded_jwt',
@@ -103,7 +103,7 @@ class DynamicConditionTests(TestCase):
         self.assertTrue(self.condition.name == 'dynamic_discount_condition')
 
     @override_flag(DYNAMIC_DISCOUNT_FLAG, active=True)
-    @patch('crum.get_current_request')
+    @patch('ecommerce.utils.get_current_request')
     @patch('ecommerce.extensions.offer.dynamic_conditional_offer.jwt_decode_handler',
            side_effect=_mock_jwt_decode_handler)
     @ddt.data(
@@ -121,7 +121,7 @@ class DynamicConditionTests(TestCase):
             self.assertFalse(self.condition.is_satisfied(self.offer, self.basket))
 
     @override_flag(DYNAMIC_DISCOUNT_FLAG, active=True)
-    @patch('crum.get_current_request')
+    @patch('ecommerce.utils.get_current_request')
     def test_is_satisfied_quantity_more_than_1(self, request):   # pylint: disable=unused-argument
         """
         This discount should not apply if are buying more than one of the same course.
@@ -131,7 +131,7 @@ class DynamicConditionTests(TestCase):
         self.assertFalse(self.condition.is_satisfied(self.offer, self.basket))
 
     @override_flag(DYNAMIC_DISCOUNT_FLAG, active=True)
-    @patch('crum.get_current_request')
+    @patch('ecommerce.utils.get_current_request')
     def test_is_satisfied_not_seat_product(self, request):   # pylint: disable=unused-argument
         """
         This discount should not apply if are not purchasing a seat product.

--- a/ecommerce/extensions/offer/tests/test_dynamic_conditional_offer.py
+++ b/ecommerce/extensions/offer/tests/test_dynamic_conditional_offer.py
@@ -42,7 +42,7 @@ class DynamicPercentageDiscountBenefitTests(BenefitTestMixin, TestCase):
     name_format = 'dynamic_discount_benefit'
 
     @override_flag(DYNAMIC_DISCOUNT_FLAG, active=True)
-    @patch('ecommerce.utils.get_current_request')
+    @patch('ecommerce.extensions.offer.dynamic_conditional_offer.get_current_request')
     @patch('ecommerce.extensions.offer.dynamic_conditional_offer.jwt_decode_handler',
            side_effect=_mock_jwt_decode_handler)
     @patch('ecommerce.enterprise.utils.get_decoded_jwt',
@@ -103,7 +103,7 @@ class DynamicConditionTests(TestCase):
         self.assertTrue(self.condition.name == 'dynamic_discount_condition')
 
     @override_flag(DYNAMIC_DISCOUNT_FLAG, active=True)
-    @patch('ecommerce.utils.get_current_request')
+    @patch('ecommerce.extensions.offer.dynamic_conditional_offer.get_current_request')
     @patch('ecommerce.extensions.offer.dynamic_conditional_offer.jwt_decode_handler',
            side_effect=_mock_jwt_decode_handler)
     @ddt.data(
@@ -121,7 +121,7 @@ class DynamicConditionTests(TestCase):
             self.assertFalse(self.condition.is_satisfied(self.offer, self.basket))
 
     @override_flag(DYNAMIC_DISCOUNT_FLAG, active=True)
-    @patch('ecommerce.utils.get_current_request')
+    @patch('ecommerce.extensions.offer.dynamic_conditional_offer.get_current_request')
     def test_is_satisfied_quantity_more_than_1(self, request):   # pylint: disable=unused-argument
         """
         This discount should not apply if are buying more than one of the same course.
@@ -131,7 +131,7 @@ class DynamicConditionTests(TestCase):
         self.assertFalse(self.condition.is_satisfied(self.offer, self.basket))
 
     @override_flag(DYNAMIC_DISCOUNT_FLAG, active=True)
-    @patch('ecommerce.utils.get_current_request')
+    @patch('ecommerce.extensions.offer.dynamic_conditional_offer.get_current_request')
     def test_is_satisfied_not_seat_product(self, request):   # pylint: disable=unused-argument
         """
         This discount should not apply if are not purchasing a seat product.

--- a/ecommerce/extensions/order/conditions.py
+++ b/ecommerce/extensions/order/conditions.py
@@ -2,11 +2,12 @@
 
 import logging
 
-import crum
 from django.urls import reverse
 from oscar.core.loading import get_model
 
 from ecommerce.extensions.offer.mixins import ConditionWithoutRangeMixin, SingleItemConsumptionConditionMixin
+from ecommerce.utils import get_current_request
+
 
 Condition = get_model('offer', 'Condition')
 ConditionalOffer = get_model('offer', 'ConditionalOffer')
@@ -33,7 +34,7 @@ class ManualEnrollmentOrderDiscountCondition(
         else
             return False
         """
-        if crum.get_current_request().META['PATH_INFO'] != reverse('api:v2:manual-course-enrollment-order-list'):
+        if get_current_request().META['PATH_INFO'] != reverse('api:v2:manual-course-enrollment-order-list'):
             self.log_error_message(
                 'This condition is only applicable to manual course enrollement orders.',
                 offer,

--- a/ecommerce/extensions/order/conditions.py
+++ b/ecommerce/extensions/order/conditions.py
@@ -8,7 +8,6 @@ from oscar.core.loading import get_model
 from ecommerce.extensions.offer.mixins import ConditionWithoutRangeMixin, SingleItemConsumptionConditionMixin
 from ecommerce.utils import get_current_request
 
-
 Condition = get_model('offer', 'Condition')
 ConditionalOffer = get_model('offer', 'ConditionalOffer')
 logger = logging.getLogger(__name__)

--- a/ecommerce/extensions/order/rules.py
+++ b/ecommerce/extensions/order/rules.py
@@ -2,7 +2,6 @@
 Django rules for Refund
 """
 
-import crum
 import rules
 from edx_rbac.utils import request_user_has_implicit_access_via_jwt, user_has_access_via_database
 # pylint: disable=no-name-in-module
@@ -11,6 +10,7 @@ from edx_rest_framework_extensions.auth.jwt.cookies import get_decoded_jwt
 
 from ecommerce.core.constants import ORDER_MANAGER_ROLE
 from ecommerce.core.models import EcommerceFeatureRoleAssignment
+from ecommerce.utils import get_current_request
 
 
 @rules.predicate
@@ -20,7 +20,7 @@ def request_user_has_implicit_access(user):  # pylint: disable=unused-argument
      Returns:
         boolean: whether the request user has access or not
     """
-    request = crum.get_current_request()
+    request = get_current_request()
     decoded_jwt = get_decoded_jwt(request) or get_decoded_jwt_from_auth(request)
 
     return request_user_has_implicit_access_via_jwt(decoded_jwt, ORDER_MANAGER_ROLE)

--- a/ecommerce/extensions/order/tests/test_conditions.py
+++ b/ecommerce/extensions/order/tests/test_conditions.py
@@ -2,7 +2,6 @@
 
 from django.test import RequestFactory
 from django.urls import reverse
-from mock import patch
 from oscar.test.factories import BasketFactory
 
 from ecommerce.courses.tests.factories import CourseFactory
@@ -13,6 +12,7 @@ from ecommerce.extensions.test.factories import (
 )
 from ecommerce.tests.factories import ProductFactory
 from ecommerce.tests.testcases import TestCase
+from ecommerce.utils import set_current_request
 
 
 class ManualEnrollmentOrderDiscountConditionTests(TestCase):
@@ -42,12 +42,11 @@ class ManualEnrollmentOrderDiscountConditionTests(TestCase):
             attribute_values__value_text='audit'
         ).first()
 
-        request_patcher = patch('get_current_request')
-        self.request_patcher = request_patcher.start()
-        self.request_patcher.return_value = RequestFactory().post(
-            reverse('api:v2:manual-course-enrollment-order-list')
+        set_current_request(
+            RequestFactory().post(
+                reverse('api:v2:manual-course-enrollment-order-list')
+            )
         )
-        self.addCleanup(request_patcher.stop)
 
     def test_is_satisfied_with_wrong_offer(self):
         """
@@ -109,9 +108,8 @@ class ManualEnrollmentOrderDiscountConditionTests(TestCase):
         """
         Test `ManualEnrollmentOrderDiscountCondition.is_satisfied` works as expected when request path_info is wrong.
         """
-        with patch('get_current_request') as request_patcher:
-            request_patcher.return_value = RequestFactory().post('some_view_path')
-            offer = ManualEnrollmentOrderOfferFactory()
-            self.basket.add_product(self.seat_product)
-            status = self.condition.is_satisfied(offer, self.basket)
-            assert not status
+        set_current_request(RequestFactory().post('some_view_path'))
+        offer = ManualEnrollmentOrderOfferFactory()
+        self.basket.add_product(self.seat_product)
+        status = self.condition.is_satisfied(offer, self.basket)
+        assert not status

--- a/ecommerce/extensions/order/tests/test_conditions.py
+++ b/ecommerce/extensions/order/tests/test_conditions.py
@@ -42,7 +42,7 @@ class ManualEnrollmentOrderDiscountConditionTests(TestCase):
             attribute_values__value_text='audit'
         ).first()
 
-        request_patcher = patch('crum.get_current_request')
+        request_patcher = patch('get_current_request')
         self.request_patcher = request_patcher.start()
         self.request_patcher.return_value = RequestFactory().post(
             reverse('api:v2:manual-course-enrollment-order-list')
@@ -109,7 +109,7 @@ class ManualEnrollmentOrderDiscountConditionTests(TestCase):
         """
         Test `ManualEnrollmentOrderDiscountCondition.is_satisfied` works as expected when request path_info is wrong.
         """
-        with patch('crum.get_current_request') as request_patcher:
+        with patch('get_current_request') as request_patcher:
             request_patcher.return_value = RequestFactory().post('some_view_path')
             offer = ManualEnrollmentOrderOfferFactory()
             self.basket.add_product(self.seat_product)

--- a/ecommerce/extensions/order/utils.py
+++ b/ecommerce/extensions/order/utils.py
@@ -4,7 +4,7 @@
 import logging
 
 import waffle
-from crum import get_current_request
+from ecommerce.utils import get_current_request
 from django.conf import settings
 from edx_django_utils.cache import TieredCache
 from edx_rest_api_client.client import EdxRestApiClient

--- a/ecommerce/extensions/order/utils.py
+++ b/ecommerce/extensions/order/utils.py
@@ -4,7 +4,6 @@
 import logging
 
 import waffle
-from ecommerce.utils import get_current_request
 from django.conf import settings
 from edx_django_utils.cache import TieredCache
 from edx_rest_api_client.client import EdxRestApiClient
@@ -18,6 +17,7 @@ from ecommerce.core.url_utils import get_lms_entitlement_api_url
 from ecommerce.extensions.order.constants import DISABLE_REPEAT_ORDER_CHECK_SWITCH_NAME
 from ecommerce.extensions.refund.status import REFUND_LINE
 from ecommerce.referrals.models import Referral
+from ecommerce.utils import get_current_request
 
 logger = logging.getLogger(__name__)
 

--- a/ecommerce/extensions/order/utils.py
+++ b/ecommerce/extensions/order/utils.py
@@ -4,6 +4,7 @@
 import logging
 
 import waffle
+from crum import get_current_request
 from django.conf import settings
 from edx_django_utils.cache import TieredCache
 from edx_rest_api_client.client import EdxRestApiClient
@@ -12,7 +13,6 @@ from oscar.apps.order.utils import OrderCreator as OscarOrderCreator
 from oscar.core.loading import get_model
 from requests.exceptions import ConnectionError as ReqConnectionError  # pylint: disable=ungrouped-imports
 from requests.exceptions import ConnectTimeout
-from threadlocals.threadlocals import get_current_request
 
 from ecommerce.core.url_utils import get_lms_entitlement_api_url
 from ecommerce.extensions.order.constants import DISABLE_REPEAT_ORDER_CHECK_SWITCH_NAME

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -226,6 +226,7 @@ MIDDLEWARE = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'waffle.middleware.WaffleMiddleware',
     'ecommerce.extensions.analytics.middleware.TrackingMiddleware',
+    'ecommerce.utils.GlobalRequestMiddleware',
     # NOTE: The overridden BasketMiddleware relies on request.site. This middleware
     # MUST appear AFTER CurrentSiteMiddleware.
     'ecommerce.extensions.basket.middleware.BasketMiddleware',

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -232,7 +232,6 @@ MIDDLEWARE = (
     'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
     'social_django.middleware.SocialAuthExceptionMiddleware',
     'simple_history.middleware.HistoryRequestMiddleware',
-    'threadlocals.middleware.ThreadLocalMiddleware',
     'ecommerce.theming.middleware.CurrentSiteThemeMiddleware',
     'ecommerce.theming.middleware.ThemePreviewMiddleware',
     'edx_django_utils.cache.middleware.TieredCacheMiddleware',

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -238,7 +238,6 @@ MIDDLEWARE = (
     'edx_django_utils.cache.middleware.TieredCacheMiddleware',
     'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
     'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
-    'crum.CurrentRequestUserMiddleware',
 )
 # END MIDDLEWARE CONFIGURATION
 

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -9,7 +9,7 @@ from decimal import Decimal
 
 import httpretty
 import jwt
-from crum import set_current_request
+from ecommerce.utils import set_current_request
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -360,7 +360,6 @@ class SiteMixin:
         self.request = RequestFactory(SERVER_NAME=domain).get('')
         self.request.session = None
         self.request.site = self.site
-        set_thread_variable('request', self.request)
         set_current_request(self.request)
         self.addCleanup(set_current_request)
 

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -23,7 +23,6 @@ from oscar.core.loading import get_class, get_model
 from oscar.test import factories
 from oscar.test.utils import RequestFactory
 from social_django.models import UserSocialAuth
-from threadlocals.threadlocals import set_thread_variable
 from waffle.models import Flag
 
 from ecommerce.core.constants import ALL_ACCESS_CONTEXT, SYSTEM_ENTERPRISE_ADMIN_ROLE, SYSTEM_ENTERPRISE_OPERATOR_ROLE

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -9,7 +9,6 @@ from decimal import Decimal
 
 import httpretty
 import jwt
-from ecommerce.utils import set_current_request
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
@@ -32,6 +31,7 @@ from ecommerce.courses.utils import mode_for_product
 from ecommerce.extensions.fulfillment.signals import SHIPPING_EVENT_NAME
 from ecommerce.extensions.payment.helpers import get_default_processor_class, get_processor_class_by_name
 from ecommerce.tests.factories import SiteConfigurationFactory, UserFactory
+from ecommerce.utils import set_current_request
 
 Applicator = get_class('offer.applicator', 'Applicator')
 Basket = get_model('basket', 'Basket')

--- a/ecommerce/theming/helpers.py
+++ b/ecommerce/theming/helpers.py
@@ -7,9 +7,9 @@ import logging
 import os
 
 import waffle
+from crum import get_current_request
 from django.conf import ImproperlyConfigured, settings
 from path import Path
-from threadlocals.threadlocals import get_current_request
 
 logger = logging.getLogger(__name__)
 

--- a/ecommerce/theming/helpers.py
+++ b/ecommerce/theming/helpers.py
@@ -7,9 +7,10 @@ import logging
 import os
 
 import waffle
-from ecommerce.utils import get_current_request
 from django.conf import ImproperlyConfigured, settings
 from path import Path
+
+from ecommerce.utils import get_current_request
 
 logger = logging.getLogger(__name__)
 

--- a/ecommerce/theming/helpers.py
+++ b/ecommerce/theming/helpers.py
@@ -7,7 +7,7 @@ import logging
 import os
 
 import waffle
-from crum import get_current_request
+from ecommerce.utils import get_current_request
 from django.conf import ImproperlyConfigured, settings
 from path import Path
 

--- a/ecommerce/theming/template_loaders.py
+++ b/ecommerce/theming/template_loaders.py
@@ -3,10 +3,10 @@ Theming aware template loaders.
 """
 
 
-from ecommerce.utils import get_current_request
 from django.template.loaders.filesystem import Loader
 
 from ecommerce.theming.helpers import get_all_theme_template_dirs, get_current_theme
+from ecommerce.utils import get_current_request
 
 
 class ThemeTemplateLoader(Loader):

--- a/ecommerce/theming/template_loaders.py
+++ b/ecommerce/theming/template_loaders.py
@@ -3,8 +3,8 @@ Theming aware template loaders.
 """
 
 
+from crum import get_current_request
 from django.template.loaders.filesystem import Loader
-from threadlocals.threadlocals import get_current_request
 
 from ecommerce.theming.helpers import get_all_theme_template_dirs, get_current_theme
 

--- a/ecommerce/theming/template_loaders.py
+++ b/ecommerce/theming/template_loaders.py
@@ -3,7 +3,7 @@ Theming aware template loaders.
 """
 
 
-from crum import get_current_request
+from ecommerce.utils import get_current_request
 from django.template.loaders.filesystem import Loader
 
 from ecommerce.theming.helpers import get_all_theme_template_dirs, get_current_theme

--- a/ecommerce/utils.py
+++ b/ecommerce/utils.py
@@ -1,0 +1,17 @@
+from threading import current_thread
+
+_requests = {}
+
+def get_current_request():
+    return _requests.get(current_thread(), None)
+
+def set_current_request(request=None):
+    _requests[current_thread()] = request
+
+class GlobalRequestMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        set_current_request(request)
+        return self.get_response(request)

--- a/ecommerce/utils.py
+++ b/ecommerce/utils.py
@@ -2,11 +2,14 @@ from threading import current_thread
 
 _requests = {}
 
+
 def get_current_request():
     return _requests.get(current_thread(), None)
 
+
 def set_current_request(request=None):
     _requests[current_thread()] = request
+
 
 class GlobalRequestMiddleware:
     def __init__(self, get_response):

--- a/ecommerce/utils.py
+++ b/ecommerce/utils.py
@@ -4,14 +4,23 @@ _requests = {}
 
 
 def get_current_request():
+    """
+    Retrieve current request from thread local variable.
+    """
     return _requests.get(current_thread(), None)
 
 
 def set_current_request(request=None):
+    """
+    Set request on thread local variable.
+    """
     _requests[current_thread()] = request
 
 
 class GlobalRequestMiddleware:
+    """
+    Middleware to store Django requests on a thread local variable.
+    """
     def __init__(self, get_response):
         self.get_response = get_response
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,7 +16,6 @@ django-oscar
 django-rest-swagger
 django-simple-history
 django-solo
-django-threadlocals
 django-waffle
 djangorestframework
 djangorestframework-csv

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -151,8 +151,6 @@ django-solo==1.1.5
     # via -r requirements/base.in
 django-tables2==1.21.2
     # via django-oscar
-django-threadlocals==0.10
-    # via -r requirements/base.in
 django-treebeard==4.5.1
     # via django-oscar
 django-waffle==2.2.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -226,8 +226,6 @@ django-tables2==1.21.2
     # via
     #   -r requirements/test.txt
     #   django-oscar
-django-threadlocals==0.10
-    # via -r requirements/test.txt
 django-treebeard==4.5.1
     # via
     #   -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -160,8 +160,6 @@ django-solo==1.1.5
     # via -r requirements/base.in
 django-tables2==1.21.2
     # via django-oscar
-django-threadlocals==0.10
-    # via -r requirements/base.in
 django-treebeard==4.5.1
     # via django-oscar
 django-waffle==2.2.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -223,8 +223,6 @@ django-tables2==1.21.2
     # via
     #   -r requirements/base.txt
     #   django-oscar
-django-threadlocals==0.10
-    # via -r requirements/base.txt
 django-treebeard==4.5.1
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
## Anyone merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Description

Contribution as Core Comitter.

Remove usages of `threadlocals` to unblock Django 3.2 upgrade: https://github.com/edx/upgrades/issues/36.

~~Found that `edx-platform` already uses `django-crum` and it's also being used in the `ecommerce` repo as well, so I'm replacing the usages and checking if things work.~~

`django-crum` does not support Django 3.2 yet! So no reason to migrate to it.

Suggestion:
Instead of adding `django-crum` or any other dependencies, why don't we build our own django middleware to handle this?
It's simple enough to implement, can live under https://github.com/edx/edx-django-utils and uses python's threading library. 
See the implementation here: https://github.com/edx/ecommerce/blob/6e23ecd8cfa1c1a839672aec6d9f0f196ac1b13b/ecommerce/utils.py

While searching for alternatives, I've analyzed `django-crum`'s source code and also found [this post](https://nedbatchelder.com/blog/201008/global_django_requests.html) by @nedbat (from 2010) which led me to research this way of saving a request.

@bradenmacdonald, what do you think? 

## Supporting information

- [Django 3.2 upgrades](https://github.com/orgs/edx/projects/5)
- https://github.com/edx/upgrades/issues/36

## Testing instructions

TBD

## Other information

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
