### PR TITLE
chore: bump version for pylint pin

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -231,7 +231,7 @@ extras==1.0.0
     #   testtools
 factory-boy==2.12.0
     # via django-oscar
-faker==11.1.0
+faker==11.3.0
     # via factory-boy
 fixtures==3.0.0
     # via
@@ -420,7 +420,7 @@ rcssmin==1.1.0
     # via django-compressor
 redis==4.1.0
     # via edx-ecommerce-worker
-requests==2.27.0
+requests==2.27.1
     # via
     #   -r requirements/base.in
     #   analytics-python

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ analytics-python==1.4.0
     # via -r requirements/base.in
 asn1crypto==1.4.0
     # via cybersource-rest-client-python
-attrs==21.2.0
+attrs==21.4.0
     # via
     #   jsonschema
     #   zeep
@@ -28,9 +28,9 @@ billiard==3.6.4.0
     # via celery
 bleach==4.1.0
     # via -r requirements/base.in
-boto3==1.19.10
+boto3==1.20.28
     # via -r requirements/base.in
-botocore==1.22.10
+botocore==1.23.28
     # via
     #   boto3
     #   s3transfer
@@ -52,9 +52,9 @@ cffi==1.15.0
     #   pynacl
 chardet==4.0.0
     # via cybersource-rest-client-python
-charset-normalizer==2.0.7
+charset-normalizer==2.0.10
     # via requests
-configparser==5.1.0
+configparser==5.2.0
     # via cybersource-rest-client-python
 coreapi==2.3.3
     # via
@@ -63,7 +63,7 @@ coreapi==2.3.3
     #   openapi-codec
 coreschema==0.0.4
     # via coreapi
-coverage==6.1.1
+coverage==6.2
     # via cybersource-rest-client-python
 crypto==1.4.1
     # via cybersource-rest-client-python
@@ -89,7 +89,9 @@ defusedxml==0.7.1
     # via
     #   python3-openid
     #   social-auth-core
-django==2.2.24
+deprecated==1.2.13
+    # via redis
+django==2.2.26
     # via
     #   -r requirements/base.in
     #   django-appconf
@@ -103,6 +105,7 @@ django==2.2.24
     #   django-model-utils
     #   django-oscar
     #   django-phonenumber-field
+    #   django-solo
     #   django-tables2
     #   django-treebeard
     #   djangorestframework
@@ -118,13 +121,13 @@ django==2.2.24
     #   xss-utils
 django-appconf==1.0.5
     # via django-compressor
-django-compressor==2.4.1
+django-compressor==3.1
     # via
     #   -r requirements/base.in
     #   django-libsass
-django-config-models==2.2.0
+django-config-models==2.2.2
     # via -r requirements/base.in
-django-cors-headers==3.10.0
+django-cors-headers==3.10.1
     # via -r requirements/base.in
 django-crispy-forms==1.13.0
     # via -r requirements/base.in
@@ -132,7 +135,7 @@ django-crum==0.7.9
     # via
     #   edx-django-utils
     #   edx-rbac
-django-extensions==3.1.3
+django-extensions==3.1.5
     # via -r requirements/base.in
 django-extra-views==0.13.0
     # via django-oscar
@@ -154,7 +157,7 @@ django-rest-swagger==2.2.0
     # via -r requirements/base.in
 django-simple-history==3.0.0
     # via -r requirements/base.in
-django-solo==1.2.0
+django-solo==2.0.0
     # via -r requirements/base.in
 django-tables2==2.2.1
     # via django-oscar
@@ -169,7 +172,7 @@ django-waffle==2.2.1
     #   edx-drf-extensions
 django-widget-tweaks==1.4.9
     # via django-oscar
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via
     #   -r requirements/base.in
     #   django-config-models
@@ -182,7 +185,7 @@ djangorestframework==3.12.4
     #   rest-condition
 djangorestframework-csv==2.1.1
     # via -r requirements/base.in
-djangorestframework-datatables==0.6.0
+djangorestframework-datatables==0.7.0
     # via -r requirements/base.in
 drf-extensions==0.7.1
     # via -r requirements/base.in
@@ -196,7 +199,7 @@ edx-django-release-util==1.1.0
     # via -r requirements/base.in
 edx-django-sites-extensions==3.1.0
     # via -r requirements/base.in
-edx-django-utils==4.4.0
+edx-django-utils==4.4.1
     # via
     #   -r requirements/base.in
     #   django-config-models
@@ -215,7 +218,7 @@ edx-opaque-keys==2.2.2
     #   edx-drf-extensions
 edx-rbac==1.5.1
     # via -r requirements/base.in
-edx-rest-api-client==5.4.0
+edx-rest-api-client==5.4.1
     # via
     #   -r requirements/base.in
     #   edx-ecommerce-worker
@@ -228,7 +231,7 @@ extras==1.0.0
     #   testtools
 factory-boy==2.12.0
     # via django-oscar
-faker==9.8.0
+faker==11.1.0
     # via factory-boy
 fixtures==3.0.0
     # via
@@ -245,11 +248,11 @@ idna==2.7
     #   requests
 ipaddress==1.0.23
     # via cybersource-rest-client-python
-isodate==0.6.0
+isodate==0.6.1
     # via zeep
 itypes==1.2.0
     # via coreapi
-jinja2==3.0.2
+jinja2==3.0.3
     # via coreschema
 jmespath==0.10.0
     # via
@@ -275,7 +278,7 @@ linecache2==1.0.0
     #   traceback2
 logger==1.4
     # via cybersource-rest-client-python
-lxml==4.6.4
+lxml==4.7.1
     # via
     #   premailer
     #   zeep
@@ -293,7 +296,7 @@ naked==0.1.31
     #   cybersource-rest-client-python
 ndg-httpsclient==0.5.1
     # via -r requirements/base.in
-newrelic==7.2.2.169
+newrelic==7.2.4.171
     # via
     #   -r requirements/base.in
     #   edx-django-utils
@@ -305,29 +308,31 @@ oauthlib==3.1.1
     #   social-auth-core
 openapi-codec==1.3.2
     # via django-rest-swagger
-packaging==21.2
-    # via bleach
-paramiko==2.8.0
+packaging==21.3
+    # via
+    #   bleach
+    #   redis
+paramiko==2.9.1
     # via cybersource-rest-client-python
 path.py==7.2
     # via -r requirements/base.in
 paypalrestsdk==1.13.1
     # via -r requirements/base.in
-pbr==5.7.0
+pbr==5.8.0
     # via
     #   cybersource-rest-client-python
     #   fixtures
     #   stevedore
     #   testtools
-phonenumbers==8.12.36
+phonenumbers==8.12.40
     # via django-oscar
-pillow==8.4.0
+pillow==9.0.0
     # via django-oscar
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via zeep
 premailer==2.9.2
     # via -r requirements/base.in
-psutil==5.8.0
+psutil==5.9.0
     # via edx-django-utils
 purl==1.6
     # via django-oscar
