### PR TITLE
chore: Upgrading oscar to 2.2 version.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -279,7 +279,7 @@ linecache2==1.0.0
     #   traceback2
 logger==1.4
     # via cybersource-rest-client-python
-lxml==4.7.0
+lxml==4.6.5
     # via
     #   premailer
     #   zeep

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,9 +15,7 @@ attrs==21.2.0
     #   jsonschema
     #   zeep
 babel==2.9.1
-    # via
-    #   django-oscar
-    #   django-phonenumber-field
+    # via django-oscar
 backoff==1.10.0
     # via analytics-python
 bcrypt==3.2.0
@@ -28,9 +26,9 @@ billiard==3.6.4.0
     # via celery
 bleach==4.1.0
     # via -r requirements/base.in
-boto3==1.19.10
+boto3==1.20.23
     # via -r requirements/base.in
-botocore==1.22.10
+botocore==1.23.23
     # via
     #   boto3
     #   s3transfer
@@ -52,9 +50,9 @@ cffi==1.15.0
     #   pynacl
 chardet==4.0.0
     # via cybersource-rest-client-python
-charset-normalizer==2.0.7
+charset-normalizer==2.0.9
     # via requests
-configparser==5.1.0
+configparser==5.2.0
     # via cybersource-rest-client-python
 coreapi==2.3.3
     # via
@@ -63,7 +61,7 @@ coreapi==2.3.3
     #   openapi-codec
 coreschema==0.0.4
     # via coreapi
-coverage==6.1.1
+coverage==6.2
     # via cybersource-rest-client-python
 crypto==1.4.1
     # via cybersource-rest-client-python
@@ -89,7 +87,9 @@ defusedxml==0.7.1
     # via
     #   python3-openid
     #   social-auth-core
-django==2.2.24
+deprecated==1.2.13
+    # via redis
+django==2.2.25
     # via
     #   -r requirements/base.in
     #   django-appconf
@@ -103,6 +103,7 @@ django==2.2.24
     #   django-model-utils
     #   django-oscar
     #   django-phonenumber-field
+    #   django-solo
     #   django-tables2
     #   django-treebeard
     #   djangorestframework
@@ -120,11 +121,12 @@ django-appconf==1.0.5
     # via django-compressor
 django-compressor==2.4.1
     # via
+    #   -c requirements/pins.txt
     #   -r requirements/base.in
     #   django-libsass
 django-config-models==2.2.0
     # via -r requirements/base.in
-django-cors-headers==3.10.0
+django-cors-headers==3.10.1
     # via -r requirements/base.in
 django-crispy-forms==1.13.0
     # via -r requirements/base.in
@@ -132,7 +134,7 @@ django-crum==0.7.9
     # via
     #   edx-django-utils
     #   edx-rbac
-django-extensions==3.1.3
+django-extensions==3.1.5
     # via -r requirements/base.in
 django-extra-views==0.13.0
     # via django-oscar
@@ -144,23 +146,25 @@ django-libsass==0.9
     # via -r requirements/base.in
 django-model-utils==4.2.0
     # via edx-rbac
-django-oscar==2.1
+django-oscar==2.2
     # via
     #   -c requirements/pins.txt
     #   -r requirements/base.in
-django-phonenumber-field==3.0.1
-    # via django-oscar
+django-phonenumber-field==5.0.0
+    # via
+    #   -c requirements/pins.txt
+    #   django-oscar
 django-rest-swagger==2.2.0
     # via -r requirements/base.in
 django-simple-history==3.0.0
     # via -r requirements/base.in
-django-solo==1.2.0
+django-solo==2.0.0
     # via -r requirements/base.in
-django-tables2==2.2.1
+django-tables2==2.4.1
     # via django-oscar
 django-threadlocals==0.10
     # via -r requirements/base.in
-django-treebeard==4.5.1
+django-treebeard==4.4
     # via django-oscar
 django-waffle==2.2.1
     # via
@@ -182,7 +186,7 @@ djangorestframework==3.12.4
     #   rest-condition
 djangorestframework-csv==2.1.1
     # via -r requirements/base.in
-djangorestframework-datatables==0.6.0
+djangorestframework-datatables==0.7.0
     # via -r requirements/base.in
 drf-extensions==0.7.1
     # via -r requirements/base.in
@@ -228,7 +232,7 @@ extras==1.0.0
     #   testtools
 factory-boy==2.12.0
     # via django-oscar
-faker==9.8.0
+faker==10.0.0
     # via factory-boy
 fixtures==3.0.0
     # via
@@ -249,7 +253,7 @@ isodate==0.6.0
     # via zeep
 itypes==1.2.0
     # via coreapi
-jinja2==3.0.2
+jinja2==3.0.3
     # via coreschema
 jmespath==0.10.0
     # via
@@ -275,7 +279,7 @@ linecache2==1.0.0
     #   traceback2
 logger==1.4
     # via cybersource-rest-client-python
-lxml==4.6.4
+lxml==4.7.0
     # via
     #   premailer
     #   zeep
@@ -293,7 +297,7 @@ naked==0.1.31
     #   cybersource-rest-client-python
 ndg-httpsclient==0.5.1
     # via -r requirements/base.in
