### PR TITLE
chore: bump seleniuim-webdriver

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "karma-selenium-webdriver-launcher": "0.0.4",
     "karma-sinon": "1.0.5",
     "karma-spec-reporter": "0.0.26",
-    "selenium-webdriver": "3.4.0",
+    "selenium-webdriver": "4.1.0",
     "sinon": "2.3.8"
   }
 }


### PR DESCRIPTION

[REV-2493](https://openedx.atlassian.net/browse/REV-2493): with our last updates to frontend-app-payment (using newer frontend-build), a test has started failing: test_verified_seat_payment_with_credit_card_payment_page. It looks like while the checkout page still loads fine in a web browser, it's not loading via selenium in this end to end test. 

Our primary suspect is a 'globalThis is not defined' error. Our selenium-webdriver version(3.4.0) is 5 years old, and globalThis was introduced around 2019, so this may be the issue. Updating this version to see if the e2e test passes. 
