### PR TITLE
BOM-2886: Upgrade pytest & pytest-django

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -291,7 +291,7 @@ naked==0.1.31
     # via
     #   crypto
     #   cybersource-rest-client-python
-ndg-httpsclient==0.5.1q
+ndg-httpsclient==0.5.1
     # via -r requirements/base.in
 newrelic==7.0.0.166
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -368,6 +368,10 @@ inflect==5.3.0
     # via
     #   -r requirements/test.txt
     #   jinja2-pluralize
+iniconfig==1.1.1
+    # via
+    #   -r requirements/test.txt
+    #   pytest
 ipaddress==1.0.23
     # via
     #   -r requirements/test.txt
@@ -458,10 +462,6 @@ monotonic==1.6
     # via
     #   -r requirements/test.txt
     #   analytics-python
-more-itertools==8.10.0
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 mysqlclient==1.4.6
     # via -r requirements/test.txt
 naked==0.1.31
@@ -628,7 +628,7 @@ pyrsistent==0.18.0
     # via
     #   -r requirements/test.txt
     #   jsonschema
-pytest==5.3.5
+pytest==6.2.5
     # via
     #   -r requirements/test.txt
     #   pytest-base-url
@@ -647,7 +647,7 @@ pytest-base-url==1.4.2
     #   pytest-selenium
 pytest-cov==3.0.0
     # via -r requirements/test.txt
-pytest-django==3.10.0
+pytest-django==4.4.0
     # via
     #   -r requirements/test.txt
     #   pytest-django-ordering
@@ -665,7 +665,7 @@ pytest-randomly==3.10.1
     # via -r requirements/test.txt
 pytest-selenium==2.0.1
     # via -r requirements/test.txt
-pytest-timeout==1.4.2
+pytest-timeout==2.0.0
     # via -r requirements/test.txt
 pytest-variables==1.9.0
     # via
@@ -925,6 +925,7 @@ text-unidecode==1.3
 toml==0.10.2
     # via
     #   -r requirements/test.txt
+    #   pytest
     #   tox
 tomli==1.2.1
     # via
@@ -979,10 +980,6 @@ waitress==2.0.0
     # via
     #   -r requirements/test.txt
     #   webtest
-wcwidth==0.2.5
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 webencodings==0.5.1
     # via
     #   -r requirements/test.txt

--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -53,7 +53,7 @@ idna==2.7
     #   requests
 importlib-metadata==4.8.1
     # via pytest-randomly
-more-itertools==8.10.0
+iniconfig==1.1.1
     # via pytest
 newrelic==7.0.0.166
     # via
@@ -68,7 +68,9 @@ pbr==5.6.0
     #   -c requirements/base.txt
     #   stevedore
 pluggy==0.13.1
-    # via pytest
+    # via
+    #   -c requirements/pins.txt
+    #   pytest
 psutil==5.8.0
     # via
     #   -c requirements/base.txt
@@ -87,9 +89,8 @@ pyparsing==2.4.7
     # via
     #   -c requirements/base.txt
     #   packaging
-pytest==5.3.5
+pytest==6.2.5
     # via
-    #   -c requirements/pins.txt
     #   -r requirements/e2e.in
     #   pytest-base-url
     #   pytest-html
@@ -108,7 +109,7 @@ pytest-randomly==3.10.1
     # via -r requirements/e2e.in
 pytest-selenium==2.0.1
     # via -r requirements/e2e.in
-pytest-timeout==1.4.2
+pytest-timeout==2.0.0
     # via -r requirements/e2e.in
 pytest-variables==1.9.0
     # via pytest-selenium
@@ -148,13 +149,13 @@ stevedore==3.4.0
     #   edx-django-utils
 tenacity==6.3.1
     # via pytest-selenium
+toml==0.10.2
+    # via pytest
 urllib3==1.26.7
     # via
     #   -c requirements/base.txt
     #   -c requirements/pins.txt
     #   requests
     #   selenium
-wcwidth==0.2.5
-    # via pytest
 zipp==3.6.0
     # via importlib-metadata

--- a/requirements/pins.txt
+++ b/requirements/pins.txt
@@ -20,10 +20,6 @@ httpretty==0.9.7
 # jsonfield2 > 3.0.3 dropped support for python 3.5
 jsonfield2<=3.0.3
 
