### PR TITLE
Revert "chore: ahead of django-oscar upgrade, do minor version update…

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -46,7 +46,7 @@ cffi==1.14.6
     #   pynacl
 chardet==4.0.0
     # via cybersource-rest-client-python
-charset-normalizer==2.0.5
+charset-normalizer==2.0.4
     # via requests
 configparser==5.0.2
     # via cybersource-rest-client-python
@@ -127,7 +127,7 @@ django-crum==0.7.9
     #   edx-rbac
 django-extensions==3.1.3
     # via -r requirements/base.in
-django-extra-views==0.13.0
+django-extra-views==0.11.0
     # via django-oscar
 django-filter==2.4.0
     # via -r requirements/base.in
@@ -221,7 +221,7 @@ extras==1.0.0
     #   testtools
 factory-boy==2.12.0
     # via django-oscar
-faker==8.13.2
+faker==8.12.1
     # via factory-boy
 fixtures==3.0.0
     # via
@@ -482,7 +482,7 @@ social-auth-core==4.0.2
     #   social-auth-app-django
 sorl-thumbnail==12.7.0
     # via -r requirements/base.in
-sqlparse==0.4.2
+sqlparse==0.4.1
     # via django
 stevedore==3.4.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -44,7 +44,7 @@ bcrypt==3.2.0
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
     #   paramiko
-beautifulsoup4==4.10.0
+beautifulsoup4==4.9.3
     # via
     #   -r requirements/test.txt
     #   webtest
@@ -82,7 +82,7 @@ chardet==4.0.0
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
     #   diff-cover
-charset-normalizer==2.0.5
+charset-normalizer==2.0.4
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -194,7 +194,7 @@ django-debug-toolbar==3.2.2
     # via -r requirements/dev.in
 django-extensions==3.1.3
     # via -r requirements/test.txt
-django-extra-views==0.13.0
+django-extra-views==0.11.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
@@ -314,7 +314,7 @@ factory-boy==2.12.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
-faker==8.13.2
+faker==8.12.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -751,7 +751,7 @@ requests-toolbelt==0.9.1
     # via
     #   -r requirements/test.txt
     #   zeep
-responses==0.14.0
+responses==0.13.4
     # via -r requirements/test.txt
 rest-condition==1.0.3
     # via
@@ -849,7 +849,7 @@ soupsieve==2.2.1
     # via
     #   -r requirements/test.txt
     #   beautifulsoup4
-sphinx==4.2.0
+sphinx==4.1.2
     # via
     #   -r requirements/docs.txt
     #   edx-sphinx-theme
@@ -877,7 +877,7 @@ sphinxcontrib-serializinghtml==1.1.5
     # via
     #   -r requirements/docs.txt
     #   sphinx
-sqlparse==0.4.2
+sqlparse==0.4.1
     # via
     #   -r requirements/test.txt
     #   django

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -10,7 +10,7 @@ babel==2.9.1
     # via sphinx
 certifi==2021.5.30
     # via requests
-charset-normalizer==2.0.5
+charset-normalizer==2.0.4
     # via requests
 docutils==0.17.1
     # via sphinx
@@ -42,7 +42,7 @@ six==1.16.0
     # via edx-sphinx-theme
 snowballstemmer==2.1.0
     # via sphinx
-sphinx==4.2.0
+sphinx==4.1.2
     # via
     #   -r requirements/docs.in
     #   edx-sphinx-theme

--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -16,7 +16,7 @@ cffi==1.14.6
     # via
     #   -c requirements/base.txt
     #   cryptography
-charset-normalizer==2.0.5
+charset-normalizer==2.0.4
     # via
     #   -c requirements/base.txt
     #   requests
@@ -137,7 +137,7 @@ slumber==0.7.1
     # via
     #   -c requirements/base.txt
     #   edx-rest-api-client
-sqlparse==0.4.2
+sqlparse==0.4.1
     # via
     #   -c requirements/base.txt
     #   django

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -28,9 +28,9 @@ billiard==3.6.4.0
     # via celery
 bleach==4.1.0
     # via -r requirements/base.in
-boto3==1.18.42
+boto3==1.18.35
     # via django-ses
-botocore==1.21.42
+botocore==1.21.35
     # via
     #   boto3
     #   s3transfer
@@ -52,7 +52,7 @@ cffi==1.14.6
     #   pynacl
 chardet==4.0.0
     # via cybersource-rest-client-python
-charset-normalizer==2.0.5
+charset-normalizer==2.0.4
     # via requests
 configparser==5.0.2
     # via cybersource-rest-client-python
@@ -134,7 +134,7 @@ django-crum==0.7.9
     #   edx-rbac
 django-extensions==3.1.3
     # via -r requirements/base.in
-django-extra-views==0.13.0
+django-extra-views==0.11.0
     # via django-oscar
 django-filter==2.4.0
     # via -r requirements/base.in
@@ -230,7 +230,7 @@ extras==1.0.0
     #   testtools
 factory-boy==2.12.0
     # via django-oscar
-faker==8.13.2
+faker==8.12.1
     # via factory-boy
 fixtures==3.0.0
     # via
@@ -512,7 +512,7 @@ social-auth-core==4.0.2
     #   social-auth-app-django
 sorl-thumbnail==12.7.0
     # via -r requirements/base.in
-sqlparse==0.4.2
+sqlparse==0.4.1
     # via django
 stevedore==3.4.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -37,7 +37,7 @@ bcrypt==3.2.0
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
     #   paramiko
-beautifulsoup4==4.10.0
+beautifulsoup4==4.9.3
     # via webtest
 billiard==3.6.4.0
     # via
@@ -75,7 +75,7 @@ chardet==4.0.0
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
     #   diff-cover
-charset-normalizer==2.0.5
+charset-normalizer==2.0.4
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -189,7 +189,7 @@ django-crum==0.7.9
     #   edx-rbac
 django-extensions==3.1.3
     # via -r requirements/base.txt
-django-extra-views==0.13.0
+django-extra-views==0.11.0
     # via
     #   -r requirements/base.txt
     #   django-oscar
@@ -312,7 +312,7 @@ factory-boy==2.12.0
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   django-oscar
-faker==8.13.2
+faker==8.12.1
     # via
     #   -r requirements/base.txt
     #   factory-boy
@@ -734,7 +734,7 @@ requests-toolbelt==0.9.1
     # via
     #   -r requirements/base.txt
     #   zeep
-responses==0.14.0
+responses==0.13.4
     # via -r requirements/test.in
 rest-condition==1.0.3
     # via
@@ -827,7 +827,7 @@ sorl-thumbnail==12.7.0
     # via -r requirements/base.txt
 soupsieve==2.2.1
     # via beautifulsoup4
-sqlparse==0.4.2
+sqlparse==0.4.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt


### PR DESCRIPTION
…s for dependent packages (#3507)"

This reverts commit 766998d9e0388849ba03c8d4c8cb56e73d60eed5.

That PR made the minor version updates for packages that will be needed for django-oscar 2.1, however, (at least?) one of them is not allowed by our current django-oscar version (2.0.4): django-extra-views. The PR checks passed, but this failed to build in the stage pipeline: 

The conflict is caused by:
    The user requested django-extra-views==0.13.0
    django-oscar 2.0.4 depends on django-extra-views<0.12 and >=0.11"



https://github.com/edx/ecommerce/pull/3507
