### PR TITLE
test: drop testing of Django 2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - django-env: django22
-            testname: quality-and-jobs
-            targets: PYTHON_ENV=py38 requirements.js check_translations_up_to_date validate_translations clean_static static quality validate_js check_keywords
-          - django-env: django22
-            testname: test-python
-            targets: PYTHON_ENV=py38 requirements.js clean_static static validate_python
-          - django-env: django22
-            testname: acceptance-python
-            targets: PYTHON_ENV=py38 requirements.js clean_static static acceptance
           - django-env: django32
             testname: quality-and-jobs
             targets: PYTHON_ENV=py38 requirements.js check_translations_up_to_date validate_translations clean_static static quality validate_js check_keywords

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist = py38-django{22,32}-{static,pylint,tests,theme_static,check_keywords},py38-{isort,pycodestyle,extract_translations,dummy_translations,compile_translations, detect_changed_translations,validate_translations},docs
+envlist = py38-django32-{static,pylint,tests,theme_static,check_keywords},py38-{isort,pycodestyle,extract_translations,dummy_translations,compile_translations, detect_changed_translations,validate_translations},docs
 
 [pytest]
 addopts = --ds=ecommerce.settings.test --cov=ecommerce --cov-report term --cov-config=.coveragerc --no-cov-on-fail -p no:randomly --no-migrations -m "not acceptance"
@@ -47,7 +47,6 @@ setenv =
     SELENIUM_BROWSER=firefox
 deps =
     -r{toxinidir}/requirements/test.txt
-    django22: Django>=2.2,<2.3
     django32: Django>=3.2,<3.3
 allowlist_externals =
     /bin/bash


### PR DESCRIPTION
As we have upgraded the Django version to 3.2 recently so now dropping support for Django 2.2