### PR TITLE
REV-2451: hold back selenium version (needed by bok-choy), make upgrade

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,9 +28,9 @@ billiard==3.6.4.0
     # via celery
 bleach==4.1.0
     # via -r requirements/base.in
-boto3==1.18.58
+boto3==1.19.6
     # via -r requirements/base.in
-botocore==1.21.58
+botocore==1.22.6
     # via
     #   boto3
     #   s3transfer
@@ -44,7 +44,7 @@ certifi==2021.10.8
     # via
     #   cybersource-rest-client-python
     #   requests
-cffi==1.14.6
+cffi==1.15.0
     # via
     #   bcrypt
     #   cryptography
@@ -52,7 +52,7 @@ cffi==1.14.6
     #   pynacl
 chardet==4.0.0
     # via cybersource-rest-client-python
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via requests
 configparser==5.0.2
     # via cybersource-rest-client-python
@@ -63,7 +63,7 @@ coreapi==2.3.3
     #   openapi-codec
 coreschema==0.0.4
     # via coreapi
-coverage==6.0.1
+coverage==6.0.2
     # via cybersource-rest-client-python
 crypto==1.4.1
     # via cybersource-rest-client-python
@@ -142,7 +142,7 @@ django-haystack==2.8.1
     # via django-oscar
 django-libsass==0.9
     # via -r requirements/base.in
-django-model-utils==4.1.1
+django-model-utils==4.2.0
     # via edx-rbac
 django-oscar==2.0.4
     # via
@@ -167,7 +167,7 @@ django-waffle==2.2.1
     #   -r requirements/base.in
     #   edx-django-utils
     #   edx-drf-extensions
-django-widget-tweaks==1.4.8
+django-widget-tweaks==1.4.9
     # via django-oscar
 djangorestframework==3.12.4
     # via
@@ -228,7 +228,7 @@ extras==1.0.0
     #   testtools
 factory-boy==2.12.0
     # via django-oscar
-faker==9.2.0
+faker==9.7.1
     # via factory-boy
 fixtures==3.0.0
     # via
@@ -293,7 +293,7 @@ naked==0.1.31
     #   cybersource-rest-client-python
 ndg-httpsclient==0.5.1
     # via -r requirements/base.in
-newrelic==7.0.0.166
+newrelic==7.2.2.169
     # via
     #   -r requirements/base.in
     #   edx-django-utils
@@ -305,7 +305,7 @@ oauthlib==3.1.1
     #   social-auth-core
 openapi-codec==1.3.2
     # via django-rest-swagger
-packaging==21.0
+packaging==21.2
     # via bleach
 paramiko==2.8.0
     # via cybersource-rest-client-python
@@ -319,11 +319,11 @@ pbr==5.6.0
     #   fixtures
     #   stevedore
     #   testtools
-phonenumbers==8.12.34
+phonenumbers==8.12.36
     # via
     #   django-oscar
     #   django-phonenumber-field
-pillow==8.3.2
+pillow==8.4.0
     # via django-oscar
 platformdirs==2.4.0
     # via zeep
@@ -362,7 +362,7 @@ pyjwt[crypto]==1.7.1
     #   edx-auth-backends
     #   edx-rest-api-client
     #   social-auth-core
-pymongo==3.12.0
+pymongo==3.12.1
     # via edx-opaque-keys
 pynacl==1.4.0
     # via
@@ -406,7 +406,7 @@ pytz==2016.10
     #   datetime
     #   django
     #   zeep
-pyyaml==5.4.1
+pyyaml==6.0
     # via
     #   cybersource-rest-client-python
     #   edx-django-release-util
@@ -500,7 +500,7 @@ sorl-thumbnail==12.7.0
     # via -r requirements/base.in
 sqlparse==0.4.2
     # via django
-stevedore==3.4.0
+stevedore==3.5.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
@@ -521,7 +521,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/base.in
     #   djangorestframework-csv
-uritemplate==4.0.0
+uritemplate==4.1.1
     # via coreapi
 urllib3==1.26.7
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -56,9 +56,9 @@ bleach==4.1.0
     # via -r requirements/test.txt
 bok-choy==1.1.1
     # via -r requirements/test.txt
