### PR TITLE
feat: ENT-5042 | added validation on sales_force_id in Enterprise Offers.

### DIFF
--- a/ecommerce/enterprise/constants.py
+++ b/ecommerce/enterprise/constants.py
@@ -13,3 +13,7 @@ USE_ENTERPRISE_CATALOG = 'use_enterprise_catalog'
 # Default Sender Alias used in Enterprise Customer Code Assign,Remind and Revoke Emails.
 
 SENDER_ALIAS = 'edX Support Team'
+
+# Salesforce Opportunity ID must be 18 alphanumeric characters and begin with 006 OR be "none" (to accommodate
+# potential edge case).
+ENTERPRISE_SALES_FORCE_ID_REGEX = r'^006[a-zA-Z0-9]{15}$|^none$'

--- a/ecommerce/enterprise/tests/test_views.py
+++ b/ecommerce/enterprise/tests/test_views.py
@@ -111,6 +111,7 @@ class EnterpriseOfferUpdateViewTests(EnterpriseServiceMockMixin, ViewTestMixin, 
             'contract_discount_type': 'Absolute',
             'contract_discount_value': 200,
             'prepaid_invoice_amount': 2000,
+            'sales_force_id': '006abcde0123456789',
             'usage_email_frequency': ConditionalOffer.DAILY
         }
         response = self.client.post(self.path, data, follow=False)
@@ -131,7 +132,7 @@ class EnterpriseOfferCreateViewTests(EnterpriseServiceMockMixin, ViewTestMixin, 
         expected_discount_value = 2000
         expected_discount_type = 'Absolute'
         expected_prepaid_invoice_amount = 12345
-        sales_force_id = 'salesforceid123'
+        sales_force_id = '006abcde0123456789'
         data = {
             'enterprise_customer_uuid': expected_ec_uuid,
             'enterprise_customer_catalog_uuid': expected_ec_catalog_uuid,

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -32,6 +32,7 @@ from ecommerce.core.utils import log_message_and_raise_validation_error
 from ecommerce.coupons.utils import is_coupon_available
 from ecommerce.courses.models import Course
 from ecommerce.enterprise.benefits import BENEFIT_MAP as ENTERPRISE_BENEFIT_MAP
+from ecommerce.enterprise.constants import ENTERPRISE_SALES_FORCE_ID_REGEX
 from ecommerce.enterprise.utils import (
     get_enterprise_customer_reply_to_email,
     get_enterprise_customer_sender_alias,
@@ -1385,7 +1386,7 @@ class CouponSerializer(CouponMixin, ProductPaymentInfoMixin, serializers.ModelSe
         Validate sales_force_id format
         """
         sales_force_id = self.initial_data.get('sales_force_id')
-        if sales_force_id and not re.match(r'^006[a-zA-Z0-9]{15}$|^none$', sales_force_id):
+        if sales_force_id and not re.match(ENTERPRISE_SALES_FORCE_ID_REGEX, sales_force_id):
             raise ValidationError({
                 'sales_force_id': 'Salesforce Opportunity ID must be 18 alphanumeric characters and begin with 006.'
             })


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Description

Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?
Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
