### PR TITLE
fix: [REV-2501] sdn fallback false positives for empty processed_name

### DIFF
--- a/ecommerce/extensions/payment/core/sdn.py
+++ b/ecommerce/extensions/payment/core/sdn.py
@@ -95,6 +95,10 @@ def checkSDNFallback(name, city, country):
     )
     records = records.filter(countries__contains=country)
     processed_name, processed_city = process_text(name), process_text(city)
+    # processing text with no transliteration can yield 0-length sets
+    # return because a 0-length set is a subset of every set
+    if len(processed_name) == 0 or len(processed_city) == 0:
+        return 0
     for record in records:
         record_names, record_addresses = set(record.names.split()), set(record.addresses.split())
         if (processed_name.issubset(record_names) and processed_city.issubset(record_addresses)):

--- a/ecommerce/extensions/payment/core/sdn.py
+++ b/ecommerce/extensions/payment/core/sdn.py
@@ -221,6 +221,7 @@ def replace_unicode_symbols(text, replace_char):
         An iterator for text with symbols replaced.
     """
     for char in text:
+        # 'L' == Letters, 'N' == Numbers in Unicode categories
         yield replace_char if not unicodedata.category(char).startswith(('L', 'N')) else char
 
 

--- a/ecommerce/extensions/payment/core/sdn.py
+++ b/ecommerce/extensions/payment/core/sdn.py
@@ -209,22 +209,6 @@ def transliterate_text(text):
     return t11e_text if t11e_text else text
 
 
-def replace_unicode_symbols(text, replace_char):
-    """
-    Replaces characters not classified as letters or numbers in Unicode.
-
-    Args:
-        text (str): a string to be cleaned of symbols
-        replace_char (str): the string to replace symbols with
-
-    Returns:
-        An iterator for text with symbols replaced.
-    """
-    for char in text:
-        # 'L' == Letters, 'N' == Numbers in Unicode categories
-        yield replace_char if not unicodedata.category(char).startswith(('L', 'N')) else char
-
-
 def process_text(text):
     """
     Lowercase, remove non-alphanumeric characters, and ignore order and word frequency.
@@ -246,11 +230,8 @@ def process_text(text):
     # Transliterate numbers and letters
     text = ''.join(map(transliterate_text, text))
 
-    # Replace non-letters and numbers with spaces
-    text = ''.join(replace_unicode_symbols(text, ' '))
-
-    # Ignore order and word frequency
-    text = set(filter(None, set(re.split(' ', text))))
+    # Ignore punctuation, order, and word frequency
+    text = set(filter(None, set(re.split(r'[\W_]+', text))))
 
     return text
 

--- a/ecommerce/extensions/payment/core/tests/test_sdn.py
+++ b/ecommerce/extensions/payment/core/tests/test_sdn.py
@@ -322,6 +322,7 @@ Joshuafort, MD 72104, TH",,,,,,,,,,,,,,https://banks-bender.com/,Michael Anderso
         self.assertEqual(output, expected_output)
 
     @ddt.data(
+        # check transliterable characters
         ('À Á Â Ã Ä Å à á â ã ä å', {'a'}),
         ('È É Ê Ë è é ê ë', {'e'}),
         ('Ì Í Î Ï ì í î ï', {'i'}),
@@ -330,14 +331,23 @@ Joshuafort, MD 72104, TH",,,,,,,,,,,,,,https://banks-bender.com/,Michael Anderso
         ('Ý ý ÿ', {'y'}),
         ('Ç ç', {'c'}),
         ('Ñ ñ', {'n'}),
-        # these cases are here to explicitly note that they are not  transliterated,
+        ('ß', {'ss'}),
+        # check characters we can't transliterate
+        # these cases are here to explicitly note that they are not transliterated,
         # not to exclude them from transliteration in the future
-        ('Ð Æ æ Ø Þ ß þ ð ø', set()),
+        ('Ð Æ æ Ø Þ þ ð ø', {'þ', 'ø', 'æ', 'ð'}),
+        ('王芳', {'王芳'}),
+        ('Πвλάτων', {'πвλάτων'}),
+        # check mix of transliterable & non-transliterable
+        ('Դանիէլ (Daniel)', {'daniel', 'դանիէլ'}),
+        ('ლომიძე (Lomidze)', {'lomidze', 'ლომიძე'}),
+        ('Иван (Ivan)', {'ivan', 'иван'}),
+        # check punctuation is excluded
         ('÷ § § ×   ¶ ¯ ¬', set()),
     )
     @ddt.unpack
     def test_process_text_unicode(self, text, expected_output):
