### PR TITLE
[REV-2513] unpin pylint so we can run 'make upgrade'

### DIFF
--- a/e2e/config.py
+++ b/e2e/config.py
@@ -19,8 +19,8 @@ if not all([OAUTH_ACCESS_TOKEN_URL, OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET]):
 
 try:
     ECOMMERCE_URL_ROOT = os.environ.get('ECOMMERCE_URL_ROOT').strip('/')
-except AttributeError:
-    raise RuntimeError('A valid URL root for the E-Commerce Service is required.')
+except AttributeError as attribute_error:
+    raise RuntimeError('A valid URL root for the E-Commerce Service is required.') from attribute_error
 
 ECOMMERCE_API_URL = os.environ.get('ECOMMERCE_API_URL', ECOMMERCE_URL_ROOT + '/api/v2')
 ECOMMERCE_TEST_WEB_SECURITY = os.environ.get('ECOMMERCE_TEST_WEB_SECURITY')
@@ -37,13 +37,13 @@ except AttributeError:
 
 try:
     LMS_URL_ROOT = os.environ.get('LMS_URL_ROOT').strip('/')
-except AttributeError:
-    raise RuntimeError('A valid LMS URL root is required.')
+except AttributeError as attribute_error:
+    raise RuntimeError('A valid LMS URL root is required.') from attribute_error
 
 try:
     DISCOVERY_API_URL_ROOT = os.environ.get('DISCOVERY_API_URL_ROOT').strip('/')
-except AttributeError:
-    raise RuntimeError('Discovery API URL root is required.')
+except AttributeError as attribute_error:
+    raise RuntimeError('Discovery API URL root is required.') from attribute_error
 
 LMS_USERNAME = os.environ.get('LMS_USERNAME')
 LMS_EMAIL = os.environ.get('LMS_EMAIL')

--- a/e2e/test_payment.py
+++ b/e2e/test_payment.py
@@ -64,7 +64,7 @@ class TestSeatPayment:
                         EC.element_to_be_clickable((locator_type, selector))
                     )
                 except:
-                    raise Exception('Timeout exception with locator (%s, %s).' % (locator_type, selector))
+                    raise Exception('Timeout exception with locator (%s, %s).' % (locator_type, selector))   # pylint: disable=raise-missing-from
 
                 select = Select(element)
                 select.select_by_value(value)

--- a/ecommerce/core/management/commands/generate_courses.py
+++ b/ecommerce/core/management/commands/generate_courses.py
@@ -42,10 +42,10 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         try:
             courses = json.loads(options["courses_json"])["courses"]
-        except ValueError:
-            raise CommandError("Invalid JSON object")
-        except KeyError:
-            raise CommandError("JSON object is missing courses list")
+        except ValueError as value_error:
+            raise CommandError("Invalid JSON object") from value_error
+        except KeyError as key_error:
+            raise CommandError("JSON object is missing courses list") from key_error
 
         Flag.objects.update_or_create(name='enable_client_side_checkout', defaults={'everyone': True})
         for course_settings in courses:

--- a/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
+++ b/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
@@ -40,7 +40,7 @@ class Command(BaseCommand):
             try:
                 download = s.get(url, timeout=timeout)
                 status_code = download.status_code
-            except Timeout as e:
+            except Timeout:
                 logger.warning(
                     "SDNFallback: DOWNLOAD FAILURE: Timeout occurred trying to download SDN csv. "
                     "Timeout threshold (in seconds): %s", timeout)

--- a/ecommerce/core/management/commands/sync_hubspot.py
+++ b/ecommerce/core/management/commands/sync_hubspot.py
@@ -525,4 +525,4 @@ class Command(BaseCommand):
                         self._call_sync_errors_messages_endpoint(site_configuration)
         except Exception as ex:
             traceback.print_exc()
-            raise CommandError('Command failed with traceback %s' % str(ex))
+            raise CommandError('Command failed with traceback %s' % str(ex)) from ex

--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -762,7 +762,7 @@ class BusinessClient(models.Model):
     history = HistoricalRecords()
 
     def __str__(self):
-        return self.name
+        return str(self.name)
 
     def save(self, *args, **kwargs):  # pylint: disable=arguments-differ
         if not self.name:

--- a/ecommerce/core/models.py
+++ b/ecommerce/core/models.py
@@ -234,7 +234,7 @@ class SiteConfiguration(models.Model):
                     self.site.id,
                     name
                 )
-                raise ValidationError(str(exc))
+                raise ValidationError(str(exc)) from exc
 
     def _clean_client_side_payment_processor(self):
         """

--- a/ecommerce/core/templatetags/core_extras.py
+++ b/ecommerce/core/templatetags/core_extras.py
@@ -34,8 +34,8 @@ def do_captureas(parser, token):
 
     try:
         __, args = token.contents.split(None, 1)
-    except ValueError:
-        raise template.TemplateSyntaxError("'captureas' node requires a variable name.")
+    except ValueError as value_error:
+        raise template.TemplateSyntaxError("'captureas' node requires a variable name.") from value_error
     nodelist = parser.parse(('endcaptureas',))
     parser.delete_first_token()
     return CaptureasNode(nodelist, args)

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -337,8 +337,8 @@ class EnrollmentCodeCsvView(View):
         """
         try:
             order = Order.objects.get(number=number)
-        except Order.DoesNotExist:
-            raise Http404('Order not found.')
+        except Order.DoesNotExist as order_no_exist:
+            raise Http404('Order not found.') from order_no_exist
 
         if request.user != order.user and not request.user.is_staff:
             raise PermissionDenied

--- a/ecommerce/courses/management/commands/create_enrollment_codes.py
+++ b/ecommerce/courses/management/commands/create_enrollment_codes.py
@@ -109,7 +109,7 @@ class Command(BaseCommand):
         """
         failed_courses = []
 
-        with open(course_ids_file, 'r') as file_handler:
+        with open(course_ids_file, 'r') as file_handler:  # pylint: disable=unspecified-encoding
             course_ids = file_handler.readlines()
             total_courses = len(course_ids)
             logger.info('Creating enrollment code for %d courses.', total_courses)

--- a/ecommerce/courses/management/commands/publish_to_lms.py
+++ b/ecommerce/courses/management/commands/publish_to_lms.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
         if not course_ids_file or not os.path.exists(course_ids_file):
             raise CommandError("Pass the correct absolute path to course ids file as --course_ids_file argument.")
 
-        with open(course_ids_file, 'r') as file_handler:
+        with open(course_ids_file, 'r') as file_handler:  # pylint: disable=unspecified-encoding
             course_ids = file_handler.readlines()
             total_courses = len(course_ids)
             logger.info("Publishing %d courses.", total_courses)

--- a/ecommerce/courses/tests/test_create_enrollment_codes_command.py
+++ b/ecommerce/courses/tests/test_create_enrollment_codes_command.py
@@ -64,7 +64,7 @@ class CreateEnrollmentCodesTests(DiscoveryTestMixin, TransactionTestCase):
         """
         Write the course_ids list to the temp file.
         """
-        with open(file_path, 'w') as temp_file:
+        with open(file_path, 'w') as temp_file:  # pylint: disable=unspecified-encoding
             temp_file.write(str("\n".join(course_ids)))
 
     def test_invalid_file_path(self):

--- a/ecommerce/courses/tests/test_publish_to_lms_command.py
+++ b/ecommerce/courses/tests/test_publish_to_lms_command.py
@@ -38,7 +38,7 @@ class PublishCoursesToLMSTests(DiscoveryTestMixin, TransactionTestCase):
     def create_course_ids_file(self, file_path, course_ids):
         """Write the course_ids list to the temp file."""
 
-        with open(file_path, 'w') as temp_file:
+        with open(file_path, 'w') as temp_file:  # pylint: disable=unspecified-encoding
             temp_file.write("\n".join(course_ids))
 
     @ddt.data("", "fake/path")

--- a/ecommerce/enterprise/management/commands/backfill_opportunity_ids.py
+++ b/ecommerce/enterprise/management/commands/backfill_opportunity_ids.py
@@ -76,7 +76,7 @@ class Command(BaseCommand):
 
     def read_csv(self, csv_path):
         data = {}
-        with open(csv_path) as csv_file:
+        with open(csv_path) as csv_file:  # pylint: disable=unspecified-encoding
             reader = csv.DictReader(csv_file)
             for row in reader:
                 data[UUID(row['enterprise_customer_uuid'])] = row['opportunity_id']
@@ -89,7 +89,7 @@ class Command(BaseCommand):
             'offers': defaultdict(list),
             'ec_uuids': defaultdict(list),
         }
-        with open(csv_path) as csv_file:
+        with open(csv_path) as csv_file:  # pylint: disable=unspecified-encoding
             reader = csv.DictReader(csv_file)
             for row in reader:
                 if row['ORDER_LINE_OFFER_TYPE'] == 'Voucher':

--- a/ecommerce/enterprise/tests/test_backfill_opportunity_ids.py
+++ b/ecommerce/enterprise/tests/test_backfill_opportunity_ids.py
@@ -125,7 +125,7 @@ class BackfillOpportunityIdsCommandTests(CouponMixin, TestCase):
         """Create csv with enterprise uuid and opportunity id"""
         tmp_csv_path = os.path.join(tempfile.gettempdir(), 'data.csv')
 
-        with open(tmp_csv_path, 'w') as csv_file:
+        with open(tmp_csv_path, 'w') as csv_file:  # pylint: disable=unspecified-encoding
             csv_writer = csv.DictWriter(csv_file, fieldnames=['enterprise_customer_uuid', 'opportunity_id'])
             csv_writer.writeheader()
             for enterprise_customer, opportunity_id in self.enterprise_without_opportunity_ids.items():
@@ -154,7 +154,7 @@ class BackfillOpportunityIdsCommandTests(CouponMixin, TestCase):
         ]
 
         tmp_csv_path = os.path.join(tempfile.gettempdir(), 'multi_contracts_data.csv')
-        with open(tmp_csv_path, 'w') as csv_file:
+        with open(tmp_csv_path, 'w') as csv_file:  # pylint: disable=unspecified-encoding
             csv_writer = csv.writer(csv_file)
             csv_writer.writerow(header_row)
 

--- a/ecommerce/extensions/analytics/utils.py
+++ b/ecommerce/extensions/analytics/utils.py
@@ -58,7 +58,7 @@ def silence_exceptions(msg):
 
     def decorator(func):  # pylint: disable=missing-docstring
         @wraps(func)
-        def wrapper(*args, **kwargs):  # pylint: disable=missing-docstring
+        def wrapper(*args, **kwargs):  # pylint: disable=missing-docstring, inconsistent-return-statements
             try:
                 return func(*args, **kwargs)
             except:  # pylint: disable=bare-except

--- a/ecommerce/extensions/api/data.py
+++ b/ecommerce/extensions/api/data.py
@@ -19,10 +19,10 @@ def get_product(sku):
     """Retrieve the product corresponding to the provided SKU."""
     try:
         return Product.objects.get(stockrecords__partner_sku=sku)
-    except Product.DoesNotExist:
+    except Product.DoesNotExist as product_no_exist:
         raise exceptions.ProductNotFoundError(
             exceptions.PRODUCT_NOT_FOUND_DEVELOPER_MESSAGE.format(sku=sku)
-        )
+        ) from product_no_exist
 
 
 def get_order_metadata(basket):

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -1414,8 +1414,8 @@ class CouponUpdateSerializer(CouponSerializer):
                 max_uses = int(max_uses)
                 if max_uses < 1:
                     raise ValueError
-            except ValueError:
-                raise ValidationError('max_global_applications field must be a positive number.')
+            except ValueError as value_error:
+                raise ValidationError('max_global_applications field must be a positive number.') from value_error
 
         return validated_data
 
@@ -1721,8 +1721,9 @@ class RefundedOrderCreateVoucherSerializer(serializers.Serializer):  # pylint: d
         """Verify the order number and return the order object."""
         try:
             order = Order.objects.get(number=order)
-        except Order.DoesNotExist:
-            raise serializers.ValidationError(_('Invalid order number or order {} does not exists.').format(order))
+        except Order.DoesNotExist as order_no_exist:
+            # pylint: disable=line-too-long
+            raise serializers.ValidationError(_('Invalid order number or order {} does not exists.').format(order)) from order_no_exist
         return order
 
     def create(self, validated_data):
@@ -1825,10 +1826,10 @@ class RefundedOrderCreateVoucherSerializer(serializers.Serializer):  # pylint: d
                 }
             ]
             attrs['note'] = note
-        except AttributeError:
+        except AttributeError as attribute_error:
             error_message = _("Could note create new voucher for the order: {}").format(order)
             logger.exception(error_message)
-            raise serializers.ValidationError(error_message)
+            raise serializers.ValidationError(error_message) from attribute_error
         return attrs
 
 

--- a/ecommerce/extensions/api/v2/tests/test_utils.py
+++ b/ecommerce/extensions/api/v2/tests/test_utils.py
@@ -97,4 +97,4 @@ class ViewUtilsTests(TestCase):
             assert '[upload_files_for_enterprise_coupons] Raised an error while uploading the files,Message' \
                    in mock_logger.exception.call_args[0][0]
             assert 'Invalid bucket name ' in str(mock_logger.exception.call_args[0][1])
-            assert not ret
+            assert ret == []  # pylint: disable=use-implicit-booleaness-not-comparison

--- a/ecommerce/extensions/api/v2/tests/test_utils.py
+++ b/ecommerce/extensions/api/v2/tests/test_utils.py
@@ -97,4 +97,4 @@ class ViewUtilsTests(TestCase):
             assert '[upload_files_for_enterprise_coupons] Raised an error while uploading the files,Message' \
                    in mock_logger.exception.call_args[0][0]
             assert 'Invalid bucket name ' in str(mock_logger.exception.call_args[0][1])
-            assert ret == []
+            assert not ret

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -577,9 +577,9 @@ class EnterpriseCouponViewSet(CouponViewSet):
             no_voucher_application,
             user_email=user_email,
             status__in=[OFFER_ASSIGNED, OFFER_ASSIGNMENT_EMAIL_PENDING], )
-            .distinct()  # pylint: disable=bad-continuation
-            .prefetch_related('offer', 'offer__vouchers', )  # pylint: disable=bad-continuation
-            .values_list('offer__vouchers__id', flat=True)]  # pylint: disable=bad-continuation
+            .distinct()
+            .prefetch_related('offer', 'offer__vouchers', )
+            .values_list('offer__vouchers__id', flat=True)]
         # We also want vouchers with VoucherApplications related to the user
         # but only if the user exists (there is a chance it does not, as code
         # assignment only requires an email, and not an account on the system)

--- a/ecommerce/extensions/api/v2/views/refunds.py
+++ b/ecommerce/extensions/api/v2/views/refunds.py
@@ -91,8 +91,8 @@ class RefundCreateView(generics.CreateAPIView):
 
         try:
             user = User.objects.get(username=username)
-        except User.DoesNotExist:
-            raise BadRequestException('User "{}" does not exist.'.format(username))
+        except User.DoesNotExist as user_no_exist:
+            raise BadRequestException('User "{}" does not exist.'.format(username)) from user_no_exist
 
         # Ensure the user has an LMS user id
         try:
@@ -104,16 +104,16 @@ class RefundCreateView(generics.CreateAPIView):
                 user_id=user.id,
                 requested_by=requested_by)
             user.add_lms_user_id('ecommerce_missing_lms_user_id_refund', called_from)
-        except MissingLmsUserIdException:
-            raise BadRequestException('User {} does not have an LMS user id.'.format(user.id))
+        except MissingLmsUserIdException as missing_user:
+            raise BadRequestException('User {} does not have an LMS user id.'.format(user.id)) from missing_user
 
         # Try and create a refund for the passed in order
         if entitlement_uuid:
             try:
                 order = user.orders.get(number=order_number)
                 refunds = create_refunds_for_entitlement(order, entitlement_uuid)
-            except (Order.DoesNotExist, OrderLine.DoesNotExist):
-                raise BadRequestException('Order {} does not exist.'.format(order_number))
+            except (Order.DoesNotExist, OrderLine.DoesNotExist) as order_line_no_exist:
+                raise BadRequestException('Order {} does not exist.'.format(order_number)) from order_line_no_exist
         else:
             if not course_id:
                 raise BadRequestException('No course_id specified.')

--- a/ecommerce/extensions/api/v2/views/vouchers.py
+++ b/ecommerce/extensions/api/v2/views/vouchers.py
@@ -310,7 +310,7 @@ class VoucherViewSet(NonDestroyableModelViewSet):
                     course_info=course_info,
                     credit_provider_price=None,
                     multiple_credit_providers=False,
-                    is_verified=(course.type == 'verified' or course.type == 'verified-only'),
+                    is_verified=(course.type in ('verified', 'verified-only')),
                     product=product,
                     stock_record=stock_record,
                     voucher=voucher

--- a/ecommerce/extensions/basket/management/commands/add_site_to_baskets.py
+++ b/ecommerce/extensions/basket/management/commands/add_site_to_baskets.py
@@ -27,8 +27,8 @@ class Command(BaseCommand):
 
         try:
             site = Site.objects.get(id=options['site_id'])
-        except Site.DoesNotExist:
-            raise CommandError('A valid Site ID must be specified!')
+        except Site.DoesNotExist as site_no_exist:
+            raise CommandError('A valid Site ID must be specified!') from site_no_exist
 
         if options['commit']:
             self.stderr.write('Associating [{}] baskets with site [{}]...'.format(count, site))

--- a/ecommerce/extensions/basket/models.py
+++ b/ecommerce/extensions/basket/models.py
@@ -130,7 +130,7 @@ class BasketAttributeType(models.Model):
     name = models.CharField(_("Name"), max_length=128, unique=True)
 
     def __str__(self):
-        return self.name
+        return str(self.name)
 
 
 class BasketAttribute(models.Model):

--- a/ecommerce/extensions/basket/models.py
+++ b/ecommerce/extensions/basket/models.py
@@ -129,8 +129,8 @@ class BasketAttributeType(models.Model):
     """
     name = models.CharField(_("Name"), max_length=128, unique=True)
 
