### PR TITLE
fix: TypeError on json.dumps of Decimal()

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -48,6 +48,7 @@ python3-openid>=3
 pytz
 requests
 rules
+simplejson
 social-auth-app-django
 sorl-thumbnail
 stripe==1.70.0


### PR DESCRIPTION
## Description

The simplejson library supports Decimal serialization. (The native Python json library does not.)

Ecommerce sends HTTP requests with JSON serialized from Decimal objects. The requests library automatically uses simplejson if available, but does not require it and fallbacks on the native Python json library.

This commit makes the implicit requirement on simplejson explicit.

## Supporting information

* Related to: https://github.com/openedx/ecommerce/pull/3654
   * See: [this diff](https://github.com/openedx/ecommerce/pull/3654/files#diff-0940fec0afe21798f617cc4522db676f15769ae28a72992b8d19216ef7b1c3b5L458-L465) showing removal of simplejson in original line 461 of requirements/base.txt

* Resolves: `TypeError: Object of type Decimal is not JSON serializable` in stage

  <details>
    <summary>See example stack trace</summary>
    
    ```
    Feb 23 20:41:09 ip-10-3-117-115 [service_variant=ecommerce][django.request] ERROR [ip-10-3-117-115  182214] [/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/utils/log.py:222] - Internal Server Error: /bff/payment/v0/payment/
    Traceback (most recent call last):
      File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/core/handlers/exception.py", line 34, in inner
        response = get_response(request)
      File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/core/handlers/base.py", line 115, in _get_response
        response = self.process_exception_by_middleware(e, request)
      File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/core/handlers/base.py", line 113, in _get_response
        response = wrapped_callback(request, *callback_args, **callback_kwargs)
      File "/usr/lib/python3.8/contextlib.py", line 75, in inner
        return func(*args, **kwds)
      File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/newrelic/hooks/framework_django.py", line 544, in wrapper
        return wrapped(*args, **kwargs)
      File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
        return view_func(*args, **kwargs)
      File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/django/views/generic/base.py", line 71, in view
        return self.dispatch(request, *args, **kwargs)
      File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/newrelic/hooks/component_djangorestframework.py", line 46, in _nr_wrapper_APIView_dispatch_
        return wrapped(*args, **kwargs)
      File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/rest_framework/views.py", line 509, in dispatch
        response = self.handle_exception(exc)
      File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/newrelic/hooks/component_djangorestframework.py", line 53, in _handle_exception_wrapper
        return wrapped(*args, **kwargs)
      File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/rest_framework/views.py", line 469, in handle_exception
        self.raise_uncaught_exception(exc)
      File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
        raise exc
      File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/rest_framework/views.py", line 506, in dispatch
        response = handler(request, *args, **kwargs)
      File "/edx/app/ecommerce/ecommerce/ecommerce/extensions/basket/views.py", line 789, in get
        track_braze_event(request.user, 'edx.bi.ecommerce.cart.viewed', properties)
      File "/edx/app/ecommerce/ecommerce/ecommerce/extensions/analytics/utils.py", line 243, in track_braze_event
        response = requests.post(
      File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/requests/api.py", line 117, in post
        return request('post', url, data=data, json=json, **kwargs)
      File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/newrelic/api/external_trace.py", line 79, in dynamic_wrapper
        return wrapped(*args, **kwargs)
      File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/requests/api.py", line 61, in request
        return session.request(method=method, url=url, **kwargs)
      File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/requests/sessions.py", line 515, in request
        prep = self.prepare_request(req)
      File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/requests/sessions.py", line 443, in prepare_request
        p.prepare(
      File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/requests/models.py", line 321, in prepare
        self.prepare_body(data, files, json)
      File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/requests/models.py", line 473, in prepare_body
        body = complexjson.dumps(json, allow_nan=False)
      File "/usr/lib/python3.8/json/__init__.py", line 234, in dumps
        return cls(
      File "/usr/lib/python3.8/json/encoder.py", line 199, in encode
        chunks = self.iterencode(o, _one_shot=True)
      File "/usr/lib/python3.8/json/encoder.py", line 257, in iterencode
        return _iterencode(o, 0)
      File "/usr/lib/python3.8/json/encoder.py", line 179, in default
        raise TypeError(f'Object of type {o.__class__.__name__} '
    TypeError: Object of type Decimal is not JSON serializable
    ```
  </details>

  <details>
    <summary>See code associated with stack trace</summary>
  
    * Dictionary with Decimal later converted to JSON in `_get_cart_viewed_event_properties()`: 
    https://github.com/openedx/ecommerce/blob/80d4ae6e8abbd7942126ba7e5b20780a7a4cbd18/ecommerce/extensions/basket/views.py#L822-L838
    
    * Inclusion of above dictionary in call to `track_braze_event()`:
    https://github.com/openedx/ecommerce/blob/80d4ae6e8abbd7942126ba7e5b20780a7a4cbd18/ecommerce/extensions/basket/views.py#L788-L789
    
    * Conversion of above dictionary to JSON in `track_braze_event()` via [`requests.post`](https://docs.python-requests.org/en/latest/api/#requests.post) `json` parameter:
    https://github.com/openedx/ecommerce/blob/80d4ae6e8abbd7942126ba7e5b20780a7a4cbd18/ecommerce/extensions/analytics/utils.py#L252
  
  </details>

* Related to: requests library elective usage of simplejson (see [this code](https://github.com/psf/requests/blob/5e749546a26ce62e53d0a14ae1455f8b066fe19f/requests/compat.py#L31-L36))

* Research: [Confluence](https://openedx.atlassian.net/wiki/spaces/~931919476/pages/3309010958/REV-2501#Stage-Error)

## Testing instructions

* On devstack:
   * [x] Able to reach payment page without error
* On stage:
   * [x] Able to reach payment page without error
* On prod:
   * [x] Able to reach payment page without error

## Other information

This PR is a fix for the code currently deployed to stage. This bug has not yet been deployed to production.