### PR TITLE
fix: prevent a 0/0 division error when neither Discount Value or Prep…

### DIFF
--- a/ecommerce/enterprise/mixins.py
+++ b/ecommerce/enterprise/mixins.py
@@ -129,13 +129,26 @@ class EnterpriseDiscountMixin:
             order.number, contract_metadata.discount_type,
             contract_metadata.discount_value, contract_metadata.amount_paid
         )
-        effective_discount_percentage = self._calculate_effective_discount_percentage(contract_metadata)
+        if not contract_metadata.discount_value and not contract_metadata.amount_paid:
+            logging.warning(
+                "No discount value or amount paid set on contract_metadata. "
+                "Avoiding 0/0 division for effective_discount_percentage. "
+                "Using 0 for effective discount for order [%s].",
+                order.number
+            )
+            effective_discount_percentage = Decimal('0')
+        else:
+            effective_discount_percentage = self._calculate_effective_discount_percentage(contract_metadata)
         logger.info(
             'Done calculating effective discount percentage for order [%s]. The result was [%s]',
             order.number, effective_discount_percentage
         )
 
-        logger.info('Calculating effective contract discount price for order [%s]', order.number)
+        logger.info(
+            'Calculating effective contract discount price for order [%s] '
+            'where line.unit_price_excl_tax=[%s] and effective_discount_percentage=[%s]',
+            order.number, line.unit_price_excl_tax, effective_discount_percentage
+        )
         effective_contract_discounted_price = self._get_enterprise_customer_cost_for_line(
             line.unit_price_excl_tax,
             effective_discount_percentage

--- a/ecommerce/enterprise/tests/test_mixins.py
+++ b/ecommerce/enterprise/tests/test_mixins.py
@@ -127,6 +127,17 @@ class EnterpriseDiscountMixinTests(EnterpriseDiscountTestMixin, TestCase):
             'expected_effective_contract_discount_percentage': Decimal('0.5'),
             'expected_effective_contract_discounted_price': Decimal('50.0000'),
         },
+        # Test with 0s for amount_paid and discount_value
+        {
+            'amount_paid': Decimal('0'),
+            'discount_value': Decimal('0'),
+            'discount_type': EnterpriseContractMetadata.FIXED,
+            'is_manual_order': False,
+            'create_order_discount_callback': 'create_order_offer_discount',
+            # FYI the line.unit_price_excl_tax = 100.00
+            'expected_effective_contract_discount_percentage': Decimal('0'),
+            'expected_effective_contract_discounted_price': Decimal('100'),
+        },
         # Test with manual order's discount.
         {
             'amount_paid': Decimal('100'),


### PR DESCRIPTION
…aid Invoice Amount set in coupon

## Description

When 0 is used as the value of Discount Value and Prepaid Invoice Amount in the admin enterprise coupon UI, this will result in a math error when calculating effective discount percentage. This PR intends to catch that error, and safety set the effective discount percentage to 0% when we would have otherwise tried to divide 0 by 0.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
