### PR TITLE
docs: add depr issue template & automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/depr-ticket.yml
+++ b/.github/ISSUE_TEMPLATE/depr-ticket.yml
@@ -1,0 +1,83 @@
+name: Deprecation (DEPR) Ticket
+description: Per OEP-21, use this template to begin the technology deprecation process.
+title: "[DEPR]: <Technology Name>"
+labels: ["DEPR"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Refer to [OEP-21](https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0021-proc-deprecation.html) for more detail on the deprecation and removal process. This ticket should only be used for proposing the removal of an Open edX technology.
+  - type: input
+    id: todays-date
+    attributes:
+      label: Proposal Date
+      description: The start date of this proposal (likely today)
+      placeholder: 29 February 2020
+    validations:
+      required: true
+  - type: input
+    id: accept-date
+    attributes:
+      label: Ticket Acceptance Date
+      description: When is the target date for getting this proposal accepted?
+      placeholder: 29 February 2020
+    validations:
+      required: true
+  - type: input
+    id: remove-date
+    attributes:
+      label: Technology Removal Date
+      description: When is the target date for getting this technology removed?
+      placeholder: 29 February 2020
+    validations:
+      required: true
+  - type: input
+    id: named-release-without
+    attributes:
+      label: First Open edX Named Release Without This Functionality
+      description: Named releases are generally CUT in early April and early October. Based on the above removal date, what named release would be the first without this code? Please reach out to the Build Test Release working group (#wg-build-test-release in Slack) if you're not sure.
+      placeholder: Dogwood
+    validations:
+      required: true
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Rationale
+      description: Explain, in a few sentences, why this technology should be removed - what's the usage pattern? What's wrong with keeping it around?
+    validations:
+      required: true
+  - type: textarea
+    id: removal
+    attributes:
+      label: Removal
+      description: Include a description with links to what exactly is being removed.
+    validations:
+      required: true
+  - type: textarea
+    id: replacement
+    attributes:
+      label: Replacement
+      description: Include a description with links to what this is being replaced by.
+    validations:
+      required: true
+  - type: textarea
+    id: deprecation
+    attributes:
+      label: Deprecation
+      description: If you plan to mark the code for deprecation, explain how.
+    validations:
+      required: false
+  - type: textarea
+    id: migration
+    attributes:
+      label: Migration
+      description: If automated migration will be needed, explain your migration plan.
+    validations:
+      required: false
+  - type: textarea
+    id: addl-info
+    attributes:
+      label: Additional Info
+      description: If there is any additional publicly sharable information or data from your earlier analysis, include that.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/override_config.yml
+++ b/.github/ISSUE_TEMPLATE/override_config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Open edX Community Support
+    url: https://discuss.openedx.org/
+    about: Please ask all questions, suggest all enhancements, and report all bugs here.

--- a/.github/workflows/add-depr-ticket-to-depr-board.yml
+++ b/.github/workflows/add-depr-ticket-to-depr-board.yml
@@ -1,0 +1,12 @@
+# Run the workflow that adds DEPR labeled issues
+# to the org-wide DEPR project board
+
+name: Add newly created DEPR issues to the DEPR project board
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  routeissue:
+    uses: openedx/.github/.github/workflows/add-depr-ticket-to-depr-board.yml@master


### PR DESCRIPTION
## Description

As per the [steps in OEP-21](https://open-edx-proposals.readthedocs.io/en/latest/processes/oep-0021-proc-deprecation.html#document) there are now default templates for DEPR issues and a default config for all Issues that turns on DEPR issues, a Forums redirect, and an option for a blank ticket.

Since this repo has previously had Issues turned off, the new default behavior will be overridden; the DEPR template is explicitly added to this repo and the "create blank issue" option is turned off. Additionally, automation will be put into this repo, since workflows don't directly inherit.

## Background

Please see the discussion in https://github.com/openedx/open-edx-proposals/pull/280 if you would like detail on "how" we are rolling out this change.

Also see [slack thread 1](https://openedx.slack.com/archives/C02M89BSV9A/p1642693537008400), [slack thread 2](https://openedx.slack.com/archives/C02M89BSV9A/p1644353782380809).
