### PR TITLE
BOM-2640: Upgrade ecommerce-worker version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -206,7 +206,7 @@ edx-drf-extensions==6.6.0
     #   -c requirements/pins.txt
     #   -r requirements/base.in
     #   edx-rbac
-edx-ecommerce-worker==2.2.2
+edx-ecommerce-worker==2.3.0
     # via -r requirements/base.in
 edx-opaque-keys==2.2.2
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -291,7 +291,7 @@ edx-drf-extensions==6.6.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-edx-ecommerce-worker==2.2.2
+edx-ecommerce-worker==2.3.0
     # via -r requirements/test.txt
 edx-i18n-tools==0.7.0
     # via -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -211,7 +211,7 @@ edx-drf-extensions==6.6.0
     #   -c requirements/pins.txt
     #   -r requirements/base.in
     #   edx-rbac
-edx-ecommerce-worker==2.2.2
+edx-ecommerce-worker==2.3.0
     # via -r requirements/base.in
 edx-opaque-keys==2.2.2
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -289,7 +289,7 @@ edx-drf-extensions==6.6.0
     #   -c requirements/pins.txt
     #   -r requirements/base.txt
     #   edx-rbac
-edx-ecommerce-worker==2.2.2
+edx-ecommerce-worker==2.3.0
     # via -r requirements/base.txt
 edx-i18n-tools==0.7.0
     # via -r requirements/test.in


### PR DESCRIPTION
**Issue:** [BOM-2640](https://openedx.atlassian.net/browse/BOM-2640)

### Description
- https://github.com/edx/ecommerce-worker/pull/144 added `Django 3.2` support in `ecommerce-worker` so now upgrading requirements to fetch new version `ecommerce-worker==2.3.0`. 