### PR TITLE
FC-0001: replace EdxRestAPIClient with OAuthAPIClient

### DIFF
--- a/e2e/api.py
+++ b/e2e/api.py
@@ -1,6 +1,6 @@
+from urllib.parse import urljoin
 
-
-from edx_rest_api_client.client import EdxRestApiClient
+from edx_rest_api_client.client import OAuthAPIClient
 
 from e2e.config import (
     DISCOVERY_API_URL_ROOT,
@@ -18,19 +18,20 @@ class BaseApi:
 
     def __init__(self):
         assert self.api_url_root
-        access_token, __ = self.get_access_token()
-        self._client = EdxRestApiClient(self.api_url_root, jwt=access_token, append_slash=self.append_slash)
+        self._client = OAuthAPIClient(OAUTH_ACCESS_TOKEN_URL, OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET)
 
-    @staticmethod
-    def get_access_token():
-        """ Returns an access token and expiration date from the OAuth provider.
-
-        Returns:
-            (str, datetime)
+    def get_api_url(self, path):
         """
-        return EdxRestApiClient.get_oauth_access_token(
-            OAUTH_ACCESS_TOKEN_URL, OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET, token_type='jwt'
-        )
+        Construct the full API URL using the api_url_root and path.
+
+        Args:
+            path (str): API endpoint path.
+        """
+        path = path.strip('/')
+        if self.append_slash:
+            path += '/'
+
+        return urljoin(f"{self.api_url_root}/", path)  # type: ignore
 
 
 class DiscoveryApi(BaseApi):
@@ -48,9 +49,15 @@ class DiscoveryApi(BaseApi):
         Returns:
             list(dict)
         """
-        results = self._client.search.course_runs.facets.get(
-            selected_query_facets='availability_current', selected_facets='seat_types_exact:{}'.format(seat_type))
-        return results['objects']['results']
+        response = self._client.get(
+            self.get_api_url("search/course_runs/facets/"),
+            params={
+                "selected_query_facets": "availability_current",
+                "selected_facets": f"seat_types_exact:{seat_type}"
+            }
+        )
+        response.raise_for_status()
+        return response.json()['objects']['results']
 
     def get_course_run(self, course_run):
         """ Returns the details for a given course run.
@@ -61,7 +68,11 @@ class DiscoveryApi(BaseApi):
         Returns:
             dict
         """
-        return self._client.course_runs(course_run).get()
+        response = self._client.get(
+            self.get_api_url(f"course_runs/{course_run}/"),
+        )
+        response.raise_for_status()
+        return response.json()
 
 
 class EcommerceApi(BaseApi):
@@ -77,10 +88,20 @@ class EcommerceApi(BaseApi):
         Returns:
             str[]: List of refund IDs.
         """
-        return self._client.refunds.post({'username': username, 'course_id': course_run_id})
+        response = self._client.post(
+            self.get_api_url("refunds/"),
+            json={'username': username, 'course_id': course_run_id}
+        )
+        response.raise_for_status()
+        return response.json()
 
     def process_refund(self, refund_id, action):
-        return self._client.refunds(refund_id).process.put({'action': action})
+        response = self._client.put(
+            self.get_api_url(f"refunds/{refund_id}/process/"),
+            json={'action': action}
+        )
+        response.raise_for_status()
+        return response.json()
 
 
 class EnrollmentApi(BaseApi):
@@ -94,4 +115,8 @@ class EnrollmentApi(BaseApi):
             username (str)
             course_run_id (str)
         """
-        return self._client.enrollment('{},{}'.format(username, course_run_id)).get()
+        response = self._client.get(
+            self.get_api_url(f"enrollment/{username},{course_run_id}")
+        )
+        response.raise_for_status()
+        return response.json()

--- a/ecommerce/core/tests/test_create_demo_data.py
+++ b/ecommerce/core/tests/test_create_demo_data.py
@@ -4,9 +4,9 @@ import sys
 from datetime import datetime
 from io import StringIO
 
-import httpretty
 import mock
 import pytz
+import responses
 from django.core.management import call_command
 
 from ecommerce.courses.models import Course
@@ -30,9 +30,10 @@ class CreateDemoDataTests(DiscoveryTestMixin, TestCase):
         self.assertTrue(verified_seat.attr.id_verification_required)
         self.assertEqual(verified_seat.stockrecords.get(partner=self.partner).price_excl_tax, price)
 
-    @httpretty.activate
+    @responses.activate
     def test_handle(self):
-        """ The command should create the demo course with audit and verified seats,
+        """
+        The command should create the demo course with audit and verified seats,
         and publish that data to the LMS.
         """
         self.mock_access_token_response()
@@ -43,9 +44,10 @@ class CreateDemoDataTests(DiscoveryTestMixin, TestCase):
 
         self.assert_seats_created('course-v1:edX+DemoX+Demo_Course', 'edX Demonstration Course', 149)
 
-    @httpretty.activate
+    @responses.activate
     def test_handle_with_existing_course(self):
-        """ The command should create the demo course with audit and verified seats,
+        """
+        The command should create the demo course with audit and verified seats,
         and publish that data to the LMS.
         """
         self.mock_access_token_response()
@@ -66,9 +68,11 @@ class CreateDemoDataTests(DiscoveryTestMixin, TestCase):
 
         self.assert_seats_created('course-v1:edX+DemoX+Demo_Course', 'edX Demonstration Course', 149)
 
-    @httpretty.activate
+    @responses.activate
     def test_handle_with_overrides(self):
-        """ Users should be able to specify the course ID, course title, and price of the verified seat. """
+        """
+        Users should be able to specify the course ID, course title, and price of the verified seat.
+        """
         course_id = 'a/b/c'
         course_title = 'ABCs'
         price = 1e6
@@ -81,7 +85,7 @@ class CreateDemoDataTests(DiscoveryTestMixin, TestCase):
 
         self.assert_seats_created(course_id, course_title, price)
 
-    @httpretty.activate
+    @responses.activate
     def test_handle_with_error_in_publish_to_lms(self):
         """
         The command should log error message if there was an error in publish to LMS.

--- a/ecommerce/core/tests/test_generate_courses.py
+++ b/ecommerce/core/tests/test_generate_courses.py
@@ -3,8 +3,8 @@
 import json
 
 import ddt
-import httpretty
 import mock
+import responses
 from django.core.management import CommandError, call_command
 
 from ecommerce.courses.models import Course
@@ -149,7 +149,7 @@ class GenerateCoursesTests(DiscoveryTestMixin, TestCase):
         call_command("generate_courses", arg)
         mock_logger.warning.assert_any_call("Enrollment json is missing %s", enrollment_setting)
 
-    @httpretty.activate
+    @responses.activate
     @mock.patch('ecommerce.core.management.commands.generate_courses.logger')
     @ddt.data("audit", "honor", "verified", "professional_education", "credit")
     def test_create_seat(self, seat_type, mock_logger):

--- a/ecommerce/coupons/tests/test_utils.py
+++ b/ecommerce/coupons/tests/test_utils.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 
 import ddt
-import httpretty
+import responses
 from edx_django_utils.cache import TieredCache
 from mock import patch
 from oscar.test.factories import ProductFactory, RangeFactory, VoucherFactory
@@ -23,7 +23,6 @@ from ecommerce.tests.testcases import TestCase
 
 
 @ddt.ddt
-@httpretty.activate
 class CouponUtilsTests(TestCase, CouponMixin, DiscoveryMockMixin):
 
     def setUp(self):
@@ -35,6 +34,12 @@ class CouponUtilsTests(TestCase, CouponMixin, DiscoveryMockMixin):
         self.user = self.create_user(email='test@tester.fake')
         self.request.user = self.user
         self.request.GET = {}
+        responses.start()
+
+    def tearDown(self):
+        super().tearDown()
+        responses.stop()
+        responses.reset()
 
     @ddt.data(
         (['verIfiEd', 'profeSSional'], 'verified,professional'),

--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -6,9 +6,9 @@ import urllib
 from decimal import Decimal
 
 import ddt
-import httpretty
 import mock
 import pytz
+import responses
 from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.urls import reverse
@@ -293,7 +293,7 @@ class CouponOfferViewTests(ApiMockMixin, CouponMixin, DiscoveryTestMixin, Enterp
         ),
     )
     @ddt.unpack
-    @httpretty.activate
+    @responses.activate
     def test_consent_failed_message(self, contact_email, expected_response):
         """ Verify that the consent failure message shows up when the consent_failed parameter is a valid SKU. """
         self.mock_access_token_response()
@@ -332,6 +332,10 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         self.stock_record = StockRecord.objects.get(product=self.seat)
         self.catalog = Catalog.objects.create(partner=self.partner)
         self.catalog.stock_records.add(StockRecord.objects.get(product=self.seat))
+
+    def tearDown(self):
+        super().tearDown()
+        responses.reset()
 
     def redeem_url_with_params(self, code=COUPON_CODE, consent_token=None):
         """ Constructs the coupon redemption URL with the proper string query parameters. """
@@ -452,7 +456,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         response = self.client.get(url)
         self.assertEqual(response.context['error'], 'This coupon code has expired.')
 
-    @httpretty.activate
+    @responses.activate
     def test_invalid_entitlement_course(self):
         """ Verify an error is returned when you apply enterprise coupon on entitled product. """
         entitle_product = ProductFactory(
@@ -476,7 +480,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
             'If you need assistance, contact edX support.'
         )
 
-    @httpretty.activate
+    @responses.activate
     def test_basket_redirect_discount_code(self):
         """ Verify the view redirects to the basket view when a discount code is provided. """
         self.mock_course_api_response(course=self.course)
@@ -486,7 +490,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         self.create_coupon(catalog=self.catalog, code=COUPON_CODE, benefit_value=5)
         self.assert_redemption_page_redirects(self.get_coupon_redeem_success_expected_redirect_url())
 
-    @httpretty.activate
+    @responses.activate
     def test_basket_redirect_enrollment_code(self):
         """ Verify the view redirects to the receipt page when an enrollment code is provided. """
         code, _ = self.create_coupon_and_get_code(benefit_value=100, code='', catalog=self.catalog)
@@ -495,7 +499,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
 
         self.assert_redirects_to_receipt_page(code=code)
 
-    @httpretty.activate
+    @responses.activate
     @mock.patch.object(EdxOrderPlacementMixin, 'place_free_order')
     def test_basket_redirect_enrollment_code_error(self, place_free_order):
         """ Verify the view redirects to checkout error page when an order hasn't completed. """
@@ -542,7 +546,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         self.mock_specific_enterprise_customer_api(uuid=ENTERPRISE_CUSTOMER, consent_enabled=consent_enabled)
         return code, coupon
 
-    @httpretty.activate
+    @responses.activate
     def test_enterprise_customer_redirect_no_consent(self):
         """ Verify the view redirects to LMS when an enrollment code is provided. """
         code, _ = self.prepare_enterprise_data(catalog=self.catalog)
@@ -564,7 +568,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, expected_url)
 
-    @httpretty.activate
+    @responses.activate
     def test_enterprise_customer_invalid_consent_token(self):
         """ Verify that the view renders an error when the consent token doesn't match. """
         code, _ = self.prepare_enterprise_data(catalog=self.catalog)
@@ -578,19 +582,20 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         response = self.client.get(self.redeem_url_with_params(code=code, consent_token='invalid_consent_token'))
         self.assertEqual(response.context['error'], 'Invalid data sharing consent token provided.')
 
-    @httpretty.activate
+    @responses.activate
     def test_enterprise_customer_does_not_exist(self):
         """
         Verify that a generic error is rendered when the corresponding EnterpriseCustomer doesn't exist
         on the Enterprise service.
         """
-        code, _ = self.prepare_enterprise_data(catalog=self.catalog)
         self.mock_enterprise_customer_api_not_found(ENTERPRISE_CUSTOMER)
+        code, _ = self.prepare_enterprise_data(catalog=self.catalog)
         self.mock_enterprise_learner_api_for_learner_with_no_enterprise()
         response = self.client.get(self.redeem_url_with_params(code=code))
+
         self.assertEqual(response.context['error'], 'Couldn\'t find a matching Enterprise Customer for this coupon.')
 
-    @httpretty.activate
+    @responses.activate
     def test_enterprise_contract_metadata_create_on_coupon_redemption(self):
         """
         Verify an orderline is updated with calculated enterprise discount data
@@ -621,7 +626,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         self.assertIsInstance(orderline.effective_contract_discount_percentage, Decimal)
         self.assertIsInstance(orderline.effective_contract_discounted_price, Decimal)
 
-    @httpretty.activate
+    @responses.activate
     def test_enterprise_contract_metadata_not_created(self):
         """
         Verify an orderline is NOT updated with calculated enterprise discount data
@@ -649,7 +654,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         assert orderline.effective_contract_discount_percentage is None
         assert orderline.effective_contract_discounted_price is None
 
-    @httpretty.activate
+    @responses.activate
     def test_enterprise_customer_successful_redemption(self):
         """ Verify the view redirects to LMS courseware page when valid consent is provided. """
         code, _ = self.prepare_enterprise_data(enterprise_customer_catalog=ENTERPRISE_CUSTOMER_CATALOG)
@@ -666,11 +671,12 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         response = self.redeem_coupon(code=code, consent_token=consent_token)
         self.assertRedirects(response, get_lms_courseware_url(self.course.id), fetch_redirect_response=False)
 
-        last_request = httpretty.last_request()
-        self.assertEqual(last_request.path, '/api/enrollment/v1/enrollment')
+        last_request = responses.calls[-1].request
+
+        self.assertEqual(last_request.path_url, '/api/enrollment/v1/enrollment')
         self.assertEqual(last_request.method, 'POST')
 
-    @httpretty.activate
+    @responses.activate
     def test_enterprise_customer_successful_free_redemption(self):
         """ Verify the view redirects to LMS course page for enterprise customers on a successful free redemption. """
         code, _ = self.prepare_enterprise_data(
@@ -684,7 +690,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         response = self.client.get(self.redeem_url_with_params(code=code), follow=False)
         self.assertRedirects(response, get_lms_courseware_url(self.course.id), fetch_redirect_response=False)
 
-    @httpretty.activate
+    @responses.activate
     def test_enterprise_customer_successful_redemption_message(self):
         """ Verify the info message appears on successful redemption. """
         expected_message = 'A discount has been applied, courtesy of BigEnterprise.'
@@ -706,7 +712,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         self.assertEqual(messages[0].tags, 'info')
         self.assertEqual(messages[0].message, expected_message)
 
-    @httpretty.activate
+    @responses.activate
     def test_enterprise_customer_coupon_redemption_for_invalid_course(self):
         """ Verify the warning message appears on redemption if coupon does not belong to course. """
         expected_message = 'This coupon code is not valid for this course. Try a different course.'
@@ -734,7 +740,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         self.assertEqual(messages[0].tags, 'warning')
         self.assertEqual(messages[0].message, expected_message)
 
-    @httpretty.activate
+    @responses.activate
     def test_enterprise_customer_coupon_redemption_for_no_offer_assignment(self):
         """
         Verify the warning message appears on redemption if coupon does not have any
@@ -768,7 +774,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         self.assertEqual(messages[0].tags, 'warning')
         self.assertEqual(messages[0].message, expected_message)
 
-    @httpretty.activate
+    @responses.activate
     def test_multiple_vouchers(self):
         """ Verify a redirect to LMS happens when a basket with already existing vouchers is used. """
         code, _ = self.create_coupon_and_get_code(benefit_value=100, code='', catalog=self.catalog)
@@ -780,7 +786,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
 
         self.assert_redirects_to_receipt_page(code=code)
 
-    @httpretty.activate
+    @responses.activate
     def test_already_enrolled_rejection(self):
         """ Verify a user is rejected from redeeming a coupon for a course he's already enrolled in."""
         self.mock_account_api(self.request, self.user.username, data={'is_active': True})
@@ -791,7 +797,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
             msg = 'You have already purchased {course} seat.'.format(course=self.course.name)
             self.assertEqual(response.context['error'], msg)
 
-    @httpretty.activate
+    @responses.activate
     def test_invalid_email_domain_rejection(self):
         """ Verify a user with invalid email domain is rejected. """
         self.create_coupon_and_get_code(email_domains='example.com', catalog=self.catalog)
@@ -806,7 +812,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         self.assertIsInstance(response, HttpResponseRedirect)
         self.assertIn(expected_redirect_url, response.url)
 
-    @httpretty.activate
+    @responses.activate
     def test_inactive_user_rejection(self):
         """ Verify that a user who hasn't activated the account is rejected. """
         self.mock_account_api(self.request, self.user.username, data={'is_active': False})
@@ -816,7 +822,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         response = self.client.get(self.redeem_url_with_params())
         self.assert_redirected_to_email_confirmation(response)
 
-    @httpretty.activate
+    @responses.activate
     def test_inactive_user_requirement_disabled(self):
         """
         Verify that a user who hasn't activated their account is redirected to the basket view
@@ -830,7 +836,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         self.create_coupon(catalog=self.catalog, code=COUPON_CODE, benefit_value=5)
         self.assert_redemption_page_redirects(self.get_coupon_redeem_success_expected_redirect_url())
 
-    @httpretty.activate
+    @responses.activate
     def test_inactive_user_email_domain_restricted_coupon_redemption(self):
         """
         Verify that a user must activate their account before being allowed

--- a/ecommerce/courses/tests/test_utils.py
+++ b/ecommerce/courses/tests/test_utils.py
@@ -1,7 +1,7 @@
 
 
 import ddt
-import httpretty
+import responses
 from edx_django_utils.cache import TieredCache
 from mock import patch
 from opaque_keys.edx.keys import CourseKey
@@ -21,7 +21,6 @@ from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
 from ecommerce.tests.testcases import TestCase
 
 
-@httpretty.activate
 @ddt.ddt
 class UtilsTests(DiscoveryTestMixin, DiscoveryMockMixin, TestCase):
     @ddt.unpack
@@ -47,6 +46,7 @@ class UtilsTests(DiscoveryTestMixin, DiscoveryMockMixin, TestCase):
     @ddt.data(
         True, False
     )
+    @responses.activate
     def test_get_course_run_info_from_catalog(self, course_run):
         """ Check to see if course info gets cached """
         self.mock_access_token_response()
@@ -85,6 +85,7 @@ class UtilsTests(DiscoveryTestMixin, DiscoveryMockMixin, TestCase):
         course_cached_response = TieredCache.get_cached_response(cache_key)
         self.assertEqual(course_cached_response.value, response)
 
+    @responses.activate
     def test_get_course_info_from_catalog_cached(self):
         """
         Verify that get_course_info_from_catalog is cached
@@ -125,18 +126,13 @@ class UtilsTests(DiscoveryTestMixin, DiscoveryMockMixin, TestCase):
 
 
 @ddt.ddt
-@httpretty.activate
 class GetCourseCatalogUtilTests(DiscoveryMockMixin, TestCase):
-
-    def tearDown(self):
-        # Reset HTTPretty state (clean up registered urls and request history)
-        httpretty.reset()
 
     def _assert_num_requests(self, count):
         """
         DRY helper for verifying request counts.
         """
-        self.assertEqual(len(httpretty.httpretty.latest_requests), count)
+        self.assertEqual(len(responses.calls), count)
 
     def _assert_get_course_catalogs(self, catalog_name_list):
         """
@@ -160,6 +156,7 @@ class GetCourseCatalogUtilTests(DiscoveryMockMixin, TestCase):
         course_cached_response = TieredCache.get_cached_response(cache_key)
         self.assertEqual(course_cached_response.value, response)
 
+    @responses.activate
     def test_get_course_catalogs_for_single_catalog_with_id(self):
         """
         Verify that method "get_course_catalogs" returns proper response for a
@@ -190,6 +187,7 @@ class GetCourseCatalogUtilTests(DiscoveryMockMixin, TestCase):
         ['Catalog 1'],
         ['Catalog 1', 'Catalog 2'],
     )
+    @responses.activate
     def test_get_course_catalogs_for_single_page_api_response(self, catalog_name_list):
         """
         Verify that method "get_course_catalogs" returns proper response for
@@ -209,6 +207,7 @@ class GetCourseCatalogUtilTests(DiscoveryMockMixin, TestCase):
         get_course_catalogs(self.request.site)
         self._assert_num_requests(2)
 
+    @responses.activate
     def test_get_course_catalogs_for_paginated_api_response(self):
         """
         Verify that method "get_course_catalogs" returns all catalogs for
@@ -225,6 +224,7 @@ class GetCourseCatalogUtilTests(DiscoveryMockMixin, TestCase):
         # Verify the API was hit for each catalog page
         self._assert_num_requests(len(catalog_name_list) + 1)
 
+    @responses.activate
     def test_get_course_catalogs_for_failure(self):
         """
         Verify that method "get_course_catalogs" raises exception in case

--- a/ecommerce/courses/utils.py
+++ b/ecommerce/courses/utils.py
@@ -1,5 +1,7 @@
 
 
+from urllib.parse import urljoin
+
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 from edx_django_utils.cache import TieredCache
@@ -40,18 +42,27 @@ def _get_discovery_response(site, cache_key, resource, resource_id):
         return course_cached_response.value
 
     params = {}
-    api = site.siteconfiguration.discovery_api_client
-    endpoint = getattr(api, resource)
 
     if resource == 'course_runs':
         params['partner'] = site.siteconfiguration.partner.short_code
-    response = endpoint(resource_id).get(**params)
+
+    api_client = site.siteconfiguration.oauth_api_client
+    resource_path = f"{resource_id}/" if resource_id else ""
+    discovery_api_url = urljoin(
+        f"{site.siteconfiguration.discovery_api_url}/",
+        f"{resource}/{resource_path}"
+    )
+
+    response = api_client.get(discovery_api_url, params=params)
+    response.raise_for_status()
+
+    result = response.json()
 
     if resource_id is None:
-        response = deprecated_traverse_pagination(response, endpoint)
+        result = deprecated_traverse_pagination(result, api_client, discovery_api_url)
 
-    TieredCache.set_all_tiers(cache_key, response, settings.COURSES_API_CACHE_TIMEOUT)
-    return response
+    TieredCache.set_all_tiers(cache_key, result, settings.COURSES_API_CACHE_TIMEOUT)
+    return result
 
 
 def get_course_detail(site, course_resource_id):
@@ -113,10 +124,7 @@ def get_course_catalogs(site, resource_id=None):
         dict: Course catalogs received from Discovery API
 
     Raises:
-        ConnectionError: requests exception "ConnectionError"
-        SlumberBaseException: slumber exception "SlumberBaseException"
-        Timeout: requests exception "Timeout"
-
+        HTTPError: requests exception "HTTPError"
     """
     resource = "catalogs"
     cache_key = get_cache_key(

--- a/ecommerce/enterprise/conditions.py
+++ b/ecommerce/enterprise/conditions.py
@@ -10,8 +10,7 @@ from django.db.models import Sum
 from django.utils.translation import ugettext as _
 from oscar.core.loading import get_model
 from requests.exceptions import ConnectionError as ReqConnectionError
-from requests.exceptions import Timeout
-from slumber.exceptions import SlumberHttpBaseException
+from requests.exceptions import HTTPError, Timeout
 
 from ecommerce.courses.utils import get_course_info_from_catalog
 from ecommerce.enterprise.api import catalog_contains_course_runs, get_enterprise_id_for_user
@@ -140,7 +139,7 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
             if line.product.is_course_entitlement_product:
                 try:
                     response = get_course_info_from_catalog(basket.site, line.product)
-                except (ReqConnectionError, KeyError, SlumberHttpBaseException, Timeout) as exc:
+                except (ReqConnectionError, KeyError, HTTPError, Timeout) as exc:
                     logger.exception(
                         '[Code Redemption Failure] Unable to apply enterprise offer because basket '
                         'contains a course entitlement product but we failed to get course info from  '
@@ -230,7 +229,7 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
                 basket.site, course_ids, enterprise_in_condition,
                 enterprise_customer_catalog_uuid=enterprise_catalog
             )
-        except (ReqConnectionError, KeyError, SlumberHttpBaseException, Timeout) as exc:
+        except (ReqConnectionError, KeyError, HTTPError, Timeout) as exc:
             logger.exception('[Code Redemption Failure] Unable to apply enterprise offer because '
                              'we failed to check if course_runs exist in the catalog. '
                              'User: %s, Offer: %s, Message: %s, Enterprise: %s, Catalog: %s, Courses: %s',

--- a/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -5,11 +5,10 @@ Management command for assigning enterprise roles to existing enterprise users.
 
 import datetime
 import logging
+from urllib.parse import urljoin
 
-import requests
 from django.core.management.base import BaseCommand
 from django.utils.timezone import now
-from edx_rest_api_client.client import EdxRestApiClient
 from oscar.core.loading import get_model
 
 from ecommerce.core.constants import ENROLLMENT_CODE_PRODUCT_CLASS_NAME
@@ -32,7 +31,6 @@ class Command(BaseCommand):
     """
     coupon = None
     site = None
-    headers = {}
     enterprise_customer = None
     enterprise_catalog = None
     help = 'Seeds an enterprise coupon for an existing enterprise customer.'
@@ -48,42 +46,20 @@ class Command(BaseCommand):
             type=str,
         )
 