@@ -339,17 +344,17 @@ pyasn1==0.4.8
     #   x509
 pycountry==17.1.8
     # via -r requirements/base.in
-pycparser==2.20
+pycparser==2.21
     # via
     #   cffi
     #   cybersource-rest-client-python
-pycryptodome==3.11.0
+pycryptodome==3.12.0
     # via cybersource-rest-client-python
-pycryptodomex==3.11.0
+pycryptodomex==3.12.0
     # via
     #   cybersource-rest-client-python
     #   pyjwkest
-pygments==2.10.0
+pygments==2.11.1
     # via -r requirements/base.in
 pyjwkest==1.4.2
     # via edx-drf-extensions
@@ -360,7 +365,7 @@ pyjwt[crypto]==1.7.1
     #   edx-auth-backends
     #   edx-rest-api-client
     #   social-auth-core
-pymongo==3.12.1
+pymongo==4.0.1
     # via edx-opaque-keys
 pynacl==1.4.0
     # via
@@ -371,7 +376,7 @@ pyopenssl==21.0.0
     #   cybersource-rest-client-python
     #   ndg-httpsclient
     #   paypalrestsdk
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 pypi==2.1
     # via cybersource-rest-client-python
@@ -403,17 +408,19 @@ pytz==2016.10
     #   cybersource-rest-client-python
     #   datetime
     #   django
+    #   djangorestframework
+    #   djangorestframework-datatables
     #   zeep
 pyyaml==6.0
     # via
     #   cybersource-rest-client-python
     #   edx-django-release-util
     #   naked
-rcssmin==1.0.6
+rcssmin==1.1.0
     # via django-compressor
-redis==3.5.3
+redis==4.1.0
     # via edx-ecommerce-worker
-requests==2.26.0
+requests==2.27.0
     # via
     #   -r requirements/base.in
     #   analytics-python
@@ -439,11 +446,11 @@ requests-toolbelt==0.9.1
     # via zeep
 rest-condition==1.0.3
     # via edx-drf-extensions
-rjsmin==1.1.0
+rjsmin==1.2.0
     # via django-compressor
-rsa==4.7.2
+rsa==4.8
     # via cybersource-rest-client-python
-rules==3.0
+rules==3.1
     # via -r requirements/base.in
 s3transfer==0.5.0
     # via boto3
@@ -453,7 +460,7 @@ shellescape==3.8.1
     # via
     #   crypto
     #   cybersource-rest-client-python
-simplejson==3.17.5
+simplejson==3.17.6
     # via django-rest-swagger
 six==1.16.0
     # via
@@ -461,7 +468,6 @@ six==1.16.0
     #   bcrypt
     #   bleach
     #   cybersource-rest-client-python
-    #   django-compressor
     #   django-extra-views
     #   djangorestframework-csv
     #   edx-auth-backends
@@ -533,8 +539,10 @@ vine==1.3.0
     #   celery
 webencodings==0.5.1
     # via bleach
-wheel==0.37.0
+wheel==0.37.1
     # via cybersource-rest-client-python
+wrapt==1.13.3
+    # via deprecated
 x509==0.1
     # via cybersource-rest-client-python
 xss-utils==0.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,11 +18,11 @@ asn1crypto==1.4.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-astroid==2.3.3
+astroid==2.9.2
     # via
     #   -r requirements/test.txt
     #   pylint
-attrs==21.2.0
+attrs==21.4.0
     # via
     #   -r requirements/test.txt
     #   jsonschema
@@ -56,9 +56,9 @@ bleach==4.1.0
     # via -r requirements/test.txt
 bok-choy==1.1.1
     # via -r requirements/test.txt
-boto3==1.19.10
+boto3==1.20.28
     # via -r requirements/test.txt
-botocore==1.22.10
+botocore==1.23.28
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -89,12 +89,12 @@ chardet==4.0.0
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
     #   diff-cover
-charset-normalizer==2.0.7
+charset-normalizer==2.0.10
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   requests
-configparser==5.1.0
+configparser==5.2.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -107,7 +107,7 @@ coreschema==0.0.4
     # via
     #   -r requirements/test.txt
     #   coreapi
-coverage[toml]==6.1.1
+coverage[toml]==6.2
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -145,9 +145,13 @@ defusedxml==0.7.1
     #   -r requirements/test.txt
     #   python3-openid
     #   social-auth-core
-diff-cover==6.4.2
+deprecated==1.2.13
+    # via
+    #   -r requirements/test.txt
+    #   redis
+diff-cover==6.4.4
     # via -r requirements/test.txt
-django==2.2.24
+django==2.2.26
     # via
     #   -r requirements/test.txt
     #   django-appconf
@@ -162,6 +166,7 @@ django==2.2.24
     #   django-model-utils
     #   django-oscar
     #   django-phonenumber-field
+    #   django-solo
     #   django-tables2
     #   django-treebeard
     #   djangorestframework
@@ -181,13 +186,13 @@ django-appconf==1.0.5
     # via
     #   -r requirements/test.txt
     #   django-compressor
-django-compressor==2.4.1
+django-compressor==3.1
     # via
     #   -r requirements/test.txt
     #   django-libsass
-django-config-models==2.2.0
+django-config-models==2.2.2
     # via -r requirements/test.txt
-django-cors-headers==3.10.0
+django-cors-headers==3.10.1
     # via -r requirements/test.txt
 django-crispy-forms==1.13.0
     # via -r requirements/test.txt
@@ -196,9 +201,9 @@ django-crum==0.7.9
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-rbac
-django-debug-toolbar==3.2.2
+django-debug-toolbar==3.2.4
     # via -r requirements/dev.in
-django-extensions==3.1.3
+django-extensions==3.1.5
     # via -r requirements/test.txt
 django-extra-views==0.13.0
     # via
@@ -226,7 +231,7 @@ django-rest-swagger==2.2.0
     # via -r requirements/test.txt
 django-simple-history==3.0.0
     # via -r requirements/test.txt
-django-solo==1.2.0
+django-solo==2.0.0
     # via -r requirements/test.txt
 django-tables2==2.2.1
     # via
@@ -243,13 +248,13 @@ django-waffle==2.2.1
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-drf-extensions
-django-webtest==1.9.8
+django-webtest==1.9.9
     # via -r requirements/test.txt
 django-widget-tweaks==1.4.9
     # via
     #   -r requirements/test.txt
     #   django-oscar
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via
     #   -r requirements/test.txt
     #   django-config-models
@@ -262,7 +267,7 @@ djangorestframework==3.12.4
     #   rest-condition
 djangorestframework-csv==2.1.1
     # via -r requirements/test.txt
-djangorestframework-datatables==0.6.0
+djangorestframework-datatables==0.7.0
     # via -r requirements/test.txt
 docutils==0.17.1
     # via
