### PR TITLE
Iamsobanjaved/replace create from breadcrumbs

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,11 +10,11 @@ from ecommerce.core.constants import (
     SEAT_PRODUCT_CLASS_NAME
 )
 from ecommerce.extensions.basket.constants import EMAIL_OPT_IN_ATTRIBUTE, PURCHASER_BEHALF_ATTRIBUTE
+from ecommerce.extensions.catalogue.utils import create_subcategories
 from ecommerce.extensions.checkout.signals import BUNDLE
 from ecommerce.core.constants import ORDER_MANAGER_ROLE
 from ecommerce.core.constants import DONATIONS_FROM_CHECKOUT_TESTS_PRODUCT_TYPE_NAME
 from ecommerce.core.constants import ENTERPRISE_COUPON_ADMIN_ROLE
-from oscar.apps.catalogue.categories import create_from_breadcrumbs
 
 
 COUPON_CATEGORY_NAME = 'Coupons'
@@ -316,6 +316,5 @@ def django_db_setup(django_db_setup, django_db_blocker, django_db_use_migrations
 
         EcommerceFeatureRole.objects.get_or_create(name=ENTERPRISE_COUPON_ADMIN_ROLE)
 
-        for category in DEFAULT_CATEGORIES:
-            create_from_breadcrumbs('{} > {}'.format(COUPON_CATEGORY_NAME, category))
+        create_subcategories(Category, COUPON_CATEGORY_NAME, DEFAULT_CATEGORIES)
 

--- a/ecommerce/extensions/catalogue/migrations/0015_default_categories.py
+++ b/ecommerce/extensions/catalogue/migrations/0015_default_categories.py
@@ -2,10 +2,9 @@
 
 
 from django.db import migrations
-from oscar.apps.catalogue.categories import create_from_breadcrumbs
-from oscar.core.loading import get_model
 
-Category = get_model("catalogue", "Category")
+from ecommerce.extensions.catalogue.utils import create_subcategories
+
 
 COUPON_CATEGORY_NAME = 'Coupons'
 
@@ -19,14 +18,16 @@ DEFAULT_CATEGORIES = [
 
 def create_default_categories(apps, schema_editor):
     """Create default coupon categories."""
-    Category.skip_history_when_saving = True
+    Category = apps.get_model("catalogue", "Category")
 
-    for category in DEFAULT_CATEGORIES:
-        create_from_breadcrumbs('{} > {}'.format(COUPON_CATEGORY_NAME, category))
+    Category.skip_history_when_saving = True
+    create_subcategories(Category, COUPON_CATEGORY_NAME, DEFAULT_CATEGORIES)
 
 
 def remove_default_categories(apps, schema_editor):
     """Remove default coupon categories."""
+    Category = apps.get_model("catalogue", "Category")
+
     Category.skip_history_when_saving = True
     Category.objects.get(name=COUPON_CATEGORY_NAME).get_children().filter(
         name__in=DEFAULT_CATEGORIES

--- a/ecommerce/extensions/catalogue/migrations/0033_add_coupon_categories.py
+++ b/ecommerce/extensions/catalogue/migrations/0033_add_coupon_categories.py
@@ -3,10 +3,8 @@
 
 
 from django.db import migrations
-from oscar.apps.catalogue.categories import create_from_breadcrumbs
-from oscar.core.loading import get_model
 
-Category = get_model('catalogue', 'Category')
+from ecommerce.extensions.catalogue.utils import create_subcategories
 
 COUPON_CATEGORY_NAME = 'Coupons'
 
@@ -18,14 +16,16 @@ DEFAULT_CATEGORIES = [
 
 def create_default_categories(apps, schema_editor):
     """Create default coupon categories."""
-    Category.skip_history_when_saving = True
+    Category = apps.get_model("catalogue", "Category")
 
-    for category in DEFAULT_CATEGORIES:
-        create_from_breadcrumbs('{} > {}'.format(COUPON_CATEGORY_NAME, category))
+    Category.skip_history_when_saving = True
+    create_subcategories(Category, COUPON_CATEGORY_NAME, DEFAULT_CATEGORIES)
 
 
 def remove_default_categories(apps, schema_editor):
     """Remove default coupon categories."""
+    Category = apps.get_model("catalogue", "Category")
+
     Category.skip_history_when_saving = True
     Category.objects.get(name=COUPON_CATEGORY_NAME).get_children().filter(
         name__in=DEFAULT_CATEGORIES

--- a/ecommerce/extensions/catalogue/migrations/0034_add_on_campus_coupon_category.py
+++ b/ecommerce/extensions/catalogue/migrations/0034_add_on_campus_coupon_category.py
@@ -6,7 +6,7 @@ from django.db import migrations
 from oscar.apps.catalogue.categories import create_from_breadcrumbs
 from oscar.core.loading import get_model
 
-Category = get_model('catalogue', 'Category')
+from ecommerce.extensions.catalogue.utils import create_subcategories
 
 COUPON_CATEGORY_NAME = 'Coupons'
 
@@ -15,12 +15,16 @@ ON_CAMPUS_CATEGORY = 'On-Campus Learners'
 
 def create_on_campus_category(apps, schema_editor):
     """ Create on-campus coupon category """
+    Category = apps.get_model("catalogue", "Category")
+
     Category.skip_history_when_saving = True
-    create_from_breadcrumbs('{} > {}'.format(COUPON_CATEGORY_NAME, ON_CAMPUS_CATEGORY))
+    create_subcategories(Category, COUPON_CATEGORY_NAME, [ON_CAMPUS_CATEGORY, ])
 
 
 def remove_on_campus_category(apps, schema_editor):
     """ Remove on-campus coupon category """
+    Category = apps.get_model("catalogue", "Category")
+
     Category.skip_history_when_saving = True
     Category.objects.get(
         name=COUPON_CATEGORY_NAME

--- a/ecommerce/extensions/catalogue/migrations/0035_add_partner_no_rev_coupon_categories.py
+++ b/ecommerce/extensions/catalogue/migrations/0035_add_partner_no_rev_coupon_categories.py
@@ -3,10 +3,8 @@
 
 
 from django.db import migrations
-from oscar.apps.catalogue.categories import create_from_breadcrumbs
-from oscar.core.loading import get_model
 
-Category = get_model('catalogue', 'Category')
+from ecommerce.extensions.catalogue.utils import create_subcategories
 
 COUPON_CATEGORY_NAME = 'Coupons'
 
@@ -15,15 +13,18 @@ DEFAULT_CATEGORIES = [
     'Partner No Rev - Upon Redemption',
 ]
 
+
 def create_default_categories(apps, schema_editor):
     """Create default coupon categories."""
+    Category = apps.get_model("catalogue", "Category")
+
     Category.skip_history_when_saving = True
-    for category in DEFAULT_CATEGORIES:
-        create_from_breadcrumbs('{} > {}'.format(COUPON_CATEGORY_NAME, category))
+    create_subcategories(Category, COUPON_CATEGORY_NAME, DEFAULT_CATEGORIES)
 
 
 def remove_default_categories(apps, schema_editor):
     """Remove default coupon categories."""
+    Category = apps.get_model("catalogue", "Category")
     Category.skip_history_when_saving = True
     Category.objects.get(name=COUPON_CATEGORY_NAME).get_children().filter(
         name__in=DEFAULT_CATEGORIES

--- a/ecommerce/extensions/catalogue/migrations/0037_add_sec_disc_reward_coupon_category.py
+++ b/ecommerce/extensions/catalogue/migrations/0037_add_sec_disc_reward_coupon_category.py
@@ -8,23 +8,26 @@ to members of the community who make security disclosures.
 
 
 from django.db import migrations
-from oscar.apps.catalogue.categories import create_from_breadcrumbs
-from oscar.core.loading import get_model
 
-Category = get_model('catalogue', 'Category')
+from ecommerce.extensions.catalogue.utils import create_subcategories
 
 COUPON_CATEGORY_NAME = 'Coupons'
 
 SECURITY_DISCLOSURE_REWARD_CATEGORY = 'Security Disclosure Reward'
 
+
 def create_security_disclosure_reward_category(apps, schema_editor):
     """ Create coupon category for rewarding security disclosures. """
+    Category = apps.get_model("catalogue", "Category")
+
     Category.skip_history_when_saving = True
-    create_from_breadcrumbs('{} > {}'.format(COUPON_CATEGORY_NAME,
-                                             SECURITY_DISCLOSURE_REWARD_CATEGORY))
+    create_subcategories(Category, COUPON_CATEGORY_NAME, [SECURITY_DISCLOSURE_REWARD_CATEGORY, ])
+
 
 def remove_security_disclosure_reward_category(apps, schema_editor):
     """ Remove the security disclosure reward category. """
+    Category = apps.get_model("catalogue", "Category")
+
     Category.skip_history_when_saving = True
     Category.objects.get(
         name=COUPON_CATEGORY_NAME

--- a/ecommerce/extensions/catalogue/migrations/0045_add_edx_employee_coupon_category.py
+++ b/ecommerce/extensions/catalogue/migrations/0045_add_edx_employee_coupon_category.py
@@ -3,27 +3,26 @@
 
 
 from django.db import migrations
-from oscar.apps.catalogue.categories import create_from_breadcrumbs
-from oscar.core.loading import get_model
 
-Category = get_model('catalogue', 'Category')
+from ecommerce.extensions.catalogue.utils import create_subcategories
 
 COUPON_CATEGORY_NAME = 'Coupons'
 
 EDX_EMPLOYEE_COUPON_CATEGORY = 'edX Employee Request'
 
+
 def create_edx_employee_category(apps, schema_editor):
     """Create edX employee coupon category."""
+    Category = apps.get_model("catalogue", "Category")
+
     Category.skip_history_when_saving = True
-    create_from_breadcrumbs(
-        '{} > {}'.format(
-            COUPON_CATEGORY_NAME, EDX_EMPLOYEE_COUPON_CATEGORY
-        )
-    )
+    create_subcategories(Category, COUPON_CATEGORY_NAME, [EDX_EMPLOYEE_COUPON_CATEGORY, ])
 
 
 def remove_edx_employee_category(apps, schema_editor):
     """Remove edX employee coupon category."""
+    Category = apps.get_model("catalogue", "Category")
+
     Category.skip_history_when_saving = True
     Category.objects.get(
         name=COUPON_CATEGORY_NAME

--- a/ecommerce/extensions/catalogue/migrations/0049_add_rap_and_orap_coupon_categories.py
+++ b/ecommerce/extensions/catalogue/migrations/0049_add_rap_and_orap_coupon_categories.py
@@ -3,10 +3,8 @@
 
 
 from django.db import migrations
-from oscar.apps.catalogue.categories import create_from_breadcrumbs
-from oscar.core.loading import get_model
 
-Category = get_model('catalogue', 'Category')
+from ecommerce.extensions.catalogue.utils import create_subcategories
 
 COUPON_CATEGORY_NAME = 'Coupons'
 
@@ -17,13 +15,16 @@ RAP_CATEGORIES = [
 
 def create_rap_categories(apps, schema_editor):
     """Create rap coupon categories."""
+    Category = apps.get_model("catalogue", "Category")
+
     Category.skip_history_when_saving = True
-    for category in RAP_CATEGORIES:
-        create_from_breadcrumbs('{} > {}'.format(COUPON_CATEGORY_NAME, category))
+    create_subcategories(Category, COUPON_CATEGORY_NAME, RAP_CATEGORIES)
 
 
 def remove_rap_categories(apps, schema_editor):
     """Remove rap coupon categories."""
+    Category = apps.get_model("catalogue", "Category")
+
     Category.skip_history_when_saving = True
     Category.objects.get(name=COUPON_CATEGORY_NAME).get_children().filter(
         name__in=RAP_CATEGORIES

--- a/ecommerce/extensions/catalogue/migrations/0050_add_b2b_affiliate_promotion_coupon_category.py
+++ b/ecommerce/extensions/catalogue/migrations/0050_add_b2b_affiliate_promotion_coupon_category.py
@@ -1,10 +1,8 @@
 """ Add 'B2B Affiliate Promotion' category to the list of coupon categories"""
 
 from django.db import migrations
-from oscar.apps.catalogue.categories import create_from_breadcrumbs
-from oscar.core.loading import get_model
 
-Category = get_model('catalogue', 'Category')
+from ecommerce.extensions.catalogue.utils import create_subcategories
 
 COUPON_CATEGORY_NAME = 'Coupons'
 
@@ -12,15 +10,19 @@ NEW_CATEGORIES = [
     'B2B Affiliate Promotion',
 ]
 
+
 def create_new_categories(apps, schema_editor):
     """ Create new coupon categories """
+    Category = apps.get_model("catalogue", "Category")
+
     Category.skip_history_when_saving = True
-    for category in NEW_CATEGORIES:
-        create_from_breadcrumbs('{} > {}'.format(COUPON_CATEGORY_NAME, category))
+    create_subcategories(Category, COUPON_CATEGORY_NAME, NEW_CATEGORIES)
 
 
 def remove_new_categories(apps, schema_editor):
     """ Remove new coupon categories """
+    Category = apps.get_model("catalogue", "Category")
+
     Category.skip_history_when_saving = True
     Category.objects.get(name=COUPON_CATEGORY_NAME).get_children().filter(
         name__in=NEW_CATEGORIES

--- a/ecommerce/extensions/catalogue/migrations/0052_add_scholarship_coupon_category.py
+++ b/ecommerce/extensions/catalogue/migrations/0052_add_scholarship_coupon_category.py
@@ -1,10 +1,8 @@
 """ Add 'Scholarship' category to the list of coupon categories."""
 
 from django.db import migrations
-from oscar.apps.catalogue.categories import create_from_breadcrumbs
-from oscar.core.loading import get_model
 
-Category = get_model('catalogue', 'Category')
+from ecommerce.extensions.catalogue.utils import create_subcategories
 
 COUPON_CATEGORY_NAME = 'Coupons'
 
@@ -12,15 +10,19 @@ NEW_CATEGORIES = [
     'Scholarship',
 ]
 
+
 def create_new_categories(apps, schema_editor):
     """ Create new coupon categories """
+    Category = apps.get_model("catalogue", "Category")
+
     Category.skip_history_when_saving = True
-    for category in NEW_CATEGORIES:
-        create_from_breadcrumbs('{} > {}'.format(COUPON_CATEGORY_NAME, category))
+    create_subcategories(Category, COUPON_CATEGORY_NAME, NEW_CATEGORIES)
 
 
 def remove_new_categories(apps, schema_editor):
     """ Remove new coupon categories """
+    Category = apps.get_model("catalogue", "Category")
+
     Category.skip_history_when_saving = True
     Category.objects.get(name=COUPON_CATEGORY_NAME).get_children().filter(
         name__in=NEW_CATEGORIES

--- a/ecommerce/extensions/catalogue/tests/test_utils.py
+++ b/ecommerce/extensions/catalogue/tests/test_utils.py
@@ -10,8 +10,12 @@ from oscar.core.loading import get_model
 from ecommerce.coupons.tests.mixins import CouponMixin
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
-from ecommerce.extensions.catalogue.utils import create_coupon_product, generate_sku, get_or_create_catalog, \
-    create_subcategories
+from ecommerce.extensions.catalogue.utils import (
+    create_coupon_product,
+    create_subcategories,
+    generate_sku,
+    get_or_create_catalog
+)
 from ecommerce.tests.factories import ProductFactory
 from ecommerce.tests.testcases import TestCase
 

--- a/ecommerce/extensions/catalogue/tests/test_utils.py
+++ b/ecommerce/extensions/catalogue/tests/test_utils.py
@@ -10,17 +10,20 @@ from oscar.core.loading import get_model
 from ecommerce.coupons.tests.mixins import CouponMixin
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
-from ecommerce.extensions.catalogue.utils import create_coupon_product, generate_sku, get_or_create_catalog
+from ecommerce.extensions.catalogue.utils import create_coupon_product, generate_sku, get_or_create_catalog, \
+    create_subcategories
 from ecommerce.tests.factories import ProductFactory
 from ecommerce.tests.testcases import TestCase
 
 Benefit = get_model('offer', 'Benefit')
 Catalog = get_model('catalogue', 'Catalog')
+Category = get_model('catalogue', 'Category')
 Product = get_model('catalogue', 'Product')
 StockRecord = get_model('partner', 'StockRecord')
 Voucher = get_model('voucher', 'Voucher')
 
 COURSE_ID = 'sku/test_course/course'
+COUPON_CATEGORY_NAME = 'Coupons'
 
 
 @ddt.ddt
@@ -85,6 +88,27 @@ class UtilsTests(DiscoveryTestMixin, TestCase):
         self.assertTrue(created)
         self.assertNotEqual(self.catalog, new_catalog)
         self.assertEqual(Catalog.objects.count(), 2)
+
+    def test_create_subcategories(self):
+        """Verify that create_subcategories method is working as per expectations."""
+        parent = Category.objects.get(name=COUPON_CATEGORY_NAME)
+        existing_children = parent.get_children_count()
+        test_categories = ['Test 1', 'Test 2', 'Test 3']
+
+        for category in test_categories:
+            assert parent.get_children().filter(name=category).count() == 0
+
+        create_subcategories(Category, COUPON_CATEGORY_NAME, test_categories)
+
+        # Get latest state of parent object from database
+        parent.refresh_from_db()
+        # Check that number of children for parent is updated after creating subcategories
+        assert parent.get_children_count() == existing_children + len(test_categories), \
+            "Number of children for parent object isn't updated"
+
+        # Now as we created the sub categories, filter should return that
+        for category in test_categories:
+            assert parent.get_children().filter(name=category).count() == 1
 
 
 class CouponUtilsTests(CouponMixin, DiscoveryTestMixin, TestCase):

--- a/ecommerce/extensions/catalogue/tests/test_utils.py
+++ b/ecommerce/extensions/catalogue/tests/test_utils.py
@@ -114,6 +114,11 @@ class UtilsTests(DiscoveryTestMixin, TestCase):
         for category in test_categories:
             assert parent.get_children().filter(name=category).count() == 1
 
+    def test_create_subcategories_no_category(self):
+        """Verify that create_subcategories returns gracefully when model isn't Category"""
+        test_categories = ['Test 1', 'Test 2', 'Test 3']
+        create_subcategories(Product, COUPON_CATEGORY_NAME, test_categories)
+
 
 class CouponUtilsTests(CouponMixin, DiscoveryTestMixin, TestCase):
     def setUp(self):

--- a/ecommerce/extensions/catalogue/utils.py
+++ b/ecommerce/extensions/catalogue/utils.py
@@ -235,3 +235,49 @@ def get_or_create_catalog(name, partner, stock_record_ids):
     for stock_record in stock_records:
         catalog.stock_records.add(stock_record)
     return catalog, True
+
+
+def _get_next_character(character):
+    ascii_code = ord(character)
+    # If character is 'Z', then return 'A' and indicate that next character should also be updated
+    if ascii_code + 1 > 90:
+        return chr(65), True
+    # If the character is '0', replace it with 'A'
+    if ascii_code == 48:
+        return chr(65), False
+    return chr(ascii_code + 1), False
+
+
+def _get_path_for_next(old_path):
+    path = list(old_path)
+    for i in reversed(range(len(path))):
+        updated_character, to_update_next = _get_next_character(old_path[i])
+        path[i] = updated_character
+        # Check whether next character should be updated or not
+        if not to_update_next:
+            break
+    return "".join(path)
+
+
+def create_subcategories(model, parent_category_name, categories):
+    """Create default coupon categories."""
+    Category = model
+    parent_category = Category.objects.get(name=parent_category_name)
+    last_path = Category.objects.filter(path__contains=parent_category.path).order_by('-path')[0].path
+    # 4 digits path means this category has no children yet so set initial path
+    if len(last_path) == 4:
+        last_path = f"{last_path}0000"
+    actual_created_count = 0
+    for category in categories:
+        new_path = _get_path_for_next(last_path)
+        _, created = Category.objects.get_or_create(
+            name=category,
+            depth=2,
+            path=new_path
+        )
+        last_path = new_path
+        if created:
+            actual_created_count += 1
+
+    parent_category.numchild = parent_category.numchild + actual_created_count
+    parent_category.save()

--- a/ecommerce/extensions/catalogue/utils.py
+++ b/ecommerce/extensions/catalogue/utils.py
@@ -238,6 +238,9 @@ def get_or_create_catalog(name, partner, stock_record_ids):
 
 
 def _get_next_character(character):
+    """
+    Provides next alphabetic character
+    """
     ascii_code = ord(character)
     # If character is 'Z', then return 'A' and indicate that next character should also be updated
     if ascii_code + 1 > 90:
@@ -249,6 +252,9 @@ def _get_next_character(character):
 
 
 def _get_path_for_next(old_path):
+    """
+    Provides path for the next child
+    """
     path = list(old_path)
     for i in reversed(range(len(path))):
         updated_character, to_update_next = _get_next_character(old_path[i])
@@ -260,7 +266,13 @@ def _get_path_for_next(old_path):
 
 
 def create_subcategories(model, parent_category_name, categories):
-    """Create default coupon categories."""
+    """
+    Create children for parent category. An alternative from create_from_breadcrumbs method of django-oscar
+    as that method can't be used in data migrations. This model requests the model class as a parameter
+    so we can provide an historical version.
+    """
+    if model.__name__ != 'Category':
+        return
     Category = model
     parent_category = Category.objects.get(name=parent_category_name)
     last_path = Category.objects.filter(path__contains=parent_category.path).order_by('-path')[0].path


### PR DESCRIPTION
**Background**
We use specific categories for coupons, and the code assumes that these records will be available in the database.
In the past we've made custom migration scripts to do data population for these category records (not advised), where we imported oscar’s create_from_breadcrumbs method, which loads the category model in its latest state. The problem: when there's an update to this oscar model, that creates a blocking model-vs-database mismatch, and any new install (or PR build) fails when trying to run all the migrations in order. The upgrade from django-oscar 2.0.4 -> 2.1 will involve a change to this model, and that PR fails for the reason just described.

https://openedx.atlassian.net/browse/BOM-1956

We need to do this change before Django-oscar2.1 [Release notes.](https://django-oscar.readthedocs.io/en/stable/releases/v2.1.html#what-s-new-in-oscar-2-1) it will reduce the complexity of the future upgrade PR and its just due to the 1 new field.

- catalogue.Category now has an **is_public** boolean field and its causing issues due to our custom migrations because is_public field appears in 51 migration

[create_from_breadcrumbs](https://github.com/django-oscar/django-oscar/blob/f2bb0fb73c83cb879fb2dec9184059dd96d814e0/src/oscar/apps/catalogue/categories.py#L38) using from custom data migrations giving error. The reason for this is explained in [Django's documentation](https://docs.djangoproject.com/en/3.0/topics/migrations/#data-migrations) on migrations - that the version of the model used in external code may be different from the one that this migration expects - which is why it fails.

`create_from_breadcrumbs` loading model like this and it expects is_public field in db.
```
from oscar.core.loading import get_model
Category = get_model('catalogue', 'category')
```
But in custom migrations it is loading older version of category model.

**Solution**: 
- implement create_from_breadcrumbs locally, and use 'apps.get_model' to use the historical version of Django app registry (to get the old/current category model instead of the new one). New functions are: create_subcategories, _get_next_character, _get_path_for_next 
- update the old category-populating migration files to use the new function (create_subcategories) instead

**Testing notes**: 
- verified that a sandbox with this branch has all the coupon categories intact (https://ecommerce-dianekaplan.sandbox.edx.org/dashboard/catalogue/categories/2/), and I was able to make a new coupon with no issue (https://ecommerce-dianekaplan.sandbox.edx.org/coupons/)
- verified that this works to remove the 'is_public' blocker that we've seen on earlier attempts to upgrade to django-oscar 2.1; combining this branch with django-oscar 2.1 (and a couple of 2.1-specific updates), that build reaches passing for the build quality checks (previously failed)
- Re: note that line #L275 was not covered by tests in ecommerce/extensions/catalogue/utils.py: I added a test to cover this
- finally, Juliana completed an order in this branch locally