-    def __str__(self):
-        return str(self.name)
+    def __str__(self):  # pylint: disable=invalid-str-returned
+        return self.name
 
 
 class BasketAttribute(models.Model):

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -1045,9 +1045,9 @@ class VoucherAddLogicMixin:
     def _get_voucher(self, code):
         try:
             return self.voucher_model._default_manager.get(code=code)  # pylint: disable=protected-access
-        except self.voucher_model.DoesNotExist:
+        except self.voucher_model.DoesNotExist as voucher_no_exist:
             messages.error(self.request, _("Coupon code '{code}' does not exist.").format(code=code))
-            raise VoucherException()
+            raise VoucherException() from voucher_no_exist
 
 
 class VoucherAddView(VoucherAddLogicMixin, BaseVoucherAddView):  # pylint: disable=function-redefined

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -424,7 +424,7 @@ class BasketAddItemsView(BasketLogicMixin, APIView):
             code = request.GET.get('code', None)
             try:
                 voucher = self._get_voucher(request)
-            except Voucher.DoesNotExist as e:  # pragma: nocover
+            except Voucher.DoesNotExist:  # pragma: nocover
                 # Display an error message when an invalid code is passed as a parameter
                 invalid_code = code
 

--- a/ecommerce/extensions/communication/apps.py
+++ b/ecommerce/extensions/communication/apps.py
@@ -1,4 +1,4 @@
-import oscar.apps.communication.apps as apps
+from oscar.apps.communication import apps
 
 
 class CommunicationConfig(apps.CommunicationConfig):

--- a/ecommerce/extensions/customer/apps.py
+++ b/ecommerce/extensions/customer/apps.py
@@ -10,6 +10,7 @@ class CustomerConfig(apps.CustomerConfig):
     def ready(self):
         super().ready()
         from auth_backends.views import EdxOAuth2LoginView
+
         from ecommerce.core.views import LogoutView
         self.login_view = EdxOAuth2LoginView
         self.logout_view = LogoutView

--- a/ecommerce/extensions/dashboard/apps.py
+++ b/ecommerce/extensions/dashboard/apps.py
@@ -13,7 +13,9 @@ class DashboardConfig(BaseDashboardConfig):
     def ready(self):
         super().ready()
         from auth_backends.urls import oauth2_urlpatterns
+
         from ecommerce.core.views import LogoutView
+
         # Note: Add ecommerce's logout override first to ensure it is registered by Django as the
         # actual logout view. Ecommerce's logout implementation supports different site configuration.
         self.AUTH_URLS = [url(r'^logout/$', LogoutView.as_view(), name='logout'), ] + oauth2_urlpatterns

--- a/ecommerce/extensions/offer/models.py
+++ b/ecommerce/extensions/offer/models.py
@@ -155,7 +155,9 @@ class Benefit(AbstractBenefit):
                         'User: %s, Offer: %s, Basket: %s, Message: %s',
                         basket.owner.username, offer.id, basket.id, err
                     )
-                    raise Exception('Failed to contact Discovery Service to retrieve offer catalog_range data.')
+                    raise Exception(
+                        'Failed to contact Discovery Service to retrieve offer catalog_range data.'
+                    ) from err
 
                 logger.info(
                     "Discovery Service results for basket: [%s], offer: [%s], query: '%s', response: %s",
@@ -492,7 +494,7 @@ class Range(AbstractRange):
             logger.exception('[Code Redemption Failure] Unable to connect to the Discovery Service '
                              'for catalog contains endpoint. '
                              'Product: %s, Message: %s, Range: %s', product.id, exc, self.id)
-            raise Exception('Unable to connect to Discovery Service for catalog contains endpoint.')
+            raise Exception('Unable to connect to Discovery Service for catalog contains endpoint.') from exc
 
     def contains_product(self, product):
         """

--- a/ecommerce/extensions/offer/views.py
+++ b/ecommerce/extensions/offer/views.py
@@ -49,7 +49,7 @@ class EmailConfirmationRequiredView(TemplateView):
                         course_id,
                         exc
                     )
-                    raise Http404
+                    raise Http404 from exc
             else:
                 course_run = get_object_or_404(Course, id=course_run_key)
                 course_keys.append(course_run.name)

--- a/ecommerce/extensions/order/management/commands/create_fake_orders.py
+++ b/ecommerce/extensions/order/management/commands/create_fake_orders.py
@@ -54,10 +54,10 @@ class Command(BaseCommand):
             stock_record = StockRecord.objects.get(partner_sku=sku)
             product = stock_record.product
             partner = stock_record.partner
-        except StockRecord.DoesNotExist:
+        except StockRecord.DoesNotExist as stock_record_no_exist:
             msg = 'No StockRecord for partner_sku {} exists.'.format(sku)
             logger.exception(msg)
-            raise CommandError(msg)
+            raise CommandError(msg) from stock_record_no_exist
 
         site = partner.default_site
         if not site:

--- a/ecommerce/extensions/order/management/commands/create_refund_for_orders.py
+++ b/ecommerce/extensions/order/management/commands/create_refund_for_orders.py
@@ -69,7 +69,7 @@ class Command(BaseCommand):
         """
         failed_orders = []
 
-        with open(order_numbers_file, 'r') as file_handler:
+        with open(order_numbers_file, 'r') as file_handler:  # pylint: disable=unspecified-encoding
             order_numbers = file_handler.readlines()
             total_orders = len(order_numbers)
             logger.info(u'Creating refund for %d orders.', total_orders)

--- a/ecommerce/extensions/order/management/commands/mark_orders_status_complete.py
+++ b/ecommerce/extensions/order/management/commands/mark_orders_status_complete.py
@@ -83,7 +83,7 @@ class Command(BaseCommand):
                     'Pass the correct absolute path to order numbers file as --order-numbers-file argument.'
                 )
 
