### PR TITLE
feat!: upgrade Django version to 3.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NODE_BIN=./node_modules/.bin
 DIFF_COVER_BASE_BRANCH=master
 PYTHON_ENV=py38
-DJANGO_ENV_VAR=$(if $(DJANGO_ENV),$(DJANGO_ENV),django22)
+DJANGO_ENV_VAR=$(if $(DJANGO_ENV),$(DJANGO_ENV),django32)
 
 help:
 	@echo ''

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,7 +5,7 @@ bleach
 boto3>=1.17.80
 coreapi
 cybersource-rest-client-python
-django<3.0
+django>=3.2,<4.0
 django-compressor
 django-config-models>=1.0.0         # Configuration models for Django allowing config management with auditing
 django-cors-headers                 #  Used to allow to configure CORS headers for cross-domain requests

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,6 +8,8 @@ amqp==2.6.1
     # via kombu
 analytics-python==1.4.0
     # via -r requirements/base.in
+asgiref==3.4.1
+    # via django
 asn1crypto==1.4.0
     # via cybersource-rest-client-python
 attrs==21.4.0
@@ -90,7 +92,7 @@ defusedxml==0.7.1
     #   social-auth-core
 deprecated==1.2.13
     # via redis
-django==2.2.26
+django==3.2.12
     # via
     #   -r requirements/base.in
     #   django-appconf

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,6 +14,10 @@ amqp==2.6.1
     #   kombu
 analytics-python==1.4.0
     # via -r requirements/test.txt
+asgiref==3.4.1
+    # via
+    #   -r requirements/test.txt
+    #   django
 asn1crypto==1.4.0
     # via
     #   -r requirements/test.txt
@@ -150,7 +154,7 @@ deprecated==1.2.13
     #   redis
 diff-cover==6.4.4
     # via -r requirements/test.txt
-django==2.2.26
+django==3.2.12
     # via
     #   -r requirements/test.txt
     #   django-appconf

--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -4,6 +4,10 @@
 #
 #    make upgrade
 #
+asgiref==3.4.1
+    # via
+    #   -c requirements/base.txt
+    #   django
 attrs==21.4.0
     # via
     #   -c requirements/base.txt
@@ -25,7 +29,7 @@ cryptography==3.4.8
     #   -c requirements/base.txt
     #   -c requirements/pins.txt
     #   pyjwt
-django==2.2.26
+django==3.2.12
     # via
     #   -c requirements/base.txt
     #   django-crum

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,6 +8,8 @@ amqp==2.6.1
     # via kombu
 analytics-python==1.4.0
     # via -r requirements/base.in
+asgiref==3.4.1
+    # via django
 asn1crypto==1.4.0
     # via cybersource-rest-client-python
 attrs==21.4.0
@@ -92,7 +94,7 @@ defusedxml==0.7.1
     #   social-auth-core
 deprecated==1.2.13
     # via redis
-django==2.2.26
+django==3.2.12
     # via
     #   -r requirements/base.in
     #   django-appconf

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,6 +10,11 @@ amqp==2.6.1
     #   kombu
 analytics-python==1.4.0
     # via -r requirements/base.txt
+asgiref==3.4.1
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/e2e.txt
+    #   django
 asn1crypto==1.4.0
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
Tested on sandbox the workflows.
- Order 
- Refund 
- Coupon creation

https://docs.djangoproject.com/en/3.2/releases/3.1/#abstractuser-first-name-max-length-increased-to-150
It will run this [migration](https://github.com/django/django/blob/main/django/contrib/auth/migrations/0012_alter_user_first_name_max_length.py) but it will not effect `ecommerce_user` table.  This old [PR](https://github.com/openedx/ecommerce/pull/3598)  has related info.


**Raw SQL from migration**
```
python manage.py sqlmigrate auth 0012
Alter field first_name on user
```