-    def get_access_token(self):
-        """
-        Returns an access token and expiration date from the OAuth provider:
-            (str, datetime)
-        """
-        logger.info('\nFetching access token for site...')
-        oauth2_provider_url = self.site.oauth_settings.get('BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL')
-        key = self.site.oauth_settings.get('BACKEND_SERVICE_EDX_OAUTH2_KEY')
-        secret = self.site.oauth_settings.get('BACKEND_SERVICE_EDX_OAUTH2_SECRET')
-        oauth_access_token_url = oauth2_provider_url + '/access_token/'
-        return EdxRestApiClient.get_oauth_access_token(
-            oauth_access_token_url, key, secret, token_type='jwt'
-        )
-
-    def get_headers(self):
-        """
-        Returns a dict containing the authenticated JWT access token
-        """
-        access_token, __ = self.get_access_token()
-        return {'Authorization': 'JWT ' + access_token}
-
-    def get_enterprise_customer(self, url, enterprise_customer_uuid=None):
+    def get_enterprise_customer(self, api_client, url, enterprise_customer_uuid=None):
         """ Returns an enterprise customer """
         logger.info('\nFetching an enterprise customer...')
         try:
-            response = requests.get(
+            response = api_client.get(
                 url,
                 params={'uuid': enterprise_customer_uuid} if enterprise_customer_uuid else None,
-                headers=self.headers,
             )
             return response.json().get('results')[0]
         except IndexError:
             logger.error('No enterprise customer found.')
             return None
 
-    def get_enterprise_catalog(self, url):
+    def get_enterprise_catalog(self, api_client, url):
         """
         Returns a catalog associated with a specified enterprise customer
         """
@@ -93,17 +69,16 @@ class Command(BaseCommand):
 
         logger.info('\nFetching catalog for enterprise customer (%s)...', self.enterprise_customer.get('uuid'))
         try:
-            response = requests.get(
+            response = api_client.get(
                 url,
                 params={'enterprise_customer': self.enterprise_customer.get('uuid')},
-                headers=self.headers,
             )
             return response.json().get('results')[0]
         except IndexError:
             logger.error('No catalog found for enterprise (%s)', self.enterprise_customer.get('uuid'))
             return None
 
-    def create_coupon(self, ecommerce_api_url, enterprise_catalog_api_url):
+    def create_coupon(self, api_client, ecommerce_api_url, enterprise_catalog_api_url):
         """
         Creates and returns a coupon associated with the specified
         enterprise customer and catalog
@@ -112,8 +87,10 @@ class Command(BaseCommand):
             logger.error('An enterprise customer and/or catalog was not specified.')
             return None
         catalog_uuid = self.enterprise_catalog.get('uuid', None)
-        catalog_url = enterprise_catalog_api_url + '/' + catalog_uuid + '/get_content_metadata' \
-            if catalog_uuid else None
+        catalog_url = urljoin(
+            f"{enterprise_catalog_api_url}/", f"{catalog_uuid}/get_content_metadata"
+        ) if catalog_uuid else None
+
         logger.info('\nCreating an enterprise coupon...')
         category = Category.objects.get(name='coupons')
         request_obj = {
@@ -151,8 +128,8 @@ class Command(BaseCommand):
             "benefit_value": 100,
             "sales_force_id": '006aaaaaaaaaaaaaaa',
         }
-        url = '{}/enterprise/coupons/'.format(ecommerce_api_url)
-        response = requests.post(url, json=request_obj, headers=self.headers)
+        url = urljoin(f"{ecommerce_api_url}/", "enterprise/coupons/")
+        response = api_client.post(url, json=request_obj)
         return response.json()
 
     def handle(self, *args, **options):
@@ -164,16 +141,16 @@ class Command(BaseCommand):
 
         ecommerce_api_url = '{}/api/v2'.format(self.site.build_ecommerce_url())
         enterprise_api_url = self.site.enterprise_api_url
-        enterprise_catalog_api_url = self.site.enterprise_catalog_api_url + 'enterprise-catalogs'
+        enterprise_catalog_api_url = urljoin(f"{self.site.enterprise_catalog_api_url}/", "enterprise-catalogs")
 
-        enterprise_customer_request_url = '{}enterprise-customer/'.format(enterprise_api_url)
-        enterprise_catalog_request_url = '{}enterprise_catalogs/'.format(enterprise_api_url)
+        enterprise_customer_request_url = urljoin(f"{enterprise_api_url}/", "enterprise-customer/")
+        enterprise_catalog_request_url = urljoin(f"{enterprise_api_url}/", "enterprise_catalogs/")
 
-        # Set up request headers with JWT access token
-        self.headers = self.get_headers()
+        api_client = self.site.oauth_api_client
 
         # Fetch enterprise customer
         self.enterprise_customer = self.get_enterprise_customer(
+            api_client,
             url=enterprise_customer_request_url,
             enterprise_customer_uuid=enterprise_customer_uuid,
         )
@@ -181,12 +158,13 @@ class Command(BaseCommand):
         if self.enterprise_customer:
             # Fetch enterprise customer catalog
             self.enterprise_catalog = self.get_enterprise_catalog(
+                api_client,
                 url=enterprise_catalog_request_url,
             )
 
         if self.enterprise_catalog:
             # Create a new enterprise coupon associated with the
             # above enterprise customer/catalog
-            self.coupon = self.create_coupon(ecommerce_api_url=ecommerce_api_url,
+            self.coupon = self.create_coupon(api_client, ecommerce_api_url=ecommerce_api_url,
                                              enterprise_catalog_api_url=enterprise_catalog_api_url)
             logger.info('\nEnterprise coupon successfully created: %s', self.coupon)

--- a/ecommerce/enterprise/tests/mixins.py
+++ b/ecommerce/enterprise/tests/mixins.py
@@ -1,11 +1,12 @@
 
 
 import json
+import re
 from urllib.parse import urlencode
 from uuid import uuid4
 
-import httpretty
 import requests
+import responses
 from django.conf import settings
 from oscar.core.loading import get_model
 from oscar.test import factories
@@ -21,10 +22,6 @@ from ecommerce.extensions.test.factories import (
 from ecommerce.extensions.voucher.models import CouponVouchers
 
 ProductClass = get_model('catalogue', 'ProductClass')
-
-
-def raise_timeout(request, uri, headers):  # pylint: disable=unused-argument
-    raise requests.Timeout('Connection timed out.')
 
 
 class EnterpriseServiceMockMixin:
@@ -72,18 +69,17 @@ class EnterpriseServiceMockMixin:
             },
         ]
 
-        enterprise_customer_api_response_json = json.dumps(enterprise_customer_api_response)
         self.mock_access_token_response()
-        httpretty.register_uri(
-            method=httpretty.GET,
-            uri=self.ENTERPRISE_CUSTOMER_BASIC_LIST_URL,
-            body=enterprise_customer_api_response_json,
+        responses.add(
+            method=responses.GET,
+            url=self.ENTERPRISE_CUSTOMER_BASIC_LIST_URL,
+            json=enterprise_customer_api_response,
             content_type='application/json'
         )
 
     def mock_enterprise_catalog_api_get(self, enterprise_catalog_uuid, custom_response=None):
         """
-        Helper function to register the legacy enterprise catalog API endpoint using httpretty.
+        Helper function to register the legacy enterprise catalog API endpoint using responses.
         """
         enterprise_catalog_api_response = {
             "count": 60,
@@ -146,13 +142,12 @@ class EnterpriseServiceMockMixin:
             ]
         }
         enterprise_catalog_api_response = custom_response or enterprise_catalog_api_response
-        enterprise_catalog_api_body = json.dumps(enterprise_catalog_api_response)
 
         self.mock_access_token_response()
-        httpretty.register_uri(
-            method=httpretty.GET,
-            uri='{}{}/'.format(self.LEGACY_ENTERPRISE_CATALOG_URL, enterprise_catalog_uuid),
-            body=enterprise_catalog_api_body,
+        responses.add(
+            method=responses.GET,
+            url='{}{}/?'.format(self.LEGACY_ENTERPRISE_CATALOG_URL, enterprise_catalog_uuid),
+            json=enterprise_catalog_api_response,
             content_type='application/json'
         )
 
@@ -177,13 +172,12 @@ class EnterpriseServiceMockMixin:
             },
             'contact_email': contact_email,
         }
-        enterprise_customer_api_response_json = json.dumps(enterprise_customer_api_response)
 
         self.mock_access_token_response()
-        httpretty.register_uri(
-            method=httpretty.GET,
-            uri='{}{}/'.format(self.ENTERPRISE_CUSTOMER_URL, uuid),
-            body=enterprise_customer_api_response_json,
+        responses.add(
+            method=responses.GET,
+            url='{}{}/'.format(self.ENTERPRISE_CUSTOMER_URL, uuid),
+            json=enterprise_customer_api_response,
             content_type='application/json'
         )
 
@@ -194,13 +188,12 @@ class EnterpriseServiceMockMixin:
         enterprise_customer_api_response = {
             'detail': 'Not found.'
         }
-        enterprise_customer_api_response_json = json.dumps(enterprise_customer_api_response)
 
         self.mock_access_token_response()
-        httpretty.register_uri(
-            method=httpretty.GET,
-            uri='{}{}/'.format(self.ENTERPRISE_CUSTOMER_URL, uuid),
-            body=enterprise_customer_api_response_json,
+        responses.add(
+            method=responses.GET,
+            url='{}{}/'.format(self.ENTERPRISE_CUSTOMER_URL, uuid),
+            json=enterprise_customer_api_response,
             content_type='application/json',
             status=404,
         )
@@ -266,13 +259,12 @@ class EnterpriseServiceMockMixin:
             'start': 0,
             'previous': None
         }
-        enterprise_learner_api_response_json = json.dumps(enterprise_learner_api_response)
 
         self.mock_access_token_response()
-        httpretty.register_uri(
-            method=httpretty.GET,
-            uri=self.ENTERPRISE_LEARNER_URL,
-            body=enterprise_learner_api_response_json,
+        responses.add(
+            method=responses.GET,
+            url=self.ENTERPRISE_LEARNER_URL,
+            json=enterprise_learner_api_response,
             content_type='application/json'
         )
 
@@ -284,13 +276,12 @@ class EnterpriseServiceMockMixin:
             'enterprise_customer': 'cf246b88-d5f6-4908-a522-fc307e0b0c59',
             'username': 'the_j_meister',
         }
-        enterprise_learner_api_response_json = json.dumps(enterprise_learner_api_response)
 
         self.mock_access_token_response()
-        httpretty.register_uri(
-            method=httpretty.POST,
-            uri=self.ENTERPRISE_LEARNER_URL,
-            body=enterprise_learner_api_response_json,
+        responses.add(
+            method=responses.POST,
+            url=self.ENTERPRISE_LEARNER_URL,
+            json=enterprise_learner_api_response,
             content_type='application/json'
         )
 
@@ -300,10 +291,10 @@ class EnterpriseServiceMockMixin:
             'contains_content_items': True
         }
         self.mock_access_token_response()
-        httpretty.register_uri(
-            method=httpretty.GET,
-            uri='{}{}/contains_content_items/'.format(self.ENTERPRISE_CATALOG_URL, uuid),
-            body=json.dumps(catalog_contains_content_response),
+        responses.add(
+            method=responses.GET,
+            url='{}{}/contains_content_items/'.format(self.ENTERPRISE_CATALOG_URL, uuid),
+            json=catalog_contains_content_response,
             content_type='application/json'
         )
 
@@ -321,13 +312,12 @@ class EnterpriseServiceMockMixin:
             'start': 0,
             'previous': None
         }
-        enterprise_learner_api_response_json = json.dumps(enterprise_learner_api_response)
 
         self.mock_access_token_response()
-        httpretty.register_uri(
-            method=httpretty.GET,
-            uri=self.ENTERPRISE_LEARNER_URL,
-            body=enterprise_learner_api_response_json,
+        responses.add(
+            method=responses.GET,
+            url=self.ENTERPRISE_LEARNER_URL,
+            json=enterprise_learner_api_response,
             content_type='application/json'
         )
 
@@ -360,13 +350,12 @@ class EnterpriseServiceMockMixin:
             'start': 0,
             'previous': None
         }
-        enterprise_learner_api_response_json = json.dumps(enterprise_learner_api_response)
 
         self.mock_access_token_response()
-        httpretty.register_uri(
-            method=httpretty.GET,
-            uri=self.ENTERPRISE_LEARNER_URL,
-            body=enterprise_learner_api_response_json,
+        responses.add(
+            method=responses.GET,
+            url=self.ENTERPRISE_LEARNER_URL,
+            json=enterprise_learner_api_response,
             content_type='application/json'
         )
 
@@ -375,10 +364,10 @@ class EnterpriseServiceMockMixin:
         Helper function to register enterprise learner API endpoint and raise an exception.
         """
         self.mock_access_token_response()
-        httpretty.register_uri(
-            method=httpretty.GET,
-            uri=self.ENTERPRISE_LEARNER_URL,
-            body=raise_timeout
+        responses.add(
+            method=responses.GET,
+            url=self.ENTERPRISE_LEARNER_URL,
+            body=requests.Timeout('Connection timed out.')
         )
 
     def mock_enterprise_learner_api_for_failure(self):
@@ -387,9 +376,9 @@ class EnterpriseServiceMockMixin:
         failure.
         """
         self.mock_access_token_response()
-        httpretty.register_uri(
-            method=httpretty.GET,
-            uri=self.ENTERPRISE_LEARNER_URL,
+        responses.add(
+            method=responses.GET,
+            url=self.ENTERPRISE_LEARNER_URL,
             status=500,
         )
 
@@ -427,13 +416,12 @@ class EnterpriseServiceMockMixin:
             'start': 0,
             'previous': None
         }
-        enterprise_enrollment_api_response_json = json.dumps(enterprise_enrollment_api_response)
 
         self.mock_access_token_response()
-        httpretty.register_uri(
-            method=httpretty.GET,
-            uri=self.ENTERPRISE_COURSE_ENROLLMENT_URL,
-            body=enterprise_enrollment_api_response_json,
+        responses.add(
+            method=responses.GET,
+            url=self.ENTERPRISE_COURSE_ENROLLMENT_URL,
+            json=enterprise_enrollment_api_response,
             content_type='application/json'
         )
 
@@ -442,7 +430,7 @@ class EnterpriseServiceMockMixin:
             username,
             course_id,
             ec_uuid,
-            method=httpretty.GET,
+            method=responses.GET,
             granted=True,
             required=False,
             exists=True,
@@ -458,11 +446,13 @@ class EnterpriseServiceMockMixin:
         }
 
         self.mock_access_token_response()
-        httpretty.register_uri(
+        url = re.compile(self.site.siteconfiguration.build_lms_url('/consent/api/v1/data_sharing_consent'))
+
+        responses.add(
             method=method,
-            uri=self.site.siteconfiguration.build_lms_url('/consent/api/v1/data_sharing_consent'),
+            url=url,
             content_type='application/json',
-            body=json.dumps(response_body),
+            json=response_body,
             status=response_code or 200,
         )
 
@@ -503,10 +493,13 @@ class EnterpriseServiceMockMixin:
     ):
         self.mock_access_token_response()
         query_params = urlencode({'course_run_ids': course_run_ids}, True)
-        body = raise_timeout if raise_exception else json.dumps({'contains_content_items': contains_content})
-        httpretty.register_uri(
-            method=httpretty.GET,
-            uri='{api_url}{enterprise_customer_uuid}/contains_content_items/?{query_params}'.format(
+        body = (
+            requests.Timeout('Connection timed out.') if raise_exception else
+            json.dumps({'contains_content_items': contains_content})
+        )
+        responses.add(
+            method=responses.GET,
+            url='{api_url}{enterprise_customer_uuid}/contains_content_items/?{query_params}'.format(
                 api_url=self.ENTERPRISE_CATALOG_URL_CUSTOMER_RESOURCE,
                 enterprise_customer_uuid=enterprise_customer_uuid,
                 query_params=query_params
@@ -515,9 +508,9 @@ class EnterpriseServiceMockMixin:
             content_type='application/json'
         )
         if enterprise_customer_catalog_uuid:
-            httpretty.register_uri(
-                method=httpretty.GET,
-                uri='{api_url}{customer_catalog_uuid}/contains_content_items/?{query_params}'.format(
+            responses.add(
+                method=responses.GET,
+                url='{api_url}{customer_catalog_uuid}/contains_content_items/?{query_params}'.format(
                     api_url=self.ENTERPRISE_CATALOG_URL,
                     customer_catalog_uuid=enterprise_customer_catalog_uuid,
                     query_params=query_params
@@ -555,10 +548,10 @@ class EnterpriseServiceMockMixin:
             'permissions': [enterprise_data_api_group],
             'enterprise_id': enterprise_id,
         }, True)
-        body = raise_timeout if raise_exception else json.dumps(expected_response)
-        httpretty.register_uri(
-            method=httpretty.GET,
-            uri='{}enterprise-customer/with_access_to/?{}'.format(
+        body = requests.Timeout('Connection timed out.') if raise_exception else json.dumps(expected_response)
+        responses.add(
+            method=responses.GET,
+            url='{}enterprise-customer/with_access_to/?{}'.format(
                 self.site.siteconfiguration.enterprise_api_url,
                 query_params
             ),
@@ -592,10 +585,13 @@ class EnterpriseServiceMockMixin:
         }
 
         self.mock_access_token_response()
-        body = raise_timeout if raise_exception else json.dumps(enterprise_catalog_api_response)
-        httpretty.register_uri(
-            method=httpretty.GET,
-            uri='{}'.format(self.LEGACY_ENTERPRISE_CATALOG_URL),
+        body = (
+            requests.Timeout('Connection timed out.')
+            if raise_exception else json.dumps(enterprise_catalog_api_response)
+        )
+        responses.add(
+            method=responses.GET,
+            url='{}'.format(self.LEGACY_ENTERPRISE_CATALOG_URL),
             body=body,
             content_type='application/json'
         )

--- a/ecommerce/enterprise/tests/test_decorators.py
+++ b/ecommerce/enterprise/tests/test_decorators.py
@@ -3,7 +3,6 @@
 import uuid
 
 import ddt
-import httpretty
 from django.conf import settings
 from django.http.response import HttpResponse
 from django.test import RequestFactory
@@ -16,7 +15,6 @@ from ecommerce.tests.testcases import TestCase
 
 
 @ddt.ddt
-@httpretty.activate
 class EnterpriseDecoratorsTests(EnterpriseServiceMockMixin, TestCase):
 
     @staticmethod

--- a/ecommerce/enterprise/tests/test_forms.py
+++ b/ecommerce/enterprise/tests/test_forms.py
@@ -4,7 +4,7 @@
 import uuid
 
 import ddt
-import httpretty
+import responses
 from oscar.core.loading import get_model
 from oscar.test.factories import OrderDiscountFactory, OrderFactory
 
@@ -229,7 +229,7 @@ class EnterpriseOfferFormTests(EnterpriseServiceMockMixin, TestCase):
             {'prepaid_invoice_amount': ['This field is required when contract discount type is absolute.']},
         )
 
-    @httpretty.activate
+    @responses.activate
     def test_save_create(self):
         """
         A new ConditionalOffer, Benefit, Condition, and
@@ -262,7 +262,7 @@ class EnterpriseOfferFormTests(EnterpriseServiceMockMixin, TestCase):
             data['max_user_discount'],
         )
 
-    @httpretty.activate
+    @responses.activate
     def test_save_create_special_char_title(self):
         """ When the Enterprise's name is international, new objects should still be created."""
         enterprise_customer_uuid = uuid.uuid4()
@@ -294,7 +294,7 @@ class EnterpriseOfferFormTests(EnterpriseServiceMockMixin, TestCase):
             data['max_user_discount'],
         )
 
-    @httpretty.activate
+    @responses.activate
     def test_save_edit(self):
         """ Previously-created ConditionalOffer, Benefit, and Condition instances should be updated. """
         offer = factories.EnterpriseOfferFactory()
@@ -336,7 +336,7 @@ class EnterpriseOfferFormTests(EnterpriseServiceMockMixin, TestCase):
             data['max_user_discount'],
         )
 