-newrelic==7.2.2.169
+newrelic==7.2.4.171
     # via
     #   -r requirements/base.in
     #   edx-django-utils
@@ -305,21 +309,21 @@ oauthlib==3.1.1
     #   social-auth-core
 openapi-codec==1.3.2
     # via django-rest-swagger
-packaging==21.2
+packaging==21.3
     # via bleach
-paramiko==2.8.0
+paramiko==2.8.1
     # via cybersource-rest-client-python
 path.py==7.2
     # via -r requirements/base.in
 paypalrestsdk==1.13.1
     # via -r requirements/base.in
-pbr==5.7.0
+pbr==5.8.0
     # via
     #   cybersource-rest-client-python
     #   fixtures
     #   stevedore
     #   testtools
-phonenumbers==8.12.36
+phonenumbers==8.12.39
     # via django-oscar
 pillow==8.4.0
     # via django-oscar
@@ -339,13 +343,13 @@ pyasn1==0.4.8
     #   x509
 pycountry==17.1.8
     # via -r requirements/base.in
-pycparser==2.20
+pycparser==2.21
     # via
     #   cffi
     #   cybersource-rest-client-python
-pycryptodome==3.11.0
+pycryptodome==3.12.0
     # via cybersource-rest-client-python
-pycryptodomex==3.11.0
+pycryptodomex==3.12.0
     # via
     #   cybersource-rest-client-python
     #   pyjwkest
@@ -360,7 +364,7 @@ pyjwt[crypto]==1.7.1
     #   edx-auth-backends
     #   edx-rest-api-client
     #   social-auth-core
-pymongo==3.12.1
+pymongo==4.0.1
     # via edx-opaque-keys
 pynacl==1.4.0
     # via
@@ -371,7 +375,7 @@ pyopenssl==21.0.0
     #   cybersource-rest-client-python
     #   ndg-httpsclient
     #   paypalrestsdk
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 pypi==2.1
     # via cybersource-rest-client-python
@@ -403,6 +407,7 @@ pytz==2016.10
     #   cybersource-rest-client-python
     #   datetime
     #   django
+    #   djangorestframework-datatables
     #   zeep
 pyyaml==6.0
     # via
@@ -411,7 +416,7 @@ pyyaml==6.0
     #   naked
 rcssmin==1.0.6
     # via django-compressor
-redis==3.5.3
+redis==4.0.2
     # via edx-ecommerce-worker
 requests==2.26.0
     # via
@@ -441,7 +446,7 @@ rest-condition==1.0.3
     # via edx-drf-extensions
 rjsmin==1.1.0
     # via django-compressor
-rsa==4.7.2
+rsa==4.8
     # via cybersource-rest-client-python
 rules==3.0
     # via -r requirements/base.in
@@ -453,7 +458,7 @@ shellescape==3.8.1
     # via
     #   crypto
     #   cybersource-rest-client-python
-simplejson==3.17.5
+simplejson==3.17.6
     # via django-rest-swagger
 six==1.16.0
     # via
@@ -535,6 +540,10 @@ webencodings==0.5.1
     # via bleach
 wheel==0.37.0
     # via cybersource-rest-client-python
+wrapt==1.11.2
+    # via
+    #   -c requirements/pins.txt
+    #   deprecated
 x509==0.1
     # via cybersource-rest-client-python
 xss-utils==0.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -33,7 +33,6 @@ babel==2.9.1
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   django-oscar
-    #   django-phonenumber-field
     #   sphinx
 backoff==1.10.0
     # via
@@ -56,9 +55,9 @@ bleach==4.1.0
     # via -r requirements/test.txt
 bok-choy==1.1.1
     # via -r requirements/test.txt
-boto3==1.19.10
+boto3==1.20.23
     # via -r requirements/test.txt
-botocore==1.22.10
+botocore==1.23.23
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -89,12 +88,12 @@ chardet==4.0.0
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
     #   diff-cover
-charset-normalizer==2.0.7
+charset-normalizer==2.0.9
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   requests
-configparser==5.1.0
+configparser==5.2.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -107,7 +106,7 @@ coreschema==0.0.4
     # via
     #   -r requirements/test.txt
     #   coreapi
-coverage[toml]==6.1.1
+coverage[toml]==6.2
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -145,9 +144,13 @@ defusedxml==0.7.1
     #   -r requirements/test.txt
     #   python3-openid
     #   social-auth-core
-diff-cover==6.4.2
+deprecated==1.2.13
+    # via
+    #   -r requirements/test.txt
+    #   redis
+diff-cover==6.4.4
     # via -r requirements/test.txt
-django==2.2.24
+django==2.2.25
     # via
     #   -r requirements/test.txt
     #   django-appconf
@@ -162,6 +165,7 @@ django==2.2.24
     #   django-model-utils
     #   django-oscar
     #   django-phonenumber-field
+    #   django-solo
     #   django-tables2
     #   django-treebeard
     #   djangorestframework
@@ -187,7 +191,7 @@ django-compressor==2.4.1
     #   django-libsass
 django-config-models==2.2.0
     # via -r requirements/test.txt
-django-cors-headers==3.10.0
+django-cors-headers==3.10.1
     # via -r requirements/test.txt
 django-crispy-forms==1.13.0
     # via -r requirements/test.txt
