### PR TITLE
feat: upgrade edx-ecommerce-worker to 3.1.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -207,7 +207,7 @@ edx-drf-extensions==6.6.0
     #   -c requirements/pins.txt
     #   -r requirements/base.in
     #   edx-rbac
-edx-ecommerce-worker==3.0.0
+edx-ecommerce-worker==3.1.0
     # via -r requirements/base.in
 edx-opaque-keys==2.2.2
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -290,7 +290,7 @@ edx-drf-extensions==6.6.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-edx-ecommerce-worker==3.0.0
+edx-ecommerce-worker==3.1.0
     # via -r requirements/test.txt
 edx-i18n-tools==0.8.1
     # via -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -212,7 +212,7 @@ edx-drf-extensions==6.6.0
     #   -c requirements/pins.txt
     #   -r requirements/base.in
     #   edx-rbac
-edx-ecommerce-worker==3.0.0
+edx-ecommerce-worker==3.1.0
     # via -r requirements/base.in
 edx-opaque-keys==2.2.2
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -289,7 +289,7 @@ edx-drf-extensions==6.6.0
     #   -c requirements/pins.txt
     #   -r requirements/base.txt
     #   edx-rbac
-edx-ecommerce-worker==3.0.0
+edx-ecommerce-worker==3.1.0
     # via -r requirements/base.txt
 edx-i18n-tools==0.8.1
     # via -r requirements/test.in


### PR DESCRIPTION
## Anyone merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Description

Now we'll include a Braze campaign ID for enterprise offer/code emails, to make
email metric-tracking easier.  Impacts only enterprise learners.

ticket: https://openedx.atlassian.net/browse/ENT-5285
ecomworker change: https://github.com/edx/ecommerce-worker/pull/153

## Testing instructions
* Get your local ecommerce, edx-platform/enterprise, and frontend-app-admin-portal running locally.
* Go to the coupon management page for some locally-configured coupon: http://localhost:1991/pied-piper/admin/coupons
* ...or, if no valid coupon exists, go to http://localhost:18130/enterprise/coupons/ to create or edit.
* Use the code "assign" and "remind" buttons in the admin-portal to send some code emails (this won't actually send an email).
* Tail the `ecommerce-logs` to watch for POST requests to e.g. `/api/v2/enterprise/coupons/7/remind/` and make sure they're successful.