-boto3==1.18.58
+boto3==1.19.6
     # via -r requirements/test.txt
-botocore==1.21.58
+botocore==1.22.6
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -77,7 +77,7 @@ certifi==2021.10.8
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
     #   requests
-cffi==1.14.6
+cffi==1.15.0
     # via
     #   -r requirements/test.txt
     #   bcrypt
@@ -89,7 +89,7 @@ chardet==4.0.0
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
     #   diff-cover
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -107,7 +107,7 @@ coreschema==0.0.4
     # via
     #   -r requirements/test.txt
     #   coreapi
-coverage[toml]==6.0.1
+coverage[toml]==6.0.2
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -212,7 +212,7 @@ django-haystack==2.8.1
     #   django-oscar
 django-libsass==0.9
     # via -r requirements/test.txt
-django-model-utils==4.1.1
+django-model-utils==4.2.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
@@ -245,7 +245,7 @@ django-waffle==2.2.1
     #   edx-drf-extensions
 django-webtest==1.9.8
     # via -r requirements/test.txt
-django-widget-tweaks==1.4.8
+django-widget-tweaks==1.4.9
     # via
     #   -r requirements/test.txt
     #   django-oscar
@@ -320,11 +320,11 @@ factory-boy==2.12.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
-faker==9.2.0
+faker==9.7.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.3.0
+filelock==3.3.2
     # via
     #   -r requirements/test.txt
     #   tox
@@ -343,7 +343,7 @@ future==0.18.2
     # via
     #   -r requirements/test.txt
     #   pyjwkest
-gitdb==4.0.7
+gitdb==4.0.9
     # via gitpython
 gitpython==3.1.24
     # via transifex-client
@@ -470,7 +470,7 @@ naked==0.1.31
     #   cybersource-rest-client-python
 ndg-httpsclient==0.5.1
     # via -r requirements/test.txt
-newrelic==7.0.0.166
+newrelic==7.2.2.169
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -487,7 +487,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
-packaging==21.0
+packaging==21.2
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -514,12 +514,12 @@ pbr==5.6.0
     #   fixtures
     #   stevedore
     #   testtools
-phonenumbers==8.12.34
+phonenumbers==8.12.36
     # via
     #   -r requirements/test.txt
     #   django-oscar
     #   django-phonenumber-field
-pillow==8.3.2
+pillow==8.4.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
@@ -599,7 +599,7 @@ pyjwt[crypto]==1.7.1
     #   social-auth-core
 pylint==2.4.4
     # via -r requirements/test.txt
-pymongo==3.12.0
+pymongo==3.12.1
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -659,7 +659,7 @@ pytest-randomly==3.10.1
     # via -r requirements/test.txt
 pytest-selenium==2.0.1
     # via -r requirements/test.txt
-pytest-timeout==2.0.0
+pytest-timeout==2.0.1
     # via -r requirements/test.txt
 pytest-variables==1.9.0
     # via
@@ -707,7 +707,7 @@ pytz==2016.10
     #   zeep
 pywatchman==1.4.1
     # via -r requirements/dev.in
-pyyaml==5.4.1
+pyyaml==6.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -758,7 +758,7 @@ requests-toolbelt==0.9.1
     # via
     #   -r requirements/test.txt
     #   zeep
-responses==0.14.0
+responses==0.15.0
     # via -r requirements/test.txt
 rest-condition==1.0.3
     # via
@@ -838,7 +838,7 @@ slumber==0.7.1
     # via
     #   -r requirements/test.txt
     #   edx-rest-api-client
-smmap==4.0.0
+smmap==5.0.0
     # via gitdb
 snowballstemmer==2.1.0
     # via
@@ -892,7 +892,7 @@ sqlparse==0.4.2
     #   -r requirements/test.txt
     #   django
     #   django-debug-toolbar
-stevedore==3.4.0
+stevedore==3.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -921,7 +921,7 @@ toml==0.10.2
     #   -r requirements/test.txt
     #   pytest
     #   tox