-    @httpretty.activate
+    @responses.activate
     def test_save_without_commit(self):
         """ No data should be persisted to the database if the commit kwarg is set to False. """
         data = self.generate_data()
@@ -348,7 +348,7 @@ class EnterpriseOfferFormTests(EnterpriseServiceMockMixin, TestCase):
         self.assertFalse(hasattr(instance, 'benefit'))
         self.assertFalse(hasattr(instance, 'condition'))
 
-    @httpretty.activate
+    @responses.activate
     def test_save_offer_name(self):
         """ If a request object is sent, the offer name should include the enterprise name. """
         data = self.generate_data()
@@ -502,7 +502,7 @@ class EnterpriseOfferFormTests(EnterpriseServiceMockMixin, TestCase):
         data = self.generate_data(max_discount=300)
         self.assert_form_errors(data, expected_errors, instance=offer)
 
-    @httpretty.activate
+    @responses.activate
     def test_offer_form_with_increased_values(self):
         """
         Verify that an existing enterprise offer can be updated with increased values.
@@ -604,7 +604,7 @@ class EnterpriseOfferFormTests(EnterpriseServiceMockMixin, TestCase):
         data = self.generate_data(max_user_applications=50, max_user_discount=300)
         self.assert_form_errors(data, expected_errors, instance=offer)
 
-    @httpretty.activate
+    @responses.activate
     def test_max_user_discount_clean_with_refunded_enrollments(self):
         """
         Verify that `clean` for `max_user_discount` and `max_user_applications` does not raise error when total consumed
@@ -631,7 +631,7 @@ class EnterpriseOfferFormTests(EnterpriseServiceMockMixin, TestCase):
         self.assertEqual(offer.max_user_applications, data['max_user_applications'])
         self.assertEqual(offer.max_user_discount, data['max_user_discount'])
 
-    @httpretty.activate
+    @responses.activate
     def test_offer_form_with_per_user_increased_limits(self):
         """
         Verify that an existing enterprise offer can be updated with per user increased limits.

--- a/ecommerce/enterprise/tests/test_seed_enterprise_devstack_data_command.py
+++ b/ecommerce/enterprise/tests/test_seed_enterprise_devstack_data_command.py
@@ -5,7 +5,6 @@ Contains the tests for creating an coupon associated with enterprise customer an
 from uuid import uuid4
 
 from django.core.management import call_command
-from django.utils.timezone import now
 from mock import Mock, patch
 from oscar.core.loading import get_model
 from oscar.test.factories import CategoryFactory
@@ -43,121 +42,91 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
         self.ent_catalog_uuid = str(uuid4())
         self.access_token = 'fake_access_token'
 
-    @patch(
-        'ecommerce.enterprise.management.commands.seed_enterprise_devstack_data'
-        '.EdxRestApiClient.get_oauth_access_token'
-    )
-    def test_get_access_token(self, mock_api_client):
-        """ Verify `get_access_token` returns the correct value """
-        # sanity check that SiteConfiguration has the correct oauth_settings
-        assert self.command.site.oauth_settings == self.site_oauth_settings
-
-        expected = (self.access_token, now())
-        mock_api_client.return_value = expected
-        result = self.command.get_access_token()
-        oauth_settings = self.command.site.oauth_settings
-        mock_api_client.assert_called_with(
-            '{}/access_token/'.format(oauth_settings.get('BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL')),
-            oauth_settings.get('BACKEND_SERVICE_EDX_OAUTH2_KEY'),
-            oauth_settings.get('BACKEND_SERVICE_EDX_OAUTH2_SECRET'),
-            token_type='jwt',
-        )
-        assert result == expected
-
-    @patch.object(seed_command, 'get_access_token')
-    def test_get_headers(self, mock_get_access_token):
-        """ Verify `get_headers` returns the correct value """
-        expected = {'Authorization': 'JWT {}'.format(self.access_token)}
-        mock_get_access_token.return_value = (self.access_token, now())
-        result = self.command.get_headers()
-        assert result == expected
-
-    @patch('requests.get')
-    def test_get_enterprise_customer(self, mock_request):
+    @patch('ecommerce.core.models.SiteConfiguration.oauth_api_client')
+    def test_get_enterprise_customer(self, mock_api_client):
         """ Verify `get_enterprise_customer` returns the correct value """
         url = '{}enterprise-customer/'.format(self.command.site.enterprise_api_url)
         expected = {'uuid': self.ent_customer_uuid}
-        mock_request.return_value = Mock(
+        mock_api_client.get.return_value = Mock(
             status_code=200,
             json=lambda: {'results': [expected]},
         )
 
         # NOT specifying an enterprise customer uuid
-        result = self.command.get_enterprise_customer(url=url)
-        mock_request.assert_called_with(url, headers={}, params=None)
+        result = self.command.get_enterprise_customer(mock_api_client, url=url)
+        mock_api_client.get.assert_called_with(url, params=None)
         assert result == expected
 
         # specifying an enterprise customer uuid
         result = self.command.get_enterprise_customer(
-            url=url, enterprise_customer_uuid=self.ent_customer_uuid
+            mock_api_client, url=url, enterprise_customer_uuid=self.ent_customer_uuid
         )
-        mock_request.assert_called_with(
-            url, headers={}, params={'uuid': self.ent_customer_uuid},
+        mock_api_client.get.assert_called_with(
+            url, params={'uuid': self.ent_customer_uuid},
         )
         assert result == expected
 
-    @patch('requests.get')
-    def test_get_enterprise_customer_index_error(self, mock_request):
+    @patch('ecommerce.core.models.SiteConfiguration.oauth_api_client')
+    def test_get_enterprise_customer_index_error(self, mock_api_client):
         """
         Verify `get_enterprise_customer` returns the correct value and
         does not make a request
         """
         url = '{}enterprise-customer/'.format(self.command.site.enterprise_api_url)
-        mock_request.return_value = Mock(
+        mock_api_client.get.return_value = Mock(
             status_code=200,
             json=lambda: {'results': []},
         )
 
-        result = self.command.get_enterprise_customer(url=url)
-        mock_request.assert_called_with(url, headers={}, params=None)
+        result = self.command.get_enterprise_customer(mock_api_client, url=url)
+        mock_api_client.get.assert_called_with(url, params=None)
         assert result is None
 
-    @patch('requests.get')
-    def test_get_enterprise_catalog(self, mock_request):
+    @patch('ecommerce.core.models.SiteConfiguration.oauth_api_client')
+    def test_get_enterprise_catalog(self, mock_api_client):
         """ Verify `get_enterprise_catalog` returns the correct value """
         url = '{}enterprise_catalogs/'.format(self.command.site.enterprise_api_url)
         self.command.enterprise_customer = {'uuid': self.ent_customer_uuid}
         expected = {'uuid': self.ent_catalog_uuid}
-        mock_request.return_value = Mock(
+        mock_api_client.get.return_value = Mock(
             status_code=200,
             json=lambda: {'results': [expected]},
         )
-        result = self.command.get_enterprise_catalog(url=url)
-        mock_request.assert_called_with(
+        result = self.command.get_enterprise_catalog(mock_api_client, url=url)
+        mock_api_client.get.assert_called_with(
             url,
-            headers={},
             params={'enterprise_customer': self.ent_customer_uuid},
         )
         assert result == expected
 
-    @patch('requests.get')
-    def test_get_enterprise_catalog_no_customer(self, mock_request):
+    @patch('ecommerce.core.models.SiteConfiguration.oauth_api_client')
+    def test_get_enterprise_catalog_no_customer(self, mock_api_client):
         """
         Verify `get_enterprise_catalog` does not make a request when
         there is no enterprise customer
         """
         url = '{}enterprise_catalogs/'.format(self.command.site.enterprise_api_url)
-        self.command.get_enterprise_catalog(url=url)
-        mock_request.assert_not_called()
+        self.command.get_enterprise_catalog(mock_api_client, url=url)
+        mock_api_client.get.assert_not_called()
 
-    @patch('requests.get')
-    def test_get_enterprise_catalog_index_error(self, mock_request):
+    @patch('ecommerce.core.models.SiteConfiguration.oauth_api_client')
+    def test_get_enterprise_catalog_index_error(self, mock_api_client):
         """
         Verify `get_enterprise_catalog` returns the correct value when
         there is no catalog returned
         """
         url = '{}enterprise_catalogs/'.format(self.command.site.enterprise_api_url)
         self.command.enterprise_customer = {'uuid': self.ent_customer_uuid}
-        mock_request.return_value = Mock(
+        mock_api_client.get.return_value = Mock(
             status_code=200,
             json=lambda: {'results': []},
         )
-        result = self.command.get_enterprise_catalog(url=url)
-        mock_request.assert_called_with(url, headers={}, params={'enterprise_customer': self.ent_customer_uuid})
+        result = self.command.get_enterprise_catalog(mock_api_client, url=url)
+        mock_api_client.get.assert_called_with(url, params={'enterprise_customer': self.ent_customer_uuid})
         assert result is None
 
-    @patch('requests.post')
-    def test_create_coupon(self, mock_request):
+    @patch('ecommerce.core.models.SiteConfiguration.oauth_api_client')
+    def test_create_coupon(self, mock_api_client):
         """ Verify `create_coupon` returns the correct value """
         ecommerce_api_url = self.command.site.build_ecommerce_url() + '/api/v2'
         enterprise_catalog_api_url = self.command.site.enterprise_catalog_api_url + '/enterprise-catalogs'
@@ -165,46 +134,44 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
         self.command.enterprise_catalog = {'uuid': self.ent_catalog_uuid}
 
         expected = {'data': 'some data'}
-        mock_request.return_value = Mock(
+        mock_api_client.post.return_value = Mock(
             status_code=200,
             json=lambda: expected,
         )
-        result = self.command.create_coupon(ecommerce_api_url=ecommerce_api_url,
+        result = self.command.create_coupon(mock_api_client, ecommerce_api_url=ecommerce_api_url,
                                             enterprise_catalog_api_url=enterprise_catalog_api_url)
-        mock_request.assert_called()
+        mock_api_client.post.assert_called()
         assert result == expected
 
-    @patch('requests.post')
-    def test_create_coupon_no_customer(self, mock_request):
+    @patch('ecommerce.core.models.SiteConfiguration.oauth_api_client')
+    def test_create_coupon_no_customer(self, mock_api_client):
         """ Verify `create_coupon` returns the correct value """
         ecommerce_api_url = self.command.site.build_ecommerce_url() + '/api/v2'
         enterprise_catalog_api_url = self.command.site.enterprise_catalog_api_url + '/enterprise-catalogs'
-        self.command.create_coupon(ecommerce_api_url=ecommerce_api_url,
+        self.command.create_coupon(mock_api_client, ecommerce_api_url=ecommerce_api_url,
                                    enterprise_catalog_api_url=enterprise_catalog_api_url)
-        mock_request.assert_not_called()
+        mock_api_client.post.assert_not_called()
 
-    @patch('requests.post')
-    def test_create_coupon_no_catalog(self, mock_request):
+    @patch('ecommerce.core.models.SiteConfiguration.oauth_api_client')
+    def test_create_coupon_no_catalog(self, mock_api_client):
         """ Verify `create_coupon` returns the correct value """
         ecommerce_api_url = self.command.site.build_ecommerce_url() + '/api/v2'
         enterprise_catalog_api_url = self.command.site.enterprise_catalog_api_url + '/enterprise-catalogs'
         self.command.enterprise_customer = {'uuid': self.ent_customer_uuid}
-        self.command.create_coupon(ecommerce_api_url=ecommerce_api_url,
+        self.command.create_coupon(mock_api_client, ecommerce_api_url=ecommerce_api_url,
                                    enterprise_catalog_api_url=enterprise_catalog_api_url)
-        mock_request.assert_not_called()
+        mock_api_client.post.assert_not_called()
 
-    @patch('requests.post')
     @patch.object(seed_command, 'get_enterprise_catalog')
     @patch.object(seed_command, 'get_enterprise_customer')
-    @patch.object(seed_command, 'get_access_token')
-    def test_handle(self, mock_access_token, mock_ent_customer, mock_ent_catalog, mock_coupon_post):
+    @patch('ecommerce.core.models.SiteConfiguration.oauth_api_client')
+    def test_handle(self, mock_api_client, mock_ent_customer, mock_ent_catalog):
         """
         Verify the entry point of the command without any args,
         and makes a POST request to create a coupon
         """
         expected = {'data': 'some data'}
         # create return values for mocked methods
-        mock_access_token.return_value = (self.access_token, now())
         mock_ent_customer.return_value = {
             'results': [
                 {
@@ -223,42 +190,38 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
                 }
             ]
         }
-        mock_coupon_post.return_value = Mock(
+        mock_api_client.post.return_value = Mock(
             status_code=200,
             json=lambda: expected,
         )
         call_command('seed_enterprise_devstack_data')
-        mock_coupon_post.assert_called()
+        mock_api_client.post.assert_called()
 
-    @patch('requests.post')
     @patch.object(seed_command, 'get_enterprise_catalog')
     @patch.object(seed_command, 'get_enterprise_customer')
-    @patch.object(seed_command, 'get_access_token')
-    def test_handle_no_customer(self, mock_access_token, mock_ent_customer, mock_ent_catalog, mock_coupon_post):
+    @patch('ecommerce.core.models.SiteConfiguration.oauth_api_client')
+    def test_handle_no_customer(self, mock_api_client, mock_ent_customer, mock_ent_catalog):
         """
         Verify the entry point of the command without any args,
         makes a POST request to create a coupon, but returns
         no enterprise customer
         """
         # create return values for mocked methods
-        mock_access_token.return_value = (self.access_token, now())
         mock_ent_customer.return_value = None
         call_command('seed_enterprise_devstack_data')
         mock_ent_catalog.assert_not_called()
-        mock_coupon_post.assert_not_called()
+        mock_api_client.post.assert_not_called()
 
-    @patch('requests.post')
     @patch.object(seed_command, 'get_enterprise_catalog')
     @patch.object(seed_command, 'get_enterprise_customer')
-    @patch.object(seed_command, 'get_access_token')
-    def test_handle_no_catalog(self, mock_access_token, mock_ent_customer, mock_ent_catalog, mock_coupon_post):
+    @patch('ecommerce.core.models.SiteConfiguration.oauth_api_client')
+    def test_handle_no_catalog(self, mock_api_client, mock_ent_customer, mock_ent_catalog):
         """
         Verify the entry point of the command without any args,
         makes a POST request to create a coupon, but returns
         no enterprise catalog
         """
         # create return values for mocked methods
-        mock_access_token.return_value = (self.access_token, now())
         mock_ent_customer.return_value = {
             'results': [
                 {
@@ -270,20 +233,18 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
         }
         mock_ent_catalog.return_value = None
         call_command('seed_enterprise_devstack_data')
-        mock_coupon_post.assert_not_called()
+        mock_api_client.post.assert_not_called()
 
-    @patch('requests.post')
     @patch.object(seed_command, 'get_enterprise_catalog')
     @patch.object(seed_command, 'get_enterprise_customer')
-    @patch.object(seed_command, 'get_access_token')
-    def test_handle_ent_customer_arg(self, mock_access_token, mock_ent_customer, mock_ent_catalog, mock_coupon_post):
+    @patch('ecommerce.core.models.SiteConfiguration.oauth_api_client')
+    def test_handle_ent_customer_arg(self, mock_api_client, mock_ent_customer, mock_ent_catalog):
         """
         Verify the entry point of the command uses the `--enterprise-customer` arg,
         and makes a POST request to create a coupon
         """
         expected = {'data': 'some data'}
         # create return values for mocked methods
-        mock_access_token.return_value = (self.access_token, now())
         mock_ent_customer.return_value = {
             'results': [
                 {
@@ -302,14 +263,15 @@ class SeedEnterpriseDevstackDataTests(TransactionTestCase):
                 }
             ]
         }
-        mock_coupon_post.return_value = Mock(
+        mock_api_client.post.return_value = Mock(
             status_code=200,
             json=lambda: expected,
         )
         call_command('seed_enterprise_devstack_data', '--enterprise-customer={}'.format(self.ent_customer_uuid))
         url = '{}enterprise-customer/'.format(self.command.site.enterprise_api_url)
         mock_ent_customer.assert_called_with(
+            mock_api_client,
             enterprise_customer_uuid=self.ent_customer_uuid,
             url=url,
         )
-        mock_coupon_post.assert_called()
+        mock_api_client.post.assert_called()

--- a/ecommerce/enterprise/tests/test_templatetags.py
+++ b/ecommerce/enterprise/tests/test_templatetags.py
@@ -1,7 +1,7 @@
 
 
-import httpretty
 import mock
+import responses
 from django.conf import settings
 from django.template import Context, Template
 from oscar.core.loading import get_model
@@ -16,7 +16,6 @@ Benefit = get_model('offer', 'Benefit')
 TEST_ENTERPRISE_CUSTOMER_UUID = 'cf246b88-d5f6-4908-a522-fc307e0b0c59'
 
 
-@httpretty.activate
 class EnterpriseTemplateTagsTests(EnterpriseServiceMockMixin, CouponMixin, TestCase):
     def setUp(self):
         super(EnterpriseTemplateTagsTests, self).setUp()
@@ -24,6 +23,7 @@ class EnterpriseTemplateTagsTests(EnterpriseServiceMockMixin, CouponMixin, TestC
         # Enable enterprise functionality
         toggle_switch(settings.ENABLE_ENTERPRISE_ON_RUNTIME_SWITCH, True)
 
+    @responses.activate
     def test_enterprise_customer_for_voucher(self):
         """
         Verify that enterprise_customer_for_voucher assignment tag returns correct

