### PR TITLE
build: adding mysql8 migrations check.

### DIFF
--- a/.github/workflows/migrations-mysql8.yml
+++ b/.github/workflows/migrations-mysql8.yml
@@ -1,0 +1,77 @@
+name: Migrations check on mysql8
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  check_migrations:
+    name: check migrations mysql8
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04 ]
+        python-version: [ 3.8 ]
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+
+    - name: Setup Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install system Packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libxmlsec1-dev
+    - name: Get pip cache dir
+      id: pip-cache-dir
+      run: |
+        echo "::set-output name=dir::$(pip cache dir)"
+    - name: Cache pip dependencies
+      id: cache-dependencies
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache-dir.outputs.dir }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements/pip_tools.txt') }}
+        restore-keys: ${{ runner.os }}-pip-
+
+    - name: Ubuntu and sql Versions
+      run: |
+        lsb_release -a
+        mysql -V
+    - name: Install Python dependencies
+      run: |
+        pip install -r requirements/pip_tools.txt
+        pip install -r requirements/production.txt
+        pip uninstall -y mysqlclient
+        pip install --no-binary mysqlclient mysqlclient
+        pip uninstall -y xmlsec
+        pip install --no-binary xmlsec xmlsec
+
+    - name: Initiate Services
+      run: |
+        sudo /etc/init.d/mysql start
+    - name: Reset mysql password
+      run: |
+        cat <<EOF | mysql -h 127.0.0.1 -u root --password=root
+          UPDATE mysql.user SET authentication_string = null WHERE user = 'root';
+          FLUSH PRIVILEGES;
+        EOF
+    - name: Run Tests
+      env:
+        DB_ENGINE: "django.db.backends.mysql"
+        DB_NAME: "ecommerce"
+        DB_USER: root
+        DB_PASSWORD:
+        DB_HOST: localhost
+        DB_PORT: 3306
+      run: |
+        echo "CREATE DATABASE IF NOT EXISTS ecommerce;" | sudo mysql -u root
+        echo "Running the migrations."
+        python manage.py migrate --settings=ecommerce.settings.test


### PR DESCRIPTION
adding mysql8 migrations check

With `django22` + `mysql8` length check doest not trigger. I have created a separate PR with max length to verify this issue triggers.

This following commit uses `mysql8+django32` +max length migration.
https://github.com/openedx/ecommerce/runs/5172684737?check_suite_focus=true#step:11:452