@@ -280,7 +285,7 @@ edx-django-release-util==1.1.0
     # via -r requirements/test.txt
 edx-django-sites-extensions==3.1.0
     # via -r requirements/test.txt
-edx-django-utils==4.4.0
+edx-django-utils==4.4.1
     # via
     #   -r requirements/test.txt
     #   django-config-models
@@ -300,7 +305,7 @@ edx-opaque-keys==2.2.2
     #   edx-drf-extensions
 edx-rbac==1.5.1
     # via -r requirements/test.txt
-edx-rest-api-client==5.4.0
+edx-rest-api-client==5.4.1
     # via
     #   -r requirements/test.txt
     #   edx-ecommerce-worker
@@ -320,11 +325,11 @@ factory-boy==2.12.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
-faker==9.8.0
+faker==11.1.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.3.2
+filelock==3.4.2
     # via
     #   -r requirements/test.txt
     #   tox
@@ -355,18 +360,14 @@ idna==2.7
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
     #   requests
-imagesize==1.2.0
+imagesize==1.3.0
     # via
     #   -r requirements/docs.txt
     #   sphinx
-importlib-metadata==4.8.1
+importlib-metadata==4.10.0
     # via
     #   -r requirements/test.txt
     #   pytest-randomly
-inflect==5.3.0
-    # via
-    #   -r requirements/test.txt
-    #   jinja2-pluralize
 iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
@@ -375,11 +376,11 @@ ipaddress==1.0.23
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-isodate==0.6.0
+isodate==0.6.1
     # via
     #   -r requirements/test.txt
     #   zeep
-isort==4.3.21
+isort==5.10.1
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -387,18 +388,13 @@ itypes==1.2.0
     # via
     #   -r requirements/test.txt
     #   coreapi
-jinja2==3.0.2
+jinja2==3.0.3
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   coreschema
     #   diff-cover
-    #   jinja2-pluralize
     #   sphinx
-jinja2-pluralize==0.3.0
-    # via
-    #   -r requirements/test.txt
-    #   diff-cover
 jmespath==0.10.0
     # via
     #   -r requirements/test.txt
@@ -418,7 +414,7 @@ lazy==1.4
     # via
     #   -r requirements/test.txt
     #   bok-choy
-lazy-object-proxy==1.4.3
+lazy-object-proxy==1.7.1
     # via
     #   -r requirements/test.txt
     #   astroid
@@ -435,7 +431,7 @@ logger==1.4
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-lxml==4.6.4
+lxml==4.7.1
     # via
     #   -r requirements/test.txt
     #   premailer
@@ -470,7 +466,7 @@ naked==0.1.31
     #   cybersource-rest-client-python
 ndg-httpsclient==0.5.1
     # via -r requirements/test.txt
-newrelic==7.2.2.169
+newrelic==7.2.4.171
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -487,15 +483,16 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
-packaging==21.2
+packaging==21.3
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   bleach
     #   pytest
+    #   redis
     #   sphinx
     #   tox
-paramiko==2.8.0
+paramiko==2.9.1
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -507,24 +504,25 @@ path.py==7.2
     # via -r requirements/test.txt
 paypalrestsdk==1.13.1
     # via -r requirements/test.txt
-pbr==5.7.0
+pbr==5.8.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
     #   fixtures
     #   stevedore
     #   testtools
-phonenumbers==8.12.36
+phonenumbers==8.12.40
     # via
     #   -r requirements/test.txt
     #   django-oscar
-pillow==8.4.0
+pillow==9.0.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via
     #   -r requirements/test.txt
+    #   pylint
     #   zeep
 pluggy==0.13.1
     # via
@@ -538,7 +536,7 @@ polib==1.1.1
     #   edx-i18n-tools
 premailer==2.9.2
     # via -r requirements/test.txt
-psutil==5.8.0
+psutil==5.9.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -548,7 +546,7 @@ purl==1.6
     # via
     #   -r requirements/test.txt
     #   django-oscar
-py==1.10.0
+py==1.11.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -564,21 +562,21 @@ pycodestyle==2.8.0
     # via -r requirements/test.txt
 pycountry==17.1.8
     # via -r requirements/test.txt
-pycparser==2.20
+pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
     #   cybersource-rest-client-python
-pycryptodome==3.11.0
+pycryptodome==3.12.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-pycryptodomex==3.11.0
+pycryptodomex==3.12.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
     #   pyjwkest
-pygments==2.10.0
+pygments==2.11.1
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -596,9 +594,9 @@ pyjwt[crypto]==1.7.1
     #   edx-auth-backends
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.4.4
+pylint==2.12.2
     # via -r requirements/test.txt
-pymongo==3.12.1
+pymongo==4.0.1
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -613,7 +611,7 @@ pyopenssl==21.0.0
     #   cybersource-rest-client-python
     #   ndg-httpsclient
     #   paypalrestsdk
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -644,7 +642,7 @@ pytest-base-url==1.4.2
     #   pytest-selenium
 pytest-cov==3.0.0
     # via -r requirements/test.txt
-pytest-django==4.4.0
+pytest-django==4.5.2
     # via -r requirements/test.txt
 pytest-html==3.1.1
     # via
@@ -654,11 +652,11 @@ pytest-metadata==1.11.0
     # via
     #   -r requirements/test.txt
     #   pytest-html
-pytest-randomly==3.10.1
+pytest-randomly==3.10.3
     # via -r requirements/test.txt
 pytest-selenium==2.0.1
     # via -r requirements/test.txt
-pytest-timeout==2.0.1
+pytest-timeout==2.0.2
     # via -r requirements/test.txt
 pytest-variables==1.9.0
     # via
@@ -672,7 +670,7 @@ python-dateutil==2.8.2
     #   edx-drf-extensions
     #   faker
     #   freezegun
-python-dotenv==0.19.1
+python-dotenv==0.19.2
     # via -r requirements/test.txt
 python-memcached==1.58
     # via -r requirements/test.txt
@@ -703,6 +701,8 @@ pytz==2016.10
     #   cybersource-rest-client-python
     #   datetime
     #   django
+    #   djangorestframework
+    #   djangorestframework-datatables
     #   zeep
 pywatchman==1.4.1
     # via -r requirements/dev.in
@@ -713,15 +713,15 @@ pyyaml==6.0
     #   edx-django-release-util
     #   edx-i18n-tools
     #   naked
-rcssmin==1.0.6
+rcssmin==1.1.0
     # via
     #   -r requirements/test.txt
     #   django-compressor
-redis==3.5.3
+redis==4.1.0
     # via
     #   -r requirements/test.txt
     #   edx-ecommerce-worker
-requests==2.26.0
+requests==2.27.0
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -757,21 +757,21 @@ requests-toolbelt==0.9.1
     # via
     #   -r requirements/test.txt
     #   zeep
-responses==0.15.0
+responses==0.16.0
     # via -r requirements/test.txt
 rest-condition==1.0.3
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-rjsmin==1.1.0
+rjsmin==1.2.0
     # via
     #   -r requirements/test.txt
     #   django-compressor