@@ -196,9 +200,9 @@ django-crum==0.7.9
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-rbac
-django-debug-toolbar==3.2.2
+django-debug-toolbar==3.2.3
     # via -r requirements/dev.in
-django-extensions==3.1.3
+django-extensions==3.1.5
     # via -r requirements/test.txt
 django-extra-views==0.13.0
     # via
@@ -216,9 +220,9 @@ django-model-utils==4.2.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-django-oscar==2.1
+django-oscar==2.2
     # via -r requirements/test.txt
-django-phonenumber-field==3.0.1
+django-phonenumber-field==5.0.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
@@ -226,15 +230,15 @@ django-rest-swagger==2.2.0
     # via -r requirements/test.txt
 django-simple-history==3.0.0
     # via -r requirements/test.txt
-django-solo==1.2.0
+django-solo==2.0.0
     # via -r requirements/test.txt
-django-tables2==2.2.1
+django-tables2==2.4.1
     # via
     #   -r requirements/test.txt
     #   django-oscar
 django-threadlocals==0.10
     # via -r requirements/test.txt
-django-treebeard==4.5.1
+django-treebeard==4.4
     # via
     #   -r requirements/test.txt
     #   django-oscar
@@ -262,7 +266,7 @@ djangorestframework==3.12.4
     #   rest-condition
 djangorestframework-csv==2.1.1
     # via -r requirements/test.txt
-djangorestframework-datatables==0.6.0
+djangorestframework-datatables==0.7.0
     # via -r requirements/test.txt
 docutils==0.17.1
     # via
@@ -320,11 +324,11 @@ factory-boy==2.12.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
-faker==9.8.0
+faker==10.0.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.3.2
+filelock==3.4.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -355,18 +359,14 @@ idna==2.7
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
     #   requests
-imagesize==1.2.0
+imagesize==1.3.0
     # via
     #   -r requirements/docs.txt
     #   sphinx
-importlib-metadata==4.8.1
+importlib-metadata==4.8.2
     # via
     #   -r requirements/test.txt
     #   pytest-randomly
-inflect==5.3.0
-    # via
-    #   -r requirements/test.txt
-    #   jinja2-pluralize
 iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
@@ -387,18 +387,13 @@ itypes==1.2.0
     # via
     #   -r requirements/test.txt
     #   coreapi
-jinja2==3.0.2
+jinja2==3.0.3
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   coreschema
     #   diff-cover
-    #   jinja2-pluralize
     #   sphinx
-jinja2-pluralize==0.3.0
-    # via
-    #   -r requirements/test.txt
-    #   diff-cover
 jmespath==0.10.0
     # via
     #   -r requirements/test.txt
@@ -435,7 +430,7 @@ logger==1.4
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-lxml==4.6.4
+lxml==4.7.0
     # via
     #   -r requirements/test.txt
     #   premailer
@@ -470,7 +465,7 @@ naked==0.1.31
     #   cybersource-rest-client-python
 ndg-httpsclient==0.5.1
     # via -r requirements/test.txt
-newrelic==7.2.2.169
+newrelic==7.2.4.171
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -487,7 +482,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
-packaging==21.2
+packaging==21.3
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -495,7 +490,7 @@ packaging==21.2
     #   pytest
     #   sphinx
     #   tox
-paramiko==2.8.0
+paramiko==2.8.1
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -507,14 +502,14 @@ path.py==7.2
     # via -r requirements/test.txt
 paypalrestsdk==1.13.1
     # via -r requirements/test.txt
-pbr==5.7.0
+pbr==5.8.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
     #   fixtures
     #   stevedore
     #   testtools
-phonenumbers==8.12.36
+phonenumbers==8.12.39
     # via
     #   -r requirements/test.txt
     #   django-oscar
@@ -548,7 +543,7 @@ purl==1.6
     # via
     #   -r requirements/test.txt
     #   django-oscar
-py==1.10.0
+py==1.11.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -564,16 +559,16 @@ pycodestyle==2.8.0
     # via -r requirements/test.txt
 pycountry==17.1.8
     # via -r requirements/test.txt
-pycparser==2.20
+pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
     #   cybersource-rest-client-python
-pycryptodome==3.11.0
+pycryptodome==3.12.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-pycryptodomex==3.11.0
+pycryptodomex==3.12.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -598,7 +593,7 @@ pyjwt[crypto]==1.7.1
     #   social-auth-core
 pylint==2.4.4
     # via -r requirements/test.txt
-pymongo==3.12.1
+pymongo==4.0.1
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -613,7 +608,7 @@ pyopenssl==21.0.0
     #   cybersource-rest-client-python
     #   ndg-httpsclient
     #   paypalrestsdk
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -644,7 +639,7 @@ pytest-base-url==1.4.2
     #   pytest-selenium
 pytest-cov==3.0.0
     # via -r requirements/test.txt
-pytest-django==4.4.0
+pytest-django==4.5.2
     # via -r requirements/test.txt
 pytest-html==3.1.1
     # via
@@ -654,7 +649,7 @@ pytest-metadata==1.11.0
     # via
     #   -r requirements/test.txt
     #   pytest-html
