### PR TITLE
chore: ahead of django-oscar upgrade, do major version updates for 3 dependent packages

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -131,7 +131,7 @@ django-extra-views==0.11.0
     # via django-oscar
 django-filter==2.4.0
     # via -r requirements/base.in
-django-haystack==2.8.1
+django-haystack==3.1.1
     # via django-oscar
 django-libsass==0.9
     # via -r requirements/base.in
@@ -141,7 +141,7 @@ django-oscar==2.0.4
     # via
     #   -c requirements/pins.txt
     #   -r requirements/base.in
-django-phonenumber-field==2.0.1
+django-phonenumber-field==3.0.1
     # via django-oscar
 django-rest-swagger==2.2.0
     # via -r requirements/base.in
@@ -149,7 +149,7 @@ django-simple-history==3.0.0
     # via -r requirements/base.in
 django-solo==1.1.5
     # via -r requirements/base.in
-django-tables2==1.21.2
+django-tables2==2.2.1
     # via django-oscar
 django-threadlocals==0.10
     # via -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -200,7 +200,7 @@ django-extra-views==0.11.0
     #   django-oscar
 django-filter==2.4.0
     # via -r requirements/test.txt
-django-haystack==2.8.1
+django-haystack==3.1.1
     # via
     #   -r requirements/test.txt
     #   django-oscar
@@ -212,7 +212,7 @@ django-model-utils==4.1.1
     #   edx-rbac
 django-oscar==2.0.4
     # via -r requirements/test.txt
-django-phonenumber-field==2.0.1
+django-phonenumber-field==3.0.1
     # via
     #   -r requirements/test.txt
     #   django-oscar
@@ -222,7 +222,7 @@ django-simple-history==3.0.0
     # via -r requirements/test.txt
 django-solo==1.1.5
     # via -r requirements/test.txt
-django-tables2==1.21.2
+django-tables2==2.2.1
     # via
     #   -r requirements/test.txt
     #   django-oscar

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -138,7 +138,7 @@ django-extra-views==0.11.0
     # via django-oscar
 django-filter==2.4.0
     # via -r requirements/base.in
-django-haystack==2.8.1
+django-haystack==3.1.1
     # via django-oscar
 django-libsass==0.9
     # via -r requirements/base.in
@@ -148,7 +148,7 @@ django-oscar==2.0.4
     # via
     #   -c requirements/pins.txt
     #   -r requirements/base.in
-django-phonenumber-field==2.0.1
+django-phonenumber-field==3.0.1
     # via django-oscar
 django-rest-swagger==2.2.0
     # via -r requirements/base.in
@@ -158,7 +158,7 @@ django-simple-history==3.0.0
     # via -r requirements/base.in
 django-solo==1.1.5
     # via -r requirements/base.in
-django-tables2==1.21.2
+django-tables2==2.2.1
     # via django-oscar
 django-threadlocals==0.10
     # via -r requirements/base.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -195,7 +195,7 @@ django-extra-views==0.11.0
     #   django-oscar
 django-filter==2.4.0
     # via -r requirements/base.txt
-django-haystack==2.8.1
+django-haystack==3.1.1
     # via
     #   -r requirements/base.txt
     #   django-oscar
@@ -209,7 +209,7 @@ django-oscar==2.0.4
     # via
     #   -c requirements/pins.txt
     #   -r requirements/base.txt
-django-phonenumber-field==2.0.1
+django-phonenumber-field==3.0.1
     # via
     #   -r requirements/base.txt
     #   django-oscar
@@ -219,7 +219,7 @@ django-simple-history==3.0.0
     # via -r requirements/base.txt
 django-solo==1.1.5
     # via -r requirements/base.txt
-django-tables2==1.21.2
+django-tables2==2.2.1
     # via
     #   -r requirements/base.txt
     #   django-oscar


### PR DESCRIPTION
https://openedx.atlassian.net/browse/REV-2370

Our django-oscar version has been held back at 2.0, and we'll need to raise it to the next LTS version: 2.1, but to reduce risk first let's upgrade its dependent packages. Previous PR 3507 updates packages with **minor** version updates: https://github.com/edx/ecommerce/pull/3507

This PR updates three packages with **major** version updates- (where more research and possibly fixes will be needed)

**Where this list of changes comes from:** 
From this larger PR that upgraded django-oscar and ran 'make upgrade', we get the list of the other dependent package updates occurring naturally from 'make upgrade'. The minor ones were covered in the first PR, and this PR has the three major version updates:  django-haystack (2.8.1->3.1.1), django-phonenumber-field (2.0.1->3.0.1), django-tables2 (1.21.2 -> 2.2.1)