-rsa==4.7.2
+rsa==4.8
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-rules==3.0
+rules==3.1
     # via -r requirements/test.txt
 s3transfer==0.5.0
     # via
@@ -791,7 +791,7 @@ shellescape==3.8.1
     #   -r requirements/test.txt
     #   crypto
     #   cybersource-rest-client-python
-simplejson==3.17.5
+simplejson==3.17.6
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
@@ -800,12 +800,10 @@ six==1.16.0
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   analytics-python
-    #   astroid
     #   bcrypt
     #   bleach
     #   bok-choy
     #   cybersource-rest-client-python
-    #   django-compressor
     #   django-extra-views
     #   djangorestframework-csv
     #   edx-auth-backends
@@ -839,7 +837,7 @@ slumber==0.7.1
     #   edx-rest-api-client
 smmap==5.0.0
     # via gitdb
-snowballstemmer==2.1.0
+snowballstemmer==2.2.0
     # via
     #   -r requirements/docs.txt
     #   sphinx
@@ -854,11 +852,11 @@ social-auth-core==4.0.2
     #   social-auth-app-django
 sorl-thumbnail==12.7.0
     # via -r requirements/test.txt
-soupsieve==2.3
+soupsieve==2.3.1
     # via
     #   -r requirements/test.txt
     #   beautifulsoup4
-sphinx==4.2.0
+sphinx==4.3.2
     # via
     #   -r requirements/docs.txt
     #   edx-sphinx-theme
@@ -918,9 +916,10 @@ text-unidecode==1.3
 toml==0.10.2
     # via
     #   -r requirements/test.txt
+    #   pylint
     #   pytest
     #   tox
-tomli==1.2.2
+tomli==2.0.0
     # via
     #   -r requirements/test.txt
     #   coverage
@@ -934,14 +933,18 @@ traceback2==1.4.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-transifex-client==0.14.3
+transifex-client==0.14.4
     # via -r requirements/dev.in
 typing==3.7.4.3
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-typing-extensions==3.10.0.2
-    # via gitpython
+typing-extensions==4.0.1
+    # via
+    #   -r requirements/test.txt
+    #   astroid
+    #   gitpython
+    #   pylint
 unicodecsv==0.14.1
     # via
     #   -r requirements/test.txt
@@ -985,14 +988,15 @@ webtest==3.0.0
     # via
     #   -r requirements/test.txt
     #   django-webtest
-wheel==0.37.0
+wheel==0.37.1
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-wrapt==1.11.2
+wrapt==1.13.3
     # via
     #   -r requirements/test.txt
     #   astroid
+    #   deprecated
 x509==0.1
     # via
     #   -r requirements/test.txt
@@ -1001,7 +1005,7 @@ xss-utils==0.3.0
     # via -r requirements/test.txt
 zeep==4.1.0
     # via -r requirements/test.txt
-zipp==3.6.0
+zipp==3.7.0
     # via
     #   -r requirements/test.txt
     #   importlib-metadata

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,7 +18,7 @@ asn1crypto==1.4.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-astroid==2.9.2
+astroid==2.8.6
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -325,7 +325,7 @@ factory-boy==2.12.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
-faker==11.1.0
+faker==11.3.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -594,7 +594,7 @@ pyjwt[crypto]==1.7.1
     #   edx-auth-backends
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.12.2
+pylint==2.11.0
     # via -r requirements/test.txt
 pymongo==4.0.1
     # via
@@ -721,7 +721,7 @@ redis==4.1.0
     # via
     #   -r requirements/test.txt
     #   edx-ecommerce-worker
-requests==2.27.0
+requests==2.27.1
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -10,7 +10,7 @@ babel==2.9.1
     # via sphinx
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.7
+charset-normalizer==2.0.10
     # via requests
 docutils==0.17.1
     # via sphinx
@@ -20,29 +20,29 @@ idna==2.7
     # via
     #   -c requirements/pins.txt
     #   requests
-imagesize==1.2.0
+imagesize==1.3.0
     # via sphinx
-jinja2==3.0.2
+jinja2==3.0.3
     # via sphinx
 markupsafe==2.0.1
     # via jinja2
-packaging==21.2
+packaging==21.3
     # via sphinx
-pygments==2.10.0
+pygments==2.11.1
     # via sphinx
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 pytz==2016.10
     # via
     #   -c requirements/pins.txt
     #   babel
-requests==2.26.0
+requests==2.27.0
     # via sphinx
 six==1.16.0
     # via edx-sphinx-theme
-snowballstemmer==2.1.0
+snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.2.0
+sphinx==4.3.2
     # via
     #   -r requirements/docs.in
     #   edx-sphinx-theme

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -36,7 +36,7 @@ pytz==2016.10
     # via
     #   -c requirements/pins.txt
     #   babel
-requests==2.27.0
+requests==2.27.1
     # via sphinx
 six==1.16.0
     # via edx-sphinx-theme

--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -120,7 +120,7 @@ pytz==2016.10
     #   -c requirements/base.txt
     #   -c requirements/pins.txt
     #   django
-requests==2.27.0
+requests==2.27.1
     # via
     #   -c requirements/base.txt
     #   edx-rest-api-client

--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-attrs==21.2.0
+attrs==21.4.0
     # via
     #   -c requirements/base.txt
     #   pytest
@@ -16,7 +16,7 @@ cffi==1.15.0
     # via
     #   -c requirements/base.txt
     #   cryptography
-charset-normalizer==2.0.7
+charset-normalizer==2.0.10
     # via
     #   -c requirements/base.txt
     #   requests
@@ -25,7 +25,7 @@ cryptography==3.4.8
     #   -c requirements/base.txt
     #   -c requirements/pins.txt
     #   pyjwt
-django==2.2.24
+django==2.2.26
     # via
     #   -c requirements/base.txt
     #   django-crum
@@ -38,11 +38,11 @@ django-waffle==2.2.1
     # via
     #   -c requirements/base.txt
     #   edx-django-utils
-edx-django-utils==4.4.0
+edx-django-utils==4.4.1
     # via
     #   -c requirements/base.txt
     #   edx-rest-api-client
-edx-rest-api-client==5.4.0
+edx-rest-api-client==5.4.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/e2e.in
@@ -51,19 +51,19 @@ idna==2.7
     #   -c requirements/base.txt
     #   -c requirements/pins.txt
     #   requests
-importlib-metadata==4.8.1
+importlib-metadata==4.10.0
     # via pytest-randomly
 iniconfig==1.1.1
     # via pytest
-newrelic==7.2.2.169
+newrelic==7.2.4.171
     # via
     #   -c requirements/base.txt
     #   edx-django-utils
-packaging==21.2
+packaging==21.3
     # via
     #   -c requirements/base.txt
     #   pytest
-pbr==5.7.0
+pbr==5.8.0
     # via
     #   -c requirements/base.txt
     #   stevedore