-pytest-randomly==3.10.1
+pytest-randomly==3.10.3
     # via -r requirements/test.txt
 pytest-selenium==2.0.1
     # via -r requirements/test.txt
@@ -672,7 +667,7 @@ python-dateutil==2.8.2
     #   edx-drf-extensions
     #   faker
     #   freezegun
-python-dotenv==0.19.1
+python-dotenv==0.19.2
     # via -r requirements/test.txt
 python-memcached==1.58
     # via -r requirements/test.txt
@@ -703,6 +698,7 @@ pytz==2016.10
     #   cybersource-rest-client-python
     #   datetime
     #   django
+    #   djangorestframework-datatables
     #   zeep
 pywatchman==1.4.1
     # via -r requirements/dev.in
@@ -717,7 +713,7 @@ rcssmin==1.0.6
     # via
     #   -r requirements/test.txt
     #   django-compressor
-redis==3.5.3
+redis==4.0.2
     # via
     #   -r requirements/test.txt
     #   edx-ecommerce-worker
@@ -757,7 +753,7 @@ requests-toolbelt==0.9.1
     # via
     #   -r requirements/test.txt
     #   zeep
-responses==0.15.0
+responses==0.16.0
     # via -r requirements/test.txt
 rest-condition==1.0.3
     # via
@@ -767,7 +763,7 @@ rjsmin==1.1.0
     # via
     #   -r requirements/test.txt
     #   django-compressor
-rsa==4.7.2
+rsa==4.8
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -791,7 +787,7 @@ shellescape==3.8.1
     #   -r requirements/test.txt
     #   crypto
     #   cybersource-rest-client-python
-simplejson==3.17.5
+simplejson==3.17.6
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
@@ -839,7 +835,7 @@ slumber==0.7.1
     #   edx-rest-api-client
 smmap==5.0.0
     # via gitdb
-snowballstemmer==2.1.0
+snowballstemmer==2.2.0
     # via
     #   -r requirements/docs.txt
     #   sphinx
@@ -854,11 +850,11 @@ social-auth-core==4.0.2
     #   social-auth-app-django
 sorl-thumbnail==12.7.0
     # via -r requirements/test.txt
-soupsieve==2.3
+soupsieve==2.3.1
     # via
     #   -r requirements/test.txt
     #   beautifulsoup4
-sphinx==4.2.0
+sphinx==4.3.1
     # via
     #   -r requirements/docs.txt
     #   edx-sphinx-theme
@@ -940,7 +936,7 @@ typing==3.7.4.3
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-typing-extensions==3.10.0.2
+typing-extensions==4.0.1
     # via gitpython
 unicodecsv==0.14.1
     # via
@@ -993,6 +989,7 @@ wrapt==1.11.2
     # via
     #   -r requirements/test.txt
     #   astroid
+    #   deprecated
 x509==0.1
     # via
     #   -r requirements/test.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -430,7 +430,7 @@ logger==1.4
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-lxml==4.7.0
+lxml==4.6.5
     # via
     #   -r requirements/test.txt
     #   premailer

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -10,7 +10,7 @@ babel==2.9.1
     # via sphinx
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.7
+charset-normalizer==2.0.9
     # via requests
 docutils==0.17.1
     # via sphinx
@@ -20,17 +20,17 @@ idna==2.7
     # via
     #   -c requirements/pins.txt
     #   requests
-imagesize==1.2.0
+imagesize==1.3.0
     # via sphinx
-jinja2==3.0.2
+jinja2==3.0.3
     # via sphinx
 markupsafe==2.0.1
     # via jinja2
-packaging==21.2
+packaging==21.3
     # via sphinx
 pygments==2.10.0
     # via sphinx
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 pytz==2016.10
     # via
@@ -40,9 +40,9 @@ requests==2.26.0
     # via sphinx
 six==1.16.0
     # via edx-sphinx-theme
-snowballstemmer==2.1.0
+snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.2.0
+sphinx==4.3.1
     # via
     #   -r requirements/docs.in
     #   edx-sphinx-theme

--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -16,7 +16,7 @@ cffi==1.15.0
     # via
     #   -c requirements/base.txt
     #   cryptography
-charset-normalizer==2.0.7
+charset-normalizer==2.0.9
     # via
     #   -c requirements/base.txt
     #   requests
@@ -25,7 +25,7 @@ cryptography==3.4.8
     #   -c requirements/base.txt
     #   -c requirements/pins.txt
     #   pyjwt
-django==2.2.24
+django==2.2.25
     # via
     #   -c requirements/base.txt
     #   django-crum
@@ -51,19 +51,19 @@ idna==2.7
     #   -c requirements/base.txt
     #   -c requirements/pins.txt
     #   requests
-importlib-metadata==4.8.1
+importlib-metadata==4.8.2
     # via pytest-randomly
 iniconfig==1.1.1
     # via pytest
-newrelic==7.2.2.169
+newrelic==7.2.4.171
     # via
     #   -c requirements/base.txt
     #   edx-django-utils
-packaging==21.2
+packaging==21.3
     # via
     #   -c requirements/base.txt
     #   pytest
-pbr==5.7.0
+pbr==5.8.0
     # via
     #   -c requirements/base.txt
     #   stevedore
@@ -75,9 +75,9 @@ psutil==5.8.0
     # via
     #   -c requirements/base.txt
     #   edx-django-utils
