### PR TITLE
Revert "BOM-2885: Unpin Django crispy forms"

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -9,7 +9,7 @@ django<3.0
 django-compressor
 django-config-models>=1.0.0         # Configuration models for Django allowing config management with auditing
 django-cors-headers                 #  Used to allow to configure CORS headers for cross-domain requests
-django-crispy-forms
+django-crispy-forms<1.9.0
 django_extensions
 django-filter
 django-libsass

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,9 +28,9 @@ billiard==3.6.4.0
     # via celery
 bleach==4.1.0
     # via -r requirements/base.in
-boto3==1.18.58
+boto3==1.18.57
     # via -r requirements/base.in
-botocore==1.21.58
+botocore==1.21.57
     # via
     #   boto3
     #   s3transfer
@@ -40,7 +40,7 @@ celery==4.4.7
     # via
     #   -c requirements/pins.txt
     #   edx-ecommerce-worker
-certifi==2021.10.8
+certifi==2021.5.30
     # via
     #   cybersource-rest-client-python
     #   requests
@@ -126,7 +126,7 @@ django-config-models==2.2.0
     # via -r requirements/base.in
 django-cors-headers==3.10.0
     # via -r requirements/base.in
-django-crispy-forms==1.13.0
+django-crispy-forms==1.8.1
     # via -r requirements/base.in
 django-crum==0.7.9
     # via
@@ -307,7 +307,7 @@ openapi-codec==1.3.2
     # via django-rest-swagger
 packaging==21.0
     # via bleach
-paramiko==2.8.0
+paramiko==2.7.2
     # via cybersource-rest-client-python
 path.py==7.2
     # via -r requirements/base.in
@@ -521,7 +521,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/base.in
     #   djangorestframework-csv
-uritemplate==4.0.0
+uritemplate==3.0.1
     # via coreapi
 urllib3==1.26.7
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -56,9 +56,9 @@ bleach==4.1.0
     # via -r requirements/test.txt
 bok-choy==1.1.1
     # via -r requirements/test.txt
-boto3==1.18.58
+boto3==1.18.57
     # via -r requirements/test.txt
-botocore==1.21.58
+botocore==1.21.57
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -71,7 +71,7 @@ celery==4.4.7
     # via
     #   -r requirements/test.txt
     #   edx-ecommerce-worker
-certifi==2021.10.8
+certifi==2021.5.30
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -190,7 +190,7 @@ django-config-models==2.2.0
     # via -r requirements/test.txt
 django-cors-headers==3.10.0
     # via -r requirements/test.txt
-django-crispy-forms==1.13.0
+django-crispy-forms==1.8.1
     # via -r requirements/test.txt
 django-crum==0.7.9
     # via
@@ -496,7 +496,7 @@ packaging==21.0
     #   pytest
     #   sphinx
     #   tox
-paramiko==2.8.0
+paramiko==2.7.2
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -562,7 +562,7 @@ pyasn1==0.4.8
     #   ndg-httpsclient
     #   rsa
     #   x509
-pycodestyle==2.8.0
+pycodestyle==2.7.0
     # via -r requirements/test.txt
 pycountry==17.1.8
     # via -r requirements/test.txt
@@ -665,7 +665,7 @@ pytest-randomly==3.10.1
     # via -r requirements/test.txt
 pytest-selenium==2.0.1
     # via -r requirements/test.txt
-pytest-timeout==2.0.0
+pytest-timeout==1.4.2
     # via -r requirements/test.txt
 pytest-variables==1.9.0
     # via
@@ -679,7 +679,7 @@ python-dateutil==2.8.2
     #   edx-drf-extensions
     #   faker
     #   freezegun
-python-dotenv==0.19.1
+python-dotenv==0.19.0
     # via -r requirements/test.txt
 python-memcached==1.58
     # via -r requirements/test.txt
@@ -953,7 +953,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/test.txt
     #   djangorestframework-csv
-uritemplate==4.0.0
+uritemplate==3.0.1
     # via
     #   -r requirements/test.txt
     #   coreapi

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12
     # via sphinx
 babel==2.9.1
     # via sphinx
-certifi==2021.10.8
+certifi==2021.5.30
     # via requests
 charset-normalizer==2.0.6
     # via requests

--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -8,7 +8,7 @@ attrs==21.2.0
     # via
     #   -c requirements/base.txt
     #   pytest
-certifi==2021.10.8
+certifi==2021.5.30
     # via
     #   -c requirements/base.txt
     #   requests
