### PR TITLE
fix: payment MFE form initialisation

### DIFF
--- a/ecommerce/extensions/payment/processors/cybersource.py
+++ b/ecommerce/extensions/payment/processors/cybersource.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 from enum import Enum
 from typing import Optional
+from urllib.parse import urlparse
 
 import jwt
 import jwt.exceptions
@@ -180,7 +181,7 @@ class CybersourceREST(ApplePayMixin, BaseClientSidePaymentProcessor):
 
         requestObj = GeneratePublicKeyRequest(
             encryption_type='RsaOaep256',
-            target_origin=self.flex_target_origin,
+            target_origin=urlparse(self.flex_target_origin)._replace(path='').geturl(),
         )
         requestObj = del_none(requestObj.__dict__)
         requestObj = json.dumps(requestObj)


### PR DESCRIPTION
The Problem:
- Cybersource uses an API call to initialize the payment form;
- request object includes required `target_origin` parameter pointing on
URL that we set in the ecommerce site configuration > Payment Microfrontend URL
- MFE's could exist on one domain and differ by the path
(e.g. `<MFE_domain>/payment` for the Payment MFE)
- Cybersource docs describing the `target_origin` as:
```
This is the protocol, URL, and if used, port number of the page that will host the Microform
```

The Decision:
- Cut the path part of the MFE URL

Note:
Similar PR #3586 already added to master