### PR TITLE
[WIP] REV-2416: move coupon category creation from custom migrations into a management command

### DIFF
--- a/ecommerce/extensions/catalogue/migrations/0015_default_categories.py
+++ b/ecommerce/extensions/catalogue/migrations/0015_default_categories.py
@@ -2,35 +2,6 @@
 
 
 from django.db import migrations
-from oscar.apps.catalogue.categories import create_from_breadcrumbs
-from oscar.core.loading import get_model
-
-Category = get_model("catalogue", "Category")
-
-COUPON_CATEGORY_NAME = 'Coupons'
-
-DEFAULT_CATEGORIES = [
-    'Affiliate Promotion', 'Bulk Enrollment', 'ConnectEd', 'Course Promotion',
-    'Customer Service', 'Financial Assistance', 'Geography Promotion',
-    'Marketing Partner Promotion', 'Marketing-Other', 'Paid Cohort', 'Other',
-    'Retention Promotion', 'Services-Other', 'Support-Other', 'Upsell Promotion',
-]
-
-
-def create_default_categories(apps, schema_editor):
-    """Create default coupon categories."""
-    Category.skip_history_when_saving = True
-
-    for category in DEFAULT_CATEGORIES:
-        create_from_breadcrumbs('{} > {}'.format(COUPON_CATEGORY_NAME, category))
-
-
-def remove_default_categories(apps, schema_editor):
-    """Remove default coupon categories."""
-    Category.skip_history_when_saving = True
-    Category.objects.get(name=COUPON_CATEGORY_NAME).get_children().filter(
-        name__in=DEFAULT_CATEGORIES
-    ).delete()
 
 
 class Migration(migrations.Migration):
@@ -40,5 +11,4 @@ class Migration(migrations.Migration):
         ('catalogue', '0014_alter_couponvouchers_attribute')
     ]
     operations = [
-        migrations.RunPython(create_default_categories, remove_default_categories)
     ]

--- a/ecommerce/extensions/catalogue/migrations/0033_add_coupon_categories.py
+++ b/ecommerce/extensions/catalogue/migrations/0033_add_coupon_categories.py
@@ -3,33 +3,6 @@
 
 
 from django.db import migrations
-from oscar.apps.catalogue.categories import create_from_breadcrumbs
-from oscar.core.loading import get_model
-
-Category = get_model('catalogue', 'Category')
-
-COUPON_CATEGORY_NAME = 'Coupons'
-
-DEFAULT_CATEGORIES = [
-    'Bulk Enrollment - Prepay',
-    'Bulk Enrollment - Upon Redemption',
-    'Bulk Enrollment - Integration',
-]
-
-def create_default_categories(apps, schema_editor):
-    """Create default coupon categories."""
-    Category.skip_history_when_saving = True
-
-    for category in DEFAULT_CATEGORIES:
-        create_from_breadcrumbs('{} > {}'.format(COUPON_CATEGORY_NAME, category))
-
-
-def remove_default_categories(apps, schema_editor):
-    """Remove default coupon categories."""
-    Category.skip_history_when_saving = True
-    Category.objects.get(name=COUPON_CATEGORY_NAME).get_children().filter(
-        name__in=DEFAULT_CATEGORIES
-    ).delete()
 
 
 class Migration(migrations.Migration):
@@ -38,5 +11,4 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(create_default_categories, remove_default_categories)
     ]

--- a/ecommerce/extensions/catalogue/migrations/0034_add_on_campus_coupon_category.py
+++ b/ecommerce/extensions/catalogue/migrations/0034_add_on_campus_coupon_category.py
@@ -1,32 +1,6 @@
 """ Add 'On-Campus Learners' to the list of default coupon categories"""
 
-
-
 from django.db import migrations
-from oscar.apps.catalogue.categories import create_from_breadcrumbs
-from oscar.core.loading import get_model
-
-Category = get_model('catalogue', 'Category')
-
-COUPON_CATEGORY_NAME = 'Coupons'
-
-ON_CAMPUS_CATEGORY = 'On-Campus Learners'
-
-
-def create_on_campus_category(apps, schema_editor):
-    """ Create on-campus coupon category """
-    Category.skip_history_when_saving = True
-    create_from_breadcrumbs('{} > {}'.format(COUPON_CATEGORY_NAME, ON_CAMPUS_CATEGORY))
-
-
-def remove_on_campus_category(apps, schema_editor):
-    """ Remove on-campus coupon category """
-    Category.skip_history_when_saving = True
-    Category.objects.get(
-        name=COUPON_CATEGORY_NAME
-    ).get_children().filter(
-        name=ON_CAMPUS_CATEGORY
-    ).delete()
 
 
 class Migration(migrations.Migration):
@@ -35,5 +9,4 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(create_on_campus_category, remove_on_campus_category)
     ]

