### PR TITLE
REV-2493: let e2e test purchase test continue after failing SKU

### DIFF
--- a/e2e/test_payment.py
+++ b/e2e/test_payment.py
@@ -201,8 +201,10 @@ class TestSeatPayment:
                 # We only want to continue on this particular error from add_item_to_basket.
                 if "No product is available" in exc.msg:
                     log.warning("Failed to get a valid course run for SKU %s, continuing", verified_seat['sku'])
-                    continue
-                raise
+                else:  # TODO: Remove else clause after investigation (REV-2493)
+                    log.warning("Failed to add basket line for SKU %s, continuing", verified_seat['sku'])
+                    log.info("exc.msg was: %s", exc.msg)
+                continue
 
         assert test_run_successfully, "Unable to find a valid course run to test!"
 


### PR DESCRIPTION
[REV-2493](https://openedx.atlassian.net/browse/REV-2493): 
We have an e2e test that makes a purchase with a credit card (test_verified_seat_payment_with_credit_card_payment_page), and it's been failing for a few weeks with a TimeoutException. The test loops through to find a SKU it can use for the purchase. The SKU previously used (D9092D3) does still allow purchases in stage, so my hunch that loop is returning a different SKU first that has some issue, and when we try and fail to purchase it, we're not continuing on to try another one. 

The original code only continues to the next SKU if the TimeoutException has a specific message, but the failure we're seeing now does not have that message (so the test just stops). This PR updates the test to log the info and continue trying the next sku for any TimeoutException (regardless of the message). This will likely allow us to continue onto a sku that works, and in the meantime will log which sku it's failing to order, so we can investigate. 
