### PR TITLE
feat: hide id verification call to action

### DIFF
--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -61,6 +61,7 @@ from ecommerce.extensions.basket.utils import (
     prepare_basket,
     validate_voucher
 )
+from ecommerce.extensions.checkout.constants import DISABLE_VERIFICATION
 from ecommerce.extensions.offer.constants import DYNAMIC_DISCOUNT_FLAG
 from ecommerce.extensions.offer.dynamic_conditional_offer import get_percentage_from_request
 from ecommerce.extensions.offer.utils import (
@@ -382,6 +383,7 @@ class BasketLogicMixin:
     @newrelic.agent.function_trace()
     def _is_id_verification_required(self, product):
         return (
+            not waffle.switch_is_active(DISABLE_VERIFICATION) and
             getattr(product.attr, 'id_verification_required', False) and
             product.attr.certificate_type != 'credit'
         )

--- a/ecommerce/extensions/checkout/constants.py
+++ b/ecommerce/extensions/checkout/constants.py
@@ -1,0 +1,9 @@
+# .. toggle_name: disable_verification
+# .. toggle_type: waffle_switch
+# .. toggle_default: False
+# .. toggle_description: Disables verification requirements shown to the user
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2021-11-02
+# .. toggle_expiration_date: 2022-02-01
+# .. toggle_tickets: MST-658
+DISABLE_VERIFICATION = 'disable_verification'

--- a/ecommerce/extensions/checkout/views.py
+++ b/ecommerce/extensions/checkout/views.py
@@ -2,6 +2,7 @@
 
 
 import logging
+import waffle
 from decimal import Decimal
 
 from django.conf import settings
@@ -26,6 +27,7 @@ from ecommerce.core.url_utils import (
 )
 from ecommerce.enterprise.api import fetch_enterprise_learner_data
 from ecommerce.enterprise.utils import has_enterprise_offer
+from ecommerce.extensions.checkout.constants import DISABLE_VERIFICATION
 from ecommerce.extensions.checkout.exceptions import BasketNotFreeError
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
 from ecommerce.extensions.checkout.utils import get_receipt_page_url
@@ -188,8 +190,11 @@ class ReceiptResponseView(ThankYouView):
             'display_credit_messaging': self.order_contains_credit_seat(order),
         })
         context.update(self.get_order_dashboard_context(order))
-        context.update(self.get_order_verification_context(order))
-        context.update(self.get_show_verification_banner_context(context))
+
+        if waffle.switch_is_active(DISABLE_VERIFICATION):
+            context.update(self.get_order_verification_context(order))
+            context.update(self.get_show_verification_banner_context(context))
+
         context.update({
             'explore_courses_url': get_lms_explore_courses_url(),
             'has_enrollment_code_product': has_enrollment_code_product,


### PR DESCRIPTION
### [MST-856](https://openedx.atlassian.net/browse/MST-856)

## Description

Introduces a waffle flag that hides the verification call to action on the receipt page. Changes to the basket page are made for the sake of consistency, afaik that view is no longer used.

This is mostly a superficial change to hide IDV from the user before we begin deprecation.

Note: A reference to IDV in the product title does still exist. 