--- a/ecommerce/enterprise/tests/test_utils.py
+++ b/ecommerce/enterprise/tests/test_utils.py
@@ -3,7 +3,7 @@
 import uuid
 
 import ddt
-import httpretty
+import responses
 from django.conf import settings
 from django.http.response import HttpResponse
 from django.test import RequestFactory
@@ -48,13 +48,13 @@ TEST_ENTERPRISE_CUSTOMER_UUID = 'cf246b88-d5f6-4908-a522-fc307e0b0c59'
 
 
 @ddt.ddt
-@httpretty.activate
 class EnterpriseUtilsTests(EnterpriseServiceMockMixin, TestCase):
     def setUp(self):
         super(EnterpriseUtilsTests, self).setUp()
         self.learner = self.create_user(is_staff=True)
         self.client.login(username=self.learner.username, password=self.password)
 
+    @responses.activate
     def test_get_enterprise_customers(self):
         """
         Verify that "get_enterprise_customers" returns an appropriate response from the
@@ -66,6 +66,7 @@ class EnterpriseUtilsTests(EnterpriseServiceMockMixin, TestCase):
         self.assertEqual(response[0]['name'], "Enterprise Customer 1")
         self.assertEqual(response[1]['name'], "Enterprise Customer 2")
 
+    @responses.activate
     def test_get_enterprise_customer(self):
         """
         Verify that "get_enterprise_customer" returns an appropriate response from the
@@ -103,6 +104,7 @@ class EnterpriseUtilsTests(EnterpriseServiceMockMixin, TestCase):
         )
     )
     @ddt.unpack
+    @responses.activate
     def test_post_enterprise_customer_user(self, mock_helpers, expected_return):
         """
         Verify that "get_enterprise_customer" returns an appropriate response from the
@@ -120,7 +122,7 @@ class EnterpriseUtilsTests(EnterpriseServiceMockMixin, TestCase):
 
         self.assertDictContainsSubset(expected_return, response)
 
-    @httpretty.activate
+    @responses.activate
     def test_ecu_needs_consent(self):
         opts = {
             'ec_uuid': 'fake-uuid',
@@ -195,6 +197,7 @@ class EnterpriseUtilsTests(EnterpriseServiceMockMixin, TestCase):
 
         self.assertNotIn(settings.ENTERPRISE_CUSTOMER_COOKIE_NAME, result.cookies)
 
+    @responses.activate
     def test_get_enterprise_catalog(self):
         """
         Verify that "get_enterprise_catalog" returns an appropriate response from the
@@ -263,6 +266,7 @@ class EnterpriseUtilsTests(EnterpriseServiceMockMixin, TestCase):
         mock_get_jwt_uuid.return_value = 'my-uuid'
         assert get_enterprise_id_for_user('some-site', self.learner) == 'my-uuid'
 
+    @responses.activate
     def test_get_enterprise_customer_catalogs(self):
         """
         Verify that "get_enterprise_customer_catalogs" works as expected with and without caching.
@@ -284,6 +288,7 @@ class EnterpriseUtilsTests(EnterpriseServiceMockMixin, TestCase):
             self.assertEqual(response, cached_response)
             self.assertEqual(mocked_set_all_tiers.call_count, 2)
 
+    @responses.activate
     def test_get_enterprise_customer_catalogs_with_exception(self):
         """
         Verify that "get_enterprise_customer_catalogs" return default response on exception.
@@ -343,6 +348,7 @@ class EnterpriseUtilsTests(EnterpriseServiceMockMixin, TestCase):
         self.assertEqual(expected_response, updated_response)
 
     @ddt.data(0, 100)
+    @responses.activate
     def test_get_enterprise_customer_from_enterprise_offer(self, discount_value):
         """
         Verify that "get_enterprise_customer_from_enterprise_offer" returns `None` if expected conditions are not met.

--- a/ecommerce/extensions/analytics/tests/test_utils.py
+++ b/ecommerce/extensions/analytics/tests/test_utils.py
@@ -3,8 +3,8 @@
 import json
 
 import ddt
-import httpretty
 import mock
+import responses
 from analytics import Client
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
@@ -200,13 +200,13 @@ class UtilsTest(DiscoveryTestMixin, BasketMixin, TransactionTestCase):
         BRAZE_EVENT_REST_ENDPOINT='rest.braze.com',
         BRAZE_API_KEY='test-api-key',
     )
-    @httpretty.activate
+    @responses.activate
     def test_track_braze_event_with_response_error(self):
         """ If the response receives an error, the function should log a debug message and NOT send an event."""
         braze_url = 'https://{url}/users/track'.format(url=getattr(settings, 'BRAZE_EVENT_REST_ENDPOINT'))
-        httpretty.register_uri(
-            httpretty.POST, braze_url,
-            body=json.dumps({'events_processed': 0, 'message': 'Braze encountered an error.'}),
+        responses.add(
+            responses.POST, braze_url,
+            json={'events_processed': 0, 'message': 'Braze encountered an error.'},
             content_type='application/json',
             status=500,
         )
@@ -220,7 +220,7 @@ class UtilsTest(DiscoveryTestMixin, BasketMixin, TransactionTestCase):
         BRAZE_EVENT_REST_ENDPOINT='rest.braze.com',
         BRAZE_API_KEY='test-api-key',
     )
-    @httpretty.activate
+    @responses.activate
     def test_track_braze_event_with_request_error(self):
         """ If the request receives an error, the function should log an exception message and NOT send an event."""
         with mock.patch('ecommerce.extensions.analytics.utils.requests.post', side_effect=RequestException):
@@ -233,13 +233,13 @@ class UtilsTest(DiscoveryTestMixin, BasketMixin, TransactionTestCase):
         BRAZE_EVENT_REST_ENDPOINT='rest.braze.com',
         BRAZE_API_KEY='test-api-key',
     )
-    @httpretty.activate
+    @responses.activate
     def test_track_braze_event_success(self):
         """ If the braze settings aren't set, the function should log a debug message and NOT send an event."""
         braze_url = 'https://{url}/users/track'.format(url=getattr(settings, 'BRAZE_EVENT_REST_ENDPOINT'))
