### PR TITLE
Upgrade to Django 3.2 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - django-env: django22
-            testname: quality-and-jobs
-            targets: PYTHON_ENV=py38 requirements.js check_translations_up_to_date validate_translations clean_static static quality validate_js check_keywords
-          - django-env: django22
-            testname: test-python
-            targets: PYTHON_ENV=py38 requirements.js clean_static static validate_python
-          - django-env: django22
-            testname: acceptance-python
-            targets: PYTHON_ENV=py38 requirements.js clean_static static acceptance
           - django-env: django32
             testname: quality-and-jobs
             targets: PYTHON_ENV=py38 requirements.js check_translations_up_to_date validate_translations clean_static static quality validate_js check_keywords

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NODE_BIN=./node_modules/.bin
 DIFF_COVER_BASE_BRANCH=master
 PYTHON_ENV=py38
-DJANGO_ENV_VAR=$(if $(DJANGO_ENV),$(DJANGO_ENV),django22)
+DJANGO_ENV_VAR=$(if $(DJANGO_ENV),$(DJANGO_ENV),django32)
 
 help:
 	@echo ''

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,7 +5,7 @@ bleach
 boto3>=1.17.80
 coreapi
 cybersource-rest-client-python
-django<3.0
+django>=3.2,<4.0
 django-compressor
 django-config-models>=1.0.0         # Configuration models for Django allowing config management with auditing
 django-cors-headers                 #  Used to allow to configure CORS headers for cross-domain requests

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,6 +8,8 @@ amqp==2.6.1
     # via kombu
 analytics-python==1.4.0
     # via -r requirements/base.in
+asgiref==3.4.1
+    # via django
 asn1crypto==1.4.0
     # via cybersource-rest-client-python
 attrs==21.4.0
@@ -89,7 +91,7 @@ defusedxml==0.7.1
     #   social-auth-core
 deprecated==1.2.13
     # via redis
-django==2.2.26
+django==3.2.12
     # via
     #   -r requirements/base.in
     #   django-appconf

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,6 +14,10 @@ amqp==2.6.1
     #   kombu
 analytics-python==1.4.0
     # via -r requirements/test.txt
+asgiref==3.4.1
+    # via
+    #   -r requirements/test.txt
+    #   django
 asn1crypto==1.4.0
     # via
     #   -r requirements/test.txt
@@ -150,7 +154,7 @@ deprecated==1.2.13
     #   redis
 diff-cover==6.4.4
     # via -r requirements/test.txt
-django==2.2.26
+django==3.2.12
     # via
     #   -r requirements/test.txt
     #   django-appconf

--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -4,6 +4,10 @@
 #
 #    make upgrade
 #
+asgiref==3.4.1
+    # via
+    #   -c requirements/base.txt
+    #   django
 attrs==21.4.0
     # via
     #   -c requirements/base.txt
@@ -25,7 +29,7 @@ cryptography==3.4.8
     #   -c requirements/base.txt
     #   -c requirements/pins.txt
     #   pyjwt
-django==2.2.26
+django==3.2.12
     # via
     #   -c requirements/base.txt
     #   django-crum

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,6 +8,8 @@ amqp==2.6.1
     # via kombu
 analytics-python==1.4.0
     # via -r requirements/base.in
+asgiref==3.4.1
+    # via django
 asn1crypto==1.4.0
     # via cybersource-rest-client-python
 attrs==21.4.0
@@ -91,7 +93,7 @@ defusedxml==0.7.1
     #   social-auth-core
 deprecated==1.2.13
     # via redis
-django==2.2.26
+django==3.2.12
     # via
     #   -r requirements/base.in
     #   django-appconf

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,6 +10,11 @@ amqp==2.6.1
     #   kombu
 analytics-python==1.4.0
     # via -r requirements/base.txt
+asgiref==3.4.1
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/e2e.txt
+    #   django
 asn1crypto==1.4.0
     # via
     #   -r requirements/base.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist = py38-django{22,32}-{static,pylint,tests,theme_static,check_keywords},py38-{isort,pycodestyle,extract_translations,dummy_translations,compile_translations, detect_changed_translations,validate_translations},docs
+envlist = py38-django32-{static,pylint,tests,theme_static,check_keywords},py38-{isort,pycodestyle,extract_translations,dummy_translations,compile_translations, detect_changed_translations,validate_translations},docs
 
 [pytest]
 addopts = --ds=ecommerce.settings.test --cov=ecommerce --cov-report term --cov-config=.coveragerc --no-cov-on-fail -p no:randomly --no-migrations -m "not acceptance"
@@ -47,7 +47,6 @@ setenv =
     SELENIUM_BROWSER=firefox
 deps =
     -r{toxinidir}/requirements/test.txt
-    django22: Django>=2.2,<2.3
     django32: Django>=3.2,<3.3
 allowlist_externals =
     /bin/bash


### PR DESCRIPTION
Tested on sandbox the workflows.
- Order 
- Refund 
- Coupon creation

https://docs.djangoproject.com/en/3.2/releases/3.1/#abstractuser-first-name-max-length-increased-to-150
It will run this [migration](https://github.com/django/django/blob/main/django/contrib/auth/migrations/0012_alter_user_first_name_max_length.py) but it will not effect `ecommerce_user` table.  This old [PR](https://github.com/openedx/ecommerce/pull/3598)  has related info.


**Raw SQL from migration**
```
python manage.py sqlmigrate auth 0012
Alter field first_name on user
```