@@ -71,13 +71,13 @@ pluggy==0.13.1
     # via
     #   -c requirements/pins.txt
     #   pytest
-psutil==5.8.0
+psutil==5.9.0
     # via
     #   -c requirements/base.txt
     #   edx-django-utils
-py==1.10.0
+py==1.11.0
     # via pytest
-pycparser==2.20
+pycparser==2.21
     # via
     #   -c requirements/base.txt
     #   cffi
@@ -85,7 +85,7 @@ pyjwt[crypto]==1.7.1
     # via
     #   -c requirements/base.txt
     #   edx-rest-api-client
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via
     #   -c requirements/base.txt
     #   packaging
@@ -105,22 +105,22 @@ pytest-html==3.1.1
     # via pytest-selenium
 pytest-metadata==1.11.0
     # via pytest-html
-pytest-randomly==3.10.1
+pytest-randomly==3.10.3
     # via -r requirements/e2e.in
 pytest-selenium==2.0.1
     # via -r requirements/e2e.in
-pytest-timeout==2.0.1
+pytest-timeout==2.0.2
     # via -r requirements/e2e.in
 pytest-variables==1.9.0
     # via pytest-selenium
-python-dotenv==0.19.1
+python-dotenv==0.19.2
     # via -r requirements/e2e.in
 pytz==2016.10
     # via
     #   -c requirements/base.txt
     #   -c requirements/pins.txt
     #   django
-requests==2.26.0
+requests==2.27.0
     # via
     #   -c requirements/base.txt
     #   edx-rest-api-client
@@ -158,5 +158,5 @@ urllib3==1.26.7
     #   -c requirements/pins.txt
     #   requests
     #   selenium
-zipp==3.6.0
+zipp==3.7.0
     # via importlib-metadata

--- a/requirements/pins.txt
+++ b/requirements/pins.txt
@@ -32,7 +32,7 @@ virtualenv==16.7.9
 # newer version seems to be causing failures
 # if tox -e py35-django22-pylint passes after
 # removing this pin, then this pin can be removed.
-pylint==2.4.4
+pylint==2.12.2  #  @TODO: trying higher version pin (original was 2.4.4)
 
 # greater versions failing with extract-translations step.
 tox==3.14.6

--- a/requirements/pins.txt
+++ b/requirements/pins.txt
@@ -32,7 +32,7 @@ virtualenv==16.7.9
 # newer version seems to be causing failures
 # if tox -e py35-django22-pylint passes after
 # removing this pin, then this pin can be removed.
-pylint==2.12.2  #  @TODO: trying higher version pin (original was 2.4.4)
+pylint==2.11.0  #  @TODO: trying higher version pin (originally pinned at 2.4.4)
 
 # greater versions failing with extract-translations step.
 tox==3.14.6

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -10,9 +10,9 @@ pep517==0.12.0
     # via pip-tools
 pip-tools==6.4.0
     # via -r requirements/pip_tools.in
-tomli==1.2.2
+tomli==2.0.0
     # via pep517
-wheel==0.37.0
+wheel==0.37.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -236,7 +236,7 @@ extras==1.0.0
     #   testtools
 factory-boy==2.12.0
     # via django-oscar
-faker==11.1.0
+faker==11.3.0
     # via factory-boy
 fixtures==3.0.0
     # via
@@ -438,7 +438,7 @@ redis==4.1.0
     # via
     #   -r requirements/production.in
     #   edx-ecommerce-worker
-requests==2.27.0
+requests==2.27.1
     # via
     #   -r requirements/base.in
     #   analytics-python

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -10,7 +10,7 @@ analytics-python==1.4.0
     # via -r requirements/base.in
 asn1crypto==1.4.0
     # via cybersource-rest-client-python
-attrs==21.2.0
+attrs==21.4.0
     # via
     #   jsonschema
     #   zeep
@@ -28,11 +28,11 @@ billiard==3.6.4.0
     # via celery
 bleach==4.1.0
     # via -r requirements/base.in
-boto3==1.19.10
+boto3==1.20.28
     # via
     #   -r requirements/base.in
     #   django-ses
-botocore==1.22.10
+botocore==1.23.28
     # via
     #   boto3
     #   s3transfer
@@ -54,9 +54,9 @@ cffi==1.15.0
     #   pynacl
 chardet==4.0.0
     # via cybersource-rest-client-python
-charset-normalizer==2.0.7
+charset-normalizer==2.0.10
     # via requests
-configparser==5.1.0
+configparser==5.2.0
     # via cybersource-rest-client-python
 coreapi==2.3.3
     # via
@@ -65,7 +65,7 @@ coreapi==2.3.3
     #   openapi-codec
 coreschema==0.0.4
     # via coreapi
-coverage==6.1.1
+coverage==6.2
     # via cybersource-rest-client-python
 crypto==1.4.1
     # via cybersource-rest-client-python
@@ -91,7 +91,9 @@ defusedxml==0.7.1
     # via
     #   python3-openid
     #   social-auth-core
-django==2.2.24
+deprecated==1.2.13
+    # via redis
+django==2.2.26
     # via
     #   -r requirements/base.in
     #   django-appconf
@@ -106,6 +108,7 @@ django==2.2.24
     #   django-oscar
     #   django-phonenumber-field
     #   django-ses
+    #   django-solo
     #   django-tables2
     #   django-treebeard
     #   djangorestframework
@@ -121,13 +124,13 @@ django==2.2.24
     #   xss-utils
 django-appconf==1.0.5
     # via django-compressor
-django-compressor==2.4.1
+django-compressor==3.1
     # via
     #   -r requirements/base.in
     #   django-libsass
-django-config-models==2.2.0
+django-config-models==2.2.2
     # via -r requirements/base.in
-django-cors-headers==3.10.0
+django-cors-headers==3.10.1
     # via -r requirements/base.in
 django-crispy-forms==1.13.0
     # via -r requirements/base.in
@@ -135,7 +138,7 @@ django-crum==0.7.9
     # via
     #   edx-django-utils
     #   edx-rbac
-django-extensions==3.1.3
+django-extensions==3.1.5
     # via -r requirements/base.in
 django-extra-views==0.13.0
     # via django-oscar
@@ -155,11 +158,11 @@ django-phonenumber-field==3.0.1
     # via django-oscar
 django-rest-swagger==2.2.0
     # via -r requirements/base.in
-django-ses==2.3.0
+django-ses==2.3.1
     # via -r requirements/production.in
 django-simple-history==3.0.0
     # via -r requirements/base.in
-django-solo==1.2.0
+django-solo==2.0.0
     # via -r requirements/base.in
 django-tables2==2.2.1
     # via django-oscar
@@ -174,7 +177,7 @@ django-waffle==2.2.1
     #   edx-drf-extensions
 django-widget-tweaks==1.4.9
     # via django-oscar
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via
     #   -r requirements/base.in
     #   django-config-models
