### PR TITLE
Dianekaplan/undo temporary changes

### DIFF
--- a/e2e/test_payment.py
+++ b/e2e/test_payment.py
@@ -130,7 +130,7 @@ class TestSeatPayment:
         ))
 
         # Wait till the selector is visible
-        WebDriverWait(selenium, 40).until(  # @TODO: put wait back to 20 after REV-2493 investigation
+        WebDriverWait(selenium, 20).until(
             EC.visibility_of_element_located((By.CSS_SELECTOR, page_css_selector))
         )
 


### PR DESCRIPTION
While troubleshooting a failing e2e test, I updated the timeout value here: https://github.com/edx/ecommerce/pull/3603

The timeout is not important here, so this PR puts it back to how it was before. 