### PR TITLE
BOM-2782: Use DeploymentMonitoringMiddleware in settings

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -213,6 +213,7 @@ TEMPLATES = [
 # See: https://docs.djangoproject.com/en/1.11/ref/settings/#middleware
 MIDDLEWARE = (
     'corsheaders.middleware.CorsMiddleware',
+    'edx_django_utils.monitoring.DeploymentMonitoringMiddleware',
     'edx_django_utils.cache.middleware.RequestCacheMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',


### PR DESCRIPTION
**Issue:** [BOM-2782](https://openedx.atlassian.net/browse/BOM-2782)

### Description
- Added the `DeploymentMonitroringMiddleware` to record `Django` and `Python` versions in the `NewRelic`.
