### PR TITLE
fix: payment_processor_active_ switches can't be saved

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -672,7 +672,7 @@ python-dateutil==2.8.2
     #   freezegun
 python-dotenv==0.19.2
     # via -r requirements/test.txt
-python-memcached==1.58
+python-memcached==1.59
     # via -r requirements/test.txt
 python-mimeparse==1.6.0
     # via

--- a/requirements/production.in
+++ b/requirements/production.in
@@ -4,7 +4,7 @@
 django-ses
 gunicorn==19.7.1
 newrelic<5
-python-memcached==1.58
+python-memcached==1.59
 PyYAML
 nodeenv==1.1.1
 redis

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -401,7 +401,7 @@ python-dateutil==2.8.2
     #   botocore
     #   edx-drf-extensions
     #   faker
-python-memcached==1.58
+python-memcached==1.59
     # via -r requirements/production.in
 python-mimeparse==1.6.0
     # via cybersource-rest-client-python

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -21,7 +21,7 @@ pylint
 pytest
 pytest-cov
 pytest-django
-python-memcached==1.58      # required by collectstatic in devstack
+python-memcached==1.59      # required by collectstatic in devstack
 responses
 selenium
 testfixtures                # Provides a LogCapture utility used by several tests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -663,7 +663,7 @@ python-dateutil==2.8.2
     #   freezegun
 python-dotenv==0.19.2
     # via -r requirements/e2e.txt
-python-memcached==1.58
+python-memcached==1.59
     # via -r requirements/test.in
 python-mimeparse==1.6.0
     # via


### PR DESCRIPTION
An issue relates to the bug in the `python-memcached` library.
This PR applies the upgrade to version `1.59` where the issue was resolved.

I've discovered only problems with functionality that uses the `TieredCache.delete_all_tiers` method.

The example could be the
`payment_processor_active_<processor_name>` waffle switch. By trying to
enable/disable it either through admin site or with management command -
there will be an error:
```
Traceback (most recent call last):
  File "./manage.py", line 11, in <module>
    execute_from_command_line(sys.argv)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
    utility.execute()
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/core/management/__init__.py", line 413, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/core/management/base.py", line 354, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/core/management/base.py", line 398, in execute
    output = self.handle(*args, **options)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/waffle/management/commands/waffle_switch.py", line 57, in handle
    switch, created = Switch.objects.get_or_create(name=switch_name)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/db/models/query.py", line 588, in get_or_create
    return self.create(**params), True
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/db/models/query.py", line 453, in create
    obj.save(force_insert=True, using=self.db)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/waffle/models.py", line 96, in save
    ret = super(BaseModel, self).save(*args, **kwargs)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/db/models/base.py", line 726, in save
    self.save_base(using=using, force_insert=force_insert,
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/db/models/base.py", line 774, in save_base
    post_save.send(
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/dispatch/dispatcher.py", line 180, in send
    return [
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/dispatch/dispatcher.py", line 181, in <listcomp>
    (receiver, receiver(signal=self, sender=sender, **named))
  File "/edx/app/ecommerce/ecommerce/ecommerce/extensions/payment/signals.py", line 27, in invalidate_processor_cache
    TieredCache.delete_all_tiers(PAYMENT_PROCESSOR_CACHE_KEY)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/edx_django_utils/cache/utils.py", line 226, in delete_all_tiers
    django_cache.delete(key)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/core/cache/backends/memcached.py", line 202, in delete
    return bool(self._cache._deletetouch([b'DELETED'], 'delete', key))
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/memcache.py", line 583, in _deletetouch
    % (cmd, ' or '.join(expected), line))
TypeError: sequence item 0: expected str instance, bytes found
```

Backport to maple: https://github.com/openedx/ecommerce/pull/3638