@@ -109,11 +109,11 @@ pytest-randomly==3.10.1
     # via -r requirements/e2e.in
 pytest-selenium==2.0.1
     # via -r requirements/e2e.in
-pytest-timeout==2.0.0
+pytest-timeout==1.4.2
     # via -r requirements/e2e.in
 pytest-variables==1.9.0
     # via pytest-selenium
-python-dotenv==0.19.1
+python-dotenv==0.19.0
     # via -r requirements/e2e.in
 pytz==2016.10
     # via

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-click==8.0.3
+click==8.0.1
     # via pip-tools
 pep517==0.11.0
     # via pip-tools
-pip-tools==6.3.1
+pip-tools==6.3.0
     # via -r requirements/pip_tools.in
 tomli==1.2.1
     # via pep517

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -28,11 +28,11 @@ billiard==3.6.4.0
     # via celery
 bleach==4.1.0
     # via -r requirements/base.in
-boto3==1.18.58
+boto3==1.18.57
     # via
     #   -r requirements/base.in
     #   django-ses
-botocore==1.21.58
+botocore==1.21.57
     # via
     #   boto3
     #   s3transfer
@@ -42,7 +42,7 @@ celery==4.4.7
     # via
     #   -c requirements/pins.txt
     #   edx-ecommerce-worker
-certifi==2021.10.8
+certifi==2021.5.30
     # via
     #   cybersource-rest-client-python
     #   requests
@@ -129,7 +129,7 @@ django-config-models==2.2.0
     # via -r requirements/base.in
 django-cors-headers==3.10.0
     # via -r requirements/base.in
-django-crispy-forms==1.13.0
+django-crispy-forms==1.8.1
     # via -r requirements/base.in
 django-crum==0.7.9
     # via
@@ -319,7 +319,7 @@ openapi-codec==1.3.2
     # via django-rest-swagger
 packaging==21.0
     # via bleach
-paramiko==2.8.0
+paramiko==2.7.2
     # via cybersource-rest-client-python
 path.py==7.2
     # via -r requirements/base.in
@@ -540,7 +540,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/base.in
     #   djangorestframework-csv
-uritemplate==4.0.0
+uritemplate==3.0.1
     # via coreapi
 urllib3==1.26.7
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -47,9 +47,9 @@ bleach==4.1.0
     # via -r requirements/base.txt
 bok-choy==1.1.1
     # via -r requirements/test.in
-boto3==1.18.58
+boto3==1.18.57
     # via -r requirements/base.txt
-botocore==1.21.58
+botocore==1.21.57
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -63,7 +63,7 @@ celery==4.4.7
     #   -c requirements/pins.txt
     #   -r requirements/base.txt
     #   edx-ecommerce-worker
-certifi==2021.10.8
+certifi==2021.5.30
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -187,7 +187,7 @@ django-config-models==2.2.0
     # via -r requirements/base.txt
 django-cors-headers==3.10.0
     # via -r requirements/base.txt
-django-crispy-forms==1.13.0
+django-crispy-forms==1.8.1
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
@@ -482,7 +482,7 @@ packaging==21.0
     #   bleach
     #   pytest
     #   tox
-paramiko==2.8.0
+paramiko==2.7.2
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
@@ -547,7 +547,7 @@ pyasn1==0.4.8
     #   ndg-httpsclient
     #   rsa
     #   x509
-pycodestyle==2.8.0
+pycodestyle==2.7.0
     # via -r requirements/test.in
 pycountry==17.1.8
     # via -r requirements/base.txt
@@ -654,7 +654,7 @@ pytest-randomly==3.10.1
     # via -r requirements/e2e.txt
 pytest-selenium==2.0.1
     # via -r requirements/e2e.txt
-pytest-timeout==2.0.0
+pytest-timeout==1.4.2
     # via -r requirements/e2e.txt
 pytest-variables==1.9.0
     # via
@@ -668,7 +668,7 @@ python-dateutil==2.8.2
     #   edx-drf-extensions
     #   faker
     #   freezegun
-python-dotenv==0.19.1
+python-dotenv==0.19.0
     # via -r requirements/e2e.txt
 python-memcached==1.58
     # via -r requirements/test.in
@@ -900,7 +900,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/base.txt
     #   djangorestframework-csv
-uritemplate==4.0.0
+uritemplate==3.0.1
     # via
     #   -r requirements/base.txt
     #   coreapi


### PR DESCRIPTION
Reverts edx/ecommerce#3538

## Reason
- e2e tests failing on stage pipeline. Reverting this change to see if this is the cause for the test failures.