### PR TITLE
Replace rest_framework_swagger with drf_yasg

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -301,7 +301,7 @@ DJANGO_APPS = [
     'crispy_forms',
     'solo',
     'social_django',
-    'rest_framework_swagger',
+    'drf_yasg',
     'rest_framework_datatables',
     'django_sites_extensions',
     # edx-drf-extensions

--- a/ecommerce/urls.py
+++ b/ecommerce/urls.py
@@ -12,7 +12,9 @@ from django.utils.translation import ugettext_lazy as _
 from django.views.defaults import page_not_found, server_error
 from django.views.generic import TemplateView
 from django.views.i18n import JavaScriptCatalog
-from rest_framework_swagger.views import get_swagger_view
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+from rest_framework import permissions
 
 from ecommerce.core import views as core_views
 from ecommerce.core.url_utils import get_lms_dashboard_url
@@ -52,11 +54,21 @@ WELL_KNOWN_URLS = [
         ApplePayMerchantDomainAssociationView.as_view(), name='apple_pay_domain_association'),
 ]
 
+schema_view = get_schema_view(
+   openapi.Info(
+      title="Ecommerce API",
+      default_version='v1',
+      description="Ecommerce docs",
+   ),
+   public=False,
+   permission_classes=[permissions.AllowAny],
+)
+
 urlpatterns = AUTH_URLS + WELL_KNOWN_URLS + [
     url(r'^admin/', admin.site.urls),
     url(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),
     url(r'^api-auth/', include((AUTH_URLS, 'rest_framework'))),
-    url(r'^api-docs/', get_swagger_view(title='Ecommerce API'), name='api_docs'),
+     url(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     url(r'^bff/', include(('ecommerce.bff.urls', 'bff'))),
     url(r'^courses/', include(('ecommerce.courses.urls', 'courses'))),
     url(r'^credit/', include(('ecommerce.credit.urls', 'credit'))),

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,9 +28,9 @@ billiard==3.6.4.0
     # via celery
 bleach==4.1.0
     # via -r requirements/base.in
-boto3==1.18.59
+boto3==1.10.10
     # via -r requirements/base.in
-botocore==1.21.59
+botocore==1.22.10
     # via
     #   boto3
     #   s3transfer
@@ -228,7 +228,7 @@ extras==1.0.0
     #   testtools
 factory-boy==2.12.0
     # via django-oscar
-faker==9.3.1
+faker==9.8.0
     # via factory-boy
 fixtures==3.0.0
     # via
@@ -521,7 +521,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/base.in
     #   djangorestframework-csv
-uritemplate==4.0.0
+uritemplate==4.1.1
     # via coreapi
 urllib3==1.26.7
     # via

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,7 +28,7 @@ billiard==3.6.4.0
     # via celery
 bleach==4.1.0
     # via -r requirements/base.in
-boto3==1.10.10
+boto3==1.19.10
     # via -r requirements/base.in
 botocore==1.22.10
     # via

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,9 +28,9 @@ billiard==3.6.4.0
     # via celery
 bleach==4.1.0
     # via -r requirements/base.in
-boto3==1.18.57
+boto3==1.18.59
     # via -r requirements/base.in
-botocore==1.21.57
+botocore==1.21.59
     # via
     #   boto3
     #   s3transfer
@@ -40,7 +40,7 @@ celery==4.4.7
     # via
     #   -c requirements/pins.txt
     #   edx-ecommerce-worker
-certifi==2021.5.30
+certifi==2021.10.8
     # via
     #   cybersource-rest-client-python
     #   requests
@@ -228,7 +228,7 @@ extras==1.0.0
     #   testtools
 factory-boy==2.12.0
     # via django-oscar
-faker==9.2.0
+faker==9.3.1
     # via factory-boy
 fixtures==3.0.0
     # via
@@ -291,7 +291,7 @@ naked==0.1.31
     # via
     #   crypto
     #   cybersource-rest-client-python
-ndg-httpsclient==0.5.1q
+ndg-httpsclient==0.5.1
     # via -r requirements/base.in
 newrelic==7.0.0.166
     # via
@@ -307,7 +307,7 @@ openapi-codec==1.3.2
     # via django-rest-swagger
 packaging==21.0
     # via bleach
-paramiko==2.7.2
+paramiko==2.8.0
     # via cybersource-rest-client-python
 path.py==7.2
     # via -r requirements/base.in
@@ -521,7 +521,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/base.in
     #   djangorestframework-csv
-uritemplate==3.0.1
+uritemplate==4.0.0
     # via coreapi
 urllib3==1.26.7
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -56,9 +56,9 @@ bleach==4.1.0
     # via -r requirements/test.txt
 bok-choy==1.1.1
     # via -r requirements/test.txt
-boto3==1.18.57
+boto3==1.18.59
     # via -r requirements/test.txt
-botocore==1.21.57
+botocore==1.21.59
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -71,7 +71,7 @@ celery==4.4.7
     # via
     #   -r requirements/test.txt
     #   edx-ecommerce-worker
-certifi==2021.5.30
+certifi==2021.10.8
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -321,7 +321,7 @@ factory-boy==2.12.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
-faker==9.2.0
+faker==9.3.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -496,7 +496,7 @@ packaging==21.0
     #   pytest
     #   sphinx
     #   tox
-paramiko==2.7.2
+paramiko==2.8.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -562,7 +562,7 @@ pyasn1==0.4.8
     #   ndg-httpsclient
     #   rsa
     #   x509
-pycodestyle==2.7.0
+pycodestyle==2.8.0
     # via -r requirements/test.txt
 pycountry==17.1.8
     # via -r requirements/test.txt
@@ -665,7 +665,7 @@ pytest-randomly==3.10.1
     # via -r requirements/test.txt
 pytest-selenium==2.0.1
     # via -r requirements/test.txt
-pytest-timeout==1.4.2
+pytest-timeout==2.0.1
     # via -r requirements/test.txt
 pytest-variables==1.9.0
     # via
@@ -679,7 +679,7 @@ python-dateutil==2.8.2
     #   edx-drf-extensions
     #   faker
     #   freezegun
-python-dotenv==0.19.0
+python-dotenv==0.19.1
     # via -r requirements/test.txt
 python-memcached==1.58
     # via -r requirements/test.txt
@@ -952,7 +952,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/test.txt
     #   djangorestframework-csv
-uritemplate==3.0.1
+uritemplate==4.0.0
     # via
     #   -r requirements/test.txt
     #   coreapi

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -56,9 +56,9 @@ bleach==4.1.0
     # via -r requirements/test.txt
 bok-choy==1.1.1
     # via -r requirements/test.txt
-boto3==1.18.59
+boto3==1.19.10
     # via -r requirements/test.txt
-botocore==1.21.59
+botocore==1.22.10
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -321,7 +321,7 @@ factory-boy==2.12.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
-faker==9.3.1
+faker==9.8.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -952,7 +952,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/test.txt
     #   djangorestframework-csv
-uritemplate==4.0.0
+uritemplate==4.1.1
     # via
     #   -r requirements/test.txt
     #   coreapi

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12
     # via sphinx
 babel==2.9.1
     # via sphinx
-certifi==2021.5.30
+certifi==2021.10.8
     # via requests
 charset-normalizer==2.0.6
     # via requests

--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -8,7 +8,7 @@ attrs==21.2.0
     # via
     #   -c requirements/base.txt
     #   pytest
-certifi==2021.5.30
+certifi==2021.10.8
     # via
     #   -c requirements/base.txt
     #   requests
@@ -108,11 +108,11 @@ pytest-randomly==3.10.1
     # via -r requirements/e2e.in
 pytest-selenium==2.0.1
     # via -r requirements/e2e.in
-pytest-timeout==1.4.2
+pytest-timeout==2.0.1
     # via -r requirements/e2e.in
 pytest-variables==1.9.0
     # via pytest-selenium
-python-dotenv==0.19.0
+python-dotenv==0.19.1
     # via -r requirements/e2e.in
 pytz==2016.10
     # via

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-click==8.0.1
+click==8.0.3
     # via pip-tools
 pep517==0.11.0
     # via pip-tools
-pip-tools==6.3.0
+pip-tools==6.3.1
     # via -r requirements/pip_tools.in
 tomli==1.2.1
     # via pep517

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -8,7 +8,7 @@ click==8.0.3
     # via pip-tools
 pep517==0.11.0
     # via pip-tools
-pip-tools==6.3.1
+pip-tools==6.4.0
     # via -r requirements/pip_tools.in
 tomli==1.2.1
     # via pep517

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -28,11 +28,11 @@ billiard==3.6.4.0
     # via celery
 bleach==4.1.0
     # via -r requirements/base.in
-boto3==1.18.59
+boto3==1.19.10
     # via
     #   -r requirements/base.in
     #   django-ses
-botocore==1.21.59
+botocore==1.22.10
     # via
     #   boto3
     #   s3transfer
@@ -233,7 +233,7 @@ extras==1.0.0
     #   testtools
 factory-boy==2.12.0
     # via django-oscar
-faker==9.3.1
+faker==9.8.0
     # via factory-boy
 fixtures==3.0.0
     # via
@@ -540,7 +540,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/base.in
     #   djangorestframework-csv
-uritemplate==4.0.0
+uritemplate==4.1.1
     # via coreapi
 urllib3==1.26.7
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -28,11 +28,11 @@ billiard==3.6.4.0
     # via celery
 bleach==4.1.0
     # via -r requirements/base.in
-boto3==1.18.57
+boto3==1.18.59
     # via
     #   -r requirements/base.in
     #   django-ses
-botocore==1.21.57
+botocore==1.21.59
     # via
     #   boto3
     #   s3transfer
@@ -42,7 +42,7 @@ celery==4.4.7
     # via
     #   -c requirements/pins.txt
     #   edx-ecommerce-worker
-certifi==2021.5.30
+certifi==2021.10.8
     # via
     #   cybersource-rest-client-python
     #   requests
@@ -233,7 +233,7 @@ extras==1.0.0
     #   testtools
 factory-boy==2.12.0
     # via django-oscar
-faker==9.2.0
+faker==9.3.1
     # via factory-boy
 fixtures==3.0.0
     # via
@@ -319,7 +319,7 @@ openapi-codec==1.3.2
     # via django-rest-swagger
 packaging==21.0
     # via bleach
-paramiko==2.7.2
+paramiko==2.8.0
     # via cybersource-rest-client-python
 path.py==7.2
     # via -r requirements/base.in
@@ -540,7 +540,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/base.in
     #   djangorestframework-csv
-uritemplate==3.0.1
+uritemplate==4.0.0
     # via coreapi
 urllib3==1.26.7
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -47,9 +47,9 @@ bleach==4.1.0
     # via -r requirements/base.txt
 bok-choy==1.1.1
     # via -r requirements/test.in
-boto3==1.18.59
+boto3==1.19.10
     # via -r requirements/base.txt
-botocore==1.21.59
+botocore==1.22.10
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -320,7 +320,7 @@ factory-boy==2.12.0
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   django-oscar
-faker==9.3.1
+faker==9.8.0
     # via
     #   -r requirements/base.txt
     #   factory-boy
@@ -899,7 +899,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/base.txt
     #   djangorestframework-csv
-uritemplate==4.0.0
+uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
     #   coreapi

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -47,9 +47,9 @@ bleach==4.1.0
     # via -r requirements/base.txt
 bok-choy==1.1.1
     # via -r requirements/test.in
-boto3==1.18.57
+boto3==1.18.59
     # via -r requirements/base.txt
-botocore==1.21.57
+botocore==1.21.59
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -63,7 +63,7 @@ celery==4.4.7
     #   -c requirements/pins.txt
     #   -r requirements/base.txt
     #   edx-ecommerce-worker
-certifi==2021.5.30
+certifi==2021.10.8
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -320,7 +320,7 @@ factory-boy==2.12.0
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   django-oscar
-faker==9.2.0
+faker==9.3.1
     # via
     #   -r requirements/base.txt
     #   factory-boy
@@ -482,7 +482,7 @@ packaging==21.0
     #   bleach
     #   pytest
     #   tox
-paramiko==2.7.2
+paramiko==2.8.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
@@ -546,7 +546,7 @@ pyasn1==0.4.8
     #   ndg-httpsclient
     #   rsa
     #   x509
-pycodestyle==2.7.0
+pycodestyle==2.8.0
     # via -r requirements/test.in
 pycountry==17.1.8
     # via -r requirements/base.txt
@@ -655,7 +655,7 @@ pytest-randomly==3.10.1
     # via -r requirements/e2e.txt
 pytest-selenium==2.0.1
     # via -r requirements/e2e.txt
-pytest-timeout==1.4.2
+pytest-timeout==2.0.1
     # via -r requirements/e2e.txt
 pytest-variables==1.9.0
     # via
@@ -669,7 +669,7 @@ python-dateutil==2.8.2
     #   edx-drf-extensions
     #   faker
     #   freezegun
-python-dotenv==0.19.0
+python-dotenv==0.19.1
     # via -r requirements/e2e.txt
 python-memcached==1.58
     # via -r requirements/test.in
@@ -899,7 +899,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/base.txt
     #   djangorestframework-csv
-uritemplate==3.0.1
+uritemplate==4.0.0
     # via
     #   -r requirements/base.txt
     #   coreapi


### PR DESCRIPTION
This PR was created following https://github.com/edx/upgrades/issues/17 to switch django rest swagger to drf-yasg