-# 5.4 introduces test order problems that need to be resolved.
-pytest<5.4.0
-pytest-django<4.0 # Newer versions require pytest >= 5.4.0
-
 # Pinned to preserve the status quo
 pytz==2016.10
 
@@ -38,8 +34,9 @@ virtualenv==16.7.9
 # removing this pin, then this pin can be removed.
 pylint==2.4.4
 
-# greater versions failing with extract-tranlsations step.
+# greater versions failing with extract-translations step.
 tox==3.14.6
+pluggy<1.0.0  # pluggy==1.0.0 requires tox>3.14.6
 
 # cybersource-rest-client-python requires 2.7, but requests gives 2.10 by default
 idna==2.7

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -8,7 +8,7 @@ click==8.0.1
     # via pip-tools
 pep517==0.11.0
     # via pip-tools
-pip-tools==6.3.0
+pip-tools==6.3.1
     # via -r requirements/pip_tools.in
 tomli==1.2.1
     # via pep517

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -360,6 +360,10 @@ importlib-metadata==4.8.1
     #   pytest-randomly
 inflect==5.3.0
     # via jinja2-pluralize
+iniconfig==1.1.1
+    # via
+    #   -r requirements/e2e.txt
+    #   pytest
 ipaddress==1.0.23
     # via
     #   -r requirements/base.txt
@@ -443,10 +447,6 @@ monotonic==1.6
     # via
     #   -r requirements/base.txt
     #   analytics-python
-more-itertools==8.10.0
-    # via
-    #   -r requirements/e2e.txt
-    #   pytest
 mysqlclient==1.4.6
     # via -r requirements/base.txt
 naked==0.1.31
@@ -515,6 +515,7 @@ platformdirs==2.4.0
     #   zeep
 pluggy==0.13.1
     # via
+    #   -c requirements/pins.txt
     #   -r requirements/e2e.txt
     #   -r requirements/tox.txt
     #   diff-cover
@@ -615,9 +616,8 @@ pyrsistent==0.18.0
     # via
     #   -r requirements/base.txt
     #   jsonschema
-pytest==5.3.5
+pytest==6.2.5
     # via
-    #   -c requirements/pins.txt
     #   -r requirements/e2e.txt
     #   -r requirements/test.in
     #   pytest-base-url
@@ -636,9 +636,8 @@ pytest-base-url==1.4.2
     #   pytest-selenium
 pytest-cov==3.0.0
     # via -r requirements/test.in
-pytest-django==3.10.0
+pytest-django==4.4.0
     # via
-    #   -c requirements/pins.txt
     #   -r requirements/test.in
     #   pytest-django-ordering
 pytest-django-ordering==1.2.0
@@ -655,7 +654,7 @@ pytest-randomly==3.10.1
     # via -r requirements/e2e.txt
 pytest-selenium==2.0.1
     # via -r requirements/e2e.txt
-pytest-timeout==1.4.2
+pytest-timeout==2.0.0
     # via -r requirements/e2e.txt
 pytest-variables==1.9.0
     # via
@@ -876,7 +875,9 @@ text-unidecode==1.3
     #   faker
 toml==0.10.2
     # via
+    #   -r requirements/e2e.txt
     #   -r requirements/tox.txt
+    #   pytest
     #   tox
 tomli==1.2.1
     # via coverage
@@ -925,10 +926,6 @@ virtualenv==16.7.9
     #   tox
 waitress==2.0.0
     # via webtest
-wcwidth==0.2.5
-    # via
-    #   -r requirements/e2e.txt
-    #   pytest
 webencodings==0.5.1
     # via
     #   -r requirements/base.txt

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -9,7 +9,9 @@ filelock==3.3.0
 packaging==21.0
     # via tox
 pluggy==0.13.1
-    # via tox
+    # via
+    #   -c requirements/pins.txt
+    #   tox
 py==1.10.0
     # via tox
 pyparsing==2.4.7


### PR DESCRIPTION
## JIRA Issue
- [BOM-2886](https://openedx.atlassian.net/browse/BOM-2886)

## Description
- Upgrading pinned `pytest` and `pytest-django` packages in preparation for `Django 3.2` upgrade.
- `pytest-django` upgraded to latest version `4.4.0` which has `Django {2.2, 3.0, 3.1, 3.2}` support in it.