### PR TITLE
fix: ecomworker to 3.1.2 | override braze frequency cap

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -207,7 +207,7 @@ edx-drf-extensions==6.6.0
     #   -c requirements/pins.txt
     #   -r requirements/base.in
     #   edx-rbac
-edx-ecommerce-worker==3.1.1
+edx-ecommerce-worker==3.1.2
     # via -r requirements/base.in
 edx-opaque-keys==2.2.2
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -290,7 +290,7 @@ edx-drf-extensions==6.6.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-edx-ecommerce-worker==3.1.1
+edx-ecommerce-worker==3.1.2
     # via -r requirements/test.txt
 edx-i18n-tools==0.8.1
     # via -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -212,7 +212,7 @@ edx-drf-extensions==6.6.0
     #   -c requirements/pins.txt
     #   -r requirements/base.in
     #   edx-rbac
-edx-ecommerce-worker==3.1.1
+edx-ecommerce-worker==3.1.2
     # via -r requirements/base.in
 edx-opaque-keys==2.2.2
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -289,7 +289,7 @@ edx-drf-extensions==6.6.0
     #   -c requirements/pins.txt
     #   -r requirements/base.txt
     #   edx-rbac
-edx-ecommerce-worker==3.1.1
+edx-ecommerce-worker==3.1.2
     # via -r requirements/base.txt
 edx-i18n-tools==0.8.1
     # via -r requirements/test.in


### PR DESCRIPTION
Do this for transactional enterprise emails, which should never be frequency-capped
ENT-5285