-py==1.10.0
+py==1.11.0
     # via pytest
-pycparser==2.20
+pycparser==2.21
     # via
     #   -c requirements/base.txt
     #   cffi
@@ -85,7 +85,7 @@ pyjwt[crypto]==1.7.1
     # via
     #   -c requirements/base.txt
     #   edx-rest-api-client
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via
     #   -c requirements/base.txt
     #   packaging
@@ -105,7 +105,7 @@ pytest-html==3.1.1
     # via pytest-selenium
 pytest-metadata==1.11.0
     # via pytest-html
-pytest-randomly==3.10.1
+pytest-randomly==3.10.3
     # via -r requirements/e2e.in
 pytest-selenium==2.0.1
     # via -r requirements/e2e.in
@@ -113,7 +113,7 @@ pytest-timeout==2.0.1
     # via -r requirements/e2e.in
 pytest-variables==1.9.0
     # via pytest-selenium
-python-dotenv==0.19.1
+python-dotenv==0.19.2
     # via -r requirements/e2e.in
 pytz==2016.10
     # via

--- a/requirements/pins.txt
+++ b/requirements/pins.txt
@@ -11,8 +11,8 @@
 # Tests failing in test_cybersouce.py on version 0.0.23
 cybersource-rest-client-python==0.0.21
 
-# REV-2370 2.0->2.1 upgrade will be major, temporarily pinning at 2.1 to miminize the change
-django-oscar==2.1
+# django-oscar==2.2 has django(2.2 and 3.2) support and also oscar=2.2 is the LTS version
+django-oscar==2.2
 
 # causing tests failures
 httpretty==0.9.7
@@ -60,3 +60,13 @@ jsonschema==3.2.0
 
 # bok-choy 1.1.1 requires <4 (can remove once we have a version without that requirement)
 selenium<4.0.0
+
+
+# greater version conflicts with pylint in upgrade job.
+wrapt==1.11.2
+
+# we are preparing for django32 support so avoiding major version bump here.
+django-compressor==2.4.1
+
+# django oscar has this pin so maintaing it
+django-phonenumber-field<5.1.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -288,7 +288,7 @@ linecache2==1.0.0
     #   traceback2
 logger==1.4
     # via cybersource-rest-client-python
-lxml==4.7.0
+lxml==4.6.5
     # via
     #   premailer
     #   zeep

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -15,9 +15,7 @@ attrs==21.2.0
     #   jsonschema
     #   zeep
 babel==2.9.1
-    # via
-    #   django-oscar
-    #   django-phonenumber-field
+    # via django-oscar
 backoff==1.10.0
     # via analytics-python
 bcrypt==3.2.0
@@ -28,11 +26,11 @@ billiard==3.6.4.0
     # via celery
 bleach==4.1.0
     # via -r requirements/base.in
-boto3==1.19.10
+boto3==1.20.23
     # via
     #   -r requirements/base.in
     #   django-ses
-botocore==1.22.10
+botocore==1.23.23
     # via
     #   boto3
     #   s3transfer
@@ -54,9 +52,9 @@ cffi==1.15.0
     #   pynacl
 chardet==4.0.0
     # via cybersource-rest-client-python
-charset-normalizer==2.0.7
+charset-normalizer==2.0.9
     # via requests
-configparser==5.1.0
+configparser==5.2.0
     # via cybersource-rest-client-python
 coreapi==2.3.3
     # via
@@ -65,7 +63,7 @@ coreapi==2.3.3
     #   openapi-codec
 coreschema==0.0.4
     # via coreapi
-coverage==6.1.1
+coverage==6.2
     # via cybersource-rest-client-python
 crypto==1.4.1
     # via cybersource-rest-client-python
@@ -91,7 +89,9 @@ defusedxml==0.7.1
     # via
     #   python3-openid
     #   social-auth-core
-django==2.2.24
+deprecated==1.2.13
+    # via redis
+django==2.2.25
     # via
     #   -r requirements/base.in
     #   django-appconf
@@ -106,6 +106,7 @@ django==2.2.24
     #   django-oscar
     #   django-phonenumber-field
     #   django-ses
+    #   django-solo
     #   django-tables2
     #   django-treebeard
     #   djangorestframework
@@ -123,11 +124,12 @@ django-appconf==1.0.5
     # via django-compressor
 django-compressor==2.4.1
     # via
+    #   -c requirements/pins.txt
     #   -r requirements/base.in
     #   django-libsass
 django-config-models==2.2.0
     # via -r requirements/base.in
-django-cors-headers==3.10.0
+django-cors-headers==3.10.1
     # via -r requirements/base.in
 django-crispy-forms==1.13.0
     # via -r requirements/base.in
@@ -135,7 +137,7 @@ django-crum==0.7.9
     # via
     #   edx-django-utils
     #   edx-rbac
-django-extensions==3.1.3
+django-extensions==3.1.5
     # via -r requirements/base.in
 django-extra-views==0.13.0
     # via django-oscar
@@ -147,25 +149,27 @@ django-libsass==0.9
     # via -r requirements/base.in
 django-model-utils==4.2.0
     # via edx-rbac
