### PR TITLE
feat: Add flag for hoisting Order History

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -394,10 +394,8 @@ class OrderSerializer(serializers.ModelSerializer):
     def get_enable_hoist_order_history(self, obj):
         try:
             request=self.context.get('request')
-            if waffle.flag_is_active(request, ENABLE_HOIST_ORDER_HISTORY):
-                obj.enable_hoist_order_history = True
-            else:
-                obj.enable_hoist_order_history = False
+            order_history_enabled = waffle.flag_is_active(request, ENABLE_HOIST_ORDER_HISTORY)
+            obj.enable_hoist_order_history = order_history_enabled
             return obj.enable_hoist_order_history
         except AttributeError:
             None

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -397,8 +397,8 @@ class OrderSerializer(serializers.ModelSerializer):
             order_history_enabled = waffle.flag_is_active(request, ENABLE_HOIST_ORDER_HISTORY)
             obj.enable_hoist_order_history = order_history_enabled
             return obj.enable_hoist_order_history
-        except AttributeError:
-            None
+        except (AttributeError, ValueError) as error:
+            logger.exception('An error occurred while attempting to set ENABLE_HOIST_ORDER_HISTORY flag, error: [%s]', error)
 
     class Meta:
         model = Order

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -40,6 +40,7 @@ from ecommerce.enterprise.utils import (
 )
 from ecommerce.entitlements.utils import create_or_update_course_entitlement
 from ecommerce.extensions.api.v2.constants import (
+    ENABLE_HOIST_ORDER_HISTORY,
     REFUND_ORDER_EMAIL_CLOSING,
     REFUND_ORDER_EMAIL_GREETING,
     REFUND_ORDER_EMAIL_SUBJECT
@@ -366,6 +367,7 @@ class OrderSerializer(serializers.ModelSerializer):
     payment_processor = serializers.SerializerMethodField()
     user = UserSerializer()
     vouchers = serializers.SerializerMethodField()
+    enable_hoist_order_history = serializers.SerializerMethodField()
 
     def get_vouchers(self, obj):
         try:
@@ -389,6 +391,17 @@ class OrderSerializer(serializers.ModelSerializer):
         except IndexError:
             return '0'
 
+    def get_enable_hoist_order_history(self, obj):
+        try:
+            request=self.context.get('request')
+            if waffle.flag_is_active(request, ENABLE_HOIST_ORDER_HISTORY):
+                obj.enable_hoist_order_history = True
+            else:
+                obj.enable_hoist_order_history = False
+            return obj.enable_hoist_order_history
+        except AttributeError:
+            None
+
     class Meta:
         model = Order
         fields = (
@@ -396,6 +409,7 @@ class OrderSerializer(serializers.ModelSerializer):
             'currency',
             'date_placed',
             'discount',
+            'enable_hoist_order_history',
             'lines',
             'number',
             'payment_processor',

--- a/ecommerce/extensions/api/v2/constants.py
+++ b/ecommerce/extensions/api/v2/constants.py
@@ -5,3 +5,13 @@ REFUND_ORDER_EMAIL_GREETING = 'Hello! We see you unenrolled from a course provid
                               'original code.'
 REFUND_ORDER_EMAIL_CLOSING = 'We hope you find a course that meets your learning needs! For any questions, reach out ' \
                              'to your Learning Manager at your organization.'
+
+# .. toggle_name: enable_hoist_order_history
+# .. toggle_type: waffle_flag
+# .. toggle_default: False
+# .. toggle_description: Allows order fetching from Commerce Coordinator API for display in Order History MFE.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2022-04-05
+# .. toggle_tickets: REV-2576
+# .. toggle_status: supported
+ENABLE_HOIST_ORDER_HISTORY = 'enable_hoist_order_history'

--- a/ecommerce/extensions/api/v2/tests/views/test_orders.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_orders.py
@@ -15,12 +15,14 @@ from django.urls import reverse
 from oscar.core.loading import get_class, get_model
 from oscar.test import factories
 from rest_framework import status
+from waffle.testutils import override_flag
 
 from ecommerce.coupons.tests.mixins import DiscoveryMockMixin
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.entitlements.utils import create_or_update_course_entitlement
 from ecommerce.extensions.api.serializers import OrderSerializer
 from ecommerce.extensions.api.tests.test_authentication import AccessTokenMixin
+from ecommerce.extensions.api.v2.constants import ENABLE_HOIST_ORDER_HISTORY
 from ecommerce.extensions.api.v2.tests.views import OrderDetailViewTestMixin
 from ecommerce.extensions.checkout.exceptions import BasketNotFreeError
 from ecommerce.extensions.fulfillment.signals import SHIPPING_EVENT_NAME
@@ -99,6 +101,19 @@ class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
         self.assertEqual(content['count'], 2)
         self.assertEqual(content['results'][0]['number'], str(order_2.number))
         self.assertEqual(content['results'][1]['number'], str(order.number))
+
+    @ddt.data(True, False)
+    def test_enable_hoist_order_history(self, enable_hoist_order_history_flag):
+        """ Verify that orders contain the Order History flag value """
+        with override_flag(ENABLE_HOIST_ORDER_HISTORY, active=enable_hoist_order_history_flag):
+            order = create_order(site=self.site, user=self.user)
+            site = SiteConfigurationFactory().site
+            create_order(site=site, user=self.user)
+            response = self.client.get(self.path, HTTP_AUTHORIZATION=self.token)
+            self.assertEqual(response.status_code, 200)
+            content = json.loads(response.content.decode('utf-8'))
+
+            self.assertEqual(content['results'][0]['enable_hoist_order_history'], enable_hoist_order_history_flag)
 
     def test_with_other_users_orders(self):
         """ The view should only return orders for the authenticated users. """

--- a/ecommerce/extensions/api/v2/views/orders.py
+++ b/ecommerce/extensions/api/v2/views/orders.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 
 import dateutil
 import django_filters
+import waffle
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.db import transaction
@@ -30,6 +31,7 @@ from ecommerce.extensions.api import serializers
 from ecommerce.extensions.api.filters import OrderFilter
 from ecommerce.extensions.api.permissions import IsStaffOrOwner
 from ecommerce.extensions.api.throttles import ServiceUserThrottle
+from ecommerce.extensions.api.v2.constants import ENABLE_HOIST_ORDER_HISTORY
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
 from ecommerce.extensions.fulfillment.status import LINE, ORDER
 from ecommerce.extensions.offer.models import OFFER_PRIORITY_MANUAL_ORDER
@@ -85,6 +87,12 @@ class OrderViewSet(viewsets.ReadOnlyModelViewSet):
 
         # Get email_opt_in from the query parameters if it exists, defaulting to false
         email_opt_in = request.query_params.get('email_opt_in', False) == 'True'
+
+        logger.info(
+            'Waffle flag ENABLE_HOIST_ORDER_HISTORY is [%s], order [%s]',
+            waffle.flag_is_active(request, ENABLE_HOIST_ORDER_HISTORY),
+            order.number
+        )
 
         logger.info('Attempting fulfillment of order [%s]...', order.number)
         with transaction.atomic():

--- a/ecommerce/extensions/api/v2/views/orders.py
+++ b/ecommerce/extensions/api/v2/views/orders.py
@@ -6,7 +6,6 @@ from decimal import Decimal
 
 import dateutil
 import django_filters
-import waffle
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.db import transaction
@@ -31,7 +30,6 @@ from ecommerce.extensions.api import serializers
 from ecommerce.extensions.api.filters import OrderFilter
 from ecommerce.extensions.api.permissions import IsStaffOrOwner
 from ecommerce.extensions.api.throttles import ServiceUserThrottle
-from ecommerce.extensions.api.v2.constants import ENABLE_HOIST_ORDER_HISTORY
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
 from ecommerce.extensions.fulfillment.status import LINE, ORDER
 from ecommerce.extensions.offer.models import OFFER_PRIORITY_MANUAL_ORDER
@@ -87,12 +85,6 @@ class OrderViewSet(viewsets.ReadOnlyModelViewSet):
 
         # Get email_opt_in from the query parameters if it exists, defaulting to false
         email_opt_in = request.query_params.get('email_opt_in', False) == 'True'
-
-        logger.info(
-            'Waffle flag ENABLE_HOIST_ORDER_HISTORY is [%s], order [%s]',
-            waffle.flag_is_active(request, ENABLE_HOIST_ORDER_HISTORY),
-            order.number
-        )
 
         logger.info('Attempting fulfillment of order [%s]...', order.number)
         with transaction.atomic():


### PR DESCRIPTION
[REV-2576](https://openedx.atlassian.net/browse/REV-2576).

For the Order History page (`frontend-app-ecommerce`), order info is displayed via a `GET` request to `/api​/v2​/orders​/` endpoint in ecommerce. We need a flag to enable/disable fetching order info from `ecommerce` API OR `commerce-coordinator`.

This should be done in the `ecommerce` side and not the MFE side because we want Django Waffle's flag rollout capabilities (turn on/off without needing to modify the code in prod, user/user group specific). 
There's a PR that was done prior that adds a flag to the MFE here https://github.com/openedx/frontend-app-ecommerce/pull/175, but we're replacing that with this PR.

**This PR:**
- Add a flag for enable hoist order history
- Logs the flag status
- Adds the flag status into the serialized data for Order
- Adds a test for the presence of the flag status in the API response