### PR TITLE
Credit Cards Fields Blurred fix

### DIFF
--- a/ecommerce/extensions/payment/processors/cybersource.py
+++ b/ecommerce/extensions/payment/processors/cybersource.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 from enum import Enum
 from typing import Optional
+from urllib.parse import urlparse
 
 import jwt
 import jwt.exceptions
@@ -155,7 +156,8 @@ class CybersourceREST(ApplePayMixin, BaseClientSidePaymentProcessor):
         self.flex_shared_secret_key_id = configuration.get('flex_shared_secret_key_id')
         self.flex_shared_secret_key = configuration.get('flex_shared_secret_key')
         if self.site.siteconfiguration.payment_microfrontend_url:
-            self.flex_target_origin = self.site.siteconfiguration.payment_microfrontend_url.rstrip('/')
+            payment_mfe_url = self.site.siteconfiguration.payment_microfrontend_url
+            self.flex_target_origin = f"{urlparse(payment_mfe_url).scheme}://{urlparse(payment_mfe_url).hostname}"
         else:
             self.flex_target_origin = None
 


### PR DESCRIPTION
As of now, requests made to Cybersources
fail if using path based MFEs like
tutor is using. This is beccause the
value of the target_origin is `https://apps.bloomed.org.np/payment`,
which the Cybersource doesn't like and sends an error.

This would not be a problem for site like edx because
its payment mfe usl is `https://payment.edx.org/` and the
trailing slash will the taken care of by the `rstrip('/')`
already present in the code.

What this edit does is that it allows people to
set the `payment_mfe_host` in the PAYMENT_PROCESSORS config
inside or cybersource and only falls back...

If that value isn't provided, the fallback is the url of
the payment mfe, which means that sites like edx will
keep working without any edit to be made.

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Description

Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?
Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
