### PR TITLE
feat: upgrade django-oscar to 2.2 for Django 3.2 support

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,9 +15,7 @@ attrs==21.4.0
     #   jsonschema
     #   zeep
 babel==2.9.1
-    # via
-    #   django-oscar
-    #   django-phonenumber-field
+    # via django-oscar
 backoff==1.10.0
     # via analytics-python
 bcrypt==3.2.0
@@ -147,11 +145,11 @@ django-libsass==0.9
     # via -r requirements/base.in
 django-model-utils==4.2.0
     # via edx-rbac
-django-oscar==2.1
+django-oscar==2.2
     # via
     #   -c requirements/pins.txt
     #   -r requirements/base.in
-django-phonenumber-field==3.0.1
+django-phonenumber-field==5.0.0
     # via django-oscar
 django-rest-swagger==2.2.0
     # via -r requirements/base.in
@@ -159,11 +157,11 @@ django-simple-history==3.0.0
     # via -r requirements/base.in
 django-solo==2.0.0
     # via -r requirements/base.in
-django-tables2==2.2.1
+django-tables2==2.4.1
     # via django-oscar
 django-threadlocals==0.10
     # via -r requirements/base.in
-django-treebeard==4.5.1
+django-treebeard==4.4
     # via django-oscar
 django-waffle==2.3.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -33,7 +33,6 @@ babel==2.9.1
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   django-oscar
-    #   django-phonenumber-field
     #   sphinx
 backoff==1.10.0
     # via
@@ -221,9 +220,9 @@ django-model-utils==4.2.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-django-oscar==2.1
+django-oscar==2.2
     # via -r requirements/test.txt
-django-phonenumber-field==3.0.1
+django-phonenumber-field==5.0.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
@@ -233,13 +232,13 @@ django-simple-history==3.0.0
     # via -r requirements/test.txt
 django-solo==2.0.0
     # via -r requirements/test.txt
-django-tables2==2.2.1
+django-tables2==2.4.1
     # via
     #   -r requirements/test.txt
     #   django-oscar
 django-threadlocals==0.10
     # via -r requirements/test.txt
-django-treebeard==4.5.1
+django-treebeard==4.4
     # via
     #   -r requirements/test.txt
     #   django-oscar

--- a/requirements/pins.txt
+++ b/requirements/pins.txt
@@ -11,8 +11,8 @@
 # Tests failing in test_cybersouce.py on version 0.0.23
 cybersource-rest-client-python==0.0.21
 
-# REV-2370 2.0->2.1 upgrade will be major, temporarily pinning at 2.1 to miminize the change
-django-oscar==2.1
+# Django 3.2 support is added in version 2.2 so pinning it to 2.2
+django-oscar==2.2
 
 # causing tests failures
 httpretty==0.9.7

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -15,9 +15,7 @@ attrs==21.4.0
     #   jsonschema
     #   zeep
 babel==2.9.1
-    # via
-    #   django-oscar
-    #   django-phonenumber-field
+    # via django-oscar
 backoff==1.10.0
     # via analytics-python
 bcrypt==3.2.0
@@ -150,11 +148,11 @@ django-libsass==0.9
     # via -r requirements/base.in
 django-model-utils==4.2.0
     # via edx-rbac
-django-oscar==2.1
+django-oscar==2.2
     # via
     #   -c requirements/pins.txt
     #   -r requirements/base.in
-django-phonenumber-field==3.0.1
+django-phonenumber-field==5.0.0
     # via django-oscar
 django-rest-swagger==2.2.0
     # via -r requirements/base.in
@@ -164,11 +162,11 @@ django-simple-history==3.0.0
     # via -r requirements/base.in
 django-solo==2.0.0
     # via -r requirements/base.in
-django-tables2==2.2.1
+django-tables2==2.4.1
     # via django-oscar
 django-threadlocals==0.10
     # via -r requirements/base.in
-django-treebeard==4.5.1
+django-treebeard==4.4
     # via django-oscar
 django-waffle==2.3.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -27,7 +27,6 @@ babel==2.9.1
     # via
     #   -r requirements/base.txt
     #   django-oscar
-    #   django-phonenumber-field
 backoff==1.10.0
     # via
     #   -r requirements/base.txt
@@ -217,11 +216,11 @@ django-model-utils==4.2.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-django-oscar==2.1
+django-oscar==2.2
     # via
     #   -c requirements/pins.txt
     #   -r requirements/base.txt
-django-phonenumber-field==3.0.1
+django-phonenumber-field==5.0.0
     # via
     #   -r requirements/base.txt
     #   django-oscar
@@ -231,13 +230,13 @@ django-simple-history==3.0.0
     # via -r requirements/base.txt
 django-solo==2.0.0
     # via -r requirements/base.txt
-django-tables2==2.2.1
+django-tables2==2.4.1
     # via
     #   -r requirements/base.txt
     #   django-oscar
 django-threadlocals==0.10
     # via -r requirements/base.txt
-django-treebeard==4.5.1
+django-treebeard==4.4
     # via
     #   -r requirements/base.txt
     #   django-oscar


### PR DESCRIPTION
It has django2.2 and django3.2 support.

change log https://github.com/django-oscar/django-oscar/compare/2.1.1...2.2.0

https://github.com/django-oscar/django-oscar/releases/tag/2.2.0

**Testing**
- [ ] Testing checkout on sandbox
- [ ] Refund using oscar dashboard.