### PR TITLE
Fix: Replace mock_django for Djando 3.2 upgrade.

### DIFF
--- a/ecommerce/extensions/refund/tests/mixins.py
+++ b/ecommerce/extensions/refund/tests/mixins.py
@@ -2,8 +2,8 @@
 import mock
 from django.conf import settings
 from django.test import override_settings
-from mock_django import mock_signal_receiver
 from oscar.core.loading import get_class, get_model
+from oscar.test.contextmanagers import mock_signal_receiver
 from oscar.test.factories import BasketFactory
 
 from ecommerce.courses.tests.factories import CourseFactory


### PR DESCRIPTION
## Description
This PR is intended to solve this [Django 3.2 Upgrade](https://github.com/orgs/edx/projects/5) issue: [Update or replace mock-django #76 ](https://github.com/edx/upgrades/issues/76). Due to the fact that the package is not maintained since 2016, the usage of it is not large, and there is a more active package (django-oscar) that implements the only feature we use from mock-django, I would go for the option 2 of the  [Handling Outdated Dependencies](https://openedx.atlassian.net/wiki/spaces/AC/pages/3036972032/Handling+Outdated+Dependencies).

I reviewed the usage of the package and found out that only one function from the package is used,`mock_signal_receiver`. It is used within the class `RefundTestMixin` to mock the `post_refund` signal, and to check that the signal is not trigger before calling `refund.approved` and that it is called after. `RefundTestMixin` is used in the following tests:

- /ecommerce/ecommerce/extensions/api/v2/tests/views/test_refunds.py
- /ecommerce/ecommerce/extensions/checkout/tests/test_mixins.py
- /ecommerce/ecommerce/extensions/checkout/tests/test_views.py
- /ecommerce/ecommerce/extensions/dashboard/orders/tests.py
- /ecommerce/ecommerce/extensions/dashboard/refunds/tests/test_acceptance.py
- /ecommerce/ecommerce/extensions/order/tests/test_utils.py
- /ecommerce/ecommerce/extensions/payment/tests/processors/mixins.py
- /ecommerce/ecommerce/extensions/refund/tests/test_api.py
- /ecommerce/ecommerce/extensions/refund/tests/test_models.py
- /ecommerce/ecommerce/extensions/refund/tests/test_signals.py

But only the last two (test_models.py and test_signals.py) actually use the mocked signal since they call `approve` within their tests.

## Additional Information:
`mock_django` and the implementation of its function `mock_signal_receiver` were introduced by this commit:
https://github.com/edx/ecommerce/commit/9ee710835fb2cae9fe63a1362833a342c0956b1b