-        """ Verify that characters with accents are transliterated correctly."""
+        """ Verify that characters with accents are transliterated correctly and non-transliterable characters are passed through."""
         output = process_text(text)
         self.assertEqual(output, expected_output)
 

--- a/ecommerce/extensions/payment/core/tests/test_sdn.py
+++ b/ecommerce/extensions/payment/core/tests/test_sdn.py
@@ -343,7 +343,7 @@ Joshuafort, MD 72104, TH",,,,,,,,,,,,,,https://banks-bender.com/,Michael Anderso
         ('ლომიძე (Lomidze)', {'lomidze', 'ლომიძე'}),
         ('Иван (Ivan)', {'ivan', 'иван'}),
         # check punctuation is excluded
-        ('÷ § § ×   ¶ ¯ ¬', set()),
+        ('_ ÷ § § ×   ¶ ¯ ¬', set()),
     )
     @ddt.unpack
     def test_process_text_unicode(self, text, expected_output):

--- a/ecommerce/extensions/payment/core/tests/test_sdn.py
+++ b/ecommerce/extensions/payment/core/tests/test_sdn.py
@@ -364,12 +364,16 @@ Joshuafort, MD 72104, TH",,,,,,,,,,,,,,https://banks-bender.com/,Michael Anderso
         ('-de-Juan-Cruz-la-', 1),
         ('.dE@jUaN.....CRUZ----!??!?!la.', 1),
         ('Cruz,,,,', 1),
-        ('João', 1),
         # check capitalizaiton properties
         ('jUan dE LA CruZ', 1),
         # check frequency properties
         ('Juan de la Cruz Juan de la Cruz', 1),
         ('Juan Juan M. M. de de la la Cruz Cruz', 1),
+        # check transliteration support
+        ('João', 1),
+        ('Rogério', 0),
+        # check no false positive on non-Latin character without transliteration
+        ('教育转型', 0),
         # other examples
         ('Juanito', 0),
         ('John de la Cruz', 0),
@@ -387,7 +391,7 @@ Joshuafort, MD 72104, TH",,,,,,,,,,,,,,https://banks-bender.com/,Michael Anderso
         """
         # pylint: disable=line-too-long
         csv_string = """_id,source,entity_number,type,programs,name,title,addresses,federal_register_notice,start_date,end_date,standard_order,license_requirement,license_policy,call_sign,vessel_type,gross_tonnage,gross_registered_tonnage,vessel_flag,vessel_owner,remarks,source_list_url,alt_names,citizenships,dates_of_birth,nationalities,places_of_birth,source_information_url,ids
-94734218,Specially Designated Nationals (SDN) - Treasury Department,96663868,Individual,material,Juan M. de la Cruz,Dr.,"17472 Christie Stream Apt. 976 North Kristinaport, HI 91033, SN",,,,,,,,,,,,,,https://www.juarez-collier.org/,Wendy João Brock,DJ,1944-03-05,Faroe Islands,PK,http://richardson-richardson.org/,CI"""
+94734218,Specially Designated Nationals (SDN) - Treasury Department,96663868,Individual,material,Juan M. de la Cruz,Dr.,"17472 Christie Stream Apt. 976 North Kristinaport, HI 91033, SN",,,,,,,,,,,,,,https://www.juarez-collier.org/,Wendy João Brock 中国,DJ,1944-03-05,Faroe Islands,PK,http://richardson-richardson.org/,CI"""
         # pylint: enable=line-too-long
         metadata_entry = populate_sdn_fallback_data_and_metadata(csv_string)
         self.assertEqual(checkSDNFallback(name, 'North Kristinaport', 'SN'), match)
