### PR TITLE
Issue: Coupon edition problem with course_id

### DIFF
--- a/ecommerce/extensions/api/v2/views/coupons.py
+++ b/ecommerce/extensions/api/v2/views/coupons.py
@@ -407,8 +407,8 @@ class CouponViewSet(EdxOrderPlacementMixin, viewsets.ModelViewSet):
         # In case of enterprise, range_data has enterprise data in it as enterprise is defined in UPDATABLE_RANGE_FIELDS
         # so Catalog should not be None if there is an enterprise is associated with it.
         if voucher_range.catalog:
-            if not enterprise_customer_data:
-                range_data['catalog'] = None
+            # if not enterprise_customer_data:
+            #     range_data['catalog'] = None
 
             if enterprise_customer_data and range_data.get('catalog_query'):
                 range_data['catalog'] = None


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Issue: Coupon edition problem with course_id


I have a problem, and it is that when editing a coupon for a single course, when saving the changes, the course associated with the coupon disappears. The course_id is set to none. When commenting [these lines](https://github.com/edx/ecommerce/blob/master/ecommerce/extensions/api/v2/views/coupons.py#L408-L409) the problem stops happening but **I don't think that is the best option**.

Had it happened to you before? How do you recommend that the approach be made to the solution of this problem?

## Useful information about the problem
Tested in branch `open-release/juniper.master`
Before edition


![coupon-before](https://user-images.githubusercontent.com/35668326/135314558-8804603f-71f0-4653-b6cd-50751a9058cb.png)
During
![coupon-during](https://user-images.githubusercontent.com/35668326/135314575-aa6428ac-6e85-4634-acc8-41fb6d01a7a0.png)
After 
![coupon-after](https://user-images.githubusercontent.com/35668326/135314603-260dbb87-24d7-48ea-9f2b-536949c039ad.png)


