### PR TITLE
fix: add missing FK django migration dependency

### DIFF
--- a/ecommerce/extensions/order/migrations/0025_auto_20210922_1857.py
+++ b/ecommerce/extensions/order/migrations/0025_auto_20210922_1857.py
@@ -8,6 +8,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('order', '0024_markordersstatuscompleteconfig'),
+        ('communication', '0001_initial'),
     ]
 
     operations = [


### PR DESCRIPTION
## Description

GoCD errors when rolling back migrations on stage. This is because there is an unstated dependency of migration `order.0025_auto_20210922_1857` on database table `communication`.

This PR explicitly adds the dependency of `order.0025_auto_20210922_1857` on `communication.0001_initial` so that a rollback of `communication.0001_initial` succeeds. 

(I believe the reason the forward migration succeeded is because unless there is a dependency constraint, Django orders migrations alphabetically, and C comes before O.)

## Testing instructions

This PR was tested by performing the full forward migration on my local, then checking the plan for a backwards migration of communication.

On `master` (before this PR):

```
% git checkout master
% python manage.py migrate --plan communication zero
Planned operations:
communication.0001_initial
    Undo Create model CommunicationEventType
    Undo Create model Notification
    Undo Create model Email
 ```

On `pshiu/communication_dependency` (after this PR):

```
% git checkout cd
% git log -1 --oneline
a6efe057 (HEAD -> cd, origin/pshiu/communication_dependency) fix: add missing FK django migration dependency
% python manage.py migrate --plan communication zero
Planned operations:
order.0025_auto_20210922_1857
    Undo Alter field event_type on communicationevent
    Undo Create model Surcharge
communication.0001_initial
    Undo Create model CommunicationEventType
    Undo Create model Notification
    Undo Create model Email
```