### PR TITLE
fix: include enterprise catalog UUID in coupon overview response.

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -177,6 +177,20 @@ def retrieve_voucher_usage(obj):
     return retrieve_voucher(obj).usage
 
 
+def retrieve_enterprise_customer_catalog(coupon):
+    """
+    Helper method to retrieve the Enterprise Customer Catalog UUID
+    attached to a given coupon.
+    """
+    offer_range = retrieve_range(coupon)
+    offer_condition = retrieve_condition(coupon)
+    if offer_range and offer_range.enterprise_customer_catalog:
+        return offer_range.enterprise_customer_catalog
+    if offer_condition.enterprise_customer_catalog_uuid:
+        return offer_condition.enterprise_customer_catalog_uuid
+    return None
+
+
 def _flatten(attrs):
     """Transform a list of attribute names and values into a dictionary keyed on the names."""
     return {attr['name']: attr['value'] for attr in attrs}
@@ -1113,6 +1127,7 @@ class EnterpriseCouponOverviewListSerializer(serializers.ModelSerializer):
             'num_unassigned': self._get_num_unassigned(vouchers),
             'errors': self._get_errors(coupon),
             'available': is_coupon_available(coupon),
+            'enterprise_catalog_uuid': retrieve_enterprise_customer_catalog(coupon),
         }
 
         return dict(representation, **data)
@@ -1300,14 +1315,7 @@ class CouponSerializer(CouponMixin, ProductPaymentInfoMixin, serializers.ModelSe
 
     def get_enterprise_customer_catalog(self, obj):
         """ Get the Enterprise Customer Catalog UUID attached to a coupon. """
-        offer_range = retrieve_range(obj)
-        offer_condition = retrieve_condition(obj)
-        if offer_range and offer_range.enterprise_customer_catalog:
-            return offer_range.enterprise_customer_catalog
-        if offer_condition.enterprise_customer_catalog_uuid:
-            return offer_condition.enterprise_customer_catalog_uuid
-
-        return None
+        return retrieve_enterprise_customer_catalog(obj)
 
     def get_inactive(self, obj):
         """ Get inactive attribute for Coupon Product"""

--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -446,6 +446,7 @@ class EnterpriseCouponViewSetRbacTests(
             'title': coupon.title,
             'usage_limitation': 'Single use',
             'available': is_coupon_available(coupon),
+            'enterprise_catalog_uuid': self.data['enterprise_customer_catalog'],
         }
 
     def get_coupon_voucher_start_date(self, coupon):


### PR DESCRIPTION
## Description
ENT-5643 | Include the enterprise catalog UUID for each coupon record in the overview response.
This is needed for the enterprise admin MFE Browse and Request feature.  It impacts users with the `enterprise_admin` role.

## Supporting information

https://openedx.atlassian.net/browse/ENT-5643

## Testing instructions

Use Postman to make a request to e.g. http://localhost:18130/api/v2/enterprise/coupons/da489708-7892-44d4-8569-c60052550827/overview/ and verify that `enterprise_catalog_uuid` is included in the response payload.