-            order_numbers_file = open(order_numbers_file, 'rb')
+            order_numbers_file = open(order_numbers_file, 'rb')  # pylint: disable=consider-using-with
 
         order_numbers = order_numbers_file.readlines()
         total_orders, failed_orders, skipped_orders = self._mark_orders_status_complete_from_file(

--- a/ecommerce/extensions/order/management/commands/tests/test_create_refund_for_orders.py
+++ b/ecommerce/extensions/order/management/commands/tests/test_create_refund_for_orders.py
@@ -114,7 +114,7 @@ class CreateRefundForOrdersTests(DiscoveryMockMixin, TestCase):
 
     def create_orders_file(self, orders, filename):
         """Create a file with order numbers - one per line"""
-        with open(filename, 'w') as f:
+        with open(filename, 'w') as f:  # pylint: disable=unspecified-encoding
             for response_order in orders:
                 order = Order.objects.get(number=response_order['detail'])
                 # add to order numbers file

--- a/ecommerce/extensions/order/management/commands/tests/test_mark_orders_status_complete.py
+++ b/ecommerce/extensions/order/management/commands/tests/test_mark_orders_status_complete.py
@@ -20,7 +20,7 @@ class MarkOrdersStatusCompleteTests(TestCase):
 
     def create_orders_file(self, order_numbers):
         """Create a file with order numbers with status `Fulfillment Error` - one per line"""
-        with open(self.filename, 'w') as f:
+        with open(self.filename, 'w') as f:  # pylint: disable=unspecified-encoding
             f.truncate(0)
             for order_number in order_numbers:
                 # add to order numbers file

--- a/ecommerce/extensions/order/management/commands/update_order_lines_partner.py
+++ b/ecommerce/extensions/order/management/commands/update_order_lines_partner.py
@@ -48,10 +48,10 @@ class Command(BaseCommand):
 
         try:
             partner = Partner.objects.get(short_code__iexact=partner_code)
-        except Partner.DoesNotExist:
+        except Partner.DoesNotExist as partner_no_exist:
             msg = 'No Partner exists for code {}.'.format(partner_code)
             logger.exception(msg)
-            raise CommandError(msg)
+            raise CommandError(msg) from partner_no_exist
 
         order_lines = OrderLine.objects.filter(partner_sku__in=skus).exclude(partner=partner)
         count = len(order_lines)

--- a/ecommerce/extensions/payment/management/commands/paypal_profile.py
+++ b/ecommerce/extensions/payment/management/commands/paypal_profile.py
@@ -73,10 +73,10 @@ class Command(BaseCommand):
 
         try:
             handler = getattr(self, 'handle_{}'.format(action))
-        except IndexError as index_error:
-            raise CommandError("no action specified.") from index_error
-        except AttributeError as attribute_error:
-            raise CommandError("unrecognized action: {}".format(action)) from attribute_error
+        except IndexError:
+            raise CommandError("no action specified.")  # pylint: disable=raise-missing-from
+        except AttributeError:
+            raise CommandError("unrecognized action: {}".format(action))  # pylint: disable=raise-missing-from
         return handler(options)
 
     def _do_create(self, profile_data):
@@ -115,14 +115,14 @@ class Command(BaseCommand):
                 log.info("Enabled profile `%s` (id=%s)", profile_name, profile_id)
             else:
                 log.info("Profile `%s` (id=%s) is already enabled", profile_name, profile_id)
-        except IntegrityError as integrity_error:
+        except IntegrityError:
             # this should never happen, unless the data in the database has gotten out of
             # sync with the profiles stored in the PayPal account that this application
             # instance has been configured to use.
-            raise CommandError(
+            raise CommandError(  # pylint: disable=raise-missing-from
                 "Could not enable web profile because a profile with the same name exists under "
                 "a different id.  This may indicate a configuration error, or simply stale data."
-            ) from integrity_error
+            )
 
     def handle_list(self, args):  # pylint: disable=unused-argument
         """Wrapper for paypalrestsdk List operation."""

--- a/ecommerce/extensions/payment/management/commands/paypal_profile.py
+++ b/ecommerce/extensions/payment/management/commands/paypal_profile.py
@@ -59,10 +59,10 @@ class Command(BaseCommand):
 
         try:
             paypal_configuration = settings.PAYMENT_PROCESSOR_CONFIG[partner.lower()][self.PAYPAL_CONFIG_KEY.lower()]
-        except KeyError:
+        except KeyError as key_error:
             raise CommandError(
                 "Payment Processor configuration for partner `{0}` does not contain PayPal settings".format(partner)
-            )
+            ) from key_error
 
         # Initialize the PayPal REST SDK
         paypalrestsdk.configure({
@@ -73,10 +73,10 @@ class Command(BaseCommand):
 
         try:
             handler = getattr(self, 'handle_{}'.format(action))
-        except IndexError:
-            raise CommandError("no action specified.")
-        except AttributeError:
-            raise CommandError("unrecognized action: {}".format(action))
+        except IndexError as index_error:
+            raise CommandError("no action specified.") from index_error
+        except AttributeError as attribute_error:
+            raise CommandError("unrecognized action: {}".format(action)) from attribute_error
         return handler(options)
 
     def _do_create(self, profile_data):
@@ -115,14 +115,14 @@ class Command(BaseCommand):
                 log.info("Enabled profile `%s` (id=%s)", profile_name, profile_id)
             else:
                 log.info("Profile `%s` (id=%s) is already enabled", profile_name, profile_id)
-        except IntegrityError:
+        except IntegrityError as integrity_error:
             # this should never happen, unless the data in the database has gotten out of
             # sync with the profiles stored in the PayPal account that this application
             # instance has been configured to use.
             raise CommandError(
                 "Could not enable web profile because a profile with the same name exists under "
                 "a different id.  This may indicate a configuration error, or simply stale data."
-            )
+            ) from integrity_error
 
     def handle_list(self, args):  # pylint: disable=unused-argument
         """Wrapper for paypalrestsdk List operation."""

--- a/ecommerce/extensions/payment/models.py
+++ b/ecommerce/extensions/payment/models.py
@@ -277,12 +277,12 @@ class SDNFallbackData(models.Model):
         try:
             current_metadata = SDNFallbackMetadata.objects.get(import_state='Current')
         # The 'get' relies on the manage command having been run. If it fails, tell engineer what's needed
-        except SDNFallbackMetadata.DoesNotExist:
+        except SDNFallbackMetadata.DoesNotExist as fallback_metadata_no_exist:
             logger.warning(
                 "SDNFallback: SDNFallbackMetadata is empty! Run this: "
                 "./manage.py populate_sdn_fallback_data_and_metadata"
             )
-            raise SDNFallbackDataEmptyError
+            raise SDNFallbackDataEmptyError from fallback_metadata_no_exist
         query_params = {'source': source, 'sdn_fallback_metadata': current_metadata, 'sdn_type': sdn_type}
         return SDNFallbackData.objects.filter(**query_params)
 

--- a/ecommerce/extensions/payment/processors/cybersource.py
+++ b/ecommerce/extensions/payment/processors/cybersource.py
@@ -505,7 +505,7 @@ class CybersourceREST(ApplePayMixin, BaseClientSidePaymentProcessor):
                 }, transaction_id=None, basket=basket)
                 logger.exception('Payment failed')
                 # This will display the generic error on the frontend
-                raise GatewayError() from e
+                raise GatewayError()  # pylint: disable=raise-missing-from
             return e, e.headers['v-c-correlation-id']
 
     def normalize_processor_response(self, response) -> UnhandledCybersourceResponse:

--- a/ecommerce/extensions/payment/processors/cybersource.py
+++ b/ecommerce/extensions/payment/processors/cybersource.py
@@ -357,7 +357,7 @@ class CybersourceREST(ApplePayMixin, BaseClientSidePaymentProcessor):
             msg = 'An error occurred while attempting to issue a credit (via CyberSource) for order [{}].'.format(
                 order_number)
             logger.exception(msg)
-            raise GatewayError(msg)
+            raise GatewayError(msg)  # pylint: disable=raise-missing-from
 
         if response.decision == 'ACCEPT':
             return request_id
@@ -448,7 +448,7 @@ class CybersourceREST(ApplePayMixin, BaseClientSidePaymentProcessor):
         except:
             msg = 'An error occurred while authorizing an Apple Pay (via CyberSource) for basket [{}]'.format(basket.id)
             logger.exception(msg)
-            raise GatewayError(msg)
+            raise GatewayError(msg)  # pylint: disable=raise-missing-from
 
         request_id = response.requestID
         ppr = self.record_processor_response(serialize_object(response), transaction_id=request_id, basket=basket)
@@ -505,7 +505,7 @@ class CybersourceREST(ApplePayMixin, BaseClientSidePaymentProcessor):
                 }, transaction_id=None, basket=basket)
                 logger.exception('Payment failed')
                 # This will display the generic error on the frontend
-                raise GatewayError()
+                raise GatewayError() from e
             return e, e.headers['v-c-correlation-id']
 
     def normalize_processor_response(self, response) -> UnhandledCybersourceResponse:

--- a/ecommerce/extensions/payment/processors/paypal.py
+++ b/ecommerce/extensions/payment/processors/paypal.py
@@ -387,7 +387,7 @@ class Paypal(BasePaymentProcessor):
             msg = 'An error occurred while attempting to issue a credit (via PayPal) for order [{}].'.format(
                 order_number)
             logger.exception(msg)
-            raise GatewayError(msg)
+            raise GatewayError(msg)  # pylint: disable=raise-missing-from
 
         if refund.success():
             transaction_id = refund.id

--- a/ecommerce/extensions/payment/processors/stripe.py
+++ b/ecommerce/extensions/payment/processors/stripe.py
@@ -102,7 +102,7 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
             msg = 'An error occurred while attempting to issue a credit (via Stripe) for order [{}].'.format(
                 order_number)
             logger.exception(msg)
-            raise GatewayError(msg) # pylint: disable=raise-missing-from
+            raise GatewayError(msg)  # pylint: disable=raise-missing-from
 
         transaction_id = refund.id
 

--- a/ecommerce/extensions/payment/processors/stripe.py
+++ b/ecommerce/extensions/payment/processors/stripe.py
@@ -81,7 +81,7 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
                 body
             )
             self.record_processor_response(body, basket=basket)
-            raise TransactionDeclined(base_message, basket.id, ex.http_status)
+            raise TransactionDeclined(base_message, basket.id, ex.http_status) from ex
 
         total = basket.total_incl_tax
         card_number = charge.source.last4
@@ -102,7 +102,7 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
             msg = 'An error occurred while attempting to issue a credit (via Stripe) for order [{}].'.format(
                 order_number)
             logger.exception(msg)
-            raise GatewayError(msg)
+            raise GatewayError(msg) # pylint: disable=raise-missing-from
 
         transaction_id = refund.id
 

--- a/ecommerce/extensions/payment/tests/mixins.py
+++ b/ecommerce/extensions/payment/tests/mixins.py
@@ -205,7 +205,6 @@ class CybersourceMixin(PaymentEventsMixin):
             url = urljoin(settings.PAYMENT_PROCESSOR_CONFIG['edx']['cybersource']['soap_api_url'], filename)
             responses.add(responses.GET, url, body=body)
 
-    # pylint:disable=bad-continuation
     def mock_refund_response(self, amount=Decimal(100), currency=CURRENCY, transaction_id=None, basket_id=None,
                              decision='ACCEPT'):
         url = 'https://ics2wstest.ic3.com/commerce/1.x/transactionProcessor'

--- a/ecommerce/extensions/payment/tests/mixins.py
+++ b/ecommerce/extensions/payment/tests/mixins.py
@@ -201,9 +201,9 @@ class CybersourceMixin(PaymentEventsMixin):
 
         for filename in files:
             path = os.path.join(os.path.dirname(__file__), filename)