@@ -187,7 +190,7 @@ djangorestframework==3.12.4
     #   rest-condition
 djangorestframework-csv==2.1.1
     # via -r requirements/base.in
-djangorestframework-datatables==0.6.0
+djangorestframework-datatables==0.7.0
     # via -r requirements/base.in
 drf-extensions==0.7.1
     # via -r requirements/base.in
@@ -201,7 +204,7 @@ edx-django-release-util==1.1.0
     # via -r requirements/base.in
 edx-django-sites-extensions==3.1.0
     # via -r requirements/base.in
-edx-django-utils==4.4.0
+edx-django-utils==4.4.1
     # via
     #   -r requirements/base.in
     #   django-config-models
@@ -220,7 +223,7 @@ edx-opaque-keys==2.2.2
     #   edx-drf-extensions
 edx-rbac==1.5.1
     # via -r requirements/base.in
-edx-rest-api-client==5.4.0
+edx-rest-api-client==5.4.1
     # via
     #   -r requirements/base.in
     #   edx-ecommerce-worker
@@ -233,7 +236,7 @@ extras==1.0.0
     #   testtools
 factory-boy==2.12.0
     # via django-oscar
-faker==9.8.0
+faker==11.1.0
     # via factory-boy
 fixtures==3.0.0
     # via
@@ -254,11 +257,11 @@ idna==2.7
     #   requests
 ipaddress==1.0.23
     # via cybersource-rest-client-python
-isodate==0.6.0
+isodate==0.6.1
     # via zeep
 itypes==1.2.0
     # via coreapi
-jinja2==3.0.2
+jinja2==3.0.3
     # via coreschema
 jmespath==0.10.0
     # via
@@ -284,7 +287,7 @@ linecache2==1.0.0
     #   traceback2
 logger==1.4
     # via cybersource-rest-client-python
-lxml==4.6.4
+lxml==4.7.1
     # via
     #   premailer
     #   zeep
@@ -317,29 +320,31 @@ oauthlib==3.1.1
     #   social-auth-core
 openapi-codec==1.3.2
     # via django-rest-swagger
-packaging==21.2
-    # via bleach
-paramiko==2.8.0
+packaging==21.3
+    # via
+    #   bleach
+    #   redis
+paramiko==2.9.1
     # via cybersource-rest-client-python
 path.py==7.2
     # via -r requirements/base.in
 paypalrestsdk==1.13.1
     # via -r requirements/base.in
-pbr==5.7.0
+pbr==5.8.0
     # via
     #   cybersource-rest-client-python
     #   fixtures
     #   stevedore
     #   testtools
-phonenumbers==8.12.36
+phonenumbers==8.12.40
     # via django-oscar
-pillow==8.4.0
+pillow==9.0.0
     # via django-oscar
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via zeep
 premailer==2.9.2
     # via -r requirements/base.in
-psutil==5.8.0
+psutil==5.9.0
     # via edx-django-utils
 purl==1.6
     # via django-oscar
@@ -351,17 +356,17 @@ pyasn1==0.4.8
     #   x509
 pycountry==17.1.8
     # via -r requirements/base.in
-pycparser==2.20
+pycparser==2.21
     # via
     #   cffi
     #   cybersource-rest-client-python
-pycryptodome==3.11.0
+pycryptodome==3.12.0
     # via cybersource-rest-client-python
-pycryptodomex==3.11.0
+pycryptodomex==3.12.0
     # via
     #   cybersource-rest-client-python
     #   pyjwkest
-pygments==2.10.0
+pygments==2.11.1
     # via -r requirements/base.in
 pyjwkest==1.4.2
     # via edx-drf-extensions
@@ -372,7 +377,7 @@ pyjwt[crypto]==1.7.1
     #   edx-auth-backends
     #   edx-rest-api-client
     #   social-auth-core
-pymongo==3.12.1
+pymongo==4.0.1
     # via edx-opaque-keys
 pynacl==1.4.0
     # via
@@ -383,7 +388,7 @@ pyopenssl==21.0.0
     #   cybersource-rest-client-python
     #   ndg-httpsclient
     #   paypalrestsdk
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 pypi==2.1
     # via cybersource-rest-client-python
@@ -418,6 +423,8 @@ pytz==2016.10
     #   datetime
     #   django
     #   django-ses
+    #   djangorestframework
+    #   djangorestframework-datatables
     #   zeep
 pyyaml==6.0
     # via
@@ -425,13 +432,13 @@ pyyaml==6.0
     #   cybersource-rest-client-python
     #   edx-django-release-util
     #   naked
-rcssmin==1.0.6
+rcssmin==1.1.0
     # via django-compressor
-redis==3.5.3
+redis==4.1.0
     # via
     #   -r requirements/production.in
     #   edx-ecommerce-worker
-requests==2.26.0
+requests==2.27.0
     # via
     #   -r requirements/base.in
     #   analytics-python
@@ -457,11 +464,11 @@ requests-toolbelt==0.9.1
     # via zeep
 rest-condition==1.0.3
     # via edx-drf-extensions
-rjsmin==1.1.0
+rjsmin==1.2.0
     # via django-compressor
-rsa==4.7.2
+rsa==4.8
     # via cybersource-rest-client-python
-rules==3.0
+rules==3.1
     # via -r requirements/base.in
 s3transfer==0.5.0
     # via boto3
@@ -471,7 +478,7 @@ shellescape==3.8.1
     # via
     #   crypto
     #   cybersource-rest-client-python
-simplejson==3.17.5
+simplejson==3.17.6
     # via django-rest-swagger
 six==1.16.0
     # via
@@ -479,7 +486,6 @@ six==1.16.0
     #   bcrypt
     #   bleach
     #   cybersource-rest-client-python
-    #   django-compressor
     #   django-extra-views
     #   djangorestframework-csv
     #   edx-auth-backends
@@ -552,8 +558,10 @@ vine==1.3.0
     #   celery
 webencodings==0.5.1
     # via bleach
-wheel==0.37.0
+wheel==0.37.1
     # via cybersource-rest-client-python
+wrapt==1.13.3
+    # via deprecated
 x509==0.1
     # via cybersource-rest-client-python
 xss-utils==0.3.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,9 +14,9 @@ asn1crypto==1.4.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-astroid==2.3.3
+astroid==2.9.2
     # via pylint
-attrs==21.2.0
+attrs==21.4.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -47,9 +47,9 @@ bleach==4.1.0
     # via -r requirements/base.txt
 bok-choy==1.1.1
     # via -r requirements/test.in
-boto3==1.19.10
+boto3==1.20.28
     # via -r requirements/base.txt
-botocore==1.22.10
+botocore==1.23.28
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -82,12 +82,12 @@ chardet==4.0.0
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
     #   diff-cover
-charset-normalizer==2.0.7
+charset-normalizer==2.0.10
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
     #   requests