-tomli==1.2.1
+tomli==1.2.2
     # via
     #   -r requirements/test.txt
     #   coverage
@@ -947,7 +947,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/test.txt
     #   djangorestframework-csv
-uritemplate==4.0.0
+uritemplate==4.1.1
     # via
     #   -r requirements/test.txt
     #   coreapi

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -10,7 +10,7 @@ babel==2.9.1
     # via sphinx
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via requests
 docutils==0.17.1
     # via sphinx
@@ -26,7 +26,7 @@ jinja2==3.0.2
     # via sphinx
 markupsafe==2.0.1
     # via jinja2
-packaging==21.0
+packaging==21.2
     # via sphinx
 pygments==2.10.0
     # via sphinx

--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -12,11 +12,11 @@ certifi==2021.10.8
     # via
     #   -c requirements/base.txt
     #   requests
-cffi==1.14.6
+cffi==1.15.0
     # via
     #   -c requirements/base.txt
     #   cryptography
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via
     #   -c requirements/base.txt
     #   requests
@@ -55,11 +55,11 @@ importlib-metadata==4.8.1
     # via pytest-randomly
 iniconfig==1.1.1
     # via pytest
-newrelic==7.0.0.166
+newrelic==7.2.2.169
     # via
     #   -c requirements/base.txt
     #   edx-django-utils
-packaging==21.0
+packaging==21.2
     # via
     #   -c requirements/base.txt
     #   pytest
@@ -109,7 +109,7 @@ pytest-randomly==3.10.1
     # via -r requirements/e2e.in
 pytest-selenium==2.0.1
     # via -r requirements/e2e.in
-pytest-timeout==2.0.0
+pytest-timeout==2.0.1
     # via -r requirements/e2e.in
 pytest-variables==1.9.0
     # via pytest-selenium
@@ -129,6 +129,7 @@ requests==2.26.0
     #   slumber
 selenium==3.141.0
     # via
+    #   -c requirements/pins.txt
     #   -r requirements/e2e.in
     #   pytest-selenium
 six==1.16.0
@@ -143,7 +144,7 @@ sqlparse==0.4.2
     # via
     #   -c requirements/base.txt
     #   django
-stevedore==3.4.0
+stevedore==3.5.0
     # via
     #   -c requirements/base.txt
     #   edx-django-utils

--- a/requirements/pins.txt
+++ b/requirements/pins.txt
@@ -57,3 +57,6 @@ social-auth-app-django<5.0.0  # version 5.0.0 requires social-auth-core>=4.1.0
 # We are planning django32 upgrade so pinning it to avoid any issue. After upgrade to 32, remove this.
 cryptography==3.4.8
 jsonschema==3.2.0
+
+# bok-choy 1.1.1 requires <4 (can remove once we have a version without that requirement)
+selenium<4.0.0

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -6,11 +6,11 @@
 #
 click==8.0.3
     # via pip-tools
-pep517==0.11.0
+pep517==0.12.0
     # via pip-tools
-pip-tools==6.3.1
+pip-tools==6.4.0
     # via -r requirements/pip_tools.in
-tomli==1.2.1
+tomli==1.2.2
     # via pep517
 wheel==0.37.0
     # via pip-tools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -28,11 +28,11 @@ billiard==3.6.4.0
     # via celery
 bleach==4.1.0
     # via -r requirements/base.in
-boto3==1.18.58
+boto3==1.19.6
     # via
     #   -r requirements/base.in
     #   django-ses
-botocore==1.21.58
+botocore==1.22.6
     # via
     #   boto3
     #   s3transfer
@@ -46,7 +46,7 @@ certifi==2021.10.8
     # via
     #   cybersource-rest-client-python
     #   requests
-cffi==1.14.6
+cffi==1.15.0
     # via
     #   bcrypt
     #   cryptography
@@ -54,7 +54,7 @@ cffi==1.14.6
     #   pynacl
 chardet==4.0.0
     # via cybersource-rest-client-python
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via requests
 configparser==5.0.2
     # via cybersource-rest-client-python
@@ -65,7 +65,7 @@ coreapi==2.3.3
     #   openapi-codec
 coreschema==0.0.4
     # via coreapi