@@ -403,11 +407,15 @@ Joshuafort, MD 72104, TH",,,,,,,,,,,,,,https://banks-bender.com/,Michael Anderso
         ('Kristinaport', 1),
         ('Kristinaport,,!@#$%^&*()', 1),
         ('Krist%^&*()inaport', False),
-        ('João', 1),
         # check capitalizaiton properties
         ('KRISTINAPORT', 1),
         # check frequency properties
         ('Kristinaport Kristinaport', 1),
+        # check transliteration support
+        ('João', 1),
+        ('São Paulo', 0),
+        # check no false positive on non-Latin character without transliteration
+        ('教育转型', 0),
     )
     @ddt.unpack
     def test_check_sdn_fallback_address(self, address, match):
@@ -421,7 +429,7 @@ Joshuafort, MD 72104, TH",,,,,,,,,,,,,,https://banks-bender.com/,Michael Anderso
         """
         # pylint: disable=line-too-long
         csv_string = """_id,source,entity_number,type,programs,name,title,addresses,federal_register_notice,start_date,end_date,standard_order,license_requirement,license_policy,call_sign,vessel_type,gross_tonnage,gross_registered_tonnage,vessel_flag,vessel_owner,remarks,source_list_url,alt_names,citizenships,dates_of_birth,nationalities,places_of_birth,source_information_url,ids
-94734218,Specially Designated Nationals (SDN) - Treasury Department,96663868,Individual,material,Juan M. de la Cruz,Dr.,"17472 Christie Stream Apt. 976 North Kristinaport João, HI 91033, SN",,,,,,,,,,,,,,https://www.juarez-collier.org/,Wendy Brock,DJ,1944-03-05,Faroe Islands,PK,http://richardson-richardson.org/,CI"""
+94734218,Specially Designated Nationals (SDN) - Treasury Department,96663868,Individual,material,Juan M. de la Cruz,Dr.,"17472 Christie Stream Apt. 976 North Kristinaport João 中国, HI 91033, SN",,,,,,,,,,,,,,https://www.juarez-collier.org/,Wendy Brock,DJ,1944-03-05,Faroe Islands,PK,http://richardson-richardson.org/,CI"""
         # pylint: enable=line-too-long
         metadata_entry = populate_sdn_fallback_data_and_metadata(csv_string)
         self.assertEqual(checkSDNFallback("Juan", address, 'SN'), match)


### PR DESCRIPTION
## Description

During a purchase, Ecommerce checks if the purchaser is on an OFAC sanctions list. Usually, an API does this check, but Ecommerce tries to mimic the API's check if the API happens to be unavailable.

If the purchaser's information has transliterable characters, like `é`, we try to transliterate it to something like `e` before checking it against the sanction lists. However, this check fails when purchasers demographic information consist entirely of untransliterable characters, like names in Thai, Russian, Greek, Korean, Amharic, etc.

This makes Ecommerce incorrectly think learners are on a OFAC sanctions list when the learner purchases a course and parts of the purchaser's information consist entirely of non-transliterable characters. This PR fixes that.

## Supporting information

* Jira: [REV-2501](https://openedx.atlassian.net/browse/REV-2501)
* Research: [Confluence](https://openedx.atlassian.net/wiki/spaces/~931919476/pages/3309010958/REV-2501)

## Testing instructions

* In devstack:
   * [X] Add test for SDN failure.
   * [X] Ensure test fails on master but passes on this PR's branch.
* In stage:
   * [x] Make successful test purchase using normal name.
   * [x] Make successful test purchase using non-transliterable characters in city name.
   * [x] Make unsuccessful test purchase using name in SDN.
* In prod:
   * [x] Make successful test purchase using normal name.
   * [x] Monitor SDN fallback dashboard in addition to regular monitoring.