--- a/ecommerce/extensions/catalogue/migrations/0035_add_partner_no_rev_coupon_categories.py
+++ b/ecommerce/extensions/catalogue/migrations/0035_add_partner_no_rev_coupon_categories.py
@@ -1,34 +1,6 @@
 """ Add 'Partner No Rev' categories to the list of default coupon categories"""
 
-
-
 from django.db import migrations
-from oscar.apps.catalogue.categories import create_from_breadcrumbs
-from oscar.core.loading import get_model
-
-Category = get_model('catalogue', 'Category')
-
-COUPON_CATEGORY_NAME = 'Coupons'
-
-DEFAULT_CATEGORIES = [
-    'Partner No Rev - Prepay',
-    'Partner No Rev - Upon Redemption',
-]
-
-def create_default_categories(apps, schema_editor):
-    """Create default coupon categories."""
-    Category.skip_history_when_saving = True
-    for category in DEFAULT_CATEGORIES:
-        create_from_breadcrumbs('{} > {}'.format(COUPON_CATEGORY_NAME, category))
-
-
-def remove_default_categories(apps, schema_editor):
-    """Remove default coupon categories."""
-    Category.skip_history_when_saving = True
-    Category.objects.get(name=COUPON_CATEGORY_NAME).get_children().filter(
-        name__in=DEFAULT_CATEGORIES
-    ).delete()
-
 
 class Migration(migrations.Migration):
     dependencies = [
@@ -36,5 +8,4 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(create_default_categories, remove_default_categories)
     ]

