### PR TITLE
test: run tests on Django 3.2 version too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,15 @@ jobs:
           - django-env: django22
             testname: acceptance-python
             targets: PYTHON_ENV=py38 requirements.js clean_static static acceptance
+          - django-env: django32
+            testname: quality-and-jobs
+            targets: PYTHON_ENV=py38 requirements.js check_translations_up_to_date validate_translations clean_static static quality validate_js check_keywords
+          - django-env: django32
+            testname: test-python
+            targets: PYTHON_ENV=py38 requirements.js clean_static static validate_python
+          - django-env: django32
+            testname: acceptance-python
+            targets: PYTHON_ENV=py38 requirements.js clean_static static acceptance
 
     steps:
       - uses: actions/checkout@v2

--- a/ecommerce/extensions/refund/tests/mixins.py
+++ b/ecommerce/extensions/refund/tests/mixins.py
@@ -2,8 +2,8 @@
 import mock
 from django.conf import settings
 from django.test import override_settings
-from mock_django import mock_signal_receiver
 from oscar.core.loading import get_class, get_model
+from oscar.test.contextmanagers import mock_signal_receiver
 from oscar.test.factories import BasketFactory
 
 from ecommerce.courses.tests.factories import CourseFactory

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -178,7 +178,6 @@ django==2.2.26
     #   edx-i18n-tools
     #   edx-rbac
     #   jsonfield2
-    #   mock-django
     #   rest-condition
     #   xss-utils
 django-appconf==1.0.5
@@ -447,10 +446,6 @@ mccabe==0.6.1
     #   -r requirements/test.txt
     #   pylint
 mock==4.0.3
-    # via
-    #   -r requirements/test.txt
-    #   mock-django
-mock-django==0.6.10
     # via -r requirements/test.txt
 monotonic==1.6
     # via

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -15,7 +15,6 @@ httpretty
 isort
 lxml
 mock
-mock-django
 pycodestyle
 pylint
 pytest

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -175,7 +175,6 @@ diff-cover==6.4.4
     #   edx-i18n-tools
     #   edx-rbac
     #   jsonfield2
-    #   mock-django
     #   rest-condition
     #   xss-utils
 django-appconf==1.0.5
@@ -436,10 +435,6 @@ markupsafe==2.0.1
 mccabe==0.6.1
     # via pylint
 mock==4.0.3
-    # via
-    #   -r requirements/test.in
-    #   mock-django
-mock-django==0.6.10
     # via -r requirements/test.in
 monotonic==1.6
     # via

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist = py38-django22-{static,pylint,tests,theme_static,check_keywords},py38-{isort,pycodestyle,extract_translations,dummy_translations,compile_translations, detect_changed_translations,validate_translations},docs
+envlist = py38-django{22,32}-{static,pylint,tests,theme_static,check_keywords},py38-{isort,pycodestyle,extract_translations,dummy_translations,compile_translations, detect_changed_translations,validate_translations},docs
 
 [pytest]
 addopts = --ds=ecommerce.settings.test --cov=ecommerce --cov-report term --cov-config=.coveragerc --no-cov-on-fail -p no:randomly --no-migrations -m "not acceptance"
@@ -48,6 +48,7 @@ setenv =
 deps =
     -r{toxinidir}/requirements/test.txt
     django22: Django>=2.2,<2.3
+    django32: Django>=3.2,<3.3
 allowlist_externals =
     /bin/bash
 changedir =


### PR DESCRIPTION
After upgrading `django-oscar` to version 2.2 now we don't have any other blockers for Django 3.2 support. Thus adding the testing for Django 3.2.