### PR TITLE
fix: modify user model to avoid large migration on ecommerce_user table

### DIFF
--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -492,6 +492,9 @@ class User(AbstractUser):
     # on the ecommerce_user table that would otherwise have come with Django 2.
     # See https://docs.djangoproject.com/en/3.0/releases/2.0/#abstractuser-last-name-max-length-increased-to-150
     last_name = models.CharField(_('last name'), max_length=30, blank=True)
+    # Similarly, this avoids a large migration which otherwise would come with Django 3.2 upgrade
+    # See, https://docs.djangoproject.com/en/3.2/releases/3.1/#abstractuser-first-name-max-length-increased-to-150
+    first_name = models.CharField(_('first name'), max_length=30, blank=True)
     full_name = models.CharField(_('Full Name'), max_length=255, blank=True, null=True)
     tracking_context = JSONField(blank=True, null=True)
     email = models.EmailField(max_length=254, verbose_name='email address', blank=True, db_index=True)


### PR DESCRIPTION
This PR is just retaining the current max_length  of `first_name` so Django 3.2 won’t create a migration to increase the limit of `first_name`.

Ref: https://docs.djangoproject.com/en/4.0/releases/3.1/#abstractuser-first-name-max-length-increased-to-150