-coverage==6.0.1
+coverage==6.0.2
     # via cybersource-rest-client-python
 crypto==1.4.1
     # via cybersource-rest-client-python
@@ -145,7 +145,7 @@ django-haystack==2.8.1
     # via django-oscar
 django-libsass==0.9
     # via -r requirements/base.in
-django-model-utils==4.1.1
+django-model-utils==4.2.0
     # via edx-rbac
 django-oscar==2.0.4
     # via
@@ -172,7 +172,7 @@ django-waffle==2.2.1
     #   -r requirements/base.in
     #   edx-django-utils
     #   edx-drf-extensions
-django-widget-tweaks==1.4.8
+django-widget-tweaks==1.4.9
     # via django-oscar
 djangorestframework==3.12.4
     # via
@@ -233,7 +233,7 @@ extras==1.0.0
     #   testtools
 factory-boy==2.12.0
     # via django-oscar
-faker==9.2.0
+faker==9.7.1
     # via factory-boy
 fixtures==3.0.0
     # via
@@ -317,7 +317,7 @@ oauthlib==3.1.1
     #   social-auth-core
 openapi-codec==1.3.2
     # via django-rest-swagger
-packaging==21.0
+packaging==21.2
     # via bleach
 paramiko==2.8.0
     # via cybersource-rest-client-python
@@ -331,11 +331,11 @@ pbr==5.6.0
     #   fixtures
     #   stevedore
     #   testtools
-phonenumbers==8.12.34
+phonenumbers==8.12.36
     # via
     #   django-oscar
     #   django-phonenumber-field
-pillow==8.3.2
+pillow==8.4.0
     # via django-oscar
 platformdirs==2.4.0
     # via zeep
@@ -374,7 +374,7 @@ pyjwt[crypto]==1.7.1
     #   edx-auth-backends
     #   edx-rest-api-client
     #   social-auth-core
-pymongo==3.12.0
+pymongo==3.12.1
     # via edx-opaque-keys
 pynacl==1.4.0
     # via
@@ -421,7 +421,7 @@ pytz==2016.10
     #   django
     #   django-ses
     #   zeep
-pyyaml==5.4.1
+pyyaml==6.0
     # via
     #   -r requirements/production.in
     #   cybersource-rest-client-python
@@ -519,7 +519,7 @@ sorl-thumbnail==12.7.0
     # via -r requirements/base.in
 sqlparse==0.4.2
     # via django
-stevedore==3.4.0
+stevedore==3.5.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
@@ -540,7 +540,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/base.in
     #   djangorestframework-csv
-uritemplate==4.0.0
+uritemplate==4.1.1
     # via coreapi
 urllib3==1.26.7
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -47,9 +47,9 @@ bleach==4.1.0
     # via -r requirements/base.txt
 bok-choy==1.1.1
     # via -r requirements/test.in
-boto3==1.18.58
+boto3==1.19.6
     # via -r requirements/base.txt
-botocore==1.21.58
+botocore==1.22.6
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -69,7 +69,7 @@ certifi==2021.10.8
     #   -r requirements/e2e.txt
     #   cybersource-rest-client-python
     #   requests
-cffi==1.14.6
+cffi==1.15.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -82,7 +82,7 @@ chardet==4.0.0
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
     #   diff-cover
-charset-normalizer==2.0.6
+charset-normalizer==2.0.7
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -100,7 +100,7 @@ coreschema==0.0.4
     # via
     #   -r requirements/base.txt
     #   coreapi
-coverage[toml]==6.0.1
+coverage[toml]==6.0.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
@@ -208,7 +208,7 @@ django-haystack==2.8.1
     #   django-oscar
 django-libsass==0.9
     # via -r requirements/base.txt
-django-model-utils==4.1.1
+django-model-utils==4.2.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
@@ -244,7 +244,7 @@ django-waffle==2.2.1
     #   edx-drf-extensions
 django-webtest==1.9.8
     # via -r requirements/test.in
-django-widget-tweaks==1.4.8
+django-widget-tweaks==1.4.9
     # via
     #   -r requirements/base.txt
     #   django-oscar
