### PR TITLE
[REV-2493] Troubleshoot e2e test failure

### DIFF
--- a/e2e/test_payment.py
+++ b/e2e/test_payment.py
@@ -130,7 +130,7 @@ class TestSeatPayment:
         ))
 
         # Wait till the selector is visible
-        WebDriverWait(selenium, 20).until(
+        WebDriverWait(selenium, 40).until(  # @TODO: put wait back to 20 after REV-2493 investigation
             EC.visibility_of_element_located((By.CSS_SELECTOR, page_css_selector))
         )
 
@@ -200,10 +200,10 @@ class TestSeatPayment:
             except TimeoutException as exc:
                 # We only want to continue on this particular error from add_item_to_basket.
                 if "No product is available" in exc.msg:
-                    log.warning("Failed to get a valid course run for SKU %s, continuing", verified_seat['sku'])
+                    log.warning("Failed to get a valid course run for SKU %s, continuing. ", verified_seat['sku'])
                 else:  # TODO: Remove else clause after investigation (REV-2493)
                     log.warning("Failed to add basket line for SKU %s, continuing", verified_seat['sku'])
-                    log.info("exc.msg was: %s", exc.msg)
+                    log.warning("exc.msg was: %s", exc.msg)
                 continue
 
         assert test_run_successfully, "Unable to find a valid course run to test!"


### PR DESCRIPTION
[REV-2493](https://openedx.atlassian.net/browse/REV-2493):
We have an e2e test that makes a purchase with a credit card (test_verified_seat_payment_with_credit_card_payment_page), and it's been failing for a few weeks with a TimeoutException, when it calls add_item_to_basket. The test loops through to find a SKU it can use for the purchase. If there's a TimeoutException, we stop the test unless it has a specific message (which this failure does not). [This PR](https://github.com/edx/ecommerce/pull/3601/files) updated the code to continue to the next SKU and log what SKU had failed. That gave us info: the same SKU that had previously passed (D9092D3) is now timing out.  (Our original incorrect hypothesis that the test had started using a different/bad SKU). 

During the test failure, Jenkins' screenshot of what was shown just has a progress spinner. This page may now need more time to render than it did before. 

This PR here: 
- updates the exc.msg output to a warning so it'll show up in the jenkins test output
- lengthens the selenium timeout from 20 to 40 
