### PR TITLE
chore: ahead of django-oscar upgrade, do all-but-one minor version updates for dependent packages

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -127,7 +127,7 @@ django-crum==0.7.9
     #   edx-rbac
 django-extensions==3.1.3
     # via -r requirements/base.in
-django-extra-views==0.13.0
+django-extra-views==0.11.0
     # via django-oscar
 django-filter==2.4.0
     # via -r requirements/base.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -46,7 +46,7 @@ cffi==1.14.6
     #   pynacl
 chardet==4.0.0
     # via cybersource-rest-client-python
-charset-normalizer==2.0.4
+charset-normalizer==2.0.5
     # via requests
 configparser==5.0.2
     # via cybersource-rest-client-python
@@ -127,7 +127,7 @@ django-crum==0.7.9
     #   edx-rbac
 django-extensions==3.1.3
     # via -r requirements/base.in
-django-extra-views==0.11.0
+django-extra-views==0.13.0
     # via django-oscar
 django-filter==2.4.0
     # via -r requirements/base.in
@@ -221,7 +221,7 @@ extras==1.0.0
     #   testtools
 factory-boy==2.12.0
     # via django-oscar
-faker==8.12.1
+faker==8.13.2
     # via factory-boy
 fixtures==3.0.0
     # via
@@ -482,7 +482,7 @@ social-auth-core==4.0.2
     #   social-auth-app-django
 sorl-thumbnail==12.7.0
     # via -r requirements/base.in
-sqlparse==0.4.1
+sqlparse==0.4.2
     # via django
 stevedore==3.4.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -44,7 +44,7 @@ bcrypt==3.2.0
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
     #   paramiko
-beautifulsoup4==4.9.3
+beautifulsoup4==4.10.0
     # via
     #   -r requirements/test.txt
     #   webtest
@@ -82,7 +82,7 @@ chardet==4.0.0
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
     #   diff-cover
-charset-normalizer==2.0.4
+charset-normalizer==2.0.5
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -194,7 +194,7 @@ django-debug-toolbar==3.2.2
     # via -r requirements/dev.in
 django-extensions==3.1.3
     # via -r requirements/test.txt
-django-extra-views==0.11.0
+django-extra-views==0.13.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
@@ -314,7 +314,7 @@ factory-boy==2.12.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
-faker==8.12.1
+faker==8.13.2
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -751,7 +751,7 @@ requests-toolbelt==0.9.1
     # via
     #   -r requirements/test.txt
     #   zeep
-responses==0.13.4
+responses==0.14.0
     # via -r requirements/test.txt
 rest-condition==1.0.3
     # via
@@ -849,7 +849,7 @@ soupsieve==2.2.1
     # via
     #   -r requirements/test.txt
     #   beautifulsoup4
-sphinx==4.1.2
+sphinx==4.2.0
     # via
     #   -r requirements/docs.txt
     #   edx-sphinx-theme
@@ -877,7 +877,7 @@ sphinxcontrib-serializinghtml==1.1.5
     # via
     #   -r requirements/docs.txt
     #   sphinx
-sqlparse==0.4.1
+sqlparse==0.4.2
     # via
     #   -r requirements/test.txt
     #   django

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -194,7 +194,7 @@ django-debug-toolbar==3.2.2
     # via -r requirements/dev.in
 django-extensions==3.1.3
     # via -r requirements/test.txt
-django-extra-views==0.13.0
+django-extra-views==0.11.0
     # via
     #   -r requirements/test.txt
     #   django-oscar

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -10,7 +10,7 @@ babel==2.9.1
     # via sphinx
 certifi==2021.5.30
     # via requests
-charset-normalizer==2.0.4
+charset-normalizer==2.0.5
     # via requests
 docutils==0.17.1
     # via sphinx
@@ -42,7 +42,7 @@ six==1.16.0
     # via edx-sphinx-theme
 snowballstemmer==2.1.0
     # via sphinx
-sphinx==4.1.2
+sphinx==4.2.0
     # via
     #   -r requirements/docs.in
     #   edx-sphinx-theme

--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -16,7 +16,7 @@ cffi==1.14.6
     # via
     #   -c requirements/base.txt
     #   cryptography
-charset-normalizer==2.0.4
+charset-normalizer==2.0.5
     # via
     #   -c requirements/base.txt
     #   requests
@@ -137,7 +137,7 @@ slumber==0.7.1
     # via
     #   -c requirements/base.txt
     #   edx-rest-api-client