-            body = open(path, 'r').read()
-            url = urljoin(settings.PAYMENT_PROCESSOR_CONFIG['edx']['cybersource']['soap_api_url'], filename)
-            responses.add(responses.GET, url, body=body)
+            with open(path, 'r').read() as body:
+                url = urljoin(settings.PAYMENT_PROCESSOR_CONFIG['edx']['cybersource']['soap_api_url'], filename)
+                responses.add(responses.GET, url, body=body)
 
     def mock_refund_response(self, amount=Decimal(100), currency=CURRENCY, transaction_id=None, basket_id=None,
                              decision='ACCEPT'):

--- a/ecommerce/extensions/payment/tests/mixins.py
+++ b/ecommerce/extensions/payment/tests/mixins.py
@@ -201,9 +201,9 @@ class CybersourceMixin(PaymentEventsMixin):
 
         for filename in files:
             path = os.path.join(os.path.dirname(__file__), filename)
-            with open(path, 'r').read() as body:
-                url = urljoin(settings.PAYMENT_PROCESSOR_CONFIG['edx']['cybersource']['soap_api_url'], filename)
-                responses.add(responses.GET, url, body=body)
+            body = open(path, 'r').read()  # pylint: disable=unspecified-encoding,consider-using-with
+            url = urljoin(settings.PAYMENT_PROCESSOR_CONFIG['edx']['cybersource']['soap_api_url'], filename)
+            responses.add(responses.GET, url, body=body)
 
     def mock_refund_response(self, amount=Decimal(100), currency=CURRENCY, transaction_id=None, basket_id=None,
                              decision='ACCEPT'):