-        httpretty.register_uri(
-            httpretty.POST, braze_url,
-            body=json.dumps({'events_processed': 1, 'message': 'success'}),
+        responses.add(
+            responses.POST, braze_url,
+            json={'events_processed': 1, 'message': 'success'},
             content_type='application/json',
         )
         with mock.patch('ecommerce.extensions.analytics.utils.logger.debug') as mock_debug:

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -1310,8 +1310,10 @@ class CouponSerializer(CouponMixin, ProductPaymentInfoMixin, serializers.ModelSe
 
     def get_enterprise_catalog_content_metadata_url(self, obj):
         uuid = self.get_enterprise_customer_catalog(obj)
-        return urljoin(settings.ENTERPRISE_CATALOG_API_URL,
-                       'enterprise-catalogs/' + str(uuid) + '/get_content_metadata') if uuid else ''
+        return urljoin(
+            f"{settings.ENTERPRISE_CATALOG_API_URL}/",
+            f"enterprise-catalogs/{str(uuid)}/get_content_metadata"
+        ) if uuid else ''
 
     def get_enterprise_customer(self, obj):
         """ Get the Enterprise Customer attached to a coupon. """

--- a/ecommerce/extensions/api/tests/test_authentication.py
+++ b/ecommerce/extensions/api/tests/test_authentication.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 
 
-import json
 from urllib.parse import urljoin
 
-import httpretty
 import mock
+import responses
 from django.test import RequestFactory
 
 from ecommerce.extensions.api.authentication import BearerAuthentication
@@ -24,7 +23,7 @@ class AccessTokenMixin:
             'given_name': 'Jane',
         }
         url = '{}/user_info/'.format(self.site.siteconfiguration.oauth2_provider_url)
-        httpretty.register_uri(httpretty.GET, url, body=json.dumps(data), content_type=self.JSON, status=status)
+        responses.add(responses.GET, url, json=data, content_type=self.JSON, status=status)
 
 
 class BearerAuthenticationTests(TestCase):
@@ -47,5 +46,5 @@ class BearerAuthenticationTests(TestCase):
         request = self.create_request()
         with mock.patch('ecommerce.extensions.order.utils.get_current_request', mock.Mock(return_value=request)):
             actual = self.auth.get_user_info_url()
-            expected = urljoin(self.site.siteconfiguration.lms_url_root, '/oauth2/user_info/')
+            expected = urljoin(f"{self.site.siteconfiguration.lms_url_root}/", "oauth2/user_info/")
             self.assertEqual(actual, expected)

--- a/ecommerce/extensions/api/v2/tests/views/test_baskets.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_baskets.py
@@ -8,8 +8,8 @@ from collections import namedtuple
 from decimal import Decimal
 
 import ddt
-import httpretty
 import mock
+import responses
 from django.contrib.auth import get_user_model
 from django.test import override_settings
 from django.urls import reverse
@@ -299,7 +299,7 @@ class BasketViewSetTests(AccessTokenMixin, ThrottlingMixin, TestCase):
         response = self.client.get(self.path)
         self.assertEqual(response.status_code, 401)
 
-    @httpretty.activate
+    @responses.activate
     def test_oauth2_authentication(self):
         """Verify clients can authenticate with OAuth 2.0."""
         auth_header = 'Bearer {}'.format(self.DEFAULT_TOKEN)
@@ -436,7 +436,7 @@ class BasketCalculateViewTests(ProgramTestMixin, ThrottlingMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, expected)
 
-    @httpretty.activate
+    @responses.activate
     def test_basket_calculate_site_offer(self):
         """ Verify successful basket calculation with a site offer """
 
@@ -459,7 +459,7 @@ class BasketCalculateViewTests(ProgramTestMixin, ThrottlingMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, expected)
 
-    @httpretty.activate
+    @responses.activate
     def test_basket_calculate_program_offer_unrelated_bundle_id(self):
         """
         Test that if bundle id is present and skus do not belong to this bundle,
@@ -483,7 +483,7 @@ class BasketCalculateViewTests(ProgramTestMixin, ThrottlingMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, expected)
 
-    @httpretty.activate
+    @responses.activate
     def test_basket_calculate_program_offer_with_bundle_id(self):
         """
         Test that if a program offer is present and bundle id is provided,
@@ -503,7 +503,7 @@ class BasketCalculateViewTests(ProgramTestMixin, ThrottlingMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, expected)
 
-    @httpretty.activate
+    @responses.activate
     def test_basket_program_offer_with_no_bundle_id(self):
         """
         Test that if a program offer is present and bundle id is not provided,
@@ -563,19 +563,19 @@ class BasketCalculateViewTests(ProgramTestMixin, ThrottlingMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, expected)
 
-    @httpretty.activate
+    @responses.activate
     def test_basket_calculate_by_staff_user_no_username(self):
         """Verify a staff user passing no username gets a response"""
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
 
-    @httpretty.activate
+    @responses.activate
     def test_basket_calculate_by_staff_user_own_username(self):
         """Verify a staff user passing their own username gets a response about themself"""
         response = self.client.get(self.url + '&username={username}'.format(username=self.user.username))
         self.assertEqual(response.status_code, 200)
 
-    @httpretty.activate
+    @responses.activate
     def test_basket_calculate_missing_lms_user_id(self):
         """Verify a staff user passing a username for a user with a missing LMS user id fails"""
         user_without_id = self.create_user(lms_user_id=None)
@@ -583,14 +583,14 @@ class BasketCalculateViewTests(ProgramTestMixin, ThrottlingMixin, TestCase):
         self.assertEqual(response.status_code, 400)
 
     @override_switch(ALLOW_MISSING_LMS_USER_ID, active=True)
-    @httpretty.activate
+    @responses.activate
     def test_basket_calculate_missing_lms_user_id_allow_missing(self):
         """Verify a staff user passing a username for a user with a missing LMS user id succeeds if the switch is on"""
         user_without_id = self.create_user(lms_user_id=None)
         response = self.client.get(self.url + '&username={username}'.format(username=user_without_id.username))
         self.assertEqual(response.status_code, 200)
 
-    @httpretty.activate
+    @responses.activate
     @mock.patch('ecommerce.programs.conditions.ProgramCourseRunSeatsCondition._get_lms_resource_for_user')
     def test_basket_calculate_by_staff_user_other_username(self, mock_get_lms_resource_for_user):
         """Verify a staff user passing a valid username gets a response about the other user"""
@@ -610,7 +610,7 @@ class BasketCalculateViewTests(ProgramTestMixin, ThrottlingMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, expected)
 
-    @httpretty.activate
+    @responses.activate
     @mock.patch('ecommerce.extensions.api.v2.views.baskets.logger.exception')
     @mock.patch('ecommerce.programs.conditions.ProgramCourseRunSeatsCondition._get_lms_resource_for_user')
     def test_basket_calculate_by_staff_user_other_username_non_atomic(
@@ -637,7 +637,7 @@ class BasketCalculateViewTests(ProgramTestMixin, ThrottlingMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, expected)
 
-    @httpretty.activate
+    @responses.activate
     @mock.patch('ecommerce.extensions.api.v2.views.baskets.logger.exception')
     @mock.patch('ecommerce.programs.conditions.ProgramCourseRunSeatsCondition._get_lms_resource_for_user')
     def test_basket_calculate_by_staff_user_other_username_non_atomic_exception(
@@ -684,7 +684,7 @@ class BasketCalculateViewTests(ProgramTestMixin, ThrottlingMixin, TestCase):
 
         return products, url
 
-    @httpretty.activate
+    @responses.activate
     @mock.patch('ecommerce.programs.conditions.ProgramCourseRunSeatsCondition._get_lms_resource_for_user')
     def test_basket_calculate_anonymous_skip_lms(self, mock_get_lms_resource_for_user):
         """Verify a call for an anonymous user skips calls to LMS for entitlements and enrollments"""
@@ -704,7 +704,7 @@ class BasketCalculateViewTests(ProgramTestMixin, ThrottlingMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, expected)
 
-    @httpretty.activate
+    @responses.activate
     def test_basket_calculate_does_not_call_tracking_events(self):
         """
         Verify successful basket calculation does NOT track any events
@@ -797,7 +797,7 @@ class BasketCalculateViewTests(ProgramTestMixin, ThrottlingMixin, TestCase):
         self.assertTrue(mock_calculate_basket_atomic.called, msg='The cache should be missed.')
         self.assertEqual(response.data, expected)
 
-    @httpretty.activate
+    @responses.activate
     @mock.patch('ecommerce.extensions.api.v2.views.baskets.logger.warning')
     def test_no_query_params_log(self, mock_logger):
         """
@@ -812,7 +812,7 @@ class BasketCalculateViewTests(ProgramTestMixin, ThrottlingMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(mock_logger.called)
 
-    @httpretty.activate
+    @responses.activate
     @mock.patch('ecommerce.extensions.api.v2.views.baskets.BasketCalculateView._calculate_temporary_basket_atomic')
     def test_conflicting_user_anonymous_params(self, mock_calculate_basket):
         """
@@ -828,7 +828,7 @@ class BasketCalculateViewTests(ProgramTestMixin, ThrottlingMixin, TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertFalse(mock_calculate_basket.called)
 
-    @httpretty.activate
+    @responses.activate
     @mock.patch('ecommerce.extensions.api.v2.views.baskets.BasketCalculateView._calculate_temporary_basket_atomic')
     def test_basket_calculate_with_anonymous_caching_disabled(self, mock_calculate_basket_atomic):
         """Verify a request made by a staff user is not cached"""
@@ -847,7 +847,7 @@ class BasketCalculateViewTests(ProgramTestMixin, ThrottlingMixin, TestCase):
         self.assertTrue(mock_calculate_basket_atomic.called, msg='The cache should be missed.')
         self.assertEqual(response.data, expected)
 
-    @httpretty.activate
+    @responses.activate
     @mock.patch('ecommerce.programs.conditions.ProgramCourseRunSeatsCondition._get_lms_resource_for_user')
     @mock.patch('ecommerce.extensions.api.v2.views.baskets.logger.exception')
     def test_basket_calculate_by_staff_user_invalid_username(self, mock_get_lms_resource_for_user, mock_logger):
@@ -884,7 +884,7 @@ class BasketCalculateViewTests(ProgramTestMixin, ThrottlingMixin, TestCase):
             self.assertTrue(mock_logger.called)
             self.assertEqual(response.data, expected)
 
-    @httpretty.activate
+    @responses.activate
     def test_basket_calculate_username_by_nonstaff_user_own_username(self):
         """Verify a non-staff user passing their own username gets a valid response"""
         nonstaffuser = self.create_user(is_staff=False)
@@ -893,7 +893,7 @@ class BasketCalculateViewTests(ProgramTestMixin, ThrottlingMixin, TestCase):
         response = self.client.get(self.url + '&username={username}'.format(username=nonstaffuser.username))
         self.assertEqual(response.status_code, 200)
 
-    @httpretty.activate
+    @responses.activate
     def test_basket_calculate_by_nonstaff_user_other_username(self):
         """Verify a non-staff user passing a different username is forbidden"""
         nonstaffuser = self.create_user(is_staff=False)

--- a/ecommerce/extensions/api/v2/tests/views/test_catalog.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_catalog.py
@@ -1,13 +1,12 @@
 
 
 import ddt
-import httpretty
 import mock
+import responses
 from django.urls import reverse
 from oscar.core.loading import get_model
 from requests.exceptions import ConnectionError as ReqConnectionError
-from requests.exceptions import Timeout
-from slumber.exceptions import SlumberBaseException
+from requests.exceptions import RequestException, Timeout
 
 from ecommerce.coupons.tests.mixins import DiscoveryMockMixin
 from ecommerce.extensions.api.serializers import ProductSerializer
@@ -20,7 +19,6 @@ Catalog = get_model('catalogue', 'Catalog')
 StockRecord = get_model('partner', 'StockRecord')
 
 
-@httpretty.activate
 @ddt.ddt
 class CatalogViewSetTest(CatalogMixin, DiscoveryMockMixin, ApiMockMixin, TestCase):
     """Test the Catalog and related products APIs."""
@@ -94,6 +92,7 @@ class CatalogViewSetTest(CatalogMixin, DiscoveryMockMixin, ApiMockMixin, TestCas
         expected_data = ProductSerializer(self.stock_record.product, context={'request': response.wsgi_request}).data
         self.assertListEqual(response_data['results'], [expected_data])
 
+    @responses.activate
     def test_preview_success(self):
         """ Verify the endpoint returns a list of catalogs from the Catalog API. """
         self.mock_access_token_response()
@@ -123,7 +122,7 @@ class CatalogViewSetTest(CatalogMixin, DiscoveryMockMixin, ApiMockMixin, TestCas
         response = self.client.get(url)
         self.assertEqual(response.status_code, 400)
 
-    @ddt.data(ReqConnectionError, SlumberBaseException, Timeout)
+    @ddt.data(ReqConnectionError, RequestException, Timeout)
     def test_preview_catalog_course_discovery_service_not_available(self, exc_class):
         """Test catalog query preview when course discovery is not available."""
         url = '{path}?query=foo&seat_types=bar'.format(path=reverse('api:v2:catalog-preview'))
@@ -132,6 +131,7 @@ class CatalogViewSetTest(CatalogMixin, DiscoveryMockMixin, ApiMockMixin, TestCas
             response = self.client.get(url)
         self.assertEqual(response.status_code, 400)
 
+    @responses.activate
     def test_course_catalogs_for_single_page_api_response(self):
         """
         Test course catalogs list view "course_catalogs" for valid response
@@ -142,11 +142,12 @@ class CatalogViewSetTest(CatalogMixin, DiscoveryMockMixin, ApiMockMixin, TestCas
         self.mock_discovery_api(catalogs, self.site_configuration.discovery_api_url)
 
         response = self.client.get(reverse('api:v2:catalog-course-catalogs'))
-        self.assertEqual(response.status_code, 200)
 
+        self.assertEqual(response.status_code, 200)
         actual = [catalog['name'] for catalog in response.data['results']]
         self.assertEqual(actual, sorted(catalogs))
 
+    @responses.activate
     @mock.patch('ecommerce.extensions.api.v2.views.catalog.logger.exception')
     def test_get_course_catalogs_with_catalog_api_failure(self, mock_exception):
         """

--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -7,9 +7,9 @@ from decimal import Decimal
 from uuid import uuid4
 
 import ddt
-import httpretty
 import mock
 import pytz
+import responses
 from django.test import RequestFactory
 from django.urls import reverse
 from django.utils.timezone import now
@@ -58,7 +58,6 @@ TEST_CATEGORIES = ['Financial Assistance', 'Partner No Rev - RAP', 'Geography Pr
                    'B2B Affiliate Promotion', 'Scholarship']
 
 
-@httpretty.activate
 class CouponViewSetTest(CouponMixin, DiscoveryTestMixin, TestCase):
     def setUp(self):
         super(CouponViewSetTest, self).setUp()
@@ -875,7 +874,7 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         self.data.update({'stock_record_ids': [StockRecord.objects.get(product=seat).id]})
         self.assert_post_response_status(self.data)
 
-    @httpretty.activate
+    @responses.activate
     def test_dynamic_catalog_coupon(self):
         """ Verify dynamic range values are returned. """
         catalog_query = 'key:*'

--- a/ecommerce/extensions/api/v2/tests/views/test_orders.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_orders.py
@@ -5,9 +5,9 @@ from datetime import datetime
 from decimal import Decimal
 
 import ddt
-import httpretty
 import mock
 import pytz
+import responses
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.test import RequestFactory, override_settings
@@ -61,7 +61,7 @@ class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
         self.assertEqual(content['count'], 0)
         self.assertEqual(content['results'], [])
 
-    @httpretty.activate
+    @responses.activate
     def test_oauth2_authentication(self):
         """Verify clients can authenticate with OAuth 2.0."""
         auth_header = 'Bearer {}'.format(self.DEFAULT_TOKEN)
@@ -372,7 +372,6 @@ class OrderDetailViewTests(OrderDetailViewTestMixin, TestCase):
 
 
 @ddt.ddt
-@httpretty.activate
 class ManualCourseEnrollmentOrderViewSetTests(TestCase, DiscoveryMockMixin):
     """
     Test the `ManualCourseEnrollmentOrderViewSet` functionality.
@@ -406,6 +405,12 @@ class ManualCourseEnrollmentOrderViewSetTests(TestCase, DiscoveryMockMixin):
                 'course_uuid': self.course_uuid
             }
         )
+        responses.start()
+
+    def tearDown(self):
+        super().tearDown()
+        responses.stop()
+        responses.reset()
 
     def build_jwt_header(self, user):
         """

--- a/ecommerce/extensions/api/v2/tests/views/test_providers.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_providers.py
@@ -1,9 +1,7 @@
 
 
-import json
-
 import ddt
-import httpretty
+import responses
 from django.urls import reverse
 from rest_framework import status
 
@@ -36,14 +34,14 @@ class ProvidersViewSetTest(TestCase):
             lms_url=self.site.siteconfiguration.build_lms_url('api/credit/v1/providers/'),
             provider=self.provider
         )
-        httpretty.register_uri(
-            httpretty.GET,
+        responses.add(
+            responses.GET,
             provider_url,
-            body=json.dumps(data if data else self.data),
+            json=data if data else self.data,
             content_type='application/json'
         )
 
-    @httpretty.activate
+    @responses.activate
     def test_getting_provider(self):
         """Verify endpoint returns correct provider data."""
         self.mock_access_token_response()
@@ -54,7 +52,7 @@ class ProvidersViewSetTest(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertDictEqual(response.json(), ProviderSerializer(self.data).data)
 
-    @httpretty.activate
+    @responses.activate
     def test_getting_provider_with_many_true(self):
         """Verify endpoint returns correct provider data with many True."""
         data = [self.data, self.data]

--- a/ecommerce/extensions/api/v2/tests/views/test_refunds.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_refunds.py
@@ -3,8 +3,8 @@
 import json
 
 import ddt
-import httpretty
 import mock
+import responses
 from django.urls import reverse
 from oscar.core.loading import get_model
 from rest_framework import status
@@ -109,7 +109,7 @@ class RefundCreateViewTests(RefundTestMixin, AccessTokenMixin, JwtMixin, TestCas
         response = self.client.post(self.path, data, JSON_CONTENT_TYPE, HTTP_AUTHORIZATION=auth_header)
         self.assert_ok_response(response)
 
-    @httpretty.activate
+    @responses.activate
     def test_oauth2_authentication(self):
         """Verify clients can authenticate with OAuth 2.0."""
         self.client.logout()

--- a/ecommerce/extensions/api/v2/views/catalog.py
+++ b/ecommerce/extensions/api/v2/views/catalog.py
@@ -4,7 +4,7 @@ import logging
 
 from oscar.core.loading import get_model
 from requests.exceptions import ConnectionError as ReqConnectionError
-from requests.exceptions import Timeout
+from requests.exceptions import RequestException, Timeout
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
@@ -12,7 +12,6 @@ from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import ReadOnlyModelViewSet
 from rest_framework_extensions.mixins import NestedViewSetMixin
-from slumber.exceptions import SlumberBaseException
 
 from ecommerce.core.constants import DEFAULT_CATALOG_PAGE_SIZE
 from ecommerce.coupons.utils import get_catalog_course_runs
@@ -91,7 +90,7 @@ class CatalogViewSet(NestedViewSetMixin, ReadOnlyModelViewSet):
                 'seats': seats
             }
             return Response(data=data)
-        except (ReqConnectionError, SlumberBaseException, Timeout):
+        except (ReqConnectionError, RequestException, Timeout):
             logger.error('Unable to connect to Catalog API.')
             return Response(status=status.HTTP_400_BAD_REQUEST)
 

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -12,14 +12,13 @@ from edx_rbac.decorators import permission_required
 from edx_rbac.mixins import PermissionRequiredMixin
 from oscar.core.loading import get_model
 from requests.exceptions import ConnectionError as ReqConnectionError
-from requests.exceptions import Timeout
+from requests.exceptions import HTTPError, Timeout
 from rest_framework import generics, serializers, status
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError as DRFValidationError
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet, ViewSet
-from slumber.exceptions import SlumberHttpBaseException
 
 from ecommerce.core.constants import COUPON_PRODUCT_CLASS_NAME, DEFAULT_CATALOG_PAGE_SIZE
 from ecommerce.coupons.utils import is_coupon_available
@@ -129,7 +128,7 @@ class EnterpriseCustomerCatalogsViewSet(ViewSet):
                 page=request.GET.get('page', '1'),
                 endpoint_request_url=endpoint_request_url
             )
-        except (ReqConnectionError, SlumberHttpBaseException, Timeout) as exc:
+        except (ReqConnectionError, HTTPError, Timeout) as exc:
             logger.exception(
                 'Unable to retrieve catalog for enterprise customer! customer: %s, Exception: %s',
                 kwargs.get('enterprise_catalog_uuid'),

--- a/ecommerce/extensions/api/v2/views/orders.py
+++ b/ecommerce/extensions/api/v2/views/orders.py
@@ -13,14 +13,14 @@ from django.db.models import Q
 from django.utils.decorators import method_decorator
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from oscar.core.loading import get_class, get_model
-from requests.exceptions import ConnectionError, Timeout  # pylint: disable=redefined-builtin
+from requests.exceptions import ConnectionError  # pylint: disable=redefined-builtin
+from requests.exceptions import HTTPError, RequestException, Timeout
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import DjangoModelPermissions, IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
-from slumber.exceptions import HttpServerError, SlumberBaseException
 
 from ecommerce.courses.models import Course
 from ecommerce.courses.utils import get_course_run_detail
@@ -281,7 +281,7 @@ class ManualCourseEnrollmentOrderViewSet(EdxOrderPlacementMixin, EnterpriseDisco
         # check if an order already exists with the requested data
         try:
             order_line = self.existing_purchased_line(seat_product, learner_user, request_site)
-        except (SlumberBaseException, ConnectionError, Timeout, HttpServerError, AttributeError) as ex:
+        except (RequestException, ConnectionError, Timeout, HTTPError, AttributeError) as ex:
             logger.exception(
                 "Could not access existing purchased line. User: %s, Site: %s, course_run_key: %s, message: %s",
                 learner_user,

--- a/ecommerce/extensions/api/v2/views/vouchers.py
+++ b/ecommerce/extensions/api/v2/views/vouchers.py
@@ -13,11 +13,10 @@ from django.utils.timezone import now
 from opaque_keys.edx.keys import CourseKey
 from oscar.core.loading import get_model
 from requests.exceptions import ConnectionError as ReqConnectionError
-from requests.exceptions import Timeout
+from requests.exceptions import RequestException, Timeout
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from slumber.exceptions import SlumberBaseException
 
 from ecommerce.core.constants import DEFAULT_CATALOG_PAGE_SIZE
 from ecommerce.coupons.utils import fetch_course_catalog, get_catalog_course_runs
@@ -83,7 +82,7 @@ class VoucherViewSet(NonDestroyableModelViewSet):
 
         try:
             offers_data = self.get_offers(request, voucher)
-        except (ReqConnectionError, SlumberBaseException, Timeout):
+        except (ReqConnectionError, RequestException, Timeout):
             logger.exception('Could not connect to Discovery Service.')
             return Response(status=status.HTTP_400_BAD_REQUEST)
         except Product.DoesNotExist:

--- a/ecommerce/extensions/basket/tests/test_utils.py
+++ b/ecommerce/extensions/basket/tests/test_utils.py
@@ -5,10 +5,10 @@ import json
 from uuid import uuid4
 
 import ddt
-import httpretty
 import mock
 import pytz
 import requests
+import responses
 from django.db import transaction
 from django.utils.timezone import now
 from oscar.core.loading import get_model
@@ -51,10 +51,6 @@ ProductClass = get_model('catalogue', 'ProductClass')
 TEST_BUNDLE_ID = '12345678-1234-1234-1234-123456789abc'
 
 
-def timeoutException():
-    raise requests.Timeout('Connection timed out')
-
-
 @ddt.ddt
 class BasketUtilsTests(DiscoveryTestMixin, BasketMixin, TestCase):
     """ Tests for basket utility functions. """
@@ -66,11 +62,11 @@ class BasketUtilsTests(DiscoveryTestMixin, BasketMixin, TestCase):
         toggle_switch(DISABLE_REPEAT_ORDER_CHECK_SWITCH_NAME, False)
 
     def mock_embargo_api(self, body=None, status=200):
-        httpretty.register_uri(
-            httpretty.GET,
+        responses.add(
+            responses.GET,
             self.site_configuration.build_lms_url('/api/embargo/v1/course_access/'),
             status=status,
-            body=body,
+            body=body() if callable(body) else body,
             content_type='application/json'
         )
 
@@ -160,7 +156,7 @@ class BasketUtilsTests(DiscoveryTestMixin, BasketMixin, TestCase):
             basket = prepare_basket(self.request, [product])
             mock_attr_method.assert_called_with(basket, self.request)
 
-    @httpretty.activate
+    @responses.activate
     def test_prepare_basket_embargo_check_fail(self):
         """ Verify an empty basket is returned after embargo check fails. """
         self.site_configuration.enable_embargo_check = True
@@ -171,7 +167,7 @@ class BasketUtilsTests(DiscoveryTestMixin, BasketMixin, TestCase):
         basket = prepare_basket(self.request, [product])
         self.assertEqual(basket.lines.count(), 0)
 
-    @httpretty.activate
+    @responses.activate
     def test_prepare_basket_embargo_with_enrollment_code(self):
         """ Verify a basket is returned after adding enrollment code. """
         self.site_configuration.enable_embargo_check = True
@@ -183,12 +179,12 @@ class BasketUtilsTests(DiscoveryTestMixin, BasketMixin, TestCase):
         basket = prepare_basket(self.request, [product])
         self.assertEqual(basket.lines.count(), 1)
 
-    @httpretty.activate
+    @responses.activate
     def test_prepare_basket_embargo_check_exception(self):
         """ Verify embargo check passes when API call throws an exception. """
         self.site_configuration.enable_embargo_check = True
         self.mock_access_token_response()
-        self.mock_embargo_api(body=timeoutException)
+        self.mock_embargo_api(body=requests.exceptions.Timeout)
         course = CourseFactory(partner=self.partner)
         product = course.create_or_update_seat('verified', False, 10)
         basket = prepare_basket(self.request, [product])

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -23,11 +23,10 @@ from oscar.apps.basket.views import VoucherAddView as BaseVoucherAddView
 from oscar.apps.basket.views import *  # pylint: disable=wildcard-import, unused-wildcard-import
 from oscar.core.prices import Price
 from requests.exceptions import ConnectionError as ReqConnectionError
-from requests.exceptions import Timeout
+from requests.exceptions import RequestException, Timeout
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from slumber.exceptions import SlumberBaseException
 
 from ecommerce.core.exceptions import SiteConfigurationError
 from ecommerce.core.url_utils import absolute_redirect, get_lms_course_about_url, get_lms_url
@@ -281,7 +280,7 @@ class BasketLogicMixin:
             # template overrides can make use of them.
             course_data['course_start'] = self._deserialize_date(course.get('start'))
             course_data['course_end'] = self._deserialize_date(course.get('end'))
-        except (ReqConnectionError, SlumberBaseException, Timeout):
+        except (ReqConnectionError, RequestException, Timeout):
             logger.exception(
                 'Failed to retrieve data from Discovery Service for course [%s].',
                 course_data['course_key'],

--- a/ecommerce/extensions/catalogue/tests/test_migrate_course.py
+++ b/ecommerce/extensions/catalogue/tests/test_migrate_course.py
@@ -2,14 +2,13 @@
 
 
 import datetime
-import json
 import logging
 from decimal import Decimal
 from urllib.parse import urlparse
 
-import httpretty
 import mock
 import pytz
+import responses
 from django.core.management import call_command
 from django.test import override_settings
 from oscar.core.loading import get_model
@@ -52,29 +51,27 @@ class CourseMigrationTestMixin(DiscoveryTestMixin):
 
     @property
     def commerce_api_url(self):
-        return self.site_configuration.build_lms_url('/api/commerce/v1/courses/{}/'.format(self.course_id))
+        return self.site_configuration.build_lms_url('api/commerce/v1/courses/{}/'.format(self.course_id))
 
     @property
     def course_structure_url(self):
-        return self.site_configuration.build_lms_url('/api/course_structure/v0/courses/{}/'.format(self.course_id))
+        return self.site_configuration.build_lms_url('api/course_structure/v0/courses/{}/'.format(self.course_id))
 
     @property
     def enrollment_api_url(self):
-        return self.site_configuration.build_lms_url('/api/enrollment/v1/course/{}'.format(self.course_id))
+        return self.site_configuration.build_lms_url('api/enrollment/v1/course/{}/'.format(self.course_id))
 
     def _mock_lms_apis(self):
-        self.assertTrue(httpretty.is_enabled(), 'httpretty must be enabled to mock LMS API calls.')
-
         # Mock Commerce API
         body = {
             'name': self.course_name,
             'verification_deadline': EXPIRES_STRING,
         }
-        httpretty.register_uri(httpretty.GET, self.commerce_api_url, body=json.dumps(body), content_type=JSON)
+        responses.add(responses.GET, self.commerce_api_url, json=body, content_type=JSON)
 
         # Mock Course Structure API
         body = {'name': self.course_name}
-        httpretty.register_uri(httpretty.GET, self.course_structure_url, body=json.dumps(body), content_type=JSON)
+        responses.add(responses.GET, self.course_structure_url, json=body, content_type=JSON)
 
         # Mock Enrollment API
         body = {
@@ -82,7 +79,7 @@ class CourseMigrationTestMixin(DiscoveryTestMixin):
             'course_modes': [{'slug': mode, 'min_price': price, 'expiration_datetime': EXPIRES_STRING} for
                              mode, price in self.prices.items()]
         }
-        httpretty.register_uri(httpretty.GET, self.enrollment_api_url, body=json.dumps(body), content_type=JSON)
+        responses.add(responses.GET, self.enrollment_api_url, json=body, content_type=JSON)
 
     def assert_stock_record_valid(self, stock_record, seat, price):
         """ Verify the given StockRecord is configured correctly. """
@@ -130,13 +127,13 @@ class MigratedCourseTests(CourseMigrationTestMixin, TestCase):
     def setUp(self):
         super(MigratedCourseTests, self).setUp()
         toggle_switch('publish_course_modes_to_lms', True)
-        httpretty.enable()
+        responses.start()
         self.mock_access_token_response()
 
     def tearDown(self):
         super(MigratedCourseTests, self).tearDown()
-        httpretty.disable()
-        httpretty.reset()
+        responses.stop()
+        responses.reset()
 
     def _migrate_course_from_lms(self):
         """ Create a new MigratedCourse and simulate the loading of data from LMS. """
@@ -173,10 +170,10 @@ class MigratedCourseTests(CourseMigrationTestMixin, TestCase):
             'name': None,
             'verification_deadline': EXPIRES_STRING,
         }
-        httpretty.register_uri(httpretty.GET, self.commerce_api_url, body=json.dumps(body), content_type=JSON)
+        responses.add(responses.GET, self.commerce_api_url, json=body, content_type=JSON)
 
         # Mock the Course Structure API
-        httpretty.register_uri(httpretty.GET, self.course_structure_url, body='{}', content_type=JSON)
+        responses.add(responses.GET, self.course_structure_url, body='{}', content_type=JSON)
 
         # Try migrating the course, which should fail.
         try:
@@ -187,8 +184,8 @@ class MigratedCourseTests(CourseMigrationTestMixin, TestCase):
                              'Aborting migration. No name is available for {}.'.format(self.course_id))
 
         # Verify the Course Structure API was called.
-        last_request = httpretty.last_request()
-        self.assertEqual(last_request.path, urlparse(self.course_structure_url).path)
+        last_request = responses.calls[-1].request
+        self.assertEqual(last_request.path_url, urlparse(self.course_structure_url).path)
 
     def test_fall_back_to_course_structure(self):
         """
@@ -197,11 +194,11 @@ class MigratedCourseTests(CourseMigrationTestMixin, TestCase):
         self._mock_lms_apis()
 
         body = {'detail': 'Not found'}
-        httpretty.register_uri(
-            httpretty.GET,
+        responses.replace(
+            responses.GET,
             self.commerce_api_url,
             status=404,
-            body=json.dumps(body),
+            json=body,
             content_type=JSON
         )
 
@@ -228,7 +225,7 @@ class MigratedCourseTests(CourseMigrationTestMixin, TestCase):
             'name': '  {}  '.format(self.course_name),
             'verification_deadline': EXPIRES_STRING,
         }
-        httpretty.register_uri(httpretty.GET, self.commerce_api_url, body=json.dumps(body), content_type=JSON)
+        responses.add(responses.GET, self.commerce_api_url, json=body, content_type=JSON)
 
         migrated_course = MigratedCourse(self.course_id, self.site.domain)
         migrated_course.load_from_lms()
@@ -247,7 +244,7 @@ class CommandTests(CourseMigrationTestMixin, TestCase):
         super(CommandTests, self).setUp()
         toggle_switch('publish_course_modes_to_lms', True)
 
-    @httpretty.activate
+    @responses.activate
     def test_handle(self):
         """ Verify the management command retrieves data, but does not save it to the database. """
         initial_product_count = Product.objects.count()
@@ -268,7 +265,7 @@ class CommandTests(CourseMigrationTestMixin, TestCase):
         self.assertEqual(StockRecord.objects.count(), initial_stock_record_count,
                          'No new StockRecords should have been saved.')
 
-    @httpretty.activate
+    @responses.activate
     def test_handle_with_commit(self):
         """ Verify the management command retrieves data, and saves it to the database. """
         self.mock_access_token_response()
@@ -288,7 +285,7 @@ class CommandTests(CourseMigrationTestMixin, TestCase):
 
         self.assert_course_migrated()
 
-    @httpretty.activate
+    @responses.activate
     def test_handle_with_no_site(self):
         """ Verify the management command does not run if no site domain is provided. """
         self._mock_lms_apis()
@@ -309,7 +306,7 @@ class CommandTests(CourseMigrationTestMixin, TestCase):
                 # Verify that the migrated course was published back to the LMS
                 self.assertFalse(mock_publish.called)
 
-    @httpretty.activate
+    @responses.activate
     def test_handle_with_commit_false(self):
         """ Verify the management command does not save data to the database if commit is false"""
         self._mock_lms_apis()
@@ -325,7 +322,7 @@ class CommandTests(CourseMigrationTestMixin, TestCase):
             # Verify that the migrated course was published back to the LMS
             self.assertFalse(mock_publish.called)
 
-    @httpretty.activate
+    @responses.activate
     def test_handle_with_false_switch(self):
         """ Verify the management command does not save data to the database if commit is false"""
         self._mock_lms_apis()

--- a/ecommerce/extensions/catalogue/tests/test_update_course_seat_expire.py
+++ b/ecommerce/extensions/catalogue/tests/test_update_course_seat_expire.py
@@ -2,15 +2,14 @@
 
 
 import datetime
-import json
 import logging
 
 import ddt
-import httpretty
 import mock
+import responses
 from django.core.management import CommandError, call_command
 from pytz import UTC
-from slumber.exceptions import HttpClientError
+from requests.exceptions import HTTPError
 from testfixtures import LogCapture
 
 from ecommerce.core.url_utils import get_lms_url
@@ -54,19 +53,17 @@ class UpdateSeatExpireDateTests(DiscoveryTestMixin, TestCase):
 
     def mock_courses_api(self, status, body=None):
         """ Mock Courses API with specific status and body. """
-        self.assertTrue(httpretty.is_enabled(), 'httpretty must be enabled to mock Course API calls.')
-
         body = body or {}
-        url = get_lms_url('/api/courses/v1/courses/?page_size=1')
-        httpretty.register_uri(
-            httpretty.GET,
+        url = get_lms_url('/api/courses/v1/courses?page_size=50&page=1')
+        responses.add(
+            responses.GET,
             url,
             status=status,
-            body=json.dumps(body),
+            json=body,
             content_type=JSON
         )
 
-    @httpretty.activate
+    @responses.activate
     def test_update_course_with_commit(self):
         """ Verify all course seats are updated successfully, when commit option is provided. """
         seats_expected_to_update = self.course.seat_products.filter(
@@ -105,7 +102,7 @@ class UpdateSeatExpireDateTests(DiscoveryTestMixin, TestCase):
         verified_seat = Product.objects.get(id=self.verified_seat.id)
         self.assertEqual(verified_seat.expires, self.verified_expire_date)
 
-    @httpretty.activate
+    @responses.activate
     def test_update_course_without_commit(self):
         """ Verify all course seats are not updated with commit option is not provided. """
         seats_expected_to_update = self.course.seat_products.filter(
@@ -135,7 +132,7 @@ class UpdateSeatExpireDateTests(DiscoveryTestMixin, TestCase):
         verified_seat = Product.objects.get(id=self.verified_seat.id)
         self.assertEqual(verified_seat.expires, self.verified_expire_date)
 
-    @httpretty.activate
+    @responses.activate
     def test_update_course_with_no_data(self):
         """ Verify all course seats are updated successfully, when commit option is provided"""
         self.course_info['results'] = []
@@ -154,7 +151,7 @@ class UpdateSeatExpireDateTests(DiscoveryTestMixin, TestCase):
                 call_command('update_course_seat_expire')
                 lc.check(*expected)
 
-    @httpretty.activate
+    @responses.activate
     def test_update_course_with_missing_enrolment(self):
         """
         Verify that management command logs `enrollment missing` log for all courses
@@ -180,7 +177,7 @@ class UpdateSeatExpireDateTests(DiscoveryTestMixin, TestCase):
             call_command('update_course_seat_expire')
             lc.check(*expected)
 
-    @httpretty.activate
+    @responses.activate
     @mock.patch(
         'ecommerce.extensions.catalogue.management.commands.update_course_seat_expire.Command.max_tries',
         new_callable=mock.PropertyMock,
@@ -209,7 +206,7 @@ class UpdateSeatExpireDateTests(DiscoveryTestMixin, TestCase):
                 'Retrying [1]'
             ),
         ]
-        with self.assertRaises(HttpClientError):
+        with self.assertRaises(HTTPError):
             with LogCapture(LOGGER_NAME) as lc:
                 call_command('update_course_seat_expire')
                 lc.check(*expected)

--- a/ecommerce/extensions/checkout/tests/test_signals.py
+++ b/ecommerce/extensions/checkout/tests/test_signals.py
@@ -1,9 +1,7 @@
 
 
-import json
-
-import httpretty
 import mock
+import responses
 from django.core import mail
 from oscar.core.loading import get_class, get_model
 from oscar.test import factories
@@ -73,7 +71,7 @@ class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
             data['courses'].append({})
         return data
 
-    @httpretty.activate
+    @responses.activate
     def test_post_checkout_callback(self):
         """
         When the post_checkout signal is emitted, the receiver should attempt
@@ -82,12 +80,12 @@ class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
         credit_provider_id = 'HGW'
         credit_provider_name = 'Hogwarts'
         body = {'display_name': credit_provider_name}
-        httpretty.register_uri(
-            httpretty.GET,
+        responses.add(
+            responses.GET,
             self.site.siteconfiguration.build_lms_url(
                 'api/credit/v1/providers/{credit_provider_id}/'.format(credit_provider_id=credit_provider_id)
             ),
-            body=json.dumps(body),
+            json=body,
             content_type='application/json'
         )
 

--- a/ecommerce/extensions/checkout/tests/test_utils.py
+++ b/ecommerce/extensions/checkout/tests/test_utils.py
@@ -1,11 +1,9 @@
 
 
-import json
-
 import ddt
-import httpretty
 import mock
 import requests
+import responses
 from requests import ConnectionError as ReqConnectionError
 from requests import Timeout
 
@@ -33,14 +31,14 @@ class UtilTests(TestCase):
         """
         return 'api/credit/v1/providers/{credit_provider_id}/'.format(credit_provider_id=credit_provider_id)
 
-    @httpretty.activate
+    @responses.activate
     def test_get_credit_provider_details(self):
         """ Check that credit provider details are returned. """
         self.mock_access_token_response()
-        httpretty.register_uri(
-            httpretty.GET,
+        responses.add(
+            responses.GET,
             self.site.siteconfiguration.build_lms_url(self.get_credit_provider_details_url(self.credit_provider_id)),
-            body=json.dumps(self.body),
+            json=self.body,
             content_type="application/json"
         )
         provider_data = get_credit_provider_details(
@@ -49,11 +47,11 @@ class UtilTests(TestCase):
         )
         self.assertDictEqual(provider_data, self.body)
 
-    @httpretty.activate
+    @responses.activate
     def test_get_credit_provider_details_unavailable_request(self):
         """ Check that None is returned on Bad Request response. """
-        httpretty.register_uri(
-            httpretty.GET,
+        responses.add(
+            responses.GET,
             self.site.siteconfiguration.build_lms_url(self.get_credit_provider_details_url(self.credit_provider_id)),
             status=400
         )

--- a/ecommerce/extensions/checkout/tests/test_views.py
+++ b/ecommerce/extensions/checkout/tests/test_views.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from urllib import parse
 
 import ddt
-import httpretty
+import responses
 from django.conf import settings
 from django.urls import reverse
 from mock import patch
@@ -66,7 +66,7 @@ class FreeCheckoutViewTests(EnterpriseServiceMockMixin, TestCase):
         with self.assertRaises(BasketNotFreeError):
             self.client.get(self.path)
 
-    @httpretty.activate
+    @responses.activate
     def test_enterprise_offer_program_redirect(self):
         """ Verify redirect to the program dashboard page. """
         self.prepare_basket(10, bundle=True)
@@ -78,7 +78,7 @@ class FreeCheckoutViewTests(EnterpriseServiceMockMixin, TestCase):
         expected_url = get_lms_program_dashboard_url(self.bundle_attribute_value)
         self.assertRedirects(response, expected_url, fetch_redirect_response=False)
 
-    @httpretty.activate
+    @responses.activate
     def test_enterprise_offer_course_redirect(self):
         """ Verify redirect to the courseware info page. """
         self.prepare_basket(10)
@@ -90,7 +90,7 @@ class FreeCheckoutViewTests(EnterpriseServiceMockMixin, TestCase):
         expected_url = get_lms_courseware_url(self.course_run.id)
         self.assertRedirects(response, expected_url, fetch_redirect_response=False)
 
-    @httpretty.activate
+    @responses.activate
     def test_successful_redirect(self):
         """ Verify redirect to the receipt page. """
         self.prepare_basket(0)
@@ -117,7 +117,7 @@ class CancelCheckoutViewTests(TestCase):
         self.user = self.create_user()
         self.client.login(username=self.user.username, password=self.password)
 
-    @httpretty.activate
+    @responses.activate
     def test_get_returns_payment_support_email_in_context(self):
         """
         Verify that after receiving a GET response, the view returns a payment support email in its context.
@@ -128,7 +128,7 @@ class CancelCheckoutViewTests(TestCase):
             response.context['payment_support_email'], self.request.site.siteconfiguration.payment_support_email
         )
 
-    @httpretty.activate
+    @responses.activate
     def test_post_returns_payment_support_email_in_context(self):
         """
         Verify that after receiving a POST response, the view returns a payment support email in its context.
@@ -151,7 +151,7 @@ class CheckoutErrorViewTests(TestCase):
         self.user = self.create_user()
         self.client.login(username=self.user.username, password=self.password)
 
-    @httpretty.activate
+    @responses.activate
     def test_get_returns_payment_support_email_in_context(self):
         """
         Verify that after receiving a GET response, the view returns a payment support email in its context.
@@ -162,7 +162,7 @@ class CheckoutErrorViewTests(TestCase):
             response.context['payment_support_email'], self.request.site.siteconfiguration.payment_support_email
         )
 
-    @httpretty.activate
+    @responses.activate
     def test_post_returns_payment_support_email_in_context(self):
         """
         Verify that after receiving a POST response, the view returns a payment support email in its context.
@@ -299,7 +299,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertEqual(payment_method, '{} {}'.format(source.card_type, source.label))
 
     @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
-    @httpretty.activate
+    @responses.activate
     def test_get_receipt_for_existing_order(self, mock_learner_data):
         """ Order owner should be able to see the Receipt Page."""
         mock_learner_data.return_value = self.non_enterprise_learner_data
@@ -314,7 +314,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertDictContainsSubset(context_data, response.context_data)
 
     @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
-    @httpretty.activate
+    @responses.activate
     def test_awin_product_tracking_for_order(self, mock_learner_data):
         """ Receipt Page should have context for awin product tracking"""
         mock_learner_data.return_value = self.non_enterprise_learner_data
@@ -331,7 +331,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertEqual(response.context_data['product_tracking'], "".join(products))
 
     @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
-    @httpretty.activate
+    @responses.activate
     def test_get_receipt_for_existing_entitlement_order(self, mock_learner_data):
         """ Order owner should be able to see the Receipt Page."""
 
@@ -347,7 +347,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertDictContainsSubset(context_data, response.context_data)
 
     @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
-    @httpretty.activate
+    @responses.activate
     def test_get_receipt_for_existing_order_as_staff_user(self, mock_learner_data):
         """ Staff users can preview Receipts for all Orders."""
         mock_learner_data.return_value = self.non_enterprise_learner_data
@@ -363,7 +363,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertDictContainsSubset(context_data, response.context_data)
 
     @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
-    @httpretty.activate
+    @responses.activate
     def test_get_receipt_for_existing_order_user_not_owner(self, mock_learner_data):
         """ Users that don't own the Order shouldn't be able to see the Receipt. """
         mock_learner_data.return_value = self.non_enterprise_learner_data
@@ -376,7 +376,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertDictContainsSubset(context_data, response.context_data)
 
     @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
-    @httpretty.activate
+    @responses.activate
     def test_order_data_for_credit_seat(self, mock_learner_data):
         """ Ensure that the context is updated with Order data. """
         mock_learner_data.return_value = self.non_enterprise_learner_data
@@ -391,7 +391,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertTrue(response.context_data['display_credit_messaging'])
 
     @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
-    @httpretty.activate
+    @responses.activate
     def test_order_value_unlocalized_for_tracking(self, mock_learner_data):
         mock_learner_data.return_value = self.non_enterprise_learner_data
         order = self._create_order_for_receipt()
@@ -403,7 +403,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertContains(response, order_value_string)
 
     @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
-    @httpretty.activate
+    @responses.activate
     def test_order_product_ids_available_for_tracking(self, mock_learner_data):
         mock_learner_data.return_value = self.non_enterprise_learner_data
         order = self._create_order_for_receipt(multiple_lines=True)
@@ -415,7 +415,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertContains(response, expected_order_product_ids_string)
 
     @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
-    @httpretty.activate
+    @responses.activate
     def test_dashboard_link_for_course_purchase(self, mock_learner_data):
         """
         The dashboard link at the bottom of the receipt for a course purchase
@@ -432,7 +432,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertDictContainsSubset(context_data, response.context_data)
 
     @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
-    @httpretty.activate
+    @responses.activate
     def test_dashboard_link_for_bundle_purchase(self, mock_learner_data):
         """
         The dashboard link at the bottom of the receipt for a bundle purchase
@@ -458,7 +458,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertDictContainsSubset(context_data, response.context_data)
 
     @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
-    @httpretty.activate
+    @responses.activate
     def test_order_without_basket(self, mock_learner_data):
         mock_learner_data.return_value = self.non_enterprise_learner_data
         order = self.create_order()
@@ -467,7 +467,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertEqual(response.status_code, 200)
 
     @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
-    @httpretty.activate
+    @responses.activate
     def test_enterprise_learner_dashboard_link_in_messages(self, mock_learner_data):
         """
         The receipt page should include a message with a link to the enterprise
@@ -497,7 +497,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertEqual(expected_message, actual_message)
 
     @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
-    @httpretty.activate
+    @responses.activate
     @ddt.data(
         ({'results': []}, None),
         (None, [KeyError])
@@ -525,7 +525,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertEqual(len(response_messages), 0)
 
     @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
-    @httpretty.activate
+    @responses.activate
     def test_no_enterprise_learner_dashboard_link_in_messages(self, mock_learner_data):
         """
         The receipt page should NOT include a message with a link to the enterprise
@@ -547,7 +547,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertEqual(len(response_messages), 0)
 
     @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
-    @httpretty.activate
+    @responses.activate
     def test_order_dashboard_url_points_to_enterprise_learner_portal(self, mock_learner_data):
         """
         The "Go to dashboard" link at the bottom of the receipt page should
@@ -571,7 +571,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         self.assertEqual(response.context_data['order_dashboard_url'], expected_dashboard_url)
 
     @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
-    @httpretty.activate
+    @responses.activate
     def test_go_to_dashboard_points_to_lms_dashboard(self, mock_learner_data):
         """
         The "Go to dashboard" link at the bottom of the receipt page should

--- a/ecommerce/extensions/checkout/views.py
+++ b/ecommerce/extensions/checkout/views.py
@@ -15,8 +15,7 @@ from django.views.generic import RedirectView, TemplateView
 from oscar.apps.checkout.views import *  # pylint: disable=wildcard-import, unused-wildcard-import
 from oscar.core.loading import get_class, get_model
 from requests.exceptions import ConnectionError as ReqConnectionError
-from requests.exceptions import Timeout
-from slumber.exceptions import SlumberHttpBaseException
+from requests.exceptions import HTTPError, Timeout
 
 from ecommerce.core.url_utils import (
     get_lms_courseware_url,
@@ -256,7 +255,7 @@ class ReceiptResponseView(ThankYouView):
         try:
             # If enterprise feature is enabled return all the enterprise_customer associated with user.
             learner_data = fetch_enterprise_learner_data(request.site, request.user)
-        except (ReqConnectionError, KeyError, SlumberHttpBaseException, Timeout) as exc:
+        except (ReqConnectionError, KeyError, HTTPError, Timeout) as exc:
             log.info('[enterprise learner message] Exception while retrieving enterprise learner data for '
                      'User: %s, Exception: %s', request.user, exc)
             return None

--- a/ecommerce/extensions/offer/tests/test_models.py
+++ b/ecommerce/extensions/offer/tests/test_models.py
@@ -7,8 +7,8 @@ from uuid import uuid4
 
 import botocore
 import ddt
-import httpretty
 import mock
+import responses
 from botocore.exceptions import ClientError
 from django.core.exceptions import ValidationError
 from django.db.models.signals import post_delete
@@ -18,8 +18,7 @@ from mock import patch
 from oscar.core.loading import get_model
 from oscar.test import factories
 from requests.exceptions import ConnectionError as ReqConnectionError
-from requests.exceptions import Timeout
-from slumber.exceptions import SlumberBaseException
+from requests.exceptions import RequestException, Timeout
 
 from ecommerce.coupons.tests.mixins import CouponMixin, DiscoveryMockMixin
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
@@ -42,7 +41,6 @@ CodeAssignmentNudgeEmailTemplates = get_model('offer', 'CodeAssignmentNudgeEmail
 
 
 @ddt.ddt
-@httpretty.activate
 class RangeTests(CouponMixin, DiscoveryTestMixin, DiscoveryMockMixin, TestCase):
     def setUp(self):
         super(RangeTests, self).setUp()
@@ -57,16 +55,17 @@ class RangeTests(CouponMixin, DiscoveryTestMixin, DiscoveryMockMixin, TestCase):
         self.range_with_catalog.catalog = self.catalog
         self.stock_record = factories.create_stockrecord(self.product, num_in_stock=2)
         self.catalog.stock_records.add(self.stock_record)
+        responses.start()
 
     def tearDown(self):
-        # Reset HTTPretty state (clean up registered urls and request history)
-        httpretty.reset()
+        # Reset responses state (clean up registered urls and request history)
+        responses.reset()
 
     def _assert_num_requests(self, count):
         """
         DRY helper for verifying request counts.
         """
-        self.assertEqual(len(httpretty.httpretty.latest_requests), count)
+        self.assertEqual(len(responses.calls), count)
 
     def test_range_contains_product(self):
         """
@@ -143,7 +142,7 @@ class RangeTests(CouponMixin, DiscoveryTestMixin, DiscoveryMockMixin, TestCase):
         # checking if course exists in course runs against the course catalog.
         self._assert_num_requests(2)
 
-    @ddt.data(ReqConnectionError, SlumberBaseException, Timeout)
+    @ddt.data(ReqConnectionError, RequestException, Timeout)
     def test_course_catalog_query_range_contains_product_for_failure(self, error):
         """
         Verify that the method "contains_product" raises exception if the
@@ -352,7 +351,6 @@ class RangeTests(CouponMixin, DiscoveryTestMixin, DiscoveryMockMixin, TestCase):
 
 
 @ddt.ddt
-@httpretty.activate
 class ConditionalOfferTests(DiscoveryTestMixin, DiscoveryMockMixin, TestCase):
     """Tests for custom ConditionalOffer model."""
     def setUp(self):
@@ -372,6 +370,7 @@ class ConditionalOfferTests(DiscoveryTestMixin, DiscoveryMockMixin, TestCase):
             benefit=factories.BenefitFactory(),
             email_domains=self.email_domains
         )
+        responses.start()
 
     def create_basket(self, email):
         """Helper method for creating a basket with specific owner."""
@@ -429,6 +428,10 @@ class ConditionalOfferTests(DiscoveryTestMixin, DiscoveryMockMixin, TestCase):
             course_run_ids=[], course_uuids=[product.attr.UUID], absent_ids=[another_product.attr.UUID],
             query=benefit.range.catalog_query, discovery_api_url=self.site_configuration.discovery_api_url
         )
+        self.mock_catalog_query_contains_endpoint(
+            course_run_ids=[], course_uuids=[another_product.attr.UUID], absent_ids=[another_product.attr.UUID],
+            query=benefit.range.catalog_query, discovery_api_url=self.site_configuration.discovery_api_url
+        )
 
         basket.add_product(product)
         self.assertTrue(offer.is_condition_satisfied(basket))
@@ -437,7 +440,7 @@ class ConditionalOfferTests(DiscoveryTestMixin, DiscoveryMockMixin, TestCase):
         self.assertFalse(offer.is_condition_satisfied(basket))
 
         # Verify that API return values are cached
-        httpretty.disable()
+        responses.reset()
         self.assertFalse(offer.is_condition_satisfied(basket))
 
     def test_is_single_use_range_condition_satisfied(self):
@@ -460,6 +463,14 @@ class ConditionalOfferTests(DiscoveryTestMixin, DiscoveryMockMixin, TestCase):
         self.mock_access_token_response()
         self.mock_catalog_query_contains_endpoint(
             course_run_ids=[], course_uuids=[product1.attr.UUID, product2.attr.UUID], absent_ids=[],
+            query=benefit.range.catalog_query, discovery_api_url=self.site_configuration.discovery_api_url
+        )
+        self.mock_catalog_query_contains_endpoint(
+            course_run_ids=[], course_uuids=[product1.attr.UUID], absent_ids=[],
+            query=benefit.range.catalog_query, discovery_api_url=self.site_configuration.discovery_api_url
+        )
+        self.mock_catalog_query_contains_endpoint(
+            course_run_ids=[], course_uuids=[product2.attr.UUID], absent_ids=[],
             query=benefit.range.catalog_query, discovery_api_url=self.site_configuration.discovery_api_url
         )
 
@@ -565,7 +576,7 @@ class BenefitTests(DiscoveryTestMixin, DiscoveryMockMixin, TestCase):
         with self.assertRaises(ValidationError):
             factories.BenefitFactory(value=-10)
 
-    @httpretty.activate
+    @responses.activate
     def test_get_applicable_lines(self):
         """ Assert that basket lines matching the range's discovery query are selected. """
         basket = factories.BasketFactory(site=self.site, owner=self.user)
@@ -585,14 +596,14 @@ class BenefitTests(DiscoveryTestMixin, DiscoveryMockMixin, TestCase):
             self.benefit.get_applicable_lines(self.offer, basket)
 
         self.mock_catalog_query_contains_endpoint(
-            course_run_ids=[], course_uuids=[entitlement_product.attr.UUID, course.id], absent_ids=[],
+            course_run_ids=[course.id], course_uuids=[entitlement_product.attr.UUID], absent_ids=[],
             query=self.benefit.range.catalog_query, discovery_api_url=self.site_configuration.discovery_api_url
         )
 
         self.assertEqual(self.benefit.get_applicable_lines(self.offer, basket), applicable_lines)
 
         # Verify that the API return value is cached
-        httpretty.disable()
+        responses.reset()
         self.assertEqual(self.benefit.get_applicable_lines(self.offer, basket), applicable_lines)
 
 

--- a/ecommerce/extensions/offer/views.py
+++ b/ecommerce/extensions/offer/views.py
@@ -6,8 +6,7 @@ from django.views.generic import TemplateView
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from requests.exceptions import ConnectionError as ReqConnectionError
-from requests.exceptions import Timeout
-from slumber.exceptions import SlumberHttpBaseException
+from requests.exceptions import HTTPError, Timeout
 
 from ecommerce.courses.models import Course
 from ecommerce.courses.utils import get_course_detail
@@ -41,7 +40,7 @@ class EmailConfirmationRequiredView(TemplateView):
                 try:
                     course = get_course_detail(self.request.site, course_id)
                     course_keys.append(course.get('title'))
-                except (ReqConnectionError, SlumberHttpBaseException, Timeout) as exc:
+                except (ReqConnectionError, HTTPError, Timeout) as exc:
                     logger.exception(
                         '[Account activation failure] User tried to excess the course from discovery and failed.'
                         'User: %s, course: %s, Message: %s',

--- a/ecommerce/extensions/order/management/commands/tests/test_create_refund_for_orders.py
+++ b/ecommerce/extensions/order/management/commands/tests/test_create_refund_for_orders.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import json
 
-import httpretty
+import responses
 from django.contrib.auth import get_user_model
 from django.core.management import CommandError, call_command
 from django.urls import reverse
@@ -20,7 +20,6 @@ Refund = get_model('refund', 'Refund')
 User = get_user_model()
 
 
-@httpretty.activate
 class CreateRefundForOrdersTests(DiscoveryMockMixin, TestCase):
     """
     Test the `create_refund_for_orders` command.
@@ -50,6 +49,7 @@ class CreateRefundForOrdersTests(DiscoveryMockMixin, TestCase):
                 'course_uuid': '620a5ce5-6ff4-4b2b-bea1-a273c6920ae5'
             }
         )
+        responses.start()
 
     def build_jwt_header(self, user):
         """

--- a/ecommerce/extensions/order/utils.py
+++ b/ecommerce/extensions/order/utils.py
@@ -6,7 +6,6 @@ import logging
 import waffle
 from django.conf import settings
 from edx_django_utils.cache import TieredCache
-from edx_rest_api_client.client import EdxRestApiClient
 from edx_rest_api_client.exceptions import HttpNotFoundError
 from oscar.apps.order.utils import OrderCreator as OscarOrderCreator
 from oscar.core.loading import get_model
@@ -14,7 +13,6 @@ from requests.exceptions import ConnectionError as ReqConnectionError  # pylint:
 from requests.exceptions import ConnectTimeout
 from threadlocals.threadlocals import get_current_request
 
-from ecommerce.core.url_utils import get_lms_entitlement_api_url
 from ecommerce.extensions.order.constants import DISABLE_REPEAT_ORDER_CHECK_SWITCH_NAME
 from ecommerce.extensions.refund.status import REFUND_LINE
 from ecommerce.referrals.models import Referral
@@ -147,8 +145,8 @@ class UserAlreadyPlacedOrder:
             bool: True if the entitlement is expired
 
         """
-        entitlement_api_client = EdxRestApiClient(get_lms_entitlement_api_url(),
-                                                  jwt=site.siteconfiguration.access_token)
+        api_client = site.siteconfiguration.oauth_api_client
+        entitlement_url = site.siteconfiguration.build_lms_url(f"api/entitlements/v1/entitlements/{entitlement_uuid}/")
         partner_short_code = site.siteconfiguration.partner.short_code
         key = 'course_entitlement_detail_{}{}'.format(entitlement_uuid, partner_short_code)
         entitlement_cached_response = TieredCache.get_cached_response(key)
@@ -156,7 +154,7 @@ class UserAlreadyPlacedOrder:
             entitlement = entitlement_cached_response.value
         else:
             logger.debug('Trying to get entitlement {%s}', entitlement_uuid)
-            entitlement = entitlement_api_client.entitlements(entitlement_uuid).get()
+            entitlement = api_client.get(entitlement_url).json()
             TieredCache.set_all_tiers(key, entitlement, settings.COURSES_API_CACHE_TIMEOUT)
 
         expired = entitlement.get('expired_at')

--- a/ecommerce/extensions/order/utils.py
+++ b/ecommerce/extensions/order/utils.py
@@ -6,11 +6,10 @@ import logging
 import waffle
 from django.conf import settings
 from edx_django_utils.cache import TieredCache
-from edx_rest_api_client.exceptions import HttpNotFoundError
 from oscar.apps.order.utils import OrderCreator as OscarOrderCreator
 from oscar.core.loading import get_model
 from requests.exceptions import ConnectionError as ReqConnectionError  # pylint: disable=ungrouped-imports
-from requests.exceptions import ConnectTimeout
+from requests.exceptions import ConnectTimeout, HTTPError
 from threadlocals.threadlocals import get_current_request
 
 from ecommerce.extensions.order.constants import DISABLE_REPEAT_ORDER_CHECK_SWITCH_NAME
@@ -196,7 +195,7 @@ class UserAlreadyPlacedOrder:
                 try:
                     if not UserAlreadyPlacedOrder.is_entitlement_expired(entitlement_uuid, site):
                         return True
-                except (ConnectTimeout, ReqConnectionError, HttpNotFoundError):
+                except (ConnectTimeout, ReqConnectionError, HTTPError):
                     logger.exception(
                         'Unable to get entitlement info [%s] due to a network problem',
                         entitlement_uuid

--- a/ecommerce/extensions/payment/tests/views/test_cybersource.py
+++ b/ecommerce/extensions/payment/tests/views/test_cybersource.py
@@ -5,7 +5,6 @@ import itertools
 import json
 
 import ddt
-import httpretty
 import mock
 import responses
 from CyberSource.rest import ApiException, RESTResponse
@@ -52,7 +51,6 @@ class LoginMixin:
 
 
 @ddt.ddt
-@httpretty.activate
 class CybersourceAuthorizeViewTests(CyberSourceRESTAPIMixin, TestCase):
     path = reverse('cybersource:authorize')
     CYBERSOURCE_VIEW_LOGGER_NAME = 'ecommerce.extensions.payment.views.cybersource'
@@ -135,6 +133,11 @@ class CybersourceAuthorizeViewTests(CyberSourceRESTAPIMixin, TestCase):
         self.addCleanup(sdn_patcher.stop)
 
         self.mock_access_token_response()
+        responses.start()
+
+    def tearDown(self):
+        super().tearDown()
+        responses.reset()
 
     def _create_valid_basket(self):
         """ Creates a Basket ready for checkout. """
@@ -498,7 +501,7 @@ class ApplePayStartSessionViewTests(LoginMixin, TestCase):
 
         expected_domain_name = self.payment_microfrontend_domain if expected_mfe else 'testserver.fake'
         self.assertEqual(
-            json.loads(responses.calls[0].request.body.decode('utf-8'))['domainName'],
+            json.loads(responses.calls[-1].request.body.decode('utf-8'))['domainName'],
             expected_domain_name,
         )
 

--- a/ecommerce/extensions/payment/utils.py
+++ b/ecommerce/extensions/payment/utils.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from urllib.parse import urljoin
 
 from django.utils.translation import ugettext_lazy as _
 from oscar.core.loading import get_model
@@ -124,7 +125,9 @@ def embargo_check(user, site, products):
         }
 
         try:
-            response = site.siteconfiguration.embargo_api_client.course_access.get(**params)
+            api_client = site.siteconfiguration.oauth_api_client
+            api_url = urljoin(f"{site.siteconfiguration.embargo_api_url}/", "course_access/")
+            response = api_client.get(api_url, params=params).json()
             return response.get('access', True)
         except:  # pylint: disable=bare-except
             # We are going to allow purchase if the API is un-reachable.

--- a/ecommerce/extensions/refund/tests/test_models.py
+++ b/ecommerce/extensions/refund/tests/test_models.py
@@ -1,6 +1,6 @@
 import ddt
-import httpretty
 import mock
+import responses
 from django.conf import settings
 from oscar.apps.payment.exceptions import PaymentError
 from oscar.core.loading import get_class, get_model
@@ -143,15 +143,15 @@ class RefundTests(RefundTestMixin, StatusTestsMixin, TestCase):
             if refund_created:
                 self.assert_refund_creation_logged(logger, refund, order)
 
-    @httpretty.activate
+    @responses.activate
     @mock.patch('ecommerce.extensions.fulfillment.modules.EnrollmentFulfillmentModule.revoke_line')
     def test_zero_dollar_refund(self, mock_revoke_line):
         """
         Given an order and order lines which total $0 and are not refunded, Refund.create_with_lines
         should create and approve a Refund with corresponding RefundLines.
         """
-        httpretty.register_uri(
-            httpretty.POST,
+        responses.add(
+            responses.POST,
             get_lms_enrollment_api_url(),
             status=200,
             body='{}',

--- a/ecommerce/extensions/voucher/tests/test_utils.py
+++ b/ecommerce/extensions/voucher/tests/test_utils.py
@@ -4,7 +4,7 @@
 import uuid
 
 import ddt
-import httpretty
+import responses
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 from django.test import override_settings
@@ -59,7 +59,6 @@ VOUCHER_CODE_LENGTH = 1
 
 
 @ddt.ddt
-@httpretty.activate
 class UtilTests(CouponMixin, DiscoveryMockMixin, DiscoveryTestMixin, LmsApiMockMixin, TestCase):
     course_id = 'edX/DemoX/Demo_Course'
     certificate_type = 'test-certificate-type'
@@ -122,6 +121,11 @@ class UtilTests(CouponMixin, DiscoveryMockMixin, DiscoveryTestMixin, LmsApiMockM
             'start_datetime': datetime.datetime.now() - datetime.timedelta(days=1),
             'voucher_type': Voucher.SINGLE_USE
         }
+        responses.start()
+
+    def tearDown(self):
+        super().tearDown()
+        responses.reset()
 
     def create_benefits(self):
         """

--- a/ecommerce/extensions/voucher/tests/test_views.py
+++ b/ecommerce/extensions/voucher/tests/test_views.py
@@ -2,7 +2,7 @@
 
 from uuid import uuid4
 
-import httpretty
+import responses
 from django.test import RequestFactory
 from oscar.core.loading import get_model
 
@@ -61,7 +61,7 @@ class CouponReportCSVViewTest(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.content.splitlines()), 7)
 
-    @httpretty.activate
+    @responses.activate
     def test_get_csv_report_for_specific_coupon(self):
         """
         Test the get method.

--- a/ecommerce/programs/forms.py
+++ b/ecommerce/programs/forms.py
@@ -85,7 +85,7 @@ class ProgramOfferForm(forms.ModelForm):
         site = self.request.site
         current_date = str(datetime.today().strftime('%Y-%m-%d'))
 
-        client = ProgramsApiClient(site.siteconfiguration.discovery_api_client, site.domain)
+        client = ProgramsApiClient(site.siteconfiguration)
         program = client.get_program(program_uuid)
         offer_name = _(u'{current_date} Discount for the {program_title} {program_type} Program'.format(
             current_date=current_date,

--- a/ecommerce/programs/tests/mixins.py
+++ b/ecommerce/programs/tests/mixins.py
@@ -1,9 +1,8 @@
 
 
-import json
 from decimal import Decimal
 
-import httpretty
+import responses
 
 from ecommerce.core.url_utils import get_lms_enrollment_api_url, get_lms_entitlement_api_url
 from ecommerce.courses.tests.factories import CourseFactory
@@ -71,13 +70,13 @@ class ProgramTestMixin(DiscoveryTestMixin):
                 ],
             }
         self.mock_access_token_response()
-        httpretty.register_uri(
-            method=httpretty.GET,
-            uri='{base}/programs/{uuid}/'.format(
+        responses.add(
+            method=responses.GET,
+            url='{base}/programs/{uuid}/'.format(
                 base=discovery_api_url.strip('/'),
                 uuid=program_uuid
             ),
-            body=json.dumps(data),
+            json=data,
             content_type='application/json'
         )
         return data
@@ -92,10 +91,11 @@ class ProgramTestMixin(DiscoveryTestMixin):
             api_url = get_lms_enrollment_api_url()
         else:
             api_url = get_lms_entitlement_api_url() + 'entitlements/'
-        httpretty.register_uri(
-            method=httpretty.GET,
-            uri='{}?user={}'.format(api_url, username),
-            body=json.dumps([] if owned_products is None else owned_products),
+
+        responses.add(
+            method=responses.GET,
+            url='{}?user={}'.format(api_url, username),
+            json=[] if owned_products is None else owned_products,
             status=response_code,
             content_type='application/json'
         )

--- a/ecommerce/programs/tests/test_api.py
+++ b/ecommerce/programs/tests/test_api.py
@@ -2,7 +2,7 @@
 
 import uuid
 
-import httpretty
+import responses
 from requests import ConnectionError as ReqConnectionError
 
 from ecommerce.programs.api import ProgramsApiClient
@@ -14,14 +14,13 @@ class ProgramsApiClientTests(ProgramTestMixin, TestCase):
     def setUp(self):
         super(ProgramsApiClientTests, self).setUp()
 
-        httpretty.enable()
+        responses.start()
         self.mock_access_token_response()
-        self.client = ProgramsApiClient(self.site.siteconfiguration.discovery_api_client, self.site.domain)
+        self.client = ProgramsApiClient(self.site.siteconfiguration)
 
     def tearDown(self):
         super(ProgramsApiClientTests, self).tearDown()
-        httpretty.disable()
-        httpretty.reset()
+        responses.reset()
 
     def test_get_program(self):
         """ The method should return data from the Programs API. Data should be cached for subsequent calls. """
@@ -30,7 +29,7 @@ class ProgramsApiClientTests(ProgramTestMixin, TestCase):
         self.assertEqual(self.client.get_program(program_uuid), data)
 
         # Subsequent calls should pull from the cache
-        httpretty.disable()
+        responses.reset()
         self.assertEqual(self.client.get_program(program_uuid), data)
 
         # Calls from different domains should not pull from cache

--- a/ecommerce/programs/tests/test_forms.py
+++ b/ecommerce/programs/tests/test_forms.py
@@ -4,7 +4,7 @@
 import uuid
 from datetime import datetime
 
-import httpretty
+import responses
 from oscar.core.loading import get_model
 
 from ecommerce.extensions.test import factories
@@ -77,7 +77,7 @@ class ProgramOfferFormTests(ProgramTestMixin, TestCase):
         data = self.generate_data(program_uuid=offer.condition.program_uuid)
         self.assert_form_errors(data, {'program_uuid': ['An offer already exists for this program.']})
 
-    @httpretty.activate
+    @responses.activate
     def test_save_create(self):
         """ A new ConditionalOffer, Benefit, and Condition should be created. """
         data = self.generate_data()
@@ -89,7 +89,7 @@ class ProgramOfferFormTests(ProgramTestMixin, TestCase):
         self.assert_program_offer_conditions(offer, data['program_uuid'], data['benefit_value'], data['benefit_type'],
                                              expected_name)
 
-    @httpretty.activate
+    @responses.activate
     def test_save_create_special_char_title(self):
         """ When the title is international, A new ConditionalOffer, Benefit, and Condition should still be created."""
         data = self.generate_data()
@@ -103,7 +103,7 @@ class ProgramOfferFormTests(ProgramTestMixin, TestCase):
         self.assert_program_offer_conditions(offer, data['program_uuid'], data['benefit_value'], data['benefit_type'],
                                              expected_name)
 
-    @httpretty.activate
+    @responses.activate
     def test_save_edit(self):
         """ Previously-created ConditionalOffer, Benefit, and Condition instances should be updated. """
         offer = factories.ProgramOfferFactory()
@@ -118,7 +118,7 @@ class ProgramOfferFormTests(ProgramTestMixin, TestCase):
         self.assert_program_offer_conditions(offer, data['program_uuid'], data['benefit_value'], data['benefit_type'],
                                              expected_name)
 
-    @httpretty.activate
+    @responses.activate
     def test_save_without_commit(self):
         """ No data should be persisted to the database if the commit kwarg is set to False. """
         data = self.generate_data()
@@ -130,7 +130,7 @@ class ProgramOfferFormTests(ProgramTestMixin, TestCase):
         self.assertFalse(hasattr(instance, 'benefit'))
         self.assertFalse(hasattr(instance, 'condition'))
 
-    @httpretty.activate
+    @responses.activate
     def test_save_offer_name(self):
         """ If a request object is sent, the offer name should include program title and type. """
         data = self.generate_data()

--- a/ecommerce/programs/tests/test_offer.py
+++ b/ecommerce/programs/tests/test_offer.py
@@ -2,7 +2,7 @@
 
 from decimal import Decimal
 
-import httpretty
+import responses
 from django.urls import reverse
 from oscar.core.loading import get_class
 from oscar.test.factories import BasketFactory, RangeFactory
@@ -20,7 +20,7 @@ Applicator = get_class('offer.applicator', 'Applicator')
 class ProgramOfferTests(LmsApiMockMixin, ProgramTestMixin, TestCase):
     """ Verification for program offer application. """
 
-    @httpretty.activate
+    @responses.activate
     def test_offer(self):
         # Our offer is for 100%, so all lines should end up with a price of 0.
         offer = factories.ProgramOfferFactory(

--- a/ecommerce/programs/tests/test_views.py
+++ b/ecommerce/programs/tests/test_views.py
@@ -2,7 +2,7 @@
 
 import uuid
 
-import httpretty
+import responses
 from django.urls import reverse
 from oscar.core.loading import get_model
 
@@ -22,13 +22,12 @@ class ProgramOfferListViewTests(ProgramTestMixin, ViewTestMixin, TestCase):
     def setUp(self):
         super(ProgramOfferListViewTests, self).setUp()
 
-        httpretty.enable()
+        responses.start()
         self.mock_access_token_response()
 
     def tearDown(self):
         super(ProgramOfferListViewTests, self).tearDown()
-        httpretty.disable()
-        httpretty.reset()
+        responses.reset()
 
     def test_get(self):
         """ The context should contain a list of program offers. """
@@ -45,7 +44,7 @@ class ProgramOfferListViewTests(ProgramTestMixin, ViewTestMixin, TestCase):
         self.assertEqual(list(response.context['object_list']), program_offers)
 
         # The page should load even if the Programs API is inaccessible
-        httpretty.disable()
+        responses.reset()
         response = self.assert_get_response_status(200)
         self.assertEqual(list(response.context['object_list']), program_offers)
 
@@ -79,16 +78,15 @@ class ProgramOfferUpdateViewTests(ProgramTestMixin, ViewTestMixin, TestCase):
         self.program_offer = factories.ProgramOfferFactory(partner=self.partner)
         self.path = reverse('programs:offers:edit', kwargs={'pk': self.program_offer.pk})
 
-        # NOTE: We activate httpretty here so that we don't have to decorate every test method.
-        httpretty.enable()
+        # NOTE: We activate responses here so that we don't have to decorate every test method.
+        responses.start()
         self.mock_program_detail_endpoint(
             self.program_offer.condition.program_uuid, self.site_configuration.discovery_api_url
         )
 
     def tearDown(self):
         super(ProgramOfferUpdateViewTests, self).tearDown()
-        httpretty.disable()
-        httpretty.reset()
+        responses.reset()
 
     def test_get(self):
         """ The context should contain the program offer. """
@@ -96,7 +94,7 @@ class ProgramOfferUpdateViewTests(ProgramTestMixin, ViewTestMixin, TestCase):
         self.assertEqual(response.context['object'], self.program_offer)
 
         # The page should load even if the Programs API is inaccessible
-        httpretty.disable()
+        responses.reset()
         response = self.assert_get_response_status(200)
         self.assertEqual(response.context['object'], self.program_offer)
 
@@ -111,7 +109,7 @@ class ProgramOfferUpdateViewTests(ProgramTestMixin, ViewTestMixin, TestCase):
         self.assertRedirects(response, self.path)
 
 
-@httpretty.activate
+@responses.activate
 class ProgramOfferCreateViewTests(ProgramTestMixin, ViewTestMixin, TestCase):
     path = reverse('programs:offers:new')
 

--- a/ecommerce/programs/utils.py
+++ b/ecommerce/programs/utils.py
@@ -3,8 +3,7 @@
 import logging
 
 from requests.exceptions import ConnectionError as ReqConnectionError
-from requests.exceptions import Timeout
-from slumber.exceptions import HttpNotFoundError, SlumberBaseException
+from requests.exceptions import HTTPError, Timeout
 
 from ecommerce.programs.api import ProgramsApiClient
 
@@ -29,13 +28,9 @@ def get_program(program_uuid, siteconfiguration):
     """
     response = None
     try:
-        client = ProgramsApiClient(siteconfiguration.discovery_api_client, siteconfiguration.site.domain)
+        client = ProgramsApiClient(siteconfiguration)
         response = client.get_program(str(program_uuid))
-    except HttpNotFoundError:
-        msg = 'No program data found for {}'.format(program_uuid)
-        log.debug(msg)
-    except (ReqConnectionError, SlumberBaseException, Timeout):
-        msg = 'Failed to retrieve program details for {}'.format(program_uuid)
-        log.debug(msg)
+    except (ReqConnectionError, HTTPError, Timeout):
+        log.debug("Failed to retrieve program details for %s", program_uuid)
 
     return response

--- a/ecommerce/settings/devstack.py
+++ b/ecommerce/settings/devstack.py
@@ -27,6 +27,10 @@ SESSION_COOKIE_SECURE = False
 COMPRESS_OFFLINE = False
 COMPRESS_ENABLED = False
 
+BACKEND_SERVICE_EDX_OAUTH2_KEY = "ecommerce-backend-service-key"
+BACKEND_SERVICE_EDX_OAUTH2_SECRET = "ecommerce-backend-service-secret"
+BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL = "http://edx.devstack.lms:18000/oauth2"
+
 JWT_AUTH.update({
     'JWT_ISSUER': 'http://localhost:18000/oauth2',
     'JWT_ISSUERS': [{
@@ -56,7 +60,7 @@ CORS_ALLOW_HEADERS = corsheaders_default_headers + (
 )
 CORS_ALLOW_CREDENTIALS = True
 
-ENTERPRISE_CATALOG_API_URL = urljoin(ENTERPRISE_CATALOG_SERVICE_URL, 'api/v1/')
+ENTERPRISE_CATALOG_API_URL = urljoin(f"{ENTERPRISE_CATALOG_SERVICE_URL}/", 'api/v1/')
 
 # PAYMENT PROCESSING
 PAYMENT_PROCESSOR_CONFIG = {

--- a/ecommerce/settings/local.py
+++ b/ecommerce/settings/local.py
@@ -160,6 +160,6 @@ REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] = REST_FRAMEWORK['DEFAULT_RENDERER_CL
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
     from .private import *  # pylint: disable=import-error
 
-ENTERPRISE_API_URL = urljoin(ENTERPRISE_SERVICE_URL, 'api/v1/')
+ENTERPRISE_API_URL = urljoin(f"{ENTERPRISE_SERVICE_URL}/", 'api/v1/')
 
-ENTERPRISE_CATALOG_API_URL = urljoin(ENTERPRISE_CATALOG_SERVICE_URL, 'api/v1/')
+ENTERPRISE_CATALOG_API_URL = urljoin(f"{ENTERPRISE_CATALOG_SERVICE_URL}/", 'api/v1/')

--- a/ecommerce/settings/production.py
+++ b/ecommerce/settings/production.py
@@ -111,9 +111,9 @@ for __, configs in PAYMENT_PROCESSOR_CONFIG.items():
         })
 # END PAYMENT PROCESSOR OVERRIDES
 
-ENTERPRISE_API_URL = urljoin(ENTERPRISE_SERVICE_URL, 'api/v1/')
+ENTERPRISE_API_URL = urljoin(f"{ENTERPRISE_SERVICE_URL}/", 'api/v1/')
 
-ENTERPRISE_CATALOG_API_URL = urljoin(ENTERPRISE_CATALOG_SERVICE_URL, 'api/v1/')
+ENTERPRISE_CATALOG_API_URL = urljoin(f"{ENTERPRISE_CATALOG_SERVICE_URL}/", 'api/v1/')
 
 CORS_ALLOW_HEADERS = corsheaders_default_headers + (
     'use-jwt-cookie',

--- a/ecommerce/settings/test.py
+++ b/ecommerce/settings/test.py
@@ -152,9 +152,9 @@ COMPREHENSIVE_THEME_DIRS = [
 
 DEFAULT_SITE_THEME = "test-theme"
 
-ENTERPRISE_API_URL = urljoin(ENTERPRISE_SERVICE_URL, 'api/v1/')
+ENTERPRISE_API_URL = urljoin(f"{ENTERPRISE_SERVICE_URL}/", 'api/v1/')
 
-ENTERPRISE_CATALOG_API_URL = urljoin(ENTERPRISE_CATALOG_SERVICE_URL, 'api/v1/')
+ENTERPRISE_CATALOG_API_URL = urljoin(f"{ENTERPRISE_CATALOG_SERVICE_URL}/", 'api/v1/')
 
 # Don't bother sending fake events to Segment. Doing so creates unnecessary threads.
 SEND_SEGMENT_EVENTS = False

--- a/ecommerce/social_auth/tests/test_strategies.py
+++ b/ecommerce/social_auth/tests/test_strategies.py
@@ -7,7 +7,7 @@ import re
 import uuid
 from calendar import timegm
 
-import httpretty
+import responses
 from django.contrib.auth import get_user_model
 from django.test import override_settings
 from django.urls import reverse
@@ -81,9 +81,6 @@ class CurrentSiteDjangoStrategyTests(TestCase):
 
     def mock_access_token_jwt_response(self, user, status=200):
         """ Mock the response from the OAuth provider's access token endpoint. """
-        assert httpretty.is_enabled(), 'httpretty must be enabled to mock the access token response.'
-
-        # Use a regex to account for the optional trailing slash
         url = '{root}/access_token/?'.format(root=self.site.siteconfiguration.oauth2_provider_url)
         url = re.compile(url)
 
@@ -93,11 +90,11 @@ class CurrentSiteDjangoStrategyTests(TestCase):
             'expires_in': 3600,
         }
         body = json.dumps(data)
-        httpretty.register_uri(httpretty.POST, url, body=body, content_type=CONTENT_TYPE, status=status)
+        responses.add(responses.POST, url, body=body, content_type=CONTENT_TYPE, status=status)
 
         return token
 
-    @httpretty.activate
+    @responses.activate
     def test_authentication(self):
         """ Returning users should be able to re-authenticate to the same acccount, rather than get a new account with
         a UUID. This validates the fix made by https://github.com/python-social-auth/social-core/pull/74.

--- a/ecommerce/tests/factories.py
+++ b/ecommerce/tests/factories.py
@@ -52,7 +52,7 @@ class UserFactory(factory.DjangoModelFactory):
     class Meta:
         model = get_model('core', 'User')
 
-    username = factory.Sequence(lambda n: 'ecommerce_test_user %d' % n)
+    username = factory.Sequence(lambda n: 'ecommerce_test_user_%d' % n)
     email = factory.Sequence(lambda n: 'ecommerce_test_%s@example.com' % n)
     first_name = 'Ecommerce'
     last_name = 'User'

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -4,11 +4,10 @@
 
 import datetime
 import json
-import re
 from decimal import Decimal
 
-import httpretty
 import jwt
+import responses
 from crum import set_current_request
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -16,6 +15,7 @@ from django.contrib.sites.models import Site
 from django.urls import reverse
 from django.utils.timezone import now
 from edx_django_utils.cache import TieredCache
+from edx_rest_api_client.client import _get_oauth_url
 from edx_rest_framework_extensions.auth.jwt.cookies import jwt_cookie_name
 from edx_rest_framework_extensions.auth.jwt.tests.utils import generate_jwt_token, generate_unversioned_payload
 from mock import patch
@@ -367,11 +367,7 @@ class SiteMixin:
 
     def mock_access_token_response(self, status=200, **token_data):
         """ Mock the response from the OAuth provider's access token endpoint. """
-        assert httpretty.is_enabled(), 'httpretty must be enabled to mock the access token response.'
-
-        # Use a regex to account for the optional trailing slash
-        url = '{root}/access_token/?'.format(root=self.site.siteconfiguration.oauth2_provider_url)
-        url = re.compile(url)
+        url = _get_oauth_url(settings.BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL)
 
         token = 'abc123'
         data = {
@@ -379,8 +375,7 @@ class SiteMixin:
             'expires_in': 3600,
         }
         data.update(token_data)
-        body = json.dumps(data)
-        httpretty.register_uri(httpretty.POST, url, body=body, content_type=CONTENT_TYPE, status=status)
+        responses.add(responses.POST, url, json=data, content_type=CONTENT_TYPE, status=status)
 
         return token
 
@@ -396,10 +391,8 @@ class ApiMockMixin:
     """ Common Mocks for the API responses. """
 
     def mock_api_error(self, error, url):
-        def callback(request, uri, headers):  # pylint: disable=unused-argument
-            raise error
 
-        httpretty.register_uri(httpretty.GET, url, body=callback, content_type=CONTENT_TYPE)
+        responses.add(responses.GET, url, body=error, content_type=CONTENT_TYPE)
 
 
 class LmsApiMockMixin:
@@ -421,10 +414,9 @@ class LmsApiMockMixin:
             'name': course.name if course else 'Test course',
             'org': 'test'
         }
-        course_info_json = json.dumps(course_info)
         course_id = course.id if course else 'course-v1:test+test+test'
         course_url = get_lms_url('api/courses/v1/courses/{}/'.format(course_id))
-        httpretty.register_uri(httpretty.GET, course_url, body=course_info_json, content_type=CONTENT_TYPE)
+        responses.add(responses.GET, course_url, json=course_info, content_type=CONTENT_TYPE)
 
     def mock_account_api(self, request, username, data):
         """ Mock the account LMS API endpoint for a user.
@@ -438,8 +430,7 @@ class LmsApiMockMixin:
             host=request.site.siteconfiguration.build_lms_url('/api/user/v1'),
             username=username,
         )
-        body = json.dumps(data)
-        httpretty.register_uri(httpretty.GET, url, body=body, content_type=CONTENT_TYPE)
+        responses.add(responses.GET, url, json=data, content_type=CONTENT_TYPE)
 
     def mock_bulk_lms_users_using_emails(self, request, users):
         """ Mock the account Bulk LMS API endpoint for users.
@@ -456,8 +447,7 @@ class LmsApiMockMixin:
             'username': user['username'],
             'email': user['email'],
         } for user in users]
-        body = json.dumps(data)
-        httpretty.register_uri(httpretty.POST, url, body=body, content_type=CONTENT_TYPE)
+        responses.add(responses.POST, url, json=data, content_type=CONTENT_TYPE)
 
     def mock_eligibility_api(self, request, user, course_key, eligible=True):
         """ Mock eligibility API endpoint. Returns eligibility data. """
@@ -469,9 +459,9 @@ class LmsApiMockMixin:
         url = '{host}/eligibility/?username={username}&course_key={course_key}'.format(
             host=request.site.siteconfiguration.build_lms_url('/api/credit/v1'),
             username=user.username,
-            course_key=course_key
+            course_key=course_key.replace("+", "%2B")
         )
-        httpretty.register_uri(httpretty.GET, url, body=json.dumps(eligibility_data), content_type=CONTENT_TYPE)
+        responses.add(responses.GET, url, json=eligibility_data, content_type=CONTENT_TYPE)
 
     @staticmethod
     def get_default_expiration():
@@ -483,7 +473,12 @@ class LmsApiMockMixin:
             host=request.site.siteconfiguration.build_lms_url('/api/user/v1'),
             username=username
         )
-        httpretty.register_uri(httpretty.POST, url, body=response, content_type=CONTENT_TYPE)
+        responses.add(
+            responses.POST,
+            url,
+            body=response() if callable(response) else response,
+            content_type=CONTENT_TYPE
+        )
 
 
 class TestWaffleFlagMixin:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -359,8 +359,6 @@ gitdb==4.0.9
     # via gitpython
 gitpython==3.1.26
     # via transifex-client
-httpretty==0.9.7
-    # via -r requirements/test.txt
 idna==2.7
     # via
     #   -r requirements/docs.txt
@@ -824,7 +822,6 @@ six==1.16.0
     #   edx-rbac
     #   edx-sphinx-theme
     #   fixtures
-    #   httpretty
     #   isodate
     #   jsonschema
     #   libsass

--- a/requirements/pins.txt
+++ b/requirements/pins.txt
@@ -14,9 +14,6 @@ cybersource-rest-client-python==0.0.21
 # Django 3.2 support is added in version 2.2 so pinning it to 2.2
 django-oscar==2.2
 
-# causing tests failures
-httpretty==0.9.7
-
 # jsonfield2 > 3.0.3 dropped support for python 3.5
 jsonfield2<=3.0.3
 

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -11,7 +11,6 @@ django-webtest
 edx-i18n-tools              # required for quality
 factory-boy
 freezegun
-httpretty
 isort
 lxml
 mock

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -356,10 +356,6 @@ future==0.18.2
     # via
     #   -r requirements/base.txt
     #   pyjwkest
-httpretty==0.9.7
-    # via
-    #   -c requirements/pins.txt
-    #   -r requirements/test.in
 idna==2.7
     # via
     #   -c requirements/pins.txt


### PR DESCRIPTION
closes https://github.com/openedx/public-engineering/issues/48

All the changes could be separated into two types:
1. Replacing EdxRestAPIClient with OAuthAPIClient
  - new client primarily used from the [core/models.py SiteConfiguration cached property](https://github.com/openedx/ecommerce/pull/3693/files#diff-565fdd6fdc70013b674f69a09880d9c8b81e11fc49dd9a1bd3adbb94a00f5c90R381). There are base API URLs stored there too instead of the old clients.
  - there are few places where pure requests are used (primary in the management commands) because there is no need for Session and authentication there.
  - responses collected from the new client requests require additional `.raise_for_status` and `.json()` to be called (this was working under the hood in the old Slumber-based client)
  - replaced Slumber error types with the appropriate requests ones. I've used following mapping:
    - SlumberBaseException -> RequestException
    - SlumberHttpBaseException / HttpNotFoundError / HttpClientError / HttpServerError -> HTTPError
2. Tests reworked
  - The `httpretty` library was replaced with `responses` because it had issues with keeping connections with requests.Session.
  - although `responses` usage is pretty the same as `httpretty`s, it requires a more strict URL format (including the query parameters). It also can't be activated at the class level using the decorator