### PR TITLE
fix: change bucket location from api call to hardcode

### DIFF
--- a/ecommerce/extensions/api/v2/tests/test_utils.py
+++ b/ecommerce/extensions/api/v2/tests/test_utils.py
@@ -2,6 +2,7 @@
 
 import botocore
 import mock
+from django.conf import settings
 
 from ecommerce.extensions.api.v2.utils import (
     SMTPException,
@@ -66,7 +67,7 @@ class ViewUtilsTests(TestCase):
             "ETag": '"6299528715bad0e3510d1e4c4952ee7e"',
         }
         if operation_name == 'GetBucketLocation':  # pylint: disable=no-else-return
-            return {'LocationConstraint': 'dummy_location'}
+            return {'LocationConstraint': settings.ENTERPRISE_EMAIL_FILE_ATTACHMENTS_BUCKET_LOCATION}
         elif operation_name == 'PutObject':
             return put_object_response
         else:
@@ -80,8 +81,10 @@ class ViewUtilsTests(TestCase):
             res = upload_files_for_enterprise_coupons(un_uploaded_files)
             assert res[0]['size'] == un_uploaded_files[0]['size']
             assert res[1]['size'] == un_uploaded_files[1]['size']
-            assert res[0]['url'].startswith('https://.s3.dummy_location.amazonaws.com')
-            assert res[1]['url'].startswith('https://.s3.dummy_location.amazonaws.com')
+            assert res[0]['url'].startswith(
+                f'https://.s3.{settings.ENTERPRISE_EMAIL_FILE_ATTACHMENTS_BUCKET_LOCATION}.amazonaws.com')
+            assert res[1]['url'].startswith(
+                f'https://.s3.{settings.ENTERPRISE_EMAIL_FILE_ATTACHMENTS_BUCKET_LOCATION}.amazonaws.com')
             assert res[0]['url'].endswith('abcpng')
             assert res[1]['url'].endswith('defpng')
 

--- a/ecommerce/extensions/api/v2/utils.py
+++ b/ecommerce/extensions/api/v2/utils.py
@@ -67,6 +67,7 @@ def upload_files_for_enterprise_coupons(files):
     if files and len(files) > 0:
         try:
             bucket_name = settings.ENTERPRISE_EMAIL_FILE_ATTACHMENTS_BUCKET_NAME
+            bucket_location = settings.ENTERPRISE_EMAIL_FILE_ATTACHMENTS_BUCKET_NAME
             session = boto3.Session()
             s3 = session.client('s3')
 
@@ -76,8 +77,7 @@ def upload_files_for_enterprise_coupons(files):
                 filename = datetime.datetime.now().strftime("%d-%m-%Y at %H.%M.%S") + " " + file['name']
                 key = slugify(filename)
                 s3.upload_fileobj(file_buf, bucket_name, key)
-                location = s3.get_bucket_location(Bucket=bucket_name)['LocationConstraint']
-                url = f"https://{bucket_name}.s3.{location}.amazonaws.com/{key}"
+                url = f"https://{bucket_name}.s3.{bucket_location}.amazonaws.com/{key}"
                 uploaded_files.append({'name': key, 'size': file['size'], 'url': url})
         except Exception as ex:  # pylint: disable=broad-except
             logger.exception(

--- a/ecommerce/extensions/api/v2/utils.py
+++ b/ecommerce/extensions/api/v2/utils.py
@@ -67,7 +67,7 @@ def upload_files_for_enterprise_coupons(files):
     if files and len(files) > 0:
         try:
             bucket_name = settings.ENTERPRISE_EMAIL_FILE_ATTACHMENTS_BUCKET_NAME
-            bucket_location = settings.ENTERPRISE_EMAIL_FILE_ATTACHMENTS_BUCKET_NAME
+            bucket_location = settings.ENTERPRISE_EMAIL_FILE_ATTACHMENTS_BUCKET_LOCATION
             session = boto3.Session()
             s3 = session.client('s3')
 

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -829,4 +829,5 @@ FAVICON_URL = None
 
 # s3 files for email-template, code management credentials
 ENTERPRISE_EMAIL_FILE_ATTACHMENTS_BUCKET_NAME = ''
+ENTERPRISE_EMAIL_FILE_ATTACHMENTS_BUCKET_LOCATION = 'us-east-1'  # change this when developing with your own bucket
 


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Description
Previously i was getting bucket location through an api call to generate the url of resource, but as all the buckets have region of us-east-1 and api call was returning None on stage, it is a better and fair approach to use hardcoded value, so i did that.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
