### PR TITLE
REV-2453: remove karma-jquery plugin from karma and link to jquery directly

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -24,6 +24,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
 	files: [
+      'node_modules/jquery/dist/jquery.min.js',
 	  'node_modules/jasmine-jquery/lib/jasmine-jquery.js',
       {pattern: 'ecommerce/static/bower_components/**/*.js', included: false},
       {pattern: 'ecommerce/static/js/**/*.js', included: false},
@@ -43,7 +44,6 @@ module.exports = function(config) {
 
     // enabled plugins
     plugins:[
-       'karma-jquery',
        'karma-jasmine',
        'karma-requirejs',
        'karma-firefox-launcher',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = function(config) {
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['jquery-3.2.1', 'jasmine', 'requirejs', 'sinon'],
+    frameworks: ['jasmine', 'requirejs', 'sinon'],
 
 
     // list of files / patterns to load in the browser

--- a/package-lock.json
+++ b/package-lock.json
@@ -4385,6 +4385,11 @@
       "integrity": "sha1-1AleZGlEomdjI1dpqwGNnzDw1Hs=",
       "dev": true
     },
+    "jquery": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
+      "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c="
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -4681,12 +4686,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-1.1.0.tgz",
       "integrity": "sha1-IuTAa/mhguUpTR9wXjczgRuBCs8=",
-      "dev": true
-    },
-    "karma-jquery": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/karma-jquery/-/karma-jquery-0.2.2.tgz",
-      "integrity": "sha1-a+6TRU2LCWvMeBVXCoHnP93bXW8=",
       "dev": true
     },
     "karma-requirejs": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "bower": "1.8.8",
+    "jquery": "^3.2.1",
     "requirejs": "2.3.3"
   },
   "devDependencies": {
@@ -24,7 +25,6 @@
     "karma-coverage-allsources": "0.0.4",
     "karma-firefox-launcher": "1.2.0",
     "karma-jasmine": "1.1.0",
-    "karma-jquery": "0.2.2",
     "karma-requirejs": "1.1.0",
     "karma-selenium-webdriver-launcher": "0.0.4",
     "karma-sinon": "1.0.5",


### PR DESCRIPTION
https://openedx.atlassian.net/browse/REV-2453

karma needs a new way to get its jquery! 

We use karma for selenium tests in ecommerce, and until now it's gotten its jquery from the karma-jquery package. 
(That package bundles up jquery versions for karma to use). Unfortunately karma-jquery was last updated 2 years ago (0.2.4), and only goes up to jquery 3.4.0, but the django-oscar 2.1 upgrade will require jquery 3.5. As a result, the upgrade branch fails quality-and-jobs with Error: No provider for "framework:jquery-3"! (Resolving: framework:jquery-3)

The recommended path forward is to have karma grab its jquery separately, so this PR is to get rid of the karma-jquery package and specify a jquery file for karma to use instead. 

Testing: if we've done this correctly, we'll know that jquery is loaded properly if 'make validate_js' passes during the quality-and-jobs check (rather than giving: Error: No provider for "framework:jquery-3"!) 
