### PR TITLE
REV-2370: upgrade django-oscar package from 2.0 to 2.1

### DIFF
--- a/ecommerce/extensions/customer/utils.py
+++ b/ecommerce/extensions/customer/utils.py
@@ -3,7 +3,8 @@
 from django.conf import settings
 from django.core.mail import EmailMessage, EmailMultiAlternatives
 from oscar.apps.customer.utils import *  # pylint: disable=wildcard-import, unused-wildcard-import
-
+# @TODO: check if the above import is obviated (does it still have other classes we need)
+from oscar.apps.communication.utils import CommunicationEvent, Dispatcher, Email
 
 # pylint: disable=abstract-method, function-redefined
 class Dispatcher(Dispatcher):

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -311,6 +311,11 @@ DJANGO_APPS = [
     'edx_django_utils.user',
 ]
 
+# Apps specific to django-oscar go here.
+OSCAR_APPS = [
+    'oscar.apps.communication.apps.CommunicationConfig',
+    ]
+
 # Apps specific to this project go here.
 LOCAL_APPS = [
     'ecommerce.core',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -221,7 +221,7 @@ extras==1.0.0
     #   testtools
 factory-boy==2.12.0
     # via django-oscar
-faker==8.13.0
+faker==8.13.2
     # via factory-boy
 fixtures==3.0.0
     # via

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -46,7 +46,7 @@ cffi==1.14.6
     #   pynacl
 chardet==4.0.0
     # via cybersource-rest-client-python
-charset-normalizer==2.0.4
+charset-normalizer==2.0.5
     # via requests
 configparser==5.0.2
     # via cybersource-rest-client-python
@@ -127,21 +127,21 @@ django-crum==0.7.9
     #   edx-rbac
 django-extensions==3.1.3
     # via -r requirements/base.in
-django-extra-views==0.11.0
+django-extra-views==0.13.0
     # via django-oscar
 django-filter==2.4.0
     # via -r requirements/base.in
-django-haystack==2.8.1
+django-haystack==3.1.1
     # via django-oscar
 django-libsass==0.9
     # via -r requirements/base.in
 django-model-utils==4.1.1
     # via edx-rbac
-django-oscar==2.0.4
+django-oscar==2.1
     # via
     #   -c requirements/pins.txt
     #   -r requirements/base.in
-django-phonenumber-field==2.0.1
+django-phonenumber-field==3.0.1
     # via django-oscar
 django-rest-swagger==2.2.0
     # via -r requirements/base.in
@@ -149,7 +149,7 @@ django-simple-history==3.0.0
     # via -r requirements/base.in
 django-solo==1.1.5
     # via -r requirements/base.in
-django-tables2==1.21.2
+django-tables2==2.2.1
     # via django-oscar
 django-threadlocals==0.10
     # via -r requirements/base.in
@@ -221,7 +221,7 @@ extras==1.0.0
     #   testtools
 factory-boy==2.12.0
     # via django-oscar
-faker==8.12.1
+faker==8.13.0
     # via factory-boy
 fixtures==3.0.0
     # via
@@ -307,9 +307,7 @@ pbr==5.6.0
     #   stevedore
     #   testtools
 phonenumbers==8.12.31
-    # via
-    #   django-oscar
-    #   django-phonenumber-field
+    # via django-oscar
 pillow==8.3.2
     # via django-oscar
 platformdirs==2.3.0
@@ -482,7 +480,7 @@ social-auth-core==4.0.2
     #   social-auth-app-django
 sorl-thumbnail==12.7.0
     # via -r requirements/base.in
-sqlparse==0.4.1
+sqlparse==0.4.2
     # via django
 stevedore==3.4.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -314,7 +314,7 @@ factory-boy==2.12.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
-faker==8.13.0
+faker==8.13.2
     # via
     #   -r requirements/test.txt
     #   factory-boy

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -44,7 +44,7 @@ bcrypt==3.2.0
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
     #   paramiko
-beautifulsoup4==4.9.3
+beautifulsoup4==4.10.0
     # via
     #   -r requirements/test.txt
     #   webtest
@@ -82,7 +82,7 @@ chardet==4.0.0
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
     #   diff-cover
-charset-normalizer==2.0.4
+charset-normalizer==2.0.5
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -194,13 +194,13 @@ django-debug-toolbar==3.2.2
     # via -r requirements/dev.in
 django-extensions==3.1.3
     # via -r requirements/test.txt
-django-extra-views==0.11.0
+django-extra-views==0.13.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
 django-filter==2.4.0
     # via -r requirements/test.txt
-django-haystack==2.8.1
+django-haystack==3.1.1
     # via
     #   -r requirements/test.txt
     #   django-oscar
@@ -210,9 +210,9 @@ django-model-utils==4.1.1
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-django-oscar==2.0.4
+django-oscar==2.1
     # via -r requirements/test.txt
-django-phonenumber-field==2.0.1
+django-phonenumber-field==3.0.1
     # via
     #   -r requirements/test.txt
     #   django-oscar
@@ -222,7 +222,7 @@ django-simple-history==3.0.0
     # via -r requirements/test.txt
 django-solo==1.1.5
     # via -r requirements/test.txt
-django-tables2==1.21.2
+django-tables2==2.2.1
     # via
     #   -r requirements/test.txt
     #   django-oscar
@@ -314,7 +314,7 @@ factory-boy==2.12.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
-faker==8.12.1
+faker==8.13.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -507,7 +507,6 @@ phonenumbers==8.12.31
     # via
     #   -r requirements/test.txt
     #   django-oscar
-    #   django-phonenumber-field
 pillow==8.3.2
     # via
     #   -r requirements/test.txt
@@ -751,7 +750,7 @@ requests-toolbelt==0.9.1
     # via
     #   -r requirements/test.txt
     #   zeep
-responses==0.13.4
+responses==0.14.0
     # via -r requirements/test.txt
 rest-condition==1.0.3
     # via
@@ -849,7 +848,7 @@ soupsieve==2.2.1
     # via
     #   -r requirements/test.txt
     #   beautifulsoup4
-sphinx==4.1.2
+sphinx==4.2.0
     # via
     #   -r requirements/docs.txt
     #   edx-sphinx-theme
@@ -877,7 +876,7 @@ sphinxcontrib-serializinghtml==1.1.5
     # via
     #   -r requirements/docs.txt
     #   sphinx
-sqlparse==0.4.1
+sqlparse==0.4.2
     # via
     #   -r requirements/test.txt
     #   django

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -10,7 +10,7 @@ babel==2.9.1
     # via sphinx
 certifi==2021.5.30
     # via requests
-charset-normalizer==2.0.4
+charset-normalizer==2.0.5
     # via requests
 docutils==0.17.1
     # via sphinx
@@ -42,7 +42,7 @@ six==1.16.0
     # via edx-sphinx-theme
 snowballstemmer==2.1.0
     # via sphinx
-sphinx==4.1.2
+sphinx==4.2.0
     # via
     #   -r requirements/docs.in
     #   edx-sphinx-theme

--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -16,7 +16,7 @@ cffi==1.14.6
     # via
     #   -c requirements/base.txt
     #   cryptography
-charset-normalizer==2.0.4
+charset-normalizer==2.0.5
     # via
     #   -c requirements/base.txt
     #   requests
@@ -137,7 +137,7 @@ slumber==0.7.1
     # via
     #   -c requirements/base.txt
     #   edx-rest-api-client
-sqlparse==0.4.1
+sqlparse==0.4.2
     # via
     #   -c requirements/base.txt
     #   django

--- a/requirements/pins.txt
+++ b/requirements/pins.txt
@@ -12,7 +12,7 @@
 cybersource-rest-client-python==0.0.21
 
 # Newer version introduces `No installed app with label 'communication'.`
-django-oscar<2.1
+django-oscar==2.1
 
 # causing tests failures
 httpretty==0.9.7

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -230,7 +230,7 @@ extras==1.0.0
     #   testtools
 factory-boy==2.12.0
     # via django-oscar
-faker==8.13.1
+faker==8.13.2
     # via factory-boy
 fixtures==3.0.0
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -28,9 +28,9 @@ billiard==3.6.4.0
     # via celery
 bleach==4.1.0
     # via -r requirements/base.in
-boto3==1.18.35
+boto3==1.18.42
     # via django-ses
-botocore==1.21.35
+botocore==1.21.42
     # via
     #   boto3
     #   s3transfer
@@ -52,7 +52,7 @@ cffi==1.14.6
     #   pynacl
 chardet==4.0.0
     # via cybersource-rest-client-python
-charset-normalizer==2.0.4
+charset-normalizer==2.0.5
     # via requests
 configparser==5.0.2
     # via cybersource-rest-client-python
@@ -134,21 +134,21 @@ django-crum==0.7.9
     #   edx-rbac
 django-extensions==3.1.3
     # via -r requirements/base.in
-django-extra-views==0.11.0
+django-extra-views==0.13.0
     # via django-oscar
 django-filter==2.4.0
     # via -r requirements/base.in
-django-haystack==2.8.1
+django-haystack==3.1.1
     # via django-oscar
 django-libsass==0.9
     # via -r requirements/base.in
 django-model-utils==4.1.1
     # via edx-rbac
-django-oscar==2.0.4
+django-oscar==2.1
     # via
     #   -c requirements/pins.txt
     #   -r requirements/base.in
-django-phonenumber-field==2.0.1
+django-phonenumber-field==3.0.1
     # via django-oscar
 django-rest-swagger==2.2.0
     # via -r requirements/base.in
@@ -158,7 +158,7 @@ django-simple-history==3.0.0
     # via -r requirements/base.in
 django-solo==1.1.5
     # via -r requirements/base.in
-django-tables2==1.21.2
+django-tables2==2.2.1
     # via django-oscar
 django-threadlocals==0.10
     # via -r requirements/base.in
@@ -230,7 +230,7 @@ extras==1.0.0
     #   testtools
 factory-boy==2.12.0
     # via django-oscar
-faker==8.12.1
+faker==8.13.1
     # via factory-boy
 fixtures==3.0.0
     # via
@@ -327,9 +327,7 @@ pbr==5.6.0
     #   stevedore
     #   testtools
 phonenumbers==8.12.31
-    # via
-    #   django-oscar
-    #   django-phonenumber-field
+    # via django-oscar
 pillow==8.3.2
     # via django-oscar
 platformdirs==2.3.0
@@ -512,7 +510,7 @@ social-auth-core==4.0.2
     #   social-auth-app-django
 sorl-thumbnail==12.7.0
     # via -r requirements/base.in
-sqlparse==0.4.1
+sqlparse==0.4.2
     # via django
 stevedore==3.4.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -37,7 +37,7 @@ bcrypt==3.2.0
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
     #   paramiko
-beautifulsoup4==4.9.3
+beautifulsoup4==4.10.0
     # via webtest
 billiard==3.6.4.0
     # via
@@ -75,7 +75,7 @@ chardet==4.0.0
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
     #   diff-cover
-charset-normalizer==2.0.4
+charset-normalizer==2.0.5
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -189,13 +189,13 @@ django-crum==0.7.9
     #   edx-rbac
 django-extensions==3.1.3
     # via -r requirements/base.txt
-django-extra-views==0.11.0
+django-extra-views==0.13.0
     # via
     #   -r requirements/base.txt
     #   django-oscar
 django-filter==2.4.0
     # via -r requirements/base.txt
-django-haystack==2.8.1
+django-haystack==3.1.1
     # via
     #   -r requirements/base.txt
     #   django-oscar
@@ -205,11 +205,11 @@ django-model-utils==4.1.1
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-django-oscar==2.0.4
+django-oscar==2.1
     # via
     #   -c requirements/pins.txt
     #   -r requirements/base.txt
-django-phonenumber-field==2.0.1
+django-phonenumber-field==3.0.1
     # via
     #   -r requirements/base.txt
     #   django-oscar
@@ -219,7 +219,7 @@ django-simple-history==3.0.0
     # via -r requirements/base.txt
 django-solo==1.1.5
     # via -r requirements/base.txt
-django-tables2==1.21.2
+django-tables2==2.2.1
     # via
     #   -r requirements/base.txt
     #   django-oscar
@@ -312,7 +312,7 @@ factory-boy==2.12.0
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   django-oscar
-faker==8.12.1
+faker==8.13.0
     # via
     #   -r requirements/base.txt
     #   factory-boy
@@ -490,7 +490,6 @@ phonenumbers==8.12.31
     # via
     #   -r requirements/base.txt
     #   django-oscar
-    #   django-phonenumber-field
 pillow==8.3.2
     # via
     #   -r requirements/base.txt
@@ -734,7 +733,7 @@ requests-toolbelt==0.9.1
     # via
     #   -r requirements/base.txt
     #   zeep
-responses==0.13.4
+responses==0.14.0
     # via -r requirements/test.in
 rest-condition==1.0.3
     # via
@@ -827,7 +826,7 @@ sorl-thumbnail==12.7.0
     # via -r requirements/base.txt
 soupsieve==2.2.1
     # via beautifulsoup4
-sqlparse==0.4.1
+sqlparse==0.4.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -312,7 +312,7 @@ factory-boy==2.12.0
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   django-oscar
-faker==8.13.0
+faker==8.13.2
     # via
     #   -r requirements/base.txt
     #   factory-boy


### PR DESCRIPTION
## Description
https://openedx.atlassian.net/browse/REV-2370

Our django-oscar version has been held back at 2.0, and we need to raise it to the next LTS version: 2.1


## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