-django-oscar==2.1
+django-oscar==2.2
     # via
     #   -c requirements/pins.txt
     #   -r requirements/base.in
-django-phonenumber-field==3.0.1
-    # via django-oscar
+django-phonenumber-field==5.0.0
+    # via
+    #   -c requirements/pins.txt
+    #   django-oscar
 django-rest-swagger==2.2.0
     # via -r requirements/base.in
-django-ses==2.3.0
+django-ses==2.3.1
     # via -r requirements/production.in
 django-simple-history==3.0.0
     # via -r requirements/base.in
-django-solo==1.2.0
+django-solo==2.0.0
     # via -r requirements/base.in
-django-tables2==2.2.1
+django-tables2==2.4.1
     # via django-oscar
 django-threadlocals==0.10
     # via -r requirements/base.in
-django-treebeard==4.5.1
+django-treebeard==4.4
     # via django-oscar
 django-waffle==2.2.1
     # via
@@ -187,7 +191,7 @@ djangorestframework==3.12.4
     #   rest-condition
 djangorestframework-csv==2.1.1
     # via -r requirements/base.in
-djangorestframework-datatables==0.6.0
+djangorestframework-datatables==0.7.0
     # via -r requirements/base.in
 drf-extensions==0.7.1
     # via -r requirements/base.in
@@ -233,7 +237,7 @@ extras==1.0.0
     #   testtools
 factory-boy==2.12.0
     # via django-oscar
-faker==9.8.0
+faker==10.0.0
     # via factory-boy
 fixtures==3.0.0
     # via
@@ -258,7 +262,7 @@ isodate==0.6.0
     # via zeep
 itypes==1.2.0
     # via coreapi
-jinja2==3.0.2
+jinja2==3.0.3
     # via coreschema
 jmespath==0.10.0
     # via
@@ -284,7 +288,7 @@ linecache2==1.0.0
     #   traceback2
 logger==1.4
     # via cybersource-rest-client-python
-lxml==4.6.4
+lxml==4.7.0
     # via
     #   premailer
     #   zeep
@@ -317,21 +321,21 @@ oauthlib==3.1.1
     #   social-auth-core
 openapi-codec==1.3.2
     # via django-rest-swagger
-packaging==21.2
+packaging==21.3
     # via bleach
-paramiko==2.8.0
+paramiko==2.8.1
     # via cybersource-rest-client-python
 path.py==7.2
     # via -r requirements/base.in
 paypalrestsdk==1.13.1
     # via -r requirements/base.in
-pbr==5.7.0
+pbr==5.8.0
     # via
     #   cybersource-rest-client-python
     #   fixtures
     #   stevedore
     #   testtools
-phonenumbers==8.12.36
+phonenumbers==8.12.39
     # via django-oscar
 pillow==8.4.0
     # via django-oscar
@@ -351,13 +355,13 @@ pyasn1==0.4.8
     #   x509
 pycountry==17.1.8
     # via -r requirements/base.in
-pycparser==2.20
+pycparser==2.21
     # via
     #   cffi
     #   cybersource-rest-client-python
-pycryptodome==3.11.0
+pycryptodome==3.12.0
     # via cybersource-rest-client-python
-pycryptodomex==3.11.0
+pycryptodomex==3.12.0
     # via
     #   cybersource-rest-client-python
     #   pyjwkest
@@ -372,7 +376,7 @@ pyjwt[crypto]==1.7.1
     #   edx-auth-backends
     #   edx-rest-api-client
     #   social-auth-core
-pymongo==3.12.1
+pymongo==4.0.1
     # via edx-opaque-keys
 pynacl==1.4.0
     # via
@@ -383,7 +387,7 @@ pyopenssl==21.0.0
     #   cybersource-rest-client-python
     #   ndg-httpsclient
     #   paypalrestsdk
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 pypi==2.1
     # via cybersource-rest-client-python
@@ -418,6 +422,7 @@ pytz==2016.10
     #   datetime
     #   django
     #   django-ses
+    #   djangorestframework-datatables
     #   zeep
 pyyaml==6.0
     # via
@@ -427,7 +432,7 @@ pyyaml==6.0
     #   naked
 rcssmin==1.0.6
     # via django-compressor
-redis==3.5.3
+redis==4.0.2
     # via
     #   -r requirements/production.in
     #   edx-ecommerce-worker
@@ -459,7 +464,7 @@ rest-condition==1.0.3
     # via edx-drf-extensions
 rjsmin==1.1.0
     # via django-compressor
-rsa==4.7.2
+rsa==4.8
     # via cybersource-rest-client-python
 rules==3.0
     # via -r requirements/base.in
@@ -471,7 +476,7 @@ shellescape==3.8.1
     # via
     #   crypto
     #   cybersource-rest-client-python
-simplejson==3.17.5
+simplejson==3.17.6
     # via django-rest-swagger
 six==1.16.0
     # via
@@ -554,6 +559,10 @@ webencodings==0.5.1
     # via bleach
 wheel==0.37.0
     # via cybersource-rest-client-python
+wrapt==1.11.2
+    # via
+    #   -c requirements/pins.txt
+    #   deprecated
 x509==0.1
     # via cybersource-rest-client-python
 xss-utils==0.3.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -27,7 +27,6 @@ babel==2.9.1
     # via
     #   -r requirements/base.txt
     #   django-oscar
