### PR TITLE
chore: remove pytest-django-ordering

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -175,7 +175,6 @@ django==2.2.24
     #   edx-rbac
     #   jsonfield2
     #   mock-django
-    #   pytest-django-ordering
     #   rest-condition
     #   xss-utils
 django-appconf==1.0.5
@@ -634,7 +633,6 @@ pytest==6.2.5
     #   pytest-base-url
     #   pytest-cov
     #   pytest-django
-    #   pytest-django-ordering
     #   pytest-html
     #   pytest-metadata
     #   pytest-randomly
@@ -648,10 +646,6 @@ pytest-base-url==1.4.2
 pytest-cov==3.0.0
     # via -r requirements/test.txt
 pytest-django==4.4.0
-    # via
-    #   -r requirements/test.txt
-    #   pytest-django-ordering
-pytest-django-ordering==1.2.0
     # via -r requirements/test.txt
 pytest-html==3.1.1
     # via

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -21,7 +21,6 @@ pylint
 pytest
 pytest-cov
 pytest-django
-pytest-django-ordering
 python-memcached==1.58      # required by collectstatic in devstack
 responses
 selenium

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -172,7 +172,6 @@ diff-cover==6.4.2
     #   edx-rbac
     #   jsonfield2
     #   mock-django
-    #   pytest-django-ordering
     #   rest-condition
     #   xss-utils
 django-appconf==1.0.5
@@ -623,7 +622,6 @@ pytest==6.2.5
     #   pytest-base-url
     #   pytest-cov
     #   pytest-django
-    #   pytest-django-ordering
     #   pytest-html
     #   pytest-metadata
     #   pytest-randomly
@@ -639,9 +637,6 @@ pytest-cov==3.0.0
 pytest-django==4.4.0
     # via
     #   -r requirements/test.in
-    #   pytest-django-ordering
-pytest-django-ordering==1.2.0
-    # via -r requirements/test.in
 pytest-html==3.1.1
     # via
     #   -r requirements/e2e.txt


### PR DESCRIPTION
Changes:
- re-generates requirements/dev.txt
- re-generates requirements/test.txt



https://github.com/edx/upgrades/issues/55#issuecomment-922457358

## Description

Package removed due to [pytest-django>=3.9](https://pytest-django.readthedocs.io/en/latest/changelog.html?highlight=ordering#id10) is used that has [required
plugin's logic](https://github.com/pytest-dev/pytest-django/blob/master/pytest_django/plugin.py#L366) to preserve the order of tests like Django test runner
does.

Useful information to include:
- https://github.com/edx/upgrades/issues/55#issuecomment-922457358

## Supporting information

- https://github.com/pytest-dev/pytest-django/issues/827
- https://github.com/pytest-dev/pytest-django/pull/830
- https://github.com/pytest-dev/pytest-django/pull/820

## Testing instructions

Run CI to ensure all tests passed and pytest-django-ordering plugin in not required for our TestSuit.


