### PR TITLE
Revert "BOM-2886: Upgrade pytest & pytest-django"

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -291,7 +291,7 @@ naked==0.1.31
     # via
     #   crypto
     #   cybersource-rest-client-python
-ndg-httpsclient==0.5.1
+ndg-httpsclient==0.5.1q
     # via -r requirements/base.in
 newrelic==7.0.0.166
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -368,10 +368,6 @@ inflect==5.3.0
     # via
     #   -r requirements/test.txt
     #   jinja2-pluralize
-iniconfig==1.1.1
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 ipaddress==1.0.23
     # via
     #   -r requirements/test.txt
@@ -462,6 +458,10 @@ monotonic==1.6
     # via
     #   -r requirements/test.txt
     #   analytics-python
+more-itertools==8.10.0
+    # via
+    #   -r requirements/test.txt
+    #   pytest
 mysqlclient==1.4.6
     # via -r requirements/test.txt
 naked==0.1.31
@@ -628,7 +628,7 @@ pyrsistent==0.18.0
     # via
     #   -r requirements/test.txt
     #   jsonschema
-pytest==6.2.5
+pytest==5.3.5
     # via
     #   -r requirements/test.txt
     #   pytest-base-url
@@ -647,7 +647,7 @@ pytest-base-url==1.4.2
     #   pytest-selenium
 pytest-cov==3.0.0
     # via -r requirements/test.txt
-pytest-django==4.4.0
+pytest-django==3.10.0
     # via
     #   -r requirements/test.txt
     #   pytest-django-ordering
@@ -925,7 +925,6 @@ text-unidecode==1.3
 toml==0.10.2
     # via
     #   -r requirements/test.txt
-    #   pytest
     #   tox
 tomli==1.2.1
     # via
@@ -980,6 +979,10 @@ waitress==2.0.0
     # via
     #   -r requirements/test.txt
     #   webtest
+wcwidth==0.2.5
+    # via
+    #   -r requirements/test.txt
+    #   pytest
 webencodings==0.5.1
     # via
     #   -r requirements/test.txt

--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -53,7 +53,7 @@ idna==2.7
     #   requests
 importlib-metadata==4.8.1
     # via pytest-randomly
-iniconfig==1.1.1
+more-itertools==8.10.0
     # via pytest
 newrelic==7.0.0.166
     # via
@@ -68,9 +68,7 @@ pbr==5.6.0
     #   -c requirements/base.txt
     #   stevedore
 pluggy==0.13.1
-    # via
-    #   -c requirements/pins.txt
-    #   pytest
+    # via pytest
 psutil==5.8.0
     # via
     #   -c requirements/base.txt
@@ -89,8 +87,9 @@ pyparsing==2.4.7
     # via
     #   -c requirements/base.txt
     #   packaging
-pytest==6.2.5
+pytest==5.3.5
     # via
+    #   -c requirements/pins.txt
     #   -r requirements/e2e.in
     #   pytest-base-url
     #   pytest-html
@@ -149,13 +148,13 @@ stevedore==3.4.0
     #   edx-django-utils
 tenacity==6.3.1
     # via pytest-selenium
-toml==0.10.2
-    # via pytest
 urllib3==1.26.7
     # via
     #   -c requirements/base.txt
     #   -c requirements/pins.txt
     #   requests
     #   selenium
+wcwidth==0.2.5
+    # via pytest
 zipp==3.6.0
     # via importlib-metadata

--- a/requirements/pins.txt
+++ b/requirements/pins.txt
@@ -20,6 +20,10 @@ httpretty==0.9.7
 # jsonfield2 > 3.0.3 dropped support for python 3.5
 jsonfield2<=3.0.3
 
+# 5.4 introduces test order problems that need to be resolved.
+pytest<5.4.0
+pytest-django<4.0 # Newer versions require pytest >= 5.4.0
+
 # Pinned to preserve the status quo
 pytz==2016.10
 
@@ -34,9 +38,8 @@ virtualenv==16.7.9
 # removing this pin, then this pin can be removed.
 pylint==2.4.4
 
-# greater versions failing with extract-translations step.
+# greater versions failing with extract-tranlsations step.
 tox==3.14.6
-pluggy<1.0.0  # pluggy==1.0.0 requires tox>3.14.6
 
 # cybersource-rest-client-python requires 2.7, but requests gives 2.10 by default
 idna==2.7

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -360,10 +360,6 @@ importlib-metadata==4.8.1
     #   pytest-randomly
 inflect==5.3.0
     # via jinja2-pluralize
-iniconfig==1.1.1
-    # via
-    #   -r requirements/e2e.txt
-    #   pytest
 ipaddress==1.0.23
     # via
     #   -r requirements/base.txt
@@ -447,6 +443,10 @@ monotonic==1.6
     # via
     #   -r requirements/base.txt
     #   analytics-python
+more-itertools==8.10.0
+    # via
+    #   -r requirements/e2e.txt
+    #   pytest
 mysqlclient==1.4.6
     # via -r requirements/base.txt
 naked==0.1.31
@@ -515,7 +515,6 @@ platformdirs==2.4.0
     #   zeep
 pluggy==0.13.1
     # via
-    #   -c requirements/pins.txt
     #   -r requirements/e2e.txt
     #   -r requirements/tox.txt
     #   diff-cover
@@ -616,8 +615,9 @@ pyrsistent==0.18.0
     # via
     #   -r requirements/base.txt
     #   jsonschema
-pytest==6.2.5
+pytest==5.3.5
     # via
+    #   -c requirements/pins.txt
     #   -r requirements/e2e.txt
     #   -r requirements/test.in
     #   pytest-base-url
@@ -636,8 +636,9 @@ pytest-base-url==1.4.2
     #   pytest-selenium
 pytest-cov==3.0.0
     # via -r requirements/test.in
-pytest-django==4.4.0
+pytest-django==3.10.0
     # via
+    #   -c requirements/pins.txt
     #   -r requirements/test.in
     #   pytest-django-ordering
 pytest-django-ordering==1.2.0
@@ -875,9 +876,7 @@ text-unidecode==1.3
     #   faker
 toml==0.10.2
     # via
-    #   -r requirements/e2e.txt
     #   -r requirements/tox.txt
-    #   pytest
     #   tox
 tomli==1.2.1
     # via coverage
@@ -926,6 +925,10 @@ virtualenv==16.7.9
     #   tox
 waitress==2.0.0
     # via webtest
+wcwidth==0.2.5
+    # via
+    #   -r requirements/e2e.txt
+    #   pytest
 webencodings==0.5.1
     # via
     #   -r requirements/base.txt

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -9,9 +9,7 @@ filelock==3.3.0
 packaging==21.0
     # via tox
 pluggy==0.13.1
-    # via
-    #   -c requirements/pins.txt
-    #   tox
+    # via tox
 py==1.10.0
     # via tox
 pyparsing==2.4.7


### PR DESCRIPTION
Reverts edx/ecommerce#3533

## Reason
- e2e tests are failing so we can't be sure of the pipeline status right now. 