--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -554,10 +554,10 @@ class CybersourceApplePayAuthorizationView(CyberSourceProcessorMixin, EdxOrderPl
 
         try:
             billing_address = self._get_billing_address(request.data.get('billingContact'))
-        except Exception:
+        except Exception as this_exception:
             logger.exception(
                 'Failed to authorize Apple Pay payment. An error occurred while parsing the billing address.')
-            raise ValidationError({'error': 'billing_address_invalid'})
+            raise ValidationError({'error': 'billing_address_invalid'}) from this_exception
 
         try:
             self.handle_payment(None, basket)

--- a/ecommerce/extensions/voucher/utils.py
+++ b/ecommerce/extensions/voucher/utils.py
@@ -625,8 +625,9 @@ def validate_voucher_fields(
             )
         try:
             int(max_uses)
-        except ValueError:
-            raise log_message_and_raise_validation_error('Failed to create Voucher. max_uses field must be a number.')
+        except ValueError as value_error:
+            # pylint: disable=raising-bad-type, line-too-long
+            raise log_message_and_raise_validation_error('Failed to create Voucher. max_uses field must be a number.') from value_error
 
     if benefit_type == Benefit.PERCENTAGE and benefit_value == 100 and code:
         log_message_and_raise_validation_error('Failed to create Voucher. Code may not be set for enrollment coupon.')

--- a/ecommerce/referrals/management/commands/add_site_to_referrals.py
+++ b/ecommerce/referrals/management/commands/add_site_to_referrals.py
@@ -28,10 +28,10 @@ class Command(BaseCommand):
 
         try:
             site = Site.objects.get(id=options['site_id'])
-        except Site.DoesNotExist:
+        except Site.DoesNotExist as site_no_exist:
             msg = 'A valid Site ID must be specified!'
             self.stderr.write(msg)
-            raise CommandError(msg)
+            raise CommandError(msg) from site_no_exist
 
         if options['commit']:
             self.stdout.write('Associating [{}] referrals with site [{}]...'.format(count, site))

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -142,6 +142,9 @@ COMPRESS_PRECOMPILERS = (
     ('text/x-scss', 'django_libsass.SassCompiler'),
 )
 
+# Note: COMPRESS_CSS_FILTERS has been replaced with COMPRESS_FILTERS in django-compressor,
+# but replacing the settings name gives an error during compression in github test-python build check
+# See info here: https://github.com/django-compressor/django-compressor/issues/985
 COMPRESS_CSS_FILTERS = ['compressor.filters.css_default.CssAbsoluteFilter']
 
 COMPRESS_OFFLINE_CONTEXT = 'ecommerce.theming.compressor.offline_context'

--- a/ecommerce/settings/production.py
+++ b/ecommerce/settings/production.py
@@ -24,6 +24,9 @@ COMPRESS_OFFLINE = True
 EMAIL_BACKEND = 'django_ses.SESBackend'
 
 # Minify CSS
+# Note: COMPRESS_CSS_FILTERS has been replaced with COMPRESS_FILTERS in django-compressor,
+# but replacing the settings name gives an error during compression in github test-python build check
+# See info here: https://github.com/django-compressor/django-compressor/issues/985
 COMPRESS_CSS_FILTERS += [
     'compressor.filters.cssmin.CSSMinFilter',
 ]

--- a/ecommerce/theming/management/commands/create_sites_and_partners.py
+++ b/ecommerce/theming/management/commands/create_sites_and_partners.py
@@ -123,7 +123,7 @@ class Command(BaseCommand):
             configuration_data = json.loads(
                 json.dumps(
                     json.load(
-                        open(config_file)
+                        open(config_file)  # pylint: disable=unspecified-encoding,consider-using-with
                     )
                 ).replace("{dns_name}", self.dns_name)
             )['ecommerce_configuration']

--- a/ecommerce/theming/tests/test_theme_style_overrides.py
+++ b/ecommerce/theming/tests/test_theme_style_overrides.py
@@ -71,7 +71,7 @@ class TestComprehensiveTheme(TestCase):
         self.assertEqual(result, themes_dir / "test-theme" / "static/css/base/main.css")
 
         main_css = ""
-        with open(result) as css_file:
+        with open(result) as css_file:  # pylint: disable=unspecified-encoding
             main_css += css_file.read()
 
         self.assertIn("background-color: #00fa00", main_css)

--- a/pylintrc
+++ b/pylintrc
@@ -63,6 +63,22 @@ disable=
 
     duplicate-code,
 
+# New when we unpinned and jumped versions (pylint 2.4.4 -> 2.12.2)
+# C0103: invalid-name
+# C0201: consider-iterating-dictionary
+# C0206: consider-using-dict-items
+# C0209: consider-using-f-string
+# R1725: super-with-arguments
+# R1728: consider-using-generator
+# R1729: use-a-generator
+# R1734: use-list-literal
+# W0237: arguments renamed
+# W1310: format-string-without-interpolation
+# W1406: redundant-u-string-prefix
+# W1514: unspecified-encoding
+
+    C0103,C0201,C0206,C0209,R1725,R1728,R1729,R1734,W0237,W1310,W1406,W1514
+
 # We can decide if names are invalid on our own
     invalid-name,
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ analytics-python==1.4.0
     # via -r requirements/base.in
 asn1crypto==1.4.0
     # via cybersource-rest-client-python
-attrs==21.2.0
+attrs==21.4.0
     # via
     #   jsonschema
     #   zeep
@@ -28,9 +28,9 @@ billiard==3.6.4.0
     # via celery
 bleach==4.1.0
     # via -r requirements/base.in
-boto3==1.19.10
+boto3==1.20.28
     # via -r requirements/base.in
-botocore==1.22.10
+botocore==1.23.28
     # via
     #   boto3
     #   s3transfer
@@ -52,9 +52,9 @@ cffi==1.15.0
     #   pynacl
 chardet==4.0.0
     # via cybersource-rest-client-python
-charset-normalizer==2.0.7
+charset-normalizer==2.0.10
     # via requests
-configparser==5.1.0
+configparser==5.2.0
     # via cybersource-rest-client-python
 coreapi==2.3.3
     # via
@@ -63,7 +63,7 @@ coreapi==2.3.3
     #   openapi-codec
 coreschema==0.0.4
     # via coreapi
-coverage==6.1.1
+coverage==6.2
     # via cybersource-rest-client-python
 crypto==1.4.1
     # via cybersource-rest-client-python
@@ -89,7 +89,9 @@ defusedxml==0.7.1
     # via
     #   python3-openid
     #   social-auth-core
-django==2.2.24
+deprecated==1.2.13
+    # via redis
+django==2.2.26
     # via
     #   -r requirements/base.in
     #   django-appconf
@@ -103,6 +105,7 @@ django==2.2.24
     #   django-model-utils
     #   django-oscar
     #   django-phonenumber-field
+    #   django-solo
     #   django-tables2
     #   django-treebeard
     #   djangorestframework
@@ -118,13 +121,13 @@ django==2.2.24
     #   xss-utils
 django-appconf==1.0.5
     # via django-compressor
-django-compressor==2.4.1
+django-compressor==3.1
     # via
     #   -r requirements/base.in
     #   django-libsass
-django-config-models==2.2.0
+django-config-models==2.2.2
     # via -r requirements/base.in
-django-cors-headers==3.10.0
+django-cors-headers==3.10.1
     # via -r requirements/base.in
 django-crispy-forms==1.13.0
     # via -r requirements/base.in
@@ -132,7 +135,7 @@ django-crum==0.7.9
     # via
     #   edx-django-utils
     #   edx-rbac
-django-extensions==3.1.3
+django-extensions==3.1.5
     # via -r requirements/base.in
 django-extra-views==0.13.0
     # via django-oscar
@@ -154,7 +157,7 @@ django-rest-swagger==2.2.0
     # via -r requirements/base.in
 django-simple-history==3.0.0
     # via -r requirements/base.in
-django-solo==1.2.0
+django-solo==2.0.0
     # via -r requirements/base.in
 django-tables2==2.2.1
     # via django-oscar
@@ -169,7 +172,7 @@ django-waffle==2.2.1
     #   edx-drf-extensions
 django-widget-tweaks==1.4.9
     # via django-oscar
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via
     #   -r requirements/base.in
     #   django-config-models
@@ -182,7 +185,7 @@ djangorestframework==3.12.4
     #   rest-condition
 djangorestframework-csv==2.1.1
     # via -r requirements/base.in
-djangorestframework-datatables==0.6.0
+djangorestframework-datatables==0.7.0
     # via -r requirements/base.in
 drf-extensions==0.7.1
     # via -r requirements/base.in
@@ -196,7 +199,7 @@ edx-django-release-util==1.1.0
     # via -r requirements/base.in
 edx-django-sites-extensions==3.1.0
     # via -r requirements/base.in
-edx-django-utils==4.4.0
+edx-django-utils==4.4.1
     # via
     #   -r requirements/base.in
     #   django-config-models
@@ -215,7 +218,7 @@ edx-opaque-keys==2.2.2
     #   edx-drf-extensions
 edx-rbac==1.5.1
     # via -r requirements/base.in
-edx-rest-api-client==5.4.0
+edx-rest-api-client==5.4.1
     # via
     #   -r requirements/base.in
     #   edx-ecommerce-worker
@@ -228,7 +231,7 @@ extras==1.0.0
     #   testtools
 factory-boy==2.12.0
     # via django-oscar
-faker==9.8.0
+faker==11.1.0
     # via factory-boy
 fixtures==3.0.0
     # via
@@ -245,11 +248,11 @@ idna==2.7
     #   requests
 ipaddress==1.0.23
     # via cybersource-rest-client-python
-isodate==0.6.0
+isodate==0.6.1
     # via zeep
 itypes==1.2.0
     # via coreapi
-jinja2==3.0.2
+jinja2==3.0.3
     # via coreschema
 jmespath==0.10.0
     # via
@@ -275,7 +278,7 @@ linecache2==1.0.0
     #   traceback2
 logger==1.4
     # via cybersource-rest-client-python
-lxml==4.6.4
+lxml==4.7.1
     # via
     #   premailer
     #   zeep
@@ -293,7 +296,7 @@ naked==0.1.31
     #   cybersource-rest-client-python
 ndg-httpsclient==0.5.1
     # via -r requirements/base.in
-newrelic==7.2.2.169
+newrelic==7.2.4.171
     # via
     #   -r requirements/base.in
     #   edx-django-utils
@@ -305,29 +308,31 @@ oauthlib==3.1.1
     #   social-auth-core
 openapi-codec==1.3.2
     # via django-rest-swagger
-packaging==21.2
-    # via bleach
-paramiko==2.8.0
+packaging==21.3
+    # via
+    #   bleach
+    #   redis
+paramiko==2.9.1
     # via cybersource-rest-client-python
 path.py==7.2
     # via -r requirements/base.in
 paypalrestsdk==1.13.1
     # via -r requirements/base.in
-pbr==5.7.0
+pbr==5.8.0
     # via
     #   cybersource-rest-client-python
     #   fixtures
     #   stevedore
     #   testtools
-phonenumbers==8.12.36
+phonenumbers==8.12.40
     # via django-oscar
-pillow==8.4.0
+pillow==9.0.0
     # via django-oscar
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via zeep
 premailer==2.9.2
     # via -r requirements/base.in
-psutil==5.8.0
+psutil==5.9.0
     # via edx-django-utils
 purl==1.6
     # via django-oscar
@@ -339,17 +344,17 @@ pyasn1==0.4.8
     #   x509
 pycountry==17.1.8
     # via -r requirements/base.in
-pycparser==2.20
+pycparser==2.21
     # via
     #   cffi
     #   cybersource-rest-client-python
-pycryptodome==3.11.0
+pycryptodome==3.12.0
     # via cybersource-rest-client-python
-pycryptodomex==3.11.0
+pycryptodomex==3.12.0
     # via
     #   cybersource-rest-client-python
     #   pyjwkest
-pygments==2.10.0
+pygments==2.11.1
     # via -r requirements/base.in
 pyjwkest==1.4.2
     # via edx-drf-extensions
@@ -360,7 +365,7 @@ pyjwt[crypto]==1.7.1
     #   edx-auth-backends
     #   edx-rest-api-client
     #   social-auth-core
-pymongo==3.12.1
+pymongo==4.0.1
     # via edx-opaque-keys
 pynacl==1.4.0
     # via
@@ -371,7 +376,7 @@ pyopenssl==21.0.0
     #   cybersource-rest-client-python
     #   ndg-httpsclient
     #   paypalrestsdk
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 pypi==2.1
     # via cybersource-rest-client-python
@@ -403,17 +408,19 @@ pytz==2016.10
     #   cybersource-rest-client-python
     #   datetime
     #   django
+    #   djangorestframework
+    #   djangorestframework-datatables
     #   zeep
 pyyaml==6.0
     # via
     #   cybersource-rest-client-python
     #   edx-django-release-util
     #   naked
-rcssmin==1.0.6
+rcssmin==1.1.0
     # via django-compressor
-redis==3.5.3
+redis==4.1.0
     # via edx-ecommerce-worker
-requests==2.26.0
+requests==2.27.0
     # via
     #   -r requirements/base.in
     #   analytics-python
@@ -439,11 +446,11 @@ requests-toolbelt==0.9.1
     # via zeep
 rest-condition==1.0.3
     # via edx-drf-extensions
-rjsmin==1.1.0
+rjsmin==1.2.0
     # via django-compressor
-rsa==4.7.2
+rsa==4.8
     # via cybersource-rest-client-python
-rules==3.0
+rules==3.1
     # via -r requirements/base.in
 s3transfer==0.5.0
     # via boto3
@@ -453,7 +460,7 @@ shellescape==3.8.1
     # via
     #   crypto
     #   cybersource-rest-client-python
-simplejson==3.17.5
+simplejson==3.17.6
     # via django-rest-swagger
 six==1.16.0
     # via
@@ -461,7 +468,6 @@ six==1.16.0
     #   bcrypt
     #   bleach
     #   cybersource-rest-client-python
-    #   django-compressor
     #   django-extra-views
     #   djangorestframework-csv
     #   edx-auth-backends
@@ -533,8 +539,10 @@ vine==1.3.0
     #   celery
 webencodings==0.5.1
     # via bleach
-wheel==0.37.0
+wheel==0.37.1
     # via cybersource-rest-client-python
+wrapt==1.13.3
+    # via deprecated
 x509==0.1
     # via cybersource-rest-client-python
 xss-utils==0.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,11 +18,11 @@ asn1crypto==1.4.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-astroid==2.3.3
+astroid==2.9.2
     # via
     #   -r requirements/test.txt
     #   pylint
-attrs==21.2.0
+attrs==21.4.0
     # via
     #   -r requirements/test.txt
     #   jsonschema
@@ -56,9 +56,9 @@ bleach==4.1.0
     # via -r requirements/test.txt
 bok-choy==1.1.1
     # via -r requirements/test.txt
-boto3==1.19.10
+boto3==1.20.28
     # via -r requirements/test.txt
-botocore==1.22.10
+botocore==1.23.28
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -89,12 +89,12 @@ chardet==4.0.0
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
     #   diff-cover
-charset-normalizer==2.0.7
+charset-normalizer==2.0.10
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   requests
-configparser==5.1.0
+configparser==5.2.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -107,7 +107,7 @@ coreschema==0.0.4
     # via
     #   -r requirements/test.txt
     #   coreapi
-coverage[toml]==6.1.1
+coverage[toml]==6.2
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -145,9 +145,13 @@ defusedxml==0.7.1
     #   -r requirements/test.txt
     #   python3-openid
     #   social-auth-core
-diff-cover==6.4.2
+deprecated==1.2.13
+    # via
+    #   -r requirements/test.txt
+    #   redis
+diff-cover==6.4.4
     # via -r requirements/test.txt
-django==2.2.24
+django==2.2.26
     # via
     #   -r requirements/test.txt
     #   django-appconf
@@ -162,6 +166,7 @@ django==2.2.24
     #   django-model-utils
     #   django-oscar
     #   django-phonenumber-field
+    #   django-solo
     #   django-tables2
     #   django-treebeard
     #   djangorestframework
@@ -181,13 +186,13 @@ django-appconf==1.0.5
     # via
     #   -r requirements/test.txt
     #   django-compressor
-django-compressor==2.4.1
+django-compressor==3.1
     # via
     #   -r requirements/test.txt
     #   django-libsass
-django-config-models==2.2.0
+django-config-models==2.2.2
     # via -r requirements/test.txt
-django-cors-headers==3.10.0
+django-cors-headers==3.10.1
     # via -r requirements/test.txt
 django-crispy-forms==1.13.0
     # via -r requirements/test.txt
@@ -196,9 +201,9 @@ django-crum==0.7.9
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-rbac
-django-debug-toolbar==3.2.2
+django-debug-toolbar==3.2.4
     # via -r requirements/dev.in
-django-extensions==3.1.3
+django-extensions==3.1.5
     # via -r requirements/test.txt
 django-extra-views==0.13.0
     # via
@@ -226,7 +231,7 @@ django-rest-swagger==2.2.0
     # via -r requirements/test.txt
 django-simple-history==3.0.0
     # via -r requirements/test.txt
-django-solo==1.2.0
+django-solo==2.0.0
     # via -r requirements/test.txt
 django-tables2==2.2.1
     # via
@@ -243,13 +248,13 @@ django-waffle==2.2.1
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-drf-extensions
-django-webtest==1.9.8
+django-webtest==1.9.9
     # via -r requirements/test.txt
 django-widget-tweaks==1.4.9
     # via
     #   -r requirements/test.txt
     #   django-oscar
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via
     #   -r requirements/test.txt
     #   django-config-models
@@ -262,7 +267,7 @@ djangorestframework==3.12.4
     #   rest-condition
 djangorestframework-csv==2.1.1
     # via -r requirements/test.txt
-djangorestframework-datatables==0.6.0
+djangorestframework-datatables==0.7.0
     # via -r requirements/test.txt
 docutils==0.17.1
     # via
@@ -280,7 +285,7 @@ edx-django-release-util==1.1.0
     # via -r requirements/test.txt
 edx-django-sites-extensions==3.1.0
     # via -r requirements/test.txt
-edx-django-utils==4.4.0
+edx-django-utils==4.4.1
     # via
     #   -r requirements/test.txt
     #   django-config-models
@@ -300,7 +305,7 @@ edx-opaque-keys==2.2.2
     #   edx-drf-extensions
 edx-rbac==1.5.1
     # via -r requirements/test.txt
-edx-rest-api-client==5.4.0
+edx-rest-api-client==5.4.1
     # via
     #   -r requirements/test.txt
     #   edx-ecommerce-worker
@@ -320,11 +325,11 @@ factory-boy==2.12.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
-faker==9.8.0
+faker==11.1.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.3.2
+filelock==3.4.2
     # via
     #   -r requirements/test.txt
     #   tox
@@ -355,18 +360,14 @@ idna==2.7
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
     #   requests
-imagesize==1.2.0
+imagesize==1.3.0
     # via
     #   -r requirements/docs.txt
     #   sphinx
-importlib-metadata==4.8.1
+importlib-metadata==4.10.0
     # via
     #   -r requirements/test.txt
     #   pytest-randomly
-inflect==5.3.0
-    # via
-    #   -r requirements/test.txt
-    #   jinja2-pluralize
 iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
@@ -375,11 +376,11 @@ ipaddress==1.0.23
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-isodate==0.6.0
+isodate==0.6.1
     # via
     #   -r requirements/test.txt
     #   zeep
-isort==4.3.21
+isort==5.10.1
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -387,18 +388,13 @@ itypes==1.2.0
     # via
     #   -r requirements/test.txt
     #   coreapi
-jinja2==3.0.2
+jinja2==3.0.3
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   coreschema
     #   diff-cover
-    #   jinja2-pluralize
     #   sphinx
-jinja2-pluralize==0.3.0
-    # via
-    #   -r requirements/test.txt
-    #   diff-cover
 jmespath==0.10.0
     # via
     #   -r requirements/test.txt
@@ -418,7 +414,7 @@ lazy==1.4
     # via
     #   -r requirements/test.txt
     #   bok-choy
-lazy-object-proxy==1.4.3
+lazy-object-proxy==1.7.1
     # via
     #   -r requirements/test.txt
     #   astroid
@@ -435,7 +431,7 @@ logger==1.4
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-lxml==4.6.4
+lxml==4.7.1
     # via
     #   -r requirements/test.txt
     #   premailer
@@ -470,7 +466,7 @@ naked==0.1.31
     #   cybersource-rest-client-python
 ndg-httpsclient==0.5.1
     # via -r requirements/test.txt
-newrelic==7.2.2.169
+newrelic==7.2.4.171
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -487,15 +483,16 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
-packaging==21.2
+packaging==21.3
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   bleach
     #   pytest
+    #   redis
     #   sphinx
     #   tox
-paramiko==2.8.0
+paramiko==2.9.1
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -507,24 +504,25 @@ path.py==7.2
     # via -r requirements/test.txt
 paypalrestsdk==1.13.1
     # via -r requirements/test.txt
-pbr==5.7.0
+pbr==5.8.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
     #   fixtures
     #   stevedore
     #   testtools
-phonenumbers==8.12.36
+phonenumbers==8.12.40
     # via
     #   -r requirements/test.txt
     #   django-oscar
-pillow==8.4.0
+pillow==9.0.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via
     #   -r requirements/test.txt
+    #   pylint
     #   zeep
 pluggy==0.13.1
     # via
@@ -538,7 +536,7 @@ polib==1.1.1
     #   edx-i18n-tools
 premailer==2.9.2
     # via -r requirements/test.txt
-psutil==5.8.0
+psutil==5.9.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -548,7 +546,7 @@ purl==1.6
     # via
     #   -r requirements/test.txt
     #   django-oscar
-py==1.10.0
+py==1.11.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -564,21 +562,21 @@ pycodestyle==2.8.0
     # via -r requirements/test.txt
 pycountry==17.1.8
     # via -r requirements/test.txt
-pycparser==2.20
+pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
     #   cybersource-rest-client-python
-pycryptodome==3.11.0
+pycryptodome==3.12.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-pycryptodomex==3.11.0
+pycryptodomex==3.12.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
     #   pyjwkest
-pygments==2.10.0
+pygments==2.11.1
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -596,9 +594,9 @@ pyjwt[crypto]==1.7.1
     #   edx-auth-backends
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.4.4
+pylint==2.12.2
     # via -r requirements/test.txt
-pymongo==3.12.1
+pymongo==4.0.1
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -613,7 +611,7 @@ pyopenssl==21.0.0
     #   cybersource-rest-client-python
     #   ndg-httpsclient
     #   paypalrestsdk
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -644,7 +642,7 @@ pytest-base-url==1.4.2
     #   pytest-selenium
 pytest-cov==3.0.0
     # via -r requirements/test.txt
-pytest-django==4.4.0
+pytest-django==4.5.2
     # via -r requirements/test.txt
 pytest-html==3.1.1
     # via
@@ -654,11 +652,11 @@ pytest-metadata==1.11.0
     # via
     #   -r requirements/test.txt
     #   pytest-html
-pytest-randomly==3.10.1
+pytest-randomly==3.10.3
     # via -r requirements/test.txt
 pytest-selenium==2.0.1
     # via -r requirements/test.txt
-pytest-timeout==2.0.1
+pytest-timeout==2.0.2
     # via -r requirements/test.txt
 pytest-variables==1.9.0
     # via
@@ -672,7 +670,7 @@ python-dateutil==2.8.2
     #   edx-drf-extensions
     #   faker
     #   freezegun
-python-dotenv==0.19.1
+python-dotenv==0.19.2
     # via -r requirements/test.txt
 python-memcached==1.58
     # via -r requirements/test.txt
@@ -703,6 +701,8 @@ pytz==2016.10
     #   cybersource-rest-client-python
     #   datetime
     #   django
+    #   djangorestframework
+    #   djangorestframework-datatables
     #   zeep
 pywatchman==1.4.1
     # via -r requirements/dev.in
@@ -713,15 +713,15 @@ pyyaml==6.0
     #   edx-django-release-util
     #   edx-i18n-tools
     #   naked
-rcssmin==1.0.6
+rcssmin==1.1.0
     # via
     #   -r requirements/test.txt
     #   django-compressor
-redis==3.5.3
+redis==4.1.0
     # via
     #   -r requirements/test.txt
     #   edx-ecommerce-worker
-requests==2.26.0
+requests==2.27.0
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -757,21 +757,21 @@ requests-toolbelt==0.9.1
     # via
     #   -r requirements/test.txt
     #   zeep
-responses==0.15.0
+responses==0.16.0
     # via -r requirements/test.txt
 rest-condition==1.0.3
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-rjsmin==1.1.0
+rjsmin==1.2.0
     # via
     #   -r requirements/test.txt
     #   django-compressor
-rsa==4.7.2
+rsa==4.8
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-rules==3.0
+rules==3.1
     # via -r requirements/test.txt
 s3transfer==0.5.0
     # via
@@ -791,7 +791,7 @@ shellescape==3.8.1
     #   -r requirements/test.txt
     #   crypto
     #   cybersource-rest-client-python
-simplejson==3.17.5
+simplejson==3.17.6
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
@@ -800,12 +800,10 @@ six==1.16.0
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   analytics-python
-    #   astroid
     #   bcrypt
     #   bleach
     #   bok-choy
     #   cybersource-rest-client-python
-    #   django-compressor
     #   django-extra-views
     #   djangorestframework-csv
     #   edx-auth-backends
@@ -839,7 +837,7 @@ slumber==0.7.1
     #   edx-rest-api-client
 smmap==5.0.0
     # via gitdb
-snowballstemmer==2.1.0
+snowballstemmer==2.2.0
     # via
     #   -r requirements/docs.txt
     #   sphinx
@@ -854,11 +852,11 @@ social-auth-core==4.0.2
     #   social-auth-app-django
 sorl-thumbnail==12.7.0
     # via -r requirements/test.txt
-soupsieve==2.3
+soupsieve==2.3.1
     # via
     #   -r requirements/test.txt
     #   beautifulsoup4
-sphinx==4.2.0
+sphinx==4.3.2
     # via
     #   -r requirements/docs.txt
     #   edx-sphinx-theme
@@ -918,9 +916,10 @@ text-unidecode==1.3
 toml==0.10.2
     # via
     #   -r requirements/test.txt
+    #   pylint
     #   pytest
     #   tox
-tomli==1.2.2
+tomli==2.0.0
     # via
     #   -r requirements/test.txt
     #   coverage
@@ -934,14 +933,18 @@ traceback2==1.4.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-transifex-client==0.14.3
+transifex-client==0.14.4
     # via -r requirements/dev.in
 typing==3.7.4.3
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-typing-extensions==3.10.0.2
-    # via gitpython
+typing-extensions==4.0.1
+    # via
+    #   -r requirements/test.txt
+    #   astroid
+    #   gitpython
+    #   pylint
 unicodecsv==0.14.1
     # via
     #   -r requirements/test.txt
@@ -985,14 +988,15 @@ webtest==3.0.0
     # via
     #   -r requirements/test.txt
     #   django-webtest
-wheel==0.37.0
+wheel==0.37.1
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-wrapt==1.11.2
+wrapt==1.13.3
     # via
     #   -r requirements/test.txt
     #   astroid
+    #   deprecated
 x509==0.1
     # via
     #   -r requirements/test.txt
@@ -1001,7 +1005,7 @@ xss-utils==0.3.0
     # via -r requirements/test.txt
 zeep==4.1.0
     # via -r requirements/test.txt
-zipp==3.6.0
+zipp==3.7.0
     # via
     #   -r requirements/test.txt
     #   importlib-metadata

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -10,7 +10,7 @@ babel==2.9.1
     # via sphinx
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.7
+charset-normalizer==2.0.10
     # via requests
 docutils==0.17.1
     # via sphinx
@@ -20,29 +20,29 @@ idna==2.7
     # via
     #   -c requirements/pins.txt
     #   requests
-imagesize==1.2.0
+imagesize==1.3.0
     # via sphinx
-jinja2==3.0.2
+jinja2==3.0.3
     # via sphinx
 markupsafe==2.0.1
     # via jinja2
-packaging==21.2
+packaging==21.3
     # via sphinx
-pygments==2.10.0
+pygments==2.11.1
     # via sphinx
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 pytz==2016.10
     # via
     #   -c requirements/pins.txt
     #   babel
-requests==2.26.0
+requests==2.27.0
     # via sphinx
 six==1.16.0
     # via edx-sphinx-theme
-snowballstemmer==2.1.0
+snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.2.0
+sphinx==4.3.2
     # via
     #   -r requirements/docs.in
     #   edx-sphinx-theme

--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-attrs==21.2.0
+attrs==21.4.0
     # via
     #   -c requirements/base.txt
     #   pytest
@@ -16,7 +16,7 @@ cffi==1.15.0
     # via
     #   -c requirements/base.txt
     #   cryptography
-charset-normalizer==2.0.7
+charset-normalizer==2.0.10
     # via
     #   -c requirements/base.txt
     #   requests
@@ -25,7 +25,7 @@ cryptography==3.4.8
     #   -c requirements/base.txt
     #   -c requirements/pins.txt
     #   pyjwt
-django==2.2.24
+django==2.2.26
     # via
     #   -c requirements/base.txt
     #   django-crum
@@ -38,11 +38,11 @@ django-waffle==2.2.1
     # via
     #   -c requirements/base.txt
     #   edx-django-utils
-edx-django-utils==4.4.0
+edx-django-utils==4.4.1
     # via
     #   -c requirements/base.txt
     #   edx-rest-api-client
-edx-rest-api-client==5.4.0
+edx-rest-api-client==5.4.1
     # via
     #   -c requirements/base.txt
     #   -r requirements/e2e.in
@@ -51,19 +51,19 @@ idna==2.7
     #   -c requirements/base.txt
     #   -c requirements/pins.txt
     #   requests
-importlib-metadata==4.8.1
+importlib-metadata==4.10.0
     # via pytest-randomly
 iniconfig==1.1.1
     # via pytest
-newrelic==7.2.2.169
+newrelic==7.2.4.171
     # via
     #   -c requirements/base.txt
     #   edx-django-utils
-packaging==21.2
+packaging==21.3
     # via
     #   -c requirements/base.txt
     #   pytest
-pbr==5.7.0
+pbr==5.8.0
     # via
     #   -c requirements/base.txt
     #   stevedore
@@ -71,13 +71,13 @@ pluggy==0.13.1
     # via
     #   -c requirements/pins.txt
     #   pytest
-psutil==5.8.0
+psutil==5.9.0
     # via
     #   -c requirements/base.txt
     #   edx-django-utils
-py==1.10.0
+py==1.11.0
     # via pytest
-pycparser==2.20
+pycparser==2.21
     # via
     #   -c requirements/base.txt
     #   cffi
@@ -85,7 +85,7 @@ pyjwt[crypto]==1.7.1
     # via
     #   -c requirements/base.txt
     #   edx-rest-api-client
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via
     #   -c requirements/base.txt
     #   packaging
@@ -105,22 +105,22 @@ pytest-html==3.1.1
     # via pytest-selenium
 pytest-metadata==1.11.0
     # via pytest-html
-pytest-randomly==3.10.1
+pytest-randomly==3.10.3
     # via -r requirements/e2e.in
 pytest-selenium==2.0.1
     # via -r requirements/e2e.in
-pytest-timeout==2.0.1
+pytest-timeout==2.0.2
     # via -r requirements/e2e.in
 pytest-variables==1.9.0
     # via pytest-selenium
-python-dotenv==0.19.1
+python-dotenv==0.19.2
     # via -r requirements/e2e.in
 pytz==2016.10
     # via
     #   -c requirements/base.txt
     #   -c requirements/pins.txt
     #   django
-requests==2.26.0
+requests==2.27.0
     # via
     #   -c requirements/base.txt
     #   edx-rest-api-client
@@ -158,5 +158,5 @@ urllib3==1.26.7
     #   -c requirements/pins.txt
     #   requests
     #   selenium
-zipp==3.6.0
+zipp==3.7.0
     # via importlib-metadata

--- a/requirements/pins.txt
+++ b/requirements/pins.txt
@@ -29,11 +29,6 @@ urllib3>=1.24.2,<2.0.0
 # Was causing some tox issues locally.
 virtualenv==16.7.9
 
-# newer version seems to be causing failures
-# if tox -e py35-django22-pylint passes after
-# removing this pin, then this pin can be removed.
-pylint==2.4.4
-
 # greater versions failing with extract-translations step.
 tox==3.14.6
 pluggy<1.0.0  # pluggy==1.0.0 requires tox>3.14.6

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -10,9 +10,9 @@ pep517==0.12.0
     # via pip-tools
 pip-tools==6.4.0
     # via -r requirements/pip_tools.in
-tomli==1.2.2
+tomli==2.0.0
     # via pep517
-wheel==0.37.0
+wheel==0.37.1
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -10,7 +10,7 @@ analytics-python==1.4.0
     # via -r requirements/base.in
 asn1crypto==1.4.0
     # via cybersource-rest-client-python
-attrs==21.2.0
+attrs==21.4.0
     # via
     #   jsonschema
     #   zeep
@@ -28,11 +28,11 @@ billiard==3.6.4.0
     # via celery
 bleach==4.1.0
     # via -r requirements/base.in
-boto3==1.19.10
+boto3==1.20.28
     # via
     #   -r requirements/base.in
     #   django-ses
-botocore==1.22.10
+botocore==1.23.28
     # via
     #   boto3
     #   s3transfer
@@ -54,9 +54,9 @@ cffi==1.15.0
     #   pynacl
 chardet==4.0.0
     # via cybersource-rest-client-python
-charset-normalizer==2.0.7
+charset-normalizer==2.0.10
     # via requests
-configparser==5.1.0
+configparser==5.2.0
     # via cybersource-rest-client-python
 coreapi==2.3.3
     # via
@@ -65,7 +65,7 @@ coreapi==2.3.3
     #   openapi-codec
 coreschema==0.0.4
     # via coreapi
-coverage==6.1.1
+coverage==6.2
     # via cybersource-rest-client-python
 crypto==1.4.1
     # via cybersource-rest-client-python
@@ -91,7 +91,9 @@ defusedxml==0.7.1
     # via
     #   python3-openid
     #   social-auth-core
-django==2.2.24
+deprecated==1.2.13
+    # via redis
+django==2.2.26
     # via
     #   -r requirements/base.in
     #   django-appconf
@@ -106,6 +108,7 @@ django==2.2.24
     #   django-oscar
     #   django-phonenumber-field
     #   django-ses
+    #   django-solo
     #   django-tables2
     #   django-treebeard
     #   djangorestframework
@@ -121,13 +124,13 @@ django==2.2.24
     #   xss-utils
 django-appconf==1.0.5
     # via django-compressor
-django-compressor==2.4.1
+django-compressor==3.1
     # via
     #   -r requirements/base.in
     #   django-libsass
-django-config-models==2.2.0
+django-config-models==2.2.2
     # via -r requirements/base.in
-django-cors-headers==3.10.0
+django-cors-headers==3.10.1
     # via -r requirements/base.in
 django-crispy-forms==1.13.0
     # via -r requirements/base.in
@@ -135,7 +138,7 @@ django-crum==0.7.9
     # via
     #   edx-django-utils
     #   edx-rbac
-django-extensions==3.1.3
+django-extensions==3.1.5
     # via -r requirements/base.in
 django-extra-views==0.13.0
     # via django-oscar
@@ -155,11 +158,11 @@ django-phonenumber-field==3.0.1
     # via django-oscar
 django-rest-swagger==2.2.0
     # via -r requirements/base.in
-django-ses==2.3.0
+django-ses==2.3.1
     # via -r requirements/production.in
 django-simple-history==3.0.0
     # via -r requirements/base.in
-django-solo==1.2.0
+django-solo==2.0.0
     # via -r requirements/base.in
 django-tables2==2.2.1
     # via django-oscar
@@ -174,7 +177,7 @@ django-waffle==2.2.1
     #   edx-drf-extensions
 django-widget-tweaks==1.4.9
     # via django-oscar
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via
     #   -r requirements/base.in
     #   django-config-models
@@ -187,7 +190,7 @@ djangorestframework==3.12.4
     #   rest-condition
 djangorestframework-csv==2.1.1
     # via -r requirements/base.in
-djangorestframework-datatables==0.6.0
+djangorestframework-datatables==0.7.0
     # via -r requirements/base.in
 drf-extensions==0.7.1
     # via -r requirements/base.in
@@ -201,7 +204,7 @@ edx-django-release-util==1.1.0
     # via -r requirements/base.in
 edx-django-sites-extensions==3.1.0
     # via -r requirements/base.in
-edx-django-utils==4.4.0
+edx-django-utils==4.4.1
     # via
     #   -r requirements/base.in
     #   django-config-models
@@ -220,7 +223,7 @@ edx-opaque-keys==2.2.2
     #   edx-drf-extensions
 edx-rbac==1.5.1
     # via -r requirements/base.in
-edx-rest-api-client==5.4.0
+edx-rest-api-client==5.4.1
     # via
     #   -r requirements/base.in
     #   edx-ecommerce-worker
@@ -233,7 +236,7 @@ extras==1.0.0
     #   testtools
 factory-boy==2.12.0
     # via django-oscar
-faker==9.8.0
+faker==11.1.0
     # via factory-boy
 fixtures==3.0.0
     # via
@@ -254,11 +257,11 @@ idna==2.7
     #   requests
 ipaddress==1.0.23
     # via cybersource-rest-client-python
-isodate==0.6.0
+isodate==0.6.1
     # via zeep
 itypes==1.2.0
     # via coreapi
-jinja2==3.0.2
+jinja2==3.0.3
     # via coreschema
 jmespath==0.10.0
     # via
@@ -284,7 +287,7 @@ linecache2==1.0.0
     #   traceback2
 logger==1.4
     # via cybersource-rest-client-python
-lxml==4.6.4
+lxml==4.7.1
     # via
     #   premailer
     #   zeep
@@ -317,29 +320,31 @@ oauthlib==3.1.1
     #   social-auth-core
 openapi-codec==1.3.2
     # via django-rest-swagger
-packaging==21.2
-    # via bleach
-paramiko==2.8.0
+packaging==21.3
+    # via
+    #   bleach
+    #   redis
+paramiko==2.9.1
     # via cybersource-rest-client-python
 path.py==7.2
     # via -r requirements/base.in
 paypalrestsdk==1.13.1
     # via -r requirements/base.in
-pbr==5.7.0
+pbr==5.8.0
     # via
     #   cybersource-rest-client-python
     #   fixtures
     #   stevedore
     #   testtools
-phonenumbers==8.12.36
+phonenumbers==8.12.40
     # via django-oscar
-pillow==8.4.0
+pillow==9.0.0
     # via django-oscar
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via zeep
 premailer==2.9.2
     # via -r requirements/base.in
-psutil==5.8.0
+psutil==5.9.0
     # via edx-django-utils
 purl==1.6
     # via django-oscar
@@ -351,17 +356,17 @@ pyasn1==0.4.8
     #   x509
 pycountry==17.1.8
     # via -r requirements/base.in
-pycparser==2.20
+pycparser==2.21
     # via
     #   cffi
     #   cybersource-rest-client-python
-pycryptodome==3.11.0
+pycryptodome==3.12.0
     # via cybersource-rest-client-python
-pycryptodomex==3.11.0
+pycryptodomex==3.12.0
     # via
     #   cybersource-rest-client-python
     #   pyjwkest
-pygments==2.10.0
+pygments==2.11.1
     # via -r requirements/base.in
 pyjwkest==1.4.2
     # via edx-drf-extensions
@@ -372,7 +377,7 @@ pyjwt[crypto]==1.7.1
     #   edx-auth-backends
     #   edx-rest-api-client
     #   social-auth-core
-pymongo==3.12.1
+pymongo==4.0.1
     # via edx-opaque-keys
 pynacl==1.4.0
     # via
@@ -383,7 +388,7 @@ pyopenssl==21.0.0
     #   cybersource-rest-client-python
     #   ndg-httpsclient
     #   paypalrestsdk
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 pypi==2.1
     # via cybersource-rest-client-python
@@ -418,6 +423,8 @@ pytz==2016.10
     #   datetime
     #   django
     #   django-ses
+    #   djangorestframework
+    #   djangorestframework-datatables
     #   zeep
 pyyaml==6.0
     # via
@@ -425,13 +432,13 @@ pyyaml==6.0
     #   cybersource-rest-client-python
     #   edx-django-release-util
     #   naked
-rcssmin==1.0.6
+rcssmin==1.1.0
     # via django-compressor
-redis==3.5.3
+redis==4.1.0
     # via
     #   -r requirements/production.in
     #   edx-ecommerce-worker
-requests==2.26.0
+requests==2.27.0
     # via
     #   -r requirements/base.in
     #   analytics-python
@@ -457,11 +464,11 @@ requests-toolbelt==0.9.1
     # via zeep
 rest-condition==1.0.3
     # via edx-drf-extensions
-rjsmin==1.1.0
+rjsmin==1.2.0
     # via django-compressor
-rsa==4.7.2
+rsa==4.8
     # via cybersource-rest-client-python
-rules==3.0
+rules==3.1
     # via -r requirements/base.in
 s3transfer==0.5.0
     # via boto3
@@ -471,7 +478,7 @@ shellescape==3.8.1
     # via
     #   crypto
     #   cybersource-rest-client-python
-simplejson==3.17.5
+simplejson==3.17.6
     # via django-rest-swagger
 six==1.16.0
     # via
@@ -479,7 +486,6 @@ six==1.16.0
     #   bcrypt
     #   bleach
     #   cybersource-rest-client-python
-    #   django-compressor
     #   django-extra-views
     #   djangorestframework-csv
     #   edx-auth-backends
@@ -552,8 +558,10 @@ vine==1.3.0
     #   celery
 webencodings==0.5.1
     # via bleach
-wheel==0.37.0
+wheel==0.37.1
     # via cybersource-rest-client-python
+wrapt==1.13.3
+    # via deprecated
 x509==0.1
     # via cybersource-rest-client-python
 xss-utils==0.3.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,9 +14,9 @@ asn1crypto==1.4.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-astroid==2.3.3
+astroid==2.9.2
     # via pylint
-attrs==21.2.0
+attrs==21.4.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -47,9 +47,9 @@ bleach==4.1.0
     # via -r requirements/base.txt
 bok-choy==1.1.1
     # via -r requirements/test.in
-boto3==1.19.10
+boto3==1.20.28
     # via -r requirements/base.txt
-botocore==1.22.10
+botocore==1.23.28
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -82,12 +82,12 @@ chardet==4.0.0
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
     #   diff-cover
-charset-normalizer==2.0.7
+charset-normalizer==2.0.10
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
     #   requests
-configparser==5.1.0
+configparser==5.2.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
@@ -100,7 +100,7 @@ coreschema==0.0.4
     # via
     #   -r requirements/base.txt
     #   coreapi
-coverage[toml]==6.1.1
+coverage[toml]==6.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
@@ -143,7 +143,11 @@ defusedxml==0.7.1
     #   -r requirements/base.txt
     #   python3-openid
     #   social-auth-core
-diff-cover==6.4.2
+deprecated==1.2.13
+    # via
+    #   -r requirements/base.txt
+    #   redis
+diff-cover==6.4.4
     # via -r requirements/test.in
     # via
     #   -r requirements/base.txt
@@ -159,6 +163,7 @@ diff-cover==6.4.2
     #   django-model-utils
     #   django-oscar
     #   django-phonenumber-field
+    #   django-solo
     #   django-tables2
     #   django-treebeard
     #   djangorestframework
@@ -178,13 +183,13 @@ django-appconf==1.0.5
     # via
     #   -r requirements/base.txt
     #   django-compressor
-django-compressor==2.4.1
+django-compressor==3.1
     # via
     #   -r requirements/base.txt
     #   django-libsass
-django-config-models==2.2.0
+django-config-models==2.2.2
     # via -r requirements/base.txt
-django-cors-headers==3.10.0
+django-cors-headers==3.10.1
     # via -r requirements/base.txt
 django-crispy-forms==1.13.0
     # via -r requirements/base.txt
@@ -194,7 +199,7 @@ django-crum==0.7.9
     #   -r requirements/e2e.txt
     #   edx-django-utils
     #   edx-rbac
-django-extensions==3.1.3
+django-extensions==3.1.5
     # via -r requirements/base.txt
 django-extra-views==0.13.0
     # via
@@ -224,7 +229,7 @@ django-rest-swagger==2.2.0
     # via -r requirements/base.txt
 django-simple-history==3.0.0
     # via -r requirements/base.txt
-django-solo==1.2.0
+django-solo==2.0.0
     # via -r requirements/base.txt
 django-tables2==2.2.1
     # via
@@ -242,13 +247,13 @@ django-waffle==2.2.1
     #   -r requirements/e2e.txt
     #   edx-django-utils
     #   edx-drf-extensions
-django-webtest==1.9.8
+django-webtest==1.9.9
     # via -r requirements/test.in
 django-widget-tweaks==1.4.9
     # via
     #   -r requirements/base.txt
     #   django-oscar
-djangorestframework==3.12.4
+djangorestframework==3.13.1
     # via
     #   -r requirements/base.txt
     #   django-config-models
@@ -261,7 +266,7 @@ djangorestframework==3.12.4
     #   rest-condition
 djangorestframework-csv==2.1.1
     # via -r requirements/base.txt
-djangorestframework-datatables==0.6.0
+djangorestframework-datatables==0.7.0
     # via -r requirements/base.txt
 drf-extensions==0.7.1
     # via -r requirements/base.txt
@@ -277,7 +282,7 @@ edx-django-release-util==1.1.0
     # via -r requirements/base.txt
 edx-django-sites-extensions==3.1.0
     # via -r requirements/base.txt
-edx-django-utils==4.4.0
+edx-django-utils==4.4.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -299,7 +304,7 @@ edx-opaque-keys==2.2.2
     #   edx-drf-extensions
 edx-rbac==1.5.1
     # via -r requirements/base.txt
-edx-rest-api-client==5.4.0
+edx-rest-api-client==5.4.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -319,11 +324,11 @@ factory-boy==2.12.0
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   django-oscar
-faker==9.8.0
+faker==11.1.0
     # via
     #   -r requirements/base.txt
     #   factory-boy
-filelock==3.3.2
+filelock==3.4.2
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -353,12 +358,10 @@ idna==2.7
     #   -r requirements/e2e.txt
     #   cybersource-rest-client-python
     #   requests
-importlib-metadata==4.8.1
+importlib-metadata==4.10.0
     # via
     #   -r requirements/e2e.txt
     #   pytest-randomly
-inflect==5.3.0
-    # via jinja2-pluralize
 iniconfig==1.1.1
     # via
     #   -r requirements/e2e.txt
@@ -367,11 +370,11 @@ ipaddress==1.0.23
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-isodate==0.6.0
+isodate==0.6.1
     # via
     #   -r requirements/base.txt
     #   zeep
-isort==4.3.21
+isort==5.10.1
     # via
     #   -r requirements/test.in
     #   pylint
@@ -379,14 +382,11 @@ itypes==1.2.0
     # via
     #   -r requirements/base.txt
     #   coreapi
-jinja2==3.0.2
+jinja2==3.0.3
     # via
     #   -r requirements/base.txt
     #   coreschema
     #   diff-cover
-    #   jinja2-pluralize
-jinja2-pluralize==0.3.0
-    # via diff-cover
 jmespath==0.10.0
     # via
     #   -r requirements/base.txt
@@ -407,7 +407,7 @@ kombu==4.6.11
     #   celery
 lazy==1.4
     # via bok-choy
-lazy-object-proxy==1.4.3
+lazy-object-proxy==1.7.1
     # via astroid
 libsass==0.9.2
     # via
@@ -422,7 +422,7 @@ logger==1.4
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-lxml==4.6.4
+lxml==4.7.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
@@ -455,7 +455,7 @@ naked==0.1.31
     #   cybersource-rest-client-python
 ndg-httpsclient==0.5.1
     # via -r requirements/base.txt
-newrelic==7.2.2.169
+newrelic==7.2.4.171
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -473,15 +473,16 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-packaging==21.2
+packaging==21.3
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
     #   -r requirements/tox.txt
     #   bleach
     #   pytest
+    #   redis
     #   tox
-paramiko==2.8.0
+paramiko==2.9.1
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
@@ -491,7 +492,7 @@ path.py==7.2
     # via -r requirements/base.txt
 paypalrestsdk==1.13.1
     # via -r requirements/base.txt
-pbr==5.7.0
+pbr==5.8.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -499,17 +500,18 @@ pbr==5.7.0
     #   fixtures
     #   stevedore
     #   testtools
-phonenumbers==8.12.36
+phonenumbers==8.12.40
     # via
     #   -r requirements/base.txt
     #   django-oscar
-pillow==8.4.0
+pillow==9.0.0
     # via
     #   -r requirements/base.txt
     #   django-oscar
-platformdirs==2.4.0
+platformdirs==2.4.1
     # via
     #   -r requirements/base.txt
+    #   pylint
     #   zeep
 pluggy==0.13.1
     # via
@@ -523,7 +525,7 @@ polib==1.1.1
     # via edx-i18n-tools
 premailer==2.9.2
     # via -r requirements/base.txt
-psutil==5.8.0
+psutil==5.9.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -532,7 +534,7 @@ purl==1.6
     # via
     #   -r requirements/base.txt
     #   django-oscar
-py==1.10.0
+py==1.11.0
     # via
     #   -r requirements/e2e.txt
     #   -r requirements/tox.txt
@@ -549,22 +551,22 @@ pycodestyle==2.8.0
     # via -r requirements/test.in
 pycountry==17.1.8
     # via -r requirements/base.txt
-pycparser==2.20
+pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
     #   cffi
     #   cybersource-rest-client-python
-pycryptodome==3.11.0
+pycryptodome==3.12.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-pycryptodomex==3.11.0
+pycryptodomex==3.12.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
     #   pyjwkest
-pygments==2.10.0
+pygments==2.11.1
     # via
     #   -r requirements/base.txt
     #   diff-cover
@@ -581,11 +583,9 @@ pyjwt[crypto]==1.7.1
     #   edx-auth-backends
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.4.4
-    # via
-    #   -c requirements/pins.txt
-    #   -r requirements/test.in
-pymongo==3.12.1
+pylint==2.12.2
+    # via -r requirements/test.in
+pymongo==4.0.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -600,7 +600,7 @@ pyopenssl==21.0.0
     #   cybersource-rest-client-python
     #   ndg-httpsclient
     #   paypalrestsdk
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -633,7 +633,7 @@ pytest-base-url==1.4.2
     #   pytest-selenium
 pytest-cov==3.0.0
     # via -r requirements/test.in
-pytest-django==4.4.0
+pytest-django==4.5.2
     # via -r requirements/test.in
 pytest-html==3.1.1
     # via
@@ -643,11 +643,11 @@ pytest-metadata==1.11.0
     # via
     #   -r requirements/e2e.txt
     #   pytest-html
-pytest-randomly==3.10.1
+pytest-randomly==3.10.3
     # via -r requirements/e2e.txt
 pytest-selenium==2.0.1
     # via -r requirements/e2e.txt
-pytest-timeout==2.0.1
+pytest-timeout==2.0.2
     # via -r requirements/e2e.txt
 pytest-variables==1.9.0
     # via
@@ -661,7 +661,7 @@ python-dateutil==2.8.2
     #   edx-drf-extensions
     #   faker
     #   freezegun
-python-dotenv==0.19.1
+python-dotenv==0.19.2
     # via -r requirements/e2e.txt
 python-memcached==1.58
     # via -r requirements/test.in
@@ -691,6 +691,8 @@ pytz==2016.10
     #   cybersource-rest-client-python
     #   datetime
     #   django
+    #   djangorestframework
+    #   djangorestframework-datatables
     #   zeep
 pyyaml==6.0
     # via
@@ -699,15 +701,15 @@ pyyaml==6.0
     #   edx-django-release-util
     #   edx-i18n-tools
     #   naked
-rcssmin==1.0.6
+rcssmin==1.1.0
     # via
     #   -r requirements/base.txt
     #   django-compressor
-redis==3.5.3
+redis==4.1.0
     # via
     #   -r requirements/base.txt
     #   edx-ecommerce-worker
-requests==2.26.0
+requests==2.27.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -741,21 +743,21 @@ requests-toolbelt==0.9.1
     # via
     #   -r requirements/base.txt
     #   zeep
-responses==0.15.0
+responses==0.16.0
     # via -r requirements/test.in
 rest-condition==1.0.3
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-rjsmin==1.1.0
+rjsmin==1.2.0
     # via
     #   -r requirements/base.txt
     #   django-compressor
-rsa==4.7.2
+rsa==4.8
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-rules==3.0
+rules==3.1
     # via -r requirements/base.txt
 s3transfer==0.5.0
     # via
@@ -777,7 +779,7 @@ shellescape==3.8.1
     #   -r requirements/base.txt
     #   crypto
     #   cybersource-rest-client-python
-simplejson==3.17.5
+simplejson==3.17.6
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
@@ -787,12 +789,10 @@ six==1.16.0
     #   -r requirements/e2e.txt
     #   -r requirements/tox.txt
     #   analytics-python
-    #   astroid
     #   bcrypt
     #   bleach
     #   bok-choy
     #   cybersource-rest-client-python
-    #   django-compressor
     #   django-extra-views
     #   djangorestframework-csv
     #   edx-auth-backends
@@ -836,7 +836,7 @@ social-auth-core==4.0.2
     #   social-auth-app-django
 sorl-thumbnail==12.7.0
     # via -r requirements/base.txt
-soupsieve==2.3
+soupsieve==2.3.1
     # via beautifulsoup4
 sqlparse==0.4.2
     # via
@@ -871,9 +871,10 @@ toml==0.10.2
     # via
     #   -r requirements/e2e.txt
     #   -r requirements/tox.txt
+    #   pylint
     #   pytest
     #   tox
-tomli==1.2.2
+tomli==2.0.0
     # via coverage
 tox==3.14.6
     # via
@@ -890,6 +891,10 @@ typing==3.7.4.3
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
+typing-extensions==4.0.1
+    # via
+    #   astroid
+    #   pylint
 unicodecsv==0.14.1
     # via
     #   -r requirements/base.txt
@@ -928,12 +933,15 @@ webob==1.8.7
     # via webtest
 webtest==3.0.0
     # via django-webtest
-wheel==0.37.0
+wheel==0.37.1
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-wrapt==1.11.2
-    # via astroid
+wrapt==1.13.3
+    # via
+    #   -r requirements/base.txt
+    #   astroid
+    #   deprecated
 x509==0.1
     # via
     #   -r requirements/base.txt
@@ -942,7 +950,7 @@ xss-utils==0.3.0
     # via -r requirements/base.txt
 zeep==4.1.0
     # via -r requirements/base.txt
-zipp==3.6.0
+zipp==3.7.0
     # via
     #   -r requirements/e2e.txt
     #   importlib-metadata

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,17 +4,17 @@
 #
 #    make upgrade
 #
-filelock==3.3.2
+filelock==3.4.2
     # via tox
-packaging==21.2
+packaging==21.3
     # via tox
 pluggy==0.13.1
     # via
     #   -c requirements/pins.txt
     #   tox
-py==1.10.0
+py==1.11.0
     # via tox
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 six==1.16.0
     # via tox


### PR DESCRIPTION
[REV-2513](https://openedx.atlassian.net/browse/REV-2513): we're currently blocked from running 'make upgrade' (to update packages) because of a conflict caused by our old pinning of pylint. 

**Part 1:** Unpinning it lets this run again, so this PR unpins pylint and runs 'make upgrade' to let packages update accordingly. 

**Part 2:** Removing the pin on the pylint version lets us go from pylint 2.4.4-> 2.12.2, which adds a bunch of new checks. We haven't validated against these before, and we want to be strategic about how much improvement to put into this codebase since much will be replaced this year. Therefore, I've added fixes for the checks that look worthwhile from a risk perspective, and disabling those checks that are just style updates: 

**Fixed all instances of code violating these checks:** 
E0012: Bad option value 'bad-continuation' (bad-option-value)
R0402: Use 'from oscar.apps.communication import apps' instead (consider-using-from-import)
R1714: Consider merging these comparisons with "in" to "course.type in ('verified', 'verified-only')" (consider-using-in)
W0612: Unused variable 'e' (unused-variable)

**Combination: fixed some, inline-disabled some**
E0307: __str__ does not return str (invalid-str-returned)
W0707: Consider explicitly re-raising using the 'from' keyword (raise-missing-from)

**Disabled inline for existing code but kept the rule for future code:** 
C1803: use-implicit-booleaness-not-comparison
E0702: Raising NoneType while only classes or instances are allowed (raising-bad-type)
R1710: inconsistent-return-statements
R1732: Consider using 'with' for resource-allocating operations (consider-using-with)
W1514: Using open without explicitly specifying an encoding (unspecified-encoding)

**Disabled the check in our pylint configuration:** 
C0103: invalid-name
C0201: consider-iterating-dictionary
C0206: consider-using-dict-items
C0209: consider-using-f-string
R1725: super-with-arguments
R1728: consider-using-generator
R1729: use-a-generator
R1734: use-list-literal
W0237: arguments renamed
W1310: format-string-without-interpolation
W1406: redundant-u-string-prefix
W1514: unspecified-encoding