-configparser==5.1.0
+configparser==5.2.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
@@ -100,7 +100,7 @@ coreschema==0.0.4
     # via
     #   -r requirements/base.txt
     #   coreapi
-coverage[toml]==6.1.1
+coverage[toml]==6.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
@@ -143,7 +143,11 @@ defusedxml==0.7.1
     #   -r requirements/base.txt
     #   python3-openid
     #   social-auth-core
-diff-cover==6.4.2
+deprecated==1.2.13
+    # via
+    #   -r requirements/base.txt
+    #   redis
+diff-cover==6.4.4
     # via -r requirements/test.in
     # via
     #   -r requirements/base.txt
@@ -159,6 +163,7 @@ diff-cover==6.4.2
     #   django-model-utils
     #   django-oscar
     #   django-phonenumber-field
+    #   django-solo
     #   django-tables2
     #   django-treebeard
     #   djangorestframework
@@ -178,13 +183,13 @@ django-appconf==1.0.5
     # via
     #   -r requirements/base.txt
     #   django-compressor
-django-compressor==2.4.1
+django-compressor==3.1
     # via
     #   -r requirements/base.txt
     #   django-libsass
-django-config-models==2.2.0
+django-config-models==2.2.2
     # via -r requirements/base.txt
-django-cors-headers==3.10.0
+django-cors-headers==3.10.1
     # via -r requirements/base.txt
 django-crispy-forms==1.13.0
     # via -r requirements/base.txt
@@ -194,7 +199,7 @@ django-crum==0.7.9
     #   -r requirements/e2e.txt
     #   edx-django-utils
     #   edx-rbac
-django-extensions==3.1.3
+django-extensions==3.1.5
     # via -r requirements/base.txt
 django-extra-views==0.13.0
     # via
@@ -224,7 +229,7 @@ django-rest-swagger==2.2.0
     # via -r requirements/base.txt
 django-simple-history==3.0.0
     # via -r requirements/base.txt
-django-solo==1.2.0
+django-solo==2.0.0
     # via -r requirements/base.txt
 django-tables2==2.2.1
     # via
@@ -242,13 +247,13 @@ django-waffle==2.2.1
     #   -r requirements/e2e.txt
     #   edx-django-utils
     #   edx-drf-extensions
-django-webtest==1.9.8
+django-webtest==1.9.9
     # via -r requirements/test.in
 django-widget-tweaks==1.4.9
     # via
     #   -r requirements/base.txt
     #   django-oscar
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via
     #   -r requirements/base.txt
     #   django-config-models
@@ -261,7 +266,7 @@ djangorestframework==3.12.4
     #   rest-condition
 djangorestframework-csv==2.1.1
     # via -r requirements/base.txt
-djangorestframework-datatables==0.6.0
+djangorestframework-datatables==0.7.0
     # via -r requirements/base.txt
 drf-extensions==0.7.1
     # via -r requirements/base.txt
@@ -277,7 +282,7 @@ edx-django-release-util==1.1.0
     # via -r requirements/base.txt
 edx-django-sites-extensions==3.1.0
     # via -r requirements/base.txt
-edx-django-utils==4.4.0
+edx-django-utils==4.4.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -299,7 +304,7 @@ edx-opaque-keys==2.2.2
     #   edx-drf-extensions
 edx-rbac==1.5.1
     # via -r requirements/base.txt
-edx-rest-api-client==5.4.0
+edx-rest-api-client==5.4.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -319,11 +324,11 @@ factory-boy==2.12.0
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   django-oscar
-faker==9.8.0
+faker==11.1.0
     # via
     #   -r requirements/base.txt
     #   factory-boy
-filelock==3.3.2
+filelock==3.4.2
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -353,12 +358,10 @@ idna==2.7
     #   -r requirements/e2e.txt
     #   cybersource-rest-client-python
     #   requests
-importlib-metadata==4.8.1
+importlib-metadata==4.10.0
     # via
     #   -r requirements/e2e.txt
     #   pytest-randomly
-inflect==5.3.0
-    # via jinja2-pluralize
 iniconfig==1.1.1
     # via
     #   -r requirements/e2e.txt
@@ -367,11 +370,11 @@ ipaddress==1.0.23
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-isodate==0.6.0
+isodate==0.6.1
     # via
     #   -r requirements/base.txt
     #   zeep
-isort==4.3.21
+isort==5.10.1
     # via
     #   -r requirements/test.in
     #   pylint
@@ -379,14 +382,11 @@ itypes==1.2.0
     # via
     #   -r requirements/base.txt
     #   coreapi
-jinja2==3.0.2
+jinja2==3.0.3
     # via
     #   -r requirements/base.txt
     #   coreschema
     #   diff-cover
-    #   jinja2-pluralize
-jinja2-pluralize==0.3.0
-    # via diff-cover
 jmespath==0.10.0
     # via
     #   -r requirements/base.txt
@@ -407,7 +407,7 @@ kombu==4.6.11
     #   celery
 lazy==1.4
     # via bok-choy
-lazy-object-proxy==1.4.3
+lazy-object-proxy==1.7.1
     # via astroid
 libsass==0.9.2
     # via
@@ -422,7 +422,7 @@ logger==1.4
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-lxml==4.6.4
+lxml==4.7.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
@@ -455,7 +455,7 @@ naked==0.1.31
     #   cybersource-rest-client-python
 ndg-httpsclient==0.5.1
     # via -r requirements/base.txt
-newrelic==7.2.2.169
+newrelic==7.2.4.171
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -473,15 +473,16 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-packaging==21.2
+packaging==21.3
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
     #   -r requirements/tox.txt
     #   bleach
     #   pytest
+    #   redis
     #   tox
-paramiko==2.8.0
+paramiko==2.9.1
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
@@ -491,7 +492,7 @@ path.py==7.2
     # via -r requirements/base.txt
 paypalrestsdk==1.13.1
     # via -r requirements/base.txt
-pbr==5.7.0
+pbr==5.8.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -499,17 +500,18 @@ pbr==5.7.0
     #   fixtures
     #   stevedore
     #   testtools
-phonenumbers==8.12.36
+phonenumbers==8.12.40
     # via
     #   -r requirements/base.txt
     #   django-oscar
-pillow==8.4.0
+pillow==9.0.0
     # via
     #   -r requirements/base.txt
     #   django-oscar
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via
     #   -r requirements/base.txt
+    #   pylint
     #   zeep
 pluggy==0.13.1
     # via
@@ -523,7 +525,7 @@ polib==1.1.1
     # via edx-i18n-tools
 premailer==2.9.2
     # via -r requirements/base.txt
-psutil==5.8.0
+psutil==5.9.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -532,7 +534,7 @@ purl==1.6
     # via
     #   -r requirements/base.txt
     #   django-oscar
-py==1.10.0
+py==1.11.0
     # via
     #   -r requirements/e2e.txt
     #   -r requirements/tox.txt
@@ -549,22 +551,22 @@ pycodestyle==2.8.0
     # via -r requirements/test.in
 pycountry==17.1.8
     # via -r requirements/base.txt