-    #   django-phonenumber-field
 backoff==1.10.0
     # via
     #   -r requirements/base.txt
@@ -47,9 +46,9 @@ bleach==4.1.0
     # via -r requirements/base.txt
 bok-choy==1.1.1
     # via -r requirements/test.in
-boto3==1.19.10
+boto3==1.20.23
     # via -r requirements/base.txt
-botocore==1.22.10
+botocore==1.23.23
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -82,12 +81,12 @@ chardet==4.0.0
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
     #   diff-cover
-charset-normalizer==2.0.7
+charset-normalizer==2.0.9
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
     #   requests
-configparser==5.1.0
+configparser==5.2.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
@@ -100,7 +99,7 @@ coreschema==0.0.4
     # via
     #   -r requirements/base.txt
     #   coreapi
-coverage[toml]==6.1.1
+coverage[toml]==6.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
@@ -143,7 +142,11 @@ defusedxml==0.7.1
     #   -r requirements/base.txt
     #   python3-openid
     #   social-auth-core
-diff-cover==6.4.2
+deprecated==1.2.13
+    # via
+    #   -r requirements/base.txt
+    #   redis
+diff-cover==6.4.4
     # via -r requirements/test.in
     # via
     #   -r requirements/base.txt
@@ -159,6 +162,7 @@ diff-cover==6.4.2
     #   django-model-utils
     #   django-oscar
     #   django-phonenumber-field
+    #   django-solo
     #   django-tables2
     #   django-treebeard
     #   djangorestframework
@@ -180,11 +184,12 @@ django-appconf==1.0.5
     #   django-compressor
 django-compressor==2.4.1
     # via
+    #   -c requirements/pins.txt
     #   -r requirements/base.txt
     #   django-libsass
 django-config-models==2.2.0
     # via -r requirements/base.txt
-django-cors-headers==3.10.0
+django-cors-headers==3.10.1
     # via -r requirements/base.txt
 django-crispy-forms==1.13.0
     # via -r requirements/base.txt
@@ -194,7 +199,7 @@ django-crum==0.7.9
     #   -r requirements/e2e.txt
     #   edx-django-utils
     #   edx-rbac
-django-extensions==3.1.3
+django-extensions==3.1.5
     # via -r requirements/base.txt
 django-extra-views==0.13.0
     # via
@@ -212,27 +217,28 @@ django-model-utils==4.2.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-django-oscar==2.1
+django-oscar==2.2
     # via
     #   -c requirements/pins.txt
     #   -r requirements/base.txt
-django-phonenumber-field==3.0.1
+django-phonenumber-field==5.0.0
     # via
+    #   -c requirements/pins.txt
     #   -r requirements/base.txt
     #   django-oscar
 django-rest-swagger==2.2.0
     # via -r requirements/base.txt
 django-simple-history==3.0.0
     # via -r requirements/base.txt
-django-solo==1.2.0
+django-solo==2.0.0
     # via -r requirements/base.txt
-django-tables2==2.2.1
+django-tables2==2.4.1
     # via
     #   -r requirements/base.txt
     #   django-oscar
 django-threadlocals==0.10
     # via -r requirements/base.txt
-django-treebeard==4.5.1
+django-treebeard==4.4
     # via
     #   -r requirements/base.txt
     #   django-oscar
@@ -261,7 +267,7 @@ djangorestframework==3.12.4
     #   rest-condition
 djangorestframework-csv==2.1.1
     # via -r requirements/base.txt
-djangorestframework-datatables==0.6.0
+djangorestframework-datatables==0.7.0
     # via -r requirements/base.txt
 drf-extensions==0.7.1
     # via -r requirements/base.txt
@@ -319,11 +325,11 @@ factory-boy==2.12.0
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   django-oscar
-faker==9.8.0
+faker==10.0.0
     # via
     #   -r requirements/base.txt
     #   factory-boy
-filelock==3.3.2
+filelock==3.4.0
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -353,12 +359,10 @@ idna==2.7
     #   -r requirements/e2e.txt
     #   cybersource-rest-client-python
     #   requests
-importlib-metadata==4.8.1
+importlib-metadata==4.8.2
     # via
     #   -r requirements/e2e.txt
     #   pytest-randomly
-inflect==5.3.0
-    # via jinja2-pluralize
 iniconfig==1.1.1
     # via
     #   -r requirements/e2e.txt
@@ -379,14 +383,11 @@ itypes==1.2.0
     # via
     #   -r requirements/base.txt
     #   coreapi
-jinja2==3.0.2
+jinja2==3.0.3
     # via
     #   -r requirements/base.txt
     #   coreschema
     #   diff-cover
-    #   jinja2-pluralize
-jinja2-pluralize==0.3.0
-    # via diff-cover
 jmespath==0.10.0
     # via
     #   -r requirements/base.txt
@@ -422,7 +423,7 @@ logger==1.4
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-lxml==4.6.4
+lxml==4.7.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
@@ -455,7 +456,7 @@ naked==0.1.31
     #   cybersource-rest-client-python
 ndg-httpsclient==0.5.1
     # via -r requirements/base.txt