--- a/ecommerce/extensions/catalogue/migrations/0037_add_sec_disc_reward_coupon_category.py
+++ b/ecommerce/extensions/catalogue/migrations/0037_add_sec_disc_reward_coupon_category.py
@@ -5,32 +5,7 @@ Adds a new couple category that will be used to track rewards given
 to members of the community who make security disclosures.
 """
 
-
-
 from django.db import migrations
-from oscar.apps.catalogue.categories import create_from_breadcrumbs
-from oscar.core.loading import get_model
-
-Category = get_model('catalogue', 'Category')
-
-COUPON_CATEGORY_NAME = 'Coupons'
-
-SECURITY_DISCLOSURE_REWARD_CATEGORY = 'Security Disclosure Reward'
-
-def create_security_disclosure_reward_category(apps, schema_editor):
-    """ Create coupon category for rewarding security disclosures. """
-    Category.skip_history_when_saving = True
-    create_from_breadcrumbs('{} > {}'.format(COUPON_CATEGORY_NAME,
-                                             SECURITY_DISCLOSURE_REWARD_CATEGORY))
-
-def remove_security_disclosure_reward_category(apps, schema_editor):
-    """ Remove the security disclosure reward category. """
-    Category.skip_history_when_saving = True
-    Category.objects.get(
-        name=COUPON_CATEGORY_NAME
-    ).get_children().filter(
-        name=SECURITY_DISCLOSURE_REWARD_CATEGORY
-    ).delete()
 
 
 class Migration(migrations.Migration):
@@ -40,6 +15,4 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(create_security_disclosure_reward_category,
-                             remove_security_disclosure_reward_category)
     ]

--- a/ecommerce/extensions/catalogue/migrations/0045_add_edx_employee_coupon_category.py
+++ b/ecommerce/extensions/catalogue/migrations/0045_add_edx_employee_coupon_category.py
@@ -3,33 +3,6 @@
 
 
 from django.db import migrations
-from oscar.apps.catalogue.categories import create_from_breadcrumbs
-from oscar.core.loading import get_model
-
-Category = get_model('catalogue', 'Category')
-
-COUPON_CATEGORY_NAME = 'Coupons'
-
-EDX_EMPLOYEE_COUPON_CATEGORY = 'edX Employee Request'
-
-def create_edx_employee_category(apps, schema_editor):
-    """Create edX employee coupon category."""
-    Category.skip_history_when_saving = True
-    create_from_breadcrumbs(
-        '{} > {}'.format(
-            COUPON_CATEGORY_NAME, EDX_EMPLOYEE_COUPON_CATEGORY
-        )
-    )
-
-
-def remove_edx_employee_category(apps, schema_editor):
-    """Remove edX employee coupon category."""
-    Category.skip_history_when_saving = True
-    Category.objects.get(
-        name=COUPON_CATEGORY_NAME
-    ).get_children().filter(
-        name=EDX_EMPLOYEE_COUPON_CATEGORY
-    ).delete()
 
 
 class Migration(migrations.Migration):
@@ -38,5 +11,4 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(create_edx_employee_category, remove_edx_employee_category)
     ]

--- a/ecommerce/extensions/catalogue/migrations/0049_add_rap_and_orap_coupon_categories.py
+++ b/ecommerce/extensions/catalogue/migrations/0049_add_rap_and_orap_coupon_categories.py
@@ -1,33 +1,7 @@
 """ Add no rev 'rap and orap' categories to the list of default coupon categories"""
 
 
-
 from django.db import migrations
-from oscar.apps.catalogue.categories import create_from_breadcrumbs
-from oscar.core.loading import get_model
-
-Category = get_model('catalogue', 'Category')
-
-COUPON_CATEGORY_NAME = 'Coupons'
-
-RAP_CATEGORIES = [
-    'Partner No Rev - RAP',
-    'Partner No Rev - ORAP',
-]
-
-def create_rap_categories(apps, schema_editor):
-    """Create rap coupon categories."""
-    Category.skip_history_when_saving = True
-    for category in RAP_CATEGORIES:
-        create_from_breadcrumbs('{} > {}'.format(COUPON_CATEGORY_NAME, category))
-
-
-def remove_rap_categories(apps, schema_editor):
-    """Remove rap coupon categories."""
-    Category.skip_history_when_saving = True
-    Category.objects.get(name=COUPON_CATEGORY_NAME).get_children().filter(
-        name__in=RAP_CATEGORIES
-    ).delete()
 
 
 class Migration(migrations.Migration):
@@ -36,5 +10,4 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(create_rap_categories, remove_rap_categories)
     ]

--- a/ecommerce/extensions/catalogue/migrations/0050_add_b2b_affiliate_promotion_coupon_category.py
+++ b/ecommerce/extensions/catalogue/migrations/0050_add_b2b_affiliate_promotion_coupon_category.py
@@ -1,30 +1,6 @@
 """ Add 'B2B Affiliate Promotion' category to the list of coupon categories"""
 
 from django.db import migrations
-from oscar.apps.catalogue.categories import create_from_breadcrumbs
-from oscar.core.loading import get_model
-
-Category = get_model('catalogue', 'Category')
-
-COUPON_CATEGORY_NAME = 'Coupons'
-
-NEW_CATEGORIES = [
-    'B2B Affiliate Promotion',
-]
-
-def create_new_categories(apps, schema_editor):
-    """ Create new coupon categories """
-    Category.skip_history_when_saving = True
-    for category in NEW_CATEGORIES:
-        create_from_breadcrumbs('{} > {}'.format(COUPON_CATEGORY_NAME, category))
-
-
-def remove_new_categories(apps, schema_editor):
-    """ Remove new coupon categories """
-    Category.skip_history_when_saving = True
-    Category.objects.get(name=COUPON_CATEGORY_NAME).get_children().filter(
-        name__in=NEW_CATEGORIES
-    ).delete()
 
 
 class Migration(migrations.Migration):
@@ -33,5 +9,4 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(create_new_categories, remove_new_categories)
     ]

--- a/ecommerce/extensions/catalogue/migrations/0052_add_scholarship_coupon_category.py
+++ b/ecommerce/extensions/catalogue/migrations/0052_add_scholarship_coupon_category.py
@@ -1,30 +1,6 @@
 """ Add 'Scholarship' category to the list of coupon categories."""
 
 from django.db import migrations
-from oscar.apps.catalogue.categories import create_from_breadcrumbs
-from oscar.core.loading import get_model
-
-Category = get_model('catalogue', 'Category')
-
-COUPON_CATEGORY_NAME = 'Coupons'
-
-NEW_CATEGORIES = [
-    'Scholarship',
-]
-
-def create_new_categories(apps, schema_editor):
-    """ Create new coupon categories """
-    Category.skip_history_when_saving = True
-    for category in NEW_CATEGORIES:
-        create_from_breadcrumbs('{} > {}'.format(COUPON_CATEGORY_NAME, category))
-
-
-def remove_new_categories(apps, schema_editor):
-    """ Remove new coupon categories """
-    Category.skip_history_when_saving = True
-    Category.objects.get(name=COUPON_CATEGORY_NAME).get_children().filter(
-        name__in=NEW_CATEGORIES
-    ).delete()
 
 
 class Migration(migrations.Migration):
@@ -33,5 +9,4 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(create_new_categories, remove_new_categories)
     ]

--- a/ecommerce/management/commands/coupon_category_list.txt
+++ b/ecommerce/management/commands/coupon_category_list.txt
@@ -1,0 +1,27 @@
+Affiliate Promotion
+B2B Affiliate Promotion
+Bulk Enrollment
+Bulk Enrollment - Prepay
+Bulk Enrollment - Upon Redemption
+Bulk Enrollment - Integration
+ConnectEd
+Course Promotion
+Customer Service
+edX Employee Request
+Financial Assistance
+Geography Promotion
+Marketing Partner Promotion
+Marketing-Other
+On-Campus Learners
+Other
+Paid Cohort
+Partner No Rev - RAP
+Partner No Rev - ORAP
+Partner No Rev - Prepay
+Partner No Rev - Upon Redemption
+Retention Promotion
+Scholarship
+Security Disclosure Reward
+Services-Other
+Support-Other
+Upsell Promotion

--- a/ecommerce/management/commands/create_categories_from_breadcrumbs.py
+++ b/ecommerce/management/commands/create_categories_from_breadcrumbs.py
@@ -1,0 +1,32 @@
+import logging
+import os
+
+from django.core.management.base import BaseCommand
+from django.urls import reverse
+from oscar.apps.catalogue.categories import create_from_breadcrumbs
+from oscar.core.loading import get_model
+
+Category = get_model("catalogue", "Category")
+logger = logging.getLogger(__name__)
+
+COUPON_CATEGORY_NAME = 'Coupons'
+
+current_dir = os.path.dirname(__file__)
+rel_path = 'coupon_category_list.txt'
+full_path = os.path.join(current_dir, rel_path)
+with open(full_path) as f:
+    DEFAULT_CATEGORIES = f.read().splitlines()
+f.close()
+
+
+class Command(BaseCommand):
+    help = 'Add default categories from text file'
+
+    def handle(self, *args, **options):
+        Category.skip_history_when_saving = True
+        existing_categories = Category.objects.all()
+        existing_category_names = [x.name for x in existing_categories]
+
+        for category in DEFAULT_CATEGORIES:
+            if category not in existing_category_names:
+                create_from_breadcrumbs('{} > {}'.format(COUPON_CATEGORY_NAME, category))

--- a/ecommerce/management/commands/tests/test_create_categories_from_breadcrumbs.py
+++ b/ecommerce/management/commands/tests/test_create_categories_from_breadcrumbs.py
@@ -1,0 +1,39 @@
+import os
+
+import ddt
+from django.core.management import call_command
+from django.urls import reverse
+from oscar.core.loading import get_model
+
+from ecommerce.tests.testcases import TestCase
+
+Category = get_model("catalogue", "Category")
+DEPRECATED_COUPON_CATEGORIES = ['Bulk Enrollment']
+
+current_dir = os.path.dirname(__file__)
+rel_path = 'coupon_category_list.txt'
+full_path = os.path.join(current_dir, '..', rel_path)
+
+with open(full_path) as f:
+    DEFAULT_CATEGORIES = f.read().splitlines()
+f.close()
+
+
+@ddt.ddt
+class CreateCategoriesFromBreadcrumbsTests(TestCase):
+    """Tests for create_categories_from_breadcrumbs management command."""
+    path = reverse('api:v2:coupons:coupons_categories')
+
+    def test_category_list(self):
+        """ Verify the endpoint returns successfully. """
+        # Create default categories
+        call_command('create_categories_from_breadcrumbs')
+
+        response = self.client.get(self.path + '?page_size=200')
+        response_data = response.json()
+        self.assertEqual(response_data['count'], 26)
+        received_coupon_categories = {category['name'] for category in response_data['results']}
+
+        for category in DEFAULT_CATEGORIES:
+            if category not in DEPRECATED_COUPON_CATEGORIES:
+                self.assertTrue(category in received_coupon_categories)


### PR DESCRIPTION
## Background
We use specific categories for coupons, and the code assumes that these records will be available in the database. 
In the past we've made custom migration scripts to do data population for these category records (not advised), where we imported oscar’s create_from_breadcrumbs method, which loads the category model in its latest state. **The problem**: when there's an update to this oscar model, that creates a blocking model-vs-database mismatch, and any new install (or PR build) fails when trying to run all the migrations in order. The upgrade from django-oscar 2.0.4 -> 2.1 will involve a change to this model, and that PR fails for the reason just described. 

## Solution
We'll use a management command to populate these coupon categories, and we'll remove the problematic code from the previous (9) custom migration files. This will mean: 
- going forward we'll be able to run the migrations in sequence (even if django-oscar models change) 
- we'll update documentation for developers: new coupon categories will be added into the new text file
- we'll update documentation for Open edX developers: if using ecommerce, run this new management command

This strategy comes from @iamsobanjaved's work [here](https://github.com/edx/ecommerce/pull/3037), I'm just separating them into pieces and I also refactored the category list into a text file for the management command and the test to share. 

## Testing Notes
Build checks: strangely the first commit (with the management command, the test, and the category list) passed all tests, but the second commit (gutting the migrations) failed codecov/patch with an error that we don't have a test for where the management command calls oscar's create_from_breadcrumbs function. I'll discuss with the team, django-oscar's tests will cover its own functions, and testing that all the categories are in place after the command is run accomplishes what we need. 

I'll also make a PR with this branch merged with the oscar-django 2.1 branch, to confirm that this work resolves the 'is_public' failure that was happening with these migrations. 