-sqlparse==0.4.1
+sqlparse==0.4.2
     # via
     #   -c requirements/base.txt
     #   django

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -134,7 +134,7 @@ django-crum==0.7.9
     #   edx-rbac
 django-extensions==3.1.3
     # via -r requirements/base.in
-django-extra-views==0.13.0
+django-extra-views==0.11.0
     # via django-oscar
 django-filter==2.4.0
     # via -r requirements/base.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -28,9 +28,9 @@ billiard==3.6.4.0
     # via celery
 bleach==4.1.0
     # via -r requirements/base.in
-boto3==1.18.35
+boto3==1.18.42
     # via django-ses
-botocore==1.21.35
+botocore==1.21.42
     # via
     #   boto3
     #   s3transfer
@@ -52,7 +52,7 @@ cffi==1.14.6
     #   pynacl
 chardet==4.0.0
     # via cybersource-rest-client-python
-charset-normalizer==2.0.4
+charset-normalizer==2.0.5
     # via requests
 configparser==5.0.2
     # via cybersource-rest-client-python
@@ -134,7 +134,7 @@ django-crum==0.7.9
     #   edx-rbac
 django-extensions==3.1.3
     # via -r requirements/base.in
-django-extra-views==0.11.0
+django-extra-views==0.13.0
     # via django-oscar
 django-filter==2.4.0
     # via -r requirements/base.in
@@ -230,7 +230,7 @@ extras==1.0.0
     #   testtools
 factory-boy==2.12.0
     # via django-oscar
-faker==8.12.1
+faker==8.13.2
     # via factory-boy
 fixtures==3.0.0
     # via
@@ -512,7 +512,7 @@ social-auth-core==4.0.2
     #   social-auth-app-django
 sorl-thumbnail==12.7.0
     # via -r requirements/base.in
-sqlparse==0.4.1
+sqlparse==0.4.2
     # via django
 stevedore==3.4.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -37,7 +37,7 @@ bcrypt==3.2.0
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
     #   paramiko
-beautifulsoup4==4.9.3
+beautifulsoup4==4.10.0
     # via webtest
 billiard==3.6.4.0
     # via
@@ -75,7 +75,7 @@ chardet==4.0.0
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
     #   diff-cover
-charset-normalizer==2.0.4
+charset-normalizer==2.0.5
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -189,7 +189,7 @@ django-crum==0.7.9
     #   edx-rbac
 django-extensions==3.1.3
     # via -r requirements/base.txt
-django-extra-views==0.11.0
+django-extra-views==0.13.0
     # via
     #   -r requirements/base.txt
     #   django-oscar
@@ -312,7 +312,7 @@ factory-boy==2.12.0
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   django-oscar
-faker==8.12.1
+faker==8.13.2
     # via
     #   -r requirements/base.txt
     #   factory-boy
@@ -734,7 +734,7 @@ requests-toolbelt==0.9.1
     # via
     #   -r requirements/base.txt
     #   zeep
-responses==0.13.4
+responses==0.14.0
     # via -r requirements/test.in
 rest-condition==1.0.3
     # via
@@ -827,7 +827,7 @@ sorl-thumbnail==12.7.0
     # via -r requirements/base.txt
 soupsieve==2.2.1
     # via beautifulsoup4
-sqlparse==0.4.1
+sqlparse==0.4.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -189,7 +189,7 @@ django-crum==0.7.9
     #   edx-rbac
 django-extensions==3.1.3
     # via -r requirements/base.txt
-django-extra-views==0.13.0
+django-extra-views==0.11.0
     # via
     #   -r requirements/base.txt
     #   django-oscar


### PR DESCRIPTION
https://openedx.atlassian.net/browse/REV-2370

Our django-oscar version has been held back at 2.0, and we'll need to raise it to the next LTS version: 2.1, but to reduce risk first let's upgrade its dependent packages. [PR 3507](https://github.com/edx/ecommerce/pull/3507) attempted to update all packages with a **minor** version update, but one of them- django-extra-views- is incompatible with our current django-oscar (2.0.4), so it failed pip install in the staging pipeline. 

This PR is the same as 3507 except for keeping django-extra-views at 0.11.0, to avoid a version conflict with django-oscar 2.0.4. 

Testing notes: 
- For minor version updates, the standard on our team is just to make sure the build checks still pass
- I ran the same pip install command that had failed in the staging pipeline for the original PR (pip3 install -r requirements.txt --exists-action w), and it passes on this branch with no conflicts or additional updates 