-pycparser==2.20
+pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
     #   cffi
     #   cybersource-rest-client-python
-pycryptodome==3.11.0
+pycryptodome==3.12.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-pycryptodomex==3.11.0
+pycryptodomex==3.12.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
     #   pyjwkest
-pygments==2.10.0
+pygments==2.11.1
     # via
     #   -r requirements/base.txt
     #   diff-cover
@@ -581,11 +583,11 @@ pyjwt[crypto]==1.7.1
     #   edx-auth-backends
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.4.4
+pylint==2.12.2
     # via
     #   -c requirements/pins.txt
     #   -r requirements/test.in
-pymongo==3.12.1
+pymongo==4.0.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -600,7 +602,7 @@ pyopenssl==21.0.0
     #   cybersource-rest-client-python
     #   ndg-httpsclient
     #   paypalrestsdk
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -633,7 +635,7 @@ pytest-base-url==1.4.2
     #   pytest-selenium
 pytest-cov==3.0.0
     # via -r requirements/test.in
-pytest-django==4.4.0
+pytest-django==4.5.2
     # via -r requirements/test.in
 pytest-html==3.1.1
     # via
@@ -643,11 +645,11 @@ pytest-metadata==1.11.0
     # via
     #   -r requirements/e2e.txt
     #   pytest-html
-pytest-randomly==3.10.1
+pytest-randomly==3.10.3
     # via -r requirements/e2e.txt
 pytest-selenium==2.0.1
     # via -r requirements/e2e.txt
-pytest-timeout==2.0.1
+pytest-timeout==2.0.2
     # via -r requirements/e2e.txt
 pytest-variables==1.9.0
     # via
@@ -661,7 +663,7 @@ python-dateutil==2.8.2
     #   edx-drf-extensions
     #   faker
     #   freezegun
-python-dotenv==0.19.1
+python-dotenv==0.19.2
     # via -r requirements/e2e.txt
 python-memcached==1.58
     # via -r requirements/test.in
@@ -691,6 +693,8 @@ pytz==2016.10
     #   cybersource-rest-client-python
     #   datetime
     #   django
+    #   djangorestframework
+    #   djangorestframework-datatables
     #   zeep
 pyyaml==6.0
     # via
@@ -699,15 +703,15 @@ pyyaml==6.0
     #   edx-django-release-util
     #   edx-i18n-tools
     #   naked
-rcssmin==1.0.6
+rcssmin==1.1.0
     # via
     #   -r requirements/base.txt
     #   django-compressor
-redis==3.5.3
+redis==4.1.0
     # via
     #   -r requirements/base.txt
     #   edx-ecommerce-worker
-requests==2.26.0
+requests==2.27.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -741,21 +745,21 @@ requests-toolbelt==0.9.1
     # via
     #   -r requirements/base.txt
     #   zeep
-responses==0.15.0
+responses==0.16.0
     # via -r requirements/test.in
 rest-condition==1.0.3
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-rjsmin==1.1.0
+rjsmin==1.2.0
     # via
     #   -r requirements/base.txt
     #   django-compressor
-rsa==4.7.2
+rsa==4.8
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-rules==3.0
+rules==3.1
     # via -r requirements/base.txt
 s3transfer==0.5.0
     # via
@@ -777,7 +781,7 @@ shellescape==3.8.1
     #   -r requirements/base.txt
     #   crypto
     #   cybersource-rest-client-python
-simplejson==3.17.5
+simplejson==3.17.6
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
@@ -787,12 +791,10 @@ six==1.16.0
     #   -r requirements/e2e.txt
     #   -r requirements/tox.txt
     #   analytics-python
-    #   astroid
     #   bcrypt
     #   bleach
     #   bok-choy
     #   cybersource-rest-client-python
-    #   django-compressor
     #   django-extra-views
     #   djangorestframework-csv
     #   edx-auth-backends
@@ -836,7 +838,7 @@ social-auth-core==4.0.2
     #   social-auth-app-django
 sorl-thumbnail==12.7.0
     # via -r requirements/base.txt
-soupsieve==2.3
+soupsieve==2.3.1
     # via beautifulsoup4
 sqlparse==0.4.2
     # via
@@ -871,9 +873,10 @@ toml==0.10.2
     # via
     #   -r requirements/e2e.txt
     #   -r requirements/tox.txt
+    #   pylint
     #   pytest
     #   tox
-tomli==1.2.2
+tomli==2.0.0
     # via coverage
 tox==3.14.6
     # via
@@ -890,6 +893,10 @@ typing==3.7.4.3
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
+typing-extensions==4.0.1
+    # via
+    #   astroid
+    #   pylint
 unicodecsv==0.14.1
     # via
     #   -r requirements/base.txt
@@ -928,12 +935,15 @@ webob==1.8.7
     # via webtest
 webtest==3.0.0
     # via django-webtest
-wheel==0.37.0
+wheel==0.37.1
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-wrapt==1.11.2
-    # via astroid
+wrapt==1.13.3
+    # via
+    #   -r requirements/base.txt
+    #   astroid
+    #   deprecated
 x509==0.1
     # via
     #   -r requirements/base.txt
@@ -942,7 +952,7 @@ xss-utils==0.3.0
     # via -r requirements/base.txt
 zeep==4.1.0
     # via -r requirements/base.txt
-zipp==3.6.0
+zipp==3.7.0
     # via
     #   -r requirements/e2e.txt
     #   importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,7 +14,7 @@ asn1crypto==1.4.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-astroid==2.9.2
+astroid==2.8.6
     # via pylint
 attrs==21.4.0
     # via
@@ -324,7 +324,7 @@ factory-boy==2.12.0
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   django-oscar
-faker==11.1.0
+faker==11.3.0
     # via
     #   -r requirements/base.txt
     #   factory-boy
@@ -583,7 +583,7 @@ pyjwt[crypto]==1.7.1
     #   edx-auth-backends
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.12.2
+pylint==2.11.0
     # via
     #   -c requirements/pins.txt
     #   -r requirements/test.in
@@ -711,7 +711,7 @@ redis==4.1.0
     # via
     #   -r requirements/base.txt
     #   edx-ecommerce-worker
-requests==2.27.0
+requests==2.27.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,17 +4,17 @@
 #
 #    make upgrade
 #
-filelock==3.3.2
+filelock==3.4.2
     # via tox
-packaging==21.2
+packaging==21.3
     # via tox
 pluggy==0.13.1
     # via
     #   -c requirements/pins.txt
     #   tox
-py==1.10.0
+py==1.11.0
     # via tox
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 six==1.16.0
     # via tox


### PR DESCRIPTION
REV-2513: we're currently blocked from running 'make upgrade' (to update packages) because of a conflict caused by our old pinning of pylint. 

If I remove the pin, the build hits a strange isort issue, so let's try bumping the pinned version higher to see if that works. 