-newrelic==7.2.2.169
+newrelic==7.2.4.171
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -473,7 +474,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-packaging==21.2
+packaging==21.3
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -481,7 +482,7 @@ packaging==21.2
     #   bleach
     #   pytest
     #   tox
-paramiko==2.8.0
+paramiko==2.8.1
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
@@ -491,7 +492,7 @@ path.py==7.2
     # via -r requirements/base.txt
 paypalrestsdk==1.13.1
     # via -r requirements/base.txt
-pbr==5.7.0
+pbr==5.8.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -499,7 +500,7 @@ pbr==5.7.0
     #   fixtures
     #   stevedore
     #   testtools
-phonenumbers==8.12.36
+phonenumbers==8.12.39
     # via
     #   -r requirements/base.txt
     #   django-oscar
@@ -532,7 +533,7 @@ purl==1.6
     # via
     #   -r requirements/base.txt
     #   django-oscar
-py==1.10.0
+py==1.11.0
     # via
     #   -r requirements/e2e.txt
     #   -r requirements/tox.txt
@@ -549,17 +550,17 @@ pycodestyle==2.8.0
     # via -r requirements/test.in
 pycountry==17.1.8
     # via -r requirements/base.txt
-pycparser==2.20
+pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
     #   cffi
     #   cybersource-rest-client-python
-pycryptodome==3.11.0
+pycryptodome==3.12.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-pycryptodomex==3.11.0
+pycryptodomex==3.12.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
@@ -585,7 +586,7 @@ pylint==2.4.4
     # via
     #   -c requirements/pins.txt
     #   -r requirements/test.in
-pymongo==3.12.1
+pymongo==4.0.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -600,7 +601,7 @@ pyopenssl==21.0.0
     #   cybersource-rest-client-python
     #   ndg-httpsclient
     #   paypalrestsdk
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -633,7 +634,7 @@ pytest-base-url==1.4.2
     #   pytest-selenium
 pytest-cov==3.0.0
     # via -r requirements/test.in
-pytest-django==4.4.0
+pytest-django==4.5.2
     # via -r requirements/test.in
 pytest-html==3.1.1
     # via
@@ -643,7 +644,7 @@ pytest-metadata==1.11.0
     # via
     #   -r requirements/e2e.txt
     #   pytest-html
-pytest-randomly==3.10.1
+pytest-randomly==3.10.3
     # via -r requirements/e2e.txt
 pytest-selenium==2.0.1
     # via -r requirements/e2e.txt
@@ -661,7 +662,7 @@ python-dateutil==2.8.2
     #   edx-drf-extensions
     #   faker
     #   freezegun
-python-dotenv==0.19.1
+python-dotenv==0.19.2
     # via -r requirements/e2e.txt
 python-memcached==1.58
     # via -r requirements/test.in
@@ -691,6 +692,7 @@ pytz==2016.10
     #   cybersource-rest-client-python
     #   datetime
     #   django
+    #   djangorestframework-datatables
     #   zeep
 pyyaml==6.0
     # via
@@ -703,7 +705,7 @@ rcssmin==1.0.6
     # via
     #   -r requirements/base.txt
     #   django-compressor
-redis==3.5.3
+redis==4.0.2
     # via
     #   -r requirements/base.txt
     #   edx-ecommerce-worker
@@ -741,7 +743,7 @@ requests-toolbelt==0.9.1
     # via
     #   -r requirements/base.txt
     #   zeep
-responses==0.15.0
+responses==0.16.0
     # via -r requirements/test.in
 rest-condition==1.0.3
     # via
@@ -751,7 +753,7 @@ rjsmin==1.1.0
     # via
     #   -r requirements/base.txt
     #   django-compressor
-rsa==4.7.2
+rsa==4.8
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
@@ -777,7 +779,7 @@ shellescape==3.8.1
     #   -r requirements/base.txt
     #   crypto
     #   cybersource-rest-client-python
-simplejson==3.17.5
+simplejson==3.17.6
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
@@ -836,7 +838,7 @@ social-auth-core==4.0.2
     #   social-auth-app-django
 sorl-thumbnail==12.7.0
     # via -r requirements/base.txt
-soupsieve==2.3
+soupsieve==2.3.1
     # via beautifulsoup4
 sqlparse==0.4.2
     # via
@@ -933,7 +935,11 @@ wheel==0.37.0
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
 wrapt==1.11.2
-    # via astroid
+    # via
+    #   -c requirements/pins.txt
+    #   -r requirements/base.txt
+    #   astroid
+    #   deprecated
 x509==0.1
     # via
     #   -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -423,7 +423,7 @@ logger==1.4
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-lxml==4.7.0
+lxml==4.6.5
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,17 +4,17 @@
 #
 #    make upgrade
 #
-filelock==3.3.2
+filelock==3.4.0
     # via tox
-packaging==21.2
+packaging==21.3
     # via tox
 pluggy==0.13.1
     # via
     #   -c requirements/pins.txt
     #   tox
-py==1.10.0
+py==1.11.0
     # via tox
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 six==1.16.0
     # via tox


### PR DESCRIPTION
It has django2.2 and django3.2 support.

change log https://github.com/django-oscar/django-oscar/compare/2.1.1...2.2.0

https://github.com/django-oscar/django-oscar/releases/tag/2.2.0
