### PR TITLE
fix: add learning MFE to CORS whitelist

### DIFF
--- a/ecommerce/settings/devstack.py
+++ b/ecommerce/settings/devstack.py
@@ -46,9 +46,10 @@ JWT_AUTH.update({
 CORS_ORIGIN_WHITELIST = (
     'http://localhost:1991',
     'http://localhost:1996',
-    'http://localhost:1998',
-    'http://localhost:8734',
     'http://localhost:1997', # Account MFE
+    'http://localhost:1998',
+    'http://localhost:2000', # Learning MFE
+    'http://localhost:8734',
 )
 CORS_ALLOW_HEADERS = corsheaders_default_headers + (
     'use-jwt-cookie',


### PR DESCRIPTION
The Learning MFE plans to start asking ecommerce to calculate a coupon discount for it.

I plan to also update configuration/edx-internal CORS lists. But this is a start.

https://openedx.atlassian.net/browse/AA-1012