@@ -319,11 +319,11 @@ factory-boy==2.12.0
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   django-oscar
-faker==9.2.0
+faker==9.7.1
     # via
     #   -r requirements/base.txt
     #   factory-boy
-filelock==3.3.0
+filelock==3.3.2
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -455,7 +455,7 @@ naked==0.1.31
     #   cybersource-rest-client-python
 ndg-httpsclient==0.5.1
     # via -r requirements/base.txt
-newrelic==7.0.0.166
+newrelic==7.2.2.169
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -473,7 +473,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-packaging==21.0
+packaging==21.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -499,12 +499,12 @@ pbr==5.6.0
     #   fixtures
     #   stevedore
     #   testtools
-phonenumbers==8.12.34
+phonenumbers==8.12.36
     # via
     #   -r requirements/base.txt
     #   django-oscar
     #   django-phonenumber-field
-pillow==8.3.2
+pillow==8.4.0
     # via
     #   -r requirements/base.txt
     #   django-oscar
@@ -586,7 +586,7 @@ pylint==2.4.4
     # via
     #   -c requirements/pins.txt
     #   -r requirements/test.in
-pymongo==3.12.0
+pymongo==3.12.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -635,8 +635,7 @@ pytest-base-url==1.4.2
 pytest-cov==3.0.0
     # via -r requirements/test.in
 pytest-django==4.4.0
-    # via
-    #   -r requirements/test.in
+    # via -r requirements/test.in
 pytest-html==3.1.1
     # via
     #   -r requirements/e2e.txt
@@ -649,7 +648,7 @@ pytest-randomly==3.10.1
     # via -r requirements/e2e.txt
 pytest-selenium==2.0.1
     # via -r requirements/e2e.txt
-pytest-timeout==2.0.0
+pytest-timeout==2.0.1
     # via -r requirements/e2e.txt
 pytest-variables==1.9.0
     # via
@@ -694,7 +693,7 @@ pytz==2016.10
     #   datetime
     #   django
     #   zeep
-pyyaml==5.4.1
+pyyaml==6.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
@@ -743,7 +742,7 @@ requests-toolbelt==0.9.1
     # via
     #   -r requirements/base.txt
     #   zeep
-responses==0.14.0
+responses==0.15.0
     # via -r requirements/test.in
 rest-condition==1.0.3
     # via
@@ -765,6 +764,7 @@ s3transfer==0.5.0
     #   boto3
 selenium==3.141.0
     # via
+    #   -c requirements/pins.txt
     #   -r requirements/e2e.txt
     #   -r requirements/test.in
     #   bok-choy
@@ -844,7 +844,7 @@ sqlparse==0.4.2
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
     #   django
-stevedore==3.4.0
+stevedore==3.5.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -874,7 +874,7 @@ toml==0.10.2
     #   -r requirements/tox.txt
     #   pytest
     #   tox
-tomli==1.2.1
+tomli==1.2.2
     # via coverage
 tox==3.14.6
     # via
@@ -895,7 +895,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/base.txt
     #   djangorestframework-csv
-uritemplate==4.0.0
+uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
     #   coreapi

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,9 +4,9 @@
 #
 #    make upgrade
 #
-filelock==3.3.0
+filelock==3.3.2
     # via tox
-packaging==21.0
+packaging==21.2
     # via tox
 pluggy==0.13.1
     # via


### PR DESCRIPTION
https://openedx.atlassian.net/browse/REV-2451

'make upgrade' was failing with a version collision for selenium (needs to be held back under 4.0.0 because of a bok-choy dependency), so I've pinned it accordingly, so we can continue doing 'make upgrade' (to work on the django-oscar 2.1 branch)

This round of updates has major version changes for two packages: 
pyyaml (5.4.1 → 6.0).  See notes with the 6.0 tag [here](https://github.com/yaml/pyyaml/tags)). Purpose: YAML parser and emitter for Python
smmap (4.0.0->5.0.0)- no info in the [5.0 tag](https://github.com/gitpython-developers/smmap/tags). Purpose: A pure Python implementation of a sliding window memory map manager
