### PR TITLE
Redeem coupon and enroll user in course

### DIFF
--- a/ecommerce/coupons/api.py
+++ b/ecommerce/coupons/api.py
@@ -1,0 +1,332 @@
+
+import logging
+from types import SimpleNamespace
+from ecommerce.extensions.payment.utils import embargo_check
+
+import newrelic.agent
+from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
+from edx_rest_api_client.client import EdxRestApiClient
+from oscar.core.loading import get_class, get_model
+
+from ecommerce.coupons.applicator import Applicator
+from ecommerce.coupons.constants import COURSE_MODES_RANKING
+from ecommerce.coupons.exceptions import RedeemCouponError
+from ecommerce.coupons.utils import is_voucher_applied
+from ecommerce.courses.utils import get_course_detail
+from ecommerce.enterprise.exceptions import EnterpriseDoesNotExist
+from ecommerce.enterprise.utils import get_enterprise_customer_from_voucher
+from ecommerce.extensions.analytics.utils import audit_log
+from ecommerce.extensions.basket.utils import (
+    _set_basket_bundle_status,
+    apply_voucher_on_basket_and_check_discount,
+    basket_add_enterprise_catalog_attribute,
+    is_duplicate_seat_attempt
+)
+from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
+from ecommerce.extensions.order.exceptions import AlreadyPlacedOrderException
+from ecommerce.extensions.order.utils import UserAlreadyPlacedOrder
+
+logger = logging.getLogger(__name__)
+
+User = get_user_model()
+Voucher = get_model('voucher', 'Voucher')
+StockRecord = get_model('partner', 'StockRecord')
+Basket = get_model('basket', 'Basket')
+BasketAttribute = get_model('basket', 'BasketAttribute')
+BasketAttributeType = get_model('basket', 'BasketAttributeType')
+Selector = get_class('partner.strategy', 'Selector')
+post_checkout = get_class('checkout.signals', 'post_checkout')
+
+
+class CustomEdxOrderPlacementMixin(EdxOrderPlacementMixin):
+    def handle_successful_order(self, order, request=None):  # pylint: disable=arguments-differ
+        """
+        Send a signal so that receivers can perform relevant tasks (e.g., fulfill the order).
+
+        Sends an additional `create_consent_record` param with the signal so that a data-sharing
+        consent is not created for the user during enrollment.
+        """
+        audit_log(
+            'order_placed',
+            amount=order.total_excl_tax,
+            basket_id=order.basket.id,
+            currency=order.currency,
+            order_number=order.number,
+            user_id=order.user.id,
+            contains_coupon=order.contains_coupon
+        )
+
+        # create offer assignment for MULTI_USE_PER_CUSTOMER
+        self.create_assignments_for_multi_use_per_customer(order)
+
+        # update offer assignment with voucher application
+        self.update_assigned_voucher_offer_assignment(order)
+
+        post_checkout.send(
+            sender=self,
+            order=order,
+            request=request,
+            email_opt_in=False,  # Do not send users fulfillment emails
+            create_consent_record=False  # Do not create consent record for user
+        )
+
+        return order
+
+
+class CouponCodeRedeemer(CustomEdxOrderPlacementMixin):
+    """
+    Allows a coupon code to be redeemed to enroll a user into a course.
+    """
+
+    def __init__(self, site=None):
+        if site:
+            self.site = site
+        else:
+            # TODO: Figure out the best way to get default, i.e.
+            # Site.objects.get(domain=learner['enterprise_customer']['site']['domain']) == request.site
+            self.site = Site.objects.first()
+
+        super().__init__()
+
+    def _is_voucher_valid(self, voucher, products, user):
+        """
+        Check if the voucher is valid.
+        """
+
+        if not voucher.is_active():
+            return False, 'This coupon code is not active.'
+
+        is_available, msg = voucher.is_available_to_user(user)
+        if not is_available:
+            return False, msg
+
+        if len(products) == 1:
+            purchase_info = Selector().strategy(user=user).fetch_for_product(products[0])
+
+            if not purchase_info.availability.is_available_to_buy:
+                return False, 'This product is not available for purchase.'
+
+        offer = voucher.best_offer
+        if offer.get_max_applications(user) == 0:
+            return False, 'This coupon code is no longer available.'
+
+        return True, ''
+
+    def _get_highest_ranking_seat(self, seats):
+        """
+        Gets the highest ranking seat for a course run.
+        """
+        if not seats:
+            return None
+
+        seats_sorted_by_rank = sorted(seats, key=lambda seat: COURSE_MODES_RANKING[seat['type']])
+        return seats_sorted_by_rank[0]
+
+    def _get_sku_for_course(self, course_id):
+        """
+        Get the sku of the product to apply the voucher against.
+        """
+        try:
+            course_detail = get_course_detail(self.site, course_id)
+            course_runs = course_detail['course_runs']
+        except Exception as ex:
+            logger.exception('[Code Redemption Failure] Could not fetch course detail for %s', course_id)
+            raise RedeemCouponError from ex
+
+        # TODO: handle active/upcoming/not enrollable course runs
+        course_run_to_enroll_in = course_runs[0]
+        seats = course_run_to_enroll_in['seats']
+        highest_ranking_seat = self._get_highest_ranking_seat(seats)
+
+        sku = highest_ranking_seat['sku']
+
+        return sku
+
+    def _get_user_details(self, user):
+        """
+        Get details of the user from the LMS.
+        """
+        user_api_client = EdxRestApiClient(
+            self.site.siteconfiguration.build_lms_url('/api/user/v1/'),
+            jwt=self.site.siteconfiguration.access_token,
+            append_slash=False
+        )
+
+        try:
+            return user_api_client.accounts.get(lms_user_id=user.lms_user_id)[0]
+        except Exception:
+            logger.exception('[Code Redemption Failure] Could not fetch user details for user %s', user)
+            raise
+
+    @newrelic.agent.function_trace()
+    def _prepare_basket(self, user, site, product, voucher, enterprise_customer_uuid):
+        """
+        Create or get the basket, adds the product, and applies the voucher.
+        """
+
+        basket = Basket.get_basket(user, site)
+
+        # set enterprise_customer_uuid on basket so that it's accessible
+        # in all contexts
+        setattr(basket, 'enterprise_customer_uuid', enterprise_customer_uuid)
+
+        # normally the enterprise catalog UUID attribute is added on basket
+        basket_add_enterprise_catalog_attribute(basket, {})
+        basket.flush()
+        basket.save()
+
+        # We won't support bundle for this flow
+        bundle = None
+        basket_addition = get_class('basket.signals', 'basket_addition')
+        already_purchased_products = []
+        _set_basket_bundle_status(bundle, basket)
+
+        if self.site.siteconfiguration.enable_embargo_check:
+            if not embargo_check(user, site, [product]):
+                logger.warning(
+                    'User %s blocked by embargo check, not adding products to basket',
+                    user
+                )
+                return basket
+
+        if is_duplicate_seat_attempt(basket, product):
+            return basket
+
+        if product.is_enrollment_code_product or \
+                not UserAlreadyPlacedOrder.user_already_placed_order(
+                    user=user,
+                    product=product,
+                    site=site
+                ):
+            basket.add_product(product, 1)
+            # Call signal handler to notify listeners that something has been added to the basket
+            basket_addition.send(
+                sender=basket_addition,
+                product=product,
+                user=user,
+                request=None,
+                basket=basket,
+                is_multi_product_basket=False
+            )
+        else:
+            already_purchased_products.append(product)
+
+        if already_purchased_products and basket.is_empty:
+            raise AlreadyPlacedOrderException
+
+        basket.clear_vouchers()
+
+        if basket.total_excl_tax == 0:
+            logger.exception(
+                '[Code Redemption Failure] Basket total is already 0. User: %s, Code: %s.',
+                user, voucher.code
+            )
+            raise RedeemCouponError
+
+        apply_voucher_on_basket_and_check_discount(
+            voucher,
+            SimpleNamespace(user=user),
+            basket,
+            Applicator
+        )
+
+        return basket
+
+    def redeem_coupon_code(self, code, course_id, lms_user_id):
+
+        error_msg_template = '[Code Redemption Failure] %s User: %s, Code: %s, Course: %s.'
+
+        # User must exist at this point
+        user = User.objects.get(lms_user_id=lms_user_id)
+
+        try:
+            voucher = Voucher.objects.get(code=code)
+        except Voucher.DoesNotExist as ex:
+            logger.exception(error_msg_template, 'No voucher found with code.', user, course_id, lms_user_id)
+            raise RedeemCouponError from ex
+
+        sku = self._get_sku_for_course(course_id)
+
+        try:
+            product = StockRecord.objects.get(partner_sku=sku).product
+        except StockRecord.DoesNotExist as ex:
+            logger.exception(error_msg_template, 'Product does not exist.', user, course_id, lms_user_id)
+            raise RedeemCouponError from ex
+
+        voucher_is_valid, invalid_voucher_message = self._is_voucher_valid(voucher, [product], user)
+
+        if not voucher_is_valid:
+            logger.exception(error_msg_template, invalid_voucher_message, user, course_id, lms_user_id)
+            raise RedeemCouponError
+
+        offer = voucher.best_offer
+
+        user_details = self._get_user_details(user)
+
+        if not offer.is_email_valid(user_details['email']):
+            logger.exception(
+                error_msg_template,
+                'User email does not meet domain requirements.', user, course_id, lms_user_id
+            )
+            raise RedeemCouponError
+
+        if not user_details['is_active']:
+            logger.exception(error_msg_template, 'User is not active.', user, course_id, lms_user_id)
+            raise RedeemCouponError
+
+        try:
+            enterprise_customer = get_enterprise_customer_from_voucher(self.site, voucher)
+        except EnterpriseDoesNotExist as ex:
+            logger.exception(
+                error_msg_template,
+                'Could not find matching enterprise customer.', user, course_id, lms_user_id
+            )
+            raise RedeemCouponError from ex
+
+        if product.is_course_entitlement_product:
+            logger.exception(
+                error_msg_template,
+                'This coupon is not valid for purchasing a program.', user, course_id, lms_user_id
+            )
+            raise RedeemCouponError
+
+        try:
+            basket = self._prepare_basket(
+                user,
+                self.site,
+                product,
+                voucher,
+                (enterprise_customer or {}).get('id')
+            )
+        except AlreadyPlacedOrderException as ex:
+            logger.exception(
+                error_msg_template,
+                'User has already purchased coursed.', user, course_id, lms_user_id
+            )
+            raise RedeemCouponError from ex
+
+        if basket.total_excl_tax == 0:
+            try:
+                self.place_free_order(basket)
+            except Exception as ex:  # pylint: disable=bare-except
+                logger.exception(
+                    error_msg_template,
+                    'Failed to create a free order for basket.', user, course_id, lms_user_id
+                )
+                raise RedeemCouponError from ex
+        else:
+            logger.exception(
+                error_msg_template,
+                'Total cost was not 0 after applying coupon.', user, course_id, lms_user_id
+            )
+            raise RedeemCouponError
+
+        if is_voucher_applied(basket, voucher):
+            logger.info('Code %s successfully redeemed for user %s for course %s.', code, user, course_id)
+        else:
+            logger.exception(
+                error_msg_template,
+                'Failed to redeem coupon.', user, course_id, lms_user_id
+            )
+            basket.vouchers.remove(voucher)

--- a/ecommerce/coupons/applicator.py
+++ b/ecommerce/coupons/applicator.py
@@ -1,0 +1,69 @@
+
+
+import logging
+from itertools import chain
+
+from oscar.core.loading import get_class, get_model
+
+from ecommerce.extensions.offer.applicator import Applicator as BaseApplicator
+
+logger = logging.getLogger(__name__)
+BUNDLE = 'bundle_identifier'
+
+OfferApplications = get_class('offer.results', 'OfferApplications')
+
+
+class Applicator(BaseApplicator):
+    """
+    Custom applicator.
+    """
+
+    def get_offers(self, basket, user=None, request=None, bundle_id=None):  # pylint: disable=arguments-differ
+        """
+        Returns all offers to apply to the basket.
+
+        Does prefiltering to filter out offers that could never apply to a particular
+        basket. As an example, if the basket has a bundle ID or an enterprise customer
+        UUID, gets only the site offers associated with that specific bundle or enterprise
+        customer, rather than all site offers. Otherwise, gets the site offers not associated
+        with a bundle.
+
+        Returns:
+            list of Offer: A sorted list of all the offers that apply to the basket.
+        """
+        program_offers = self._get_program_offers(basket, bundle_id)
+        enterprise_customer_uuid = getattr(
+            basket, 'enterprise_customer_uuid', None
+        )
+        enterprise_offers = self._get_enterprise_offers(basket.site, user, enterprise_customer_uuid)
+        site_offers = [] if program_offers or enterprise_offers else self.get_site_offers()
+
+        basket_offers = self.get_basket_offers(basket, user)
+
+        # edX currently does not use user offers or session offers.
+        # The default oscar implementations which return [] are here in case edX ever starts using these offers.
+        user_offers = self.get_user_offers(user)
+        session_offers = self.get_session_offers(request)
+
+        return list(
+            sorted(
+                chain(session_offers, basket_offers, user_offers, program_offers, enterprise_offers, site_offers),
+                key=lambda o: o.priority,
+                reverse=True,
+            )
+        )
+
+    def _get_enterprise_offers(self, site, user, enterprise_customer_uuid=None):  # pylint: disable=arguments-differ
+        """
+        Return enterprise offers filtered by the user's enterprise, if it exists.
+        """
+        # enterprise_id = get_enterprise_id_for_user(site, user)
+        if enterprise_customer_uuid:
+            ConditionalOffer = get_model('offer', 'ConditionalOffer')
+            offers = ConditionalOffer.active.filter(
+                offer_type=ConditionalOffer.SITE,
+                condition__enterprise_customer_uuid=enterprise_customer_uuid
+            )
+            return offers.select_related('condition', 'benefit')
+
+        return []

--- a/ecommerce/coupons/constants.py
+++ b/ecommerce/coupons/constants.py
@@ -1,0 +1,8 @@
+#  Modes are ranked ['verified', 'professional', 'no-id-professional', 'audit', 'honor']
+COURSE_MODES_RANKING = {
+    'verified': 1,
+    'professional': 2,
+    'no-id-professional': 3,
+    'audit': 4,
+    'honor': 5
+}

--- a/ecommerce/coupons/exceptions.py
+++ b/ecommerce/coupons/exceptions.py
@@ -1,0 +1,2 @@
+class RedeemCouponError(Exception):
+    """ Raised when failing to redeem a coupon. """

--- a/ecommerce/coupons/tests/test_api.py
+++ b/ecommerce/coupons/tests/test_api.py
@@ -1,0 +1,257 @@
+import ddt
+import httpretty
+import mock
+from django.utils.timezone import now, timedelta
+from oscar.core.loading import get_class, get_model
+from oscar.test.factories import BasketFactory, OrderFactory
+from pytest import mark
+
+from ecommerce.coupons.api import CouponCodeRedeemer, CustomEdxOrderPlacementMixin
+from ecommerce.coupons.exceptions import RedeemCouponError
+from ecommerce.coupons.tests.mixins import CouponMixin, DiscoveryMockMixin
+from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
+from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
+from ecommerce.extensions.payment.models import EnterpriseContractMetadata
+from ecommerce.extensions.test.factories import prepare_voucher
+from ecommerce.tests.factories import UserFactory
+from ecommerce.tests.mixins import LmsApiMockMixin
+from ecommerce.tests.testcases import TestCase
+
+Applicator = get_class('offer.applicator', 'Applicator')
+Basket = get_model('basket', 'Basket')
+Benefit = get_model('offer', 'Benefit')
+Catalog = get_model('catalogue', 'Catalog')
+Course = get_model('courses', 'Course')
+Product = get_model('catalogue', 'Product')
+Order = get_model('order', 'Order')
+OrderLine = get_model('order', 'Line')
+OrderLineVouchers = get_model('voucher', 'OrderLineVouchers')
+StockRecord = get_model('partner', 'StockRecord')
+Voucher = get_model('voucher', 'Voucher')
+VoucherApplication = get_model('voucher', 'VoucherApplication')
+post_checkout = get_class('checkout.signals', 'post_checkout')
+
+CONTENT_TYPE = 'application/json'
+COUPON_CODE = 'COUPONTEST'
+ENTERPRISE_CUSTOMER = 'cf246b88-d5f6-4908-a522-fc307e0b0c59'
+ENTERPRISE_CUSTOMER_CATALOG = 'abc18838-adcb-41d5-abec-b28be5bfcc13'
+
+
+@ddt.ddt
+@mark.django_db
+class CustomEdxOrderPlacemenMixinTests(TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        class Stub(CustomEdxOrderPlacementMixin):
+            def create_assignments_for_multi_use_per_customer(self, order):
+                pass
+
+            def update_assigned_voucher_offer_assignment(self, order):
+                pass
+
+        self.stub = Stub()
+
+    def test_handle_successful_order(self):
+        order = OrderFactory()
+        order.basket = BasketFactory()
+        order.user = UserFactory()
+
+        with mock.patch.object(post_checkout, 'send', side_effect=post_checkout.send):
+            self.stub.handle_successful_order(order)
+            send_arguments = {
+                'sender': mock.ANY,
+                'order': order,
+                'request': mock.ANY,
+                'email_opt_in': False,
+                'create_consent_record': False
+            }
+            post_checkout.send.assert_called_once_with(**send_arguments)
+
+
+@ddt.ddt
+@mark.django_db
+class CouponCodeRedeemerTests(
+        CouponMixin,
+        DiscoveryTestMixin,
+        LmsApiMockMixin,
+        EnterpriseServiceMockMixin,
+        TestCase,
+        DiscoveryMockMixin):
+
+    def setUp(self):
+        super().setUp()
+
+        self.user = self.create_user(email='test@tester.fake')
+        self.course_1, self.seat_1 = self.create_course_and_seat(
+            seat_type='verified',
+            id_verification=True,
+            price=50,
+            partner=self.partner
+        )
+        self.course_2, self.seat_2 = self.create_course_and_seat(
+            seat_type='professional',
+            id_verification=True,
+            price=0,
+            partner=self.partner
+        )
+        self.stock_record_1 = StockRecord.objects.get(product=self.seat_1)
+        self.stock_record_2 = StockRecord.objects.get(product=self.seat_2)
+        self.catalog = Catalog.objects.create(partner=self.partner)
+        self.catalog.stock_records.add(StockRecord.objects.get(product=self.seat_1))
+        self.catalog.stock_records.add(StockRecord.objects.get(product=self.seat_2))
+
+        self.coupon_code_redeemer = CouponCodeRedeemer(site=self.site)
+
+        coupon_code, _ = self._create_coupon_and_get_code()
+        self.coupon_code = coupon_code
+        self.voucher = Voucher.objects.get(code=coupon_code)
+
+        self.logger_patcher = mock.patch('ecommerce.coupons.api.logger')
+        self.mock_logger = self.logger_patcher.start()
+
+        self.get_course_detail_patcher = mock.patch('ecommerce.coupons.api.get_course_detail')
+        self.mock_get_course_detail = self.get_course_detail_patcher.start()
+        self.mock_get_course_detail.return_value = {
+            'course_runs': [
+                {
+                    'seats': [
+                        {
+                            'type': 'verified',
+                            'sku': self.stock_record_1.partner_sku
+                        },
+                        {
+                            'type': 'professional',
+                            'sku': self.stock_record_2.partner_sku
+                        }
+                    ]
+                }
+            ]
+        }
+
+        self.edx_rest_api_client_patcher = mock.patch('ecommerce.coupons.api.EdxRestApiClient')
+        self.mock_edx_rest_api_client = self.edx_rest_api_client_patcher.start()
+        self.mock_edx_rest_api_client().accounts.get.return_value = [{
+            'is_active': True,
+            'email': self.user.email
+        }]
+
+        self.addCleanup(self.logger_patcher.stop)
+        self.addCleanup(self.mock_get_course_detail.stop)
+        self.addCleanup(self.mock_edx_rest_api_client.stop)
+
+    def _create_coupon_and_get_code(
+            self,
+            benefit_value=100,
+            email_domains=None,
+            enterprise_customer=ENTERPRISE_CUSTOMER,
+            enterprise_customer_catalog=ENTERPRISE_CUSTOMER_CATALOG,
+            course_id=None,
+            catalog=None,
+            contract_discount_value=None,
+            contract_discount_type=EnterpriseContractMetadata.PERCENTAGE,
+            prepaid_invoice_amount=None,
+    ):
+        """ Creates coupon and returns code. """
+        coupon = self.create_coupon(
+            benefit_value=benefit_value,
+            catalog=catalog,
+            email_domains=email_domains,
+            enterprise_customer=enterprise_customer,
+            enterprise_customer_catalog=enterprise_customer_catalog,
+        )
+        coupon.course_id = course_id
+        if contract_discount_value is not None:
+            ecm = EnterpriseContractMetadata.objects.create(
+                discount_type=contract_discount_type,
+                discount_value=contract_discount_value,
+                amount_paid=prepaid_invoice_amount,
+            )
+            coupon.attr.enterprise_contract_metadata = ecm
+        coupon.save()
+        coupon_code = coupon.attr.coupon_vouchers.vouchers.first().code
+        self.assertEqual(Voucher.objects.filter(code=coupon_code).count(), 1)
+        return coupon_code, coupon
+
+    def test_no_voucher(self):
+        with self.assertRaises(RedeemCouponError):
+            self.coupon_code_redeemer.redeem_coupon_code('code', 'edx+101', self.user.lms_user_id)
+
+        assert self.mock_logger.exception.call_args[0][1] == 'No voucher found with code.'
+
+    def test_inactive_voucher(self):
+        self.voucher.start_datetime = now() + timedelta(days=1)
+        self.voucher.save()
+        with self.assertRaises(RedeemCouponError):
+            self.coupon_code_redeemer.redeem_coupon_code(self.coupon_code, 'edx+101', self.user.lms_user_id)
+
+        assert self.mock_logger.exception.call_args[0][1] == 'This coupon code is not active.'
+
+    def test_used_voucher(self):
+        order = OrderFactory()
+        VoucherApplication.objects.create(voucher=self.voucher, user=self.user, order=order)
+
+        with self.assertRaises(RedeemCouponError):
+            self.coupon_code_redeemer.redeem_coupon_code(self.coupon_code, 'edx+101', self.user.lms_user_id)
+
+        assert self.mock_logger.exception.call_args[0][1] == 'This coupon has already been used'
+
+    def test_usage_exceeded_coupon(self):
+        voucher, _ = prepare_voucher(usage=Voucher.ONCE_PER_CUSTOMER, max_usage=1)
+        voucher.offers.first().record_usage(discount={'freq': 1, 'discount': 1})
+        with self.assertRaises(RedeemCouponError):
+            self.coupon_code_redeemer.redeem_coupon_code(voucher.code, 'edx+101', self.user.lms_user_id)
+
+        assert self.mock_logger.exception.call_args[0][1] == 'This coupon code is no longer available.'
+
+    @httpretty.activate
+    def test_invalid_email_domain(self):
+        self.mock_access_token_response()
+
+        coupon_code, _ = self._create_coupon_and_get_code(email_domains='abc.com')
+        with self.assertRaises(RedeemCouponError):
+            self.coupon_code_redeemer.redeem_coupon_code(coupon_code, 'edx+101', self.user.lms_user_id)
+
+        assert self.mock_logger.exception.call_args[0][1] == 'User email does not meet domain requirements.'
+
+    @httpretty.activate
+    def test_user_not_active(self):
+        self.mock_access_token_response()
+        self.mock_edx_rest_api_client().accounts.get.return_value = [{
+            'is_active': False,
+            'email': self.user.email
+        }]
+
+        with self.assertRaises(RedeemCouponError):
+            self.coupon_code_redeemer.redeem_coupon_code(self.coupon_code, 'edx+101', self.user.lms_user_id)
+
+        assert self.mock_logger.exception.call_args[0][1] == 'User is not active.'
+
+    def test_no_stock_record(self):
+        self.mock_get_course_detail.return_value = {
+            'course_runs': [
+                {
+                    'seats': [
+                        {
+                            'type': 'verified',
+                            'sku': 'abc'
+                        }
+                    ]
+                }
+            ]
+        }
+
+        with self.assertRaises(RedeemCouponError):
+            self.coupon_code_redeemer.redeem_coupon_code(self.coupon_code, 'edx+101', self.user.lms_user_id)
+
+        assert self.mock_logger.exception.call_args[0][1] == 'Product does not exist.'
+
+    @httpretty.activate
+    def test_successful_redemption(self):
+        self.mock_assignable_enterprise_condition_calls(ENTERPRISE_CUSTOMER_CATALOG)
+        self.mock_specific_enterprise_customer_api(ENTERPRISE_CUSTOMER)
+
+        self.coupon_code_redeemer.redeem_coupon_code(self.coupon_code, 'edx+101', self.user.lms_user_id)
+
+        assert self.mock_logger.info.call_args[0][0] == 'Code %s successfully redeemed for user %s for course %s.'

--- a/ecommerce/coupons/tests/test_applicator.py
+++ b/ecommerce/coupons/tests/test_applicator.py
@@ -1,0 +1,57 @@
+
+
+from uuid import uuid4
+
+import ddt
+from oscar.core.loading import get_model
+from oscar.test import factories
+from oscar.test.factories import BasketFactory
+
+from ecommerce.coupons.applicator import Applicator
+from ecommerce.extensions.test.factories import ConditionalOfferFactory, ConditionFactory
+from ecommerce.tests.factories import UserFactory
+from ecommerce.tests.testcases import TestCase
+
+BasketAttribute = get_model('basket', 'BasketAttribute')
+BasketAttributeType = get_model('basket', 'BasketAttributeType')
+ConditionalOffer = get_model('offer', 'ConditionalOffer')
+
+@ddt.ddt
+class ApplicatorTests(TestCase):
+    """ Tests for the custom Applicator. """
+
+    def setUp(self):
+        self.applicator = Applicator()
+        self.basket = factories.create_basket(empty=True)
+        self.user = UserFactory()
+
+    @ddt.unpack
+    def test_get_offers(self):
+        """ Verify get_offers returns correct objects based on filter"""
+
+        enterprise_uuid = uuid4()
+        basket = BasketFactory()
+        setattr(basket, 'enterprise_customer_uuid', enterprise_uuid)
+
+        for _ in range(2):
+            condition = ConditionFactory(
+                program_uuid=None,
+                enterprise_customer_uuid=enterprise_uuid
+            )
+            ConditionalOfferFactory(condition=condition)
+
+        # Make some condition offers with a uuid other than ours
+        for _ in range(4):
+            condition = ConditionFactory(
+                program_uuid=None,
+                enterprise_customer_uuid=uuid4()
+            )
+            ConditionalOfferFactory(condition=condition)
+
+        offers = self.applicator.get_offers(
+            basket,
+            self.user,
+            enterprise_uuid
+        )
+
+        assert len(offers) == 2

--- a/ecommerce/enterprise/conditions.py
+++ b/ecommerce/enterprise/conditions.py
@@ -178,7 +178,11 @@ class EnterpriseCustomerCondition(ConditionWithoutRangeMixin, SingleItemConsumpt
             course_ids.append(course.id)
 
         courses_in_basket = ','.join(course_ids)
-        user_enterprise = get_enterprise_id_for_user(basket.site, basket.owner)
+
+        user_enterprise = getattr(
+            basket, 'enterprise_customer_uuid', None
+        ) or get_enterprise_id_for_user(basket.site, basket.owner)
+
         if user_enterprise and enterprise_in_condition != user_enterprise:
             # Learner is not linked to the EnterpriseCustomer associated with this condition.
             if offer.offer_type == ConditionalOffer.VOUCHER:

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -516,7 +516,7 @@ def apply_offers_on_basket(request, basket):
 
 
 @newrelic.agent.function_trace()
-def apply_voucher_on_basket_and_check_discount(voucher, request, basket):
+def apply_voucher_on_basket_and_check_discount(voucher, request, basket, applicator_cls=Applicator):
     """
     Applies voucher on a product.
 
@@ -533,7 +533,7 @@ def apply_voucher_on_basket_and_check_discount(voucher, request, basket):
     basket.vouchers.add(voucher)
     voucher_addition.send(sender=None, basket=basket, voucher=voucher)
 
-    Applicator().apply(basket, request.user, request)
+    applicator_cls().apply(basket, request.user, request)
 
     # Recalculate discounts to see if the voucher gives any
     discounts_after = basket.offer_applications

--- a/ecommerce/extensions/fulfillment/api.py
+++ b/ecommerce/extensions/fulfillment/api.py
@@ -20,7 +20,7 @@ from ecommerce.extensions.refund.status import REFUND_LINE
 logger = logging.getLogger(__name__)
 
 
-def fulfill_order(order, lines, email_opt_in=False):
+def fulfill_order(order, lines, email_opt_in=False, **kwargs):
     """ Fulfills line items in an Order
 
     Attempts to fulfill the products in the Order. Checks the mapping of fulfillment modules to product types, and
@@ -59,7 +59,7 @@ def fulfill_order(order, lines, email_opt_in=False):
             supported_lines = module.get_supported_lines(line_items)
             if supported_lines:
                 line_items = list(set(line_items) - set(supported_lines))
-                module.fulfill_product(order, supported_lines, email_opt_in=email_opt_in)
+                module.fulfill_product(order, supported_lines, email_opt_in=email_opt_in, **kwargs)
 
         # Check to see if any line items in the order have not been accounted for by a FulfillmentModule
         # Any product does not line up with a module, we have to mark a fulfillment error.

--- a/ecommerce/extensions/fulfillment/tests/modules.py
+++ b/ecommerce/extensions/fulfillment/tests/modules.py
@@ -11,7 +11,7 @@ class MockFulfillmentModule(BaseFulfillmentModule):
     def get_supported_lines(self, lines):
         """Returns a list of lines this mock module supposedly supports."""
 
-    def fulfill_product(self, order, lines, email_opt_in=False):
+    def fulfill_product(self, order, lines, email_opt_in=False, **kwargs):
         """Fulfill product. Mark all lines success."""
 
     def revoke_line(self, line):
@@ -28,7 +28,7 @@ class FakeFulfillmentModule(MockFulfillmentModule):
         """Returns a list of lines this Fake module supposedly supports."""
         return lines
 
-    def fulfill_product(self, order, lines, email_opt_in=False):
+    def fulfill_product(self, order, lines, email_opt_in=False, **kwargs):
         """Fulfill product. Mark all lines success."""
         for line in lines:
             line.set_status(LINE.COMPLETE)

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -187,6 +187,7 @@ class EnrollmentFulfillmentModuleTests(
             'course_details': {
                 'course_id': self.course_id,
             },
+            'create_consent_record': True,
             'enrollment_attributes': [
                 {
                     'namespace': 'order',
@@ -468,6 +469,7 @@ class EnrollmentFulfillmentModuleTests(
             'course_details': {
                 'course_id': self.course_id,
             },
+            'create_consent_record': True,
             'enrollment_attributes': [
                 {
                     'namespace': 'order',

--- a/ecommerce/extensions/order/processing.py
+++ b/ecommerce/extensions/order/processing.py
@@ -21,8 +21,8 @@ class EventHandler(processing.EventHandler):
     def handle_shipping_event(self, order, event_type, lines, line_quantities, **kwargs):
         self.validate_shipping_event(order, event_type, lines, line_quantities, **kwargs)
 
-        email_opt_in = kwargs.get('email_opt_in', False)
-        order = fulfillment_api.fulfill_order(order, lines, email_opt_in=email_opt_in)
+        email_opt_in = kwargs.pop('email_opt_in', False)
+        order = fulfillment_api.fulfill_order(order, lines, email_opt_in=email_opt_in, **kwargs)
 
         self.create_shipping_event(order, event_type, lines, line_quantities, **kwargs)
 

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -9,6 +9,7 @@ from os.path import abspath, basename, dirname, join, normpath
 from sys import path
 
 from django.utils.translation import ugettext_lazy as _
+from edx_django_utils.plugins import get_plugin_apps
 
 from ecommerce.core.constants import (
     ENTERPRISE_COUPON_ADMIN_ROLE,
@@ -333,6 +334,10 @@ LOCAL_APPS = [
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#installed-apps
 INSTALLED_APPS = DJANGO_APPS + LOCAL_APPS + OSCAR_APPS
 # END APP CONFIGURATION
+
+# Plugins
+INSTALLED_APPS.extend(get_plugin_apps('ecommerce.djangoapp'))
+# End plugins
 
 
 # LOGGING CONFIGURATION

--- a/ecommerce/settings/devstack.py
+++ b/ecommerce/settings/devstack.py
@@ -2,6 +2,7 @@
 
 
 from corsheaders.defaults import default_headers as corsheaders_default_headers
+from edx_django_utils.plugins import add_plugins
 
 from ecommerce.settings.production import *
 
@@ -42,6 +43,8 @@ JWT_AUTH.update({
         'y5ZLcTUomo4rZLjghVpq6KZxfS6I1Vz79ZsMVUWEdXOYePCKKsrQG20ogQEkmTf9FT_SouC6jPcHLXw"}]}'
     ),
 })
+
+add_plugins(__name__, 'ecommerce.djangoapp', 'devstack')
 
 CORS_ORIGIN_WHITELIST = (
     'http://localhost:1991',

--- a/ecommerce/urls.py
+++ b/ecommerce/urls.py
@@ -22,6 +22,8 @@ from ecommerce.core.views import LogoutView
 from ecommerce.extensions.payment.views.apple_pay import ApplePayMerchantDomainAssociationView
 from ecommerce.extensions.urls import urlpatterns as extensions_patterns
 
+from edx_django_utils.plugins import get_plugin_url_patterns  # isort:skip
+
 
 def handler403(_, exception):  # pylint: disable=unused-argument
     """Redirect unauthorized users to the LMS student dashboard.
@@ -116,3 +118,5 @@ if settings.DEBUG:  # pragma: no cover
         urlpatterns += [
             url(r'^__debug__/', include(debug_toolbar.urls))
         ]
+
+urlpatterns.extend(get_plugin_url_patterns('ecommerce.djangoapp'))


### PR DESCRIPTION
Context:

We recently created a "browse and request" feature that allows enterprise learners to request access to courses. We only assign a coupon code as part of the approval process, but we want to enroll the learners directly into the course. Ecommerce will consume coupon-request-approval events sent by enterprise-access (via ecommerce-plugin-events which will be installed in a separate pr), and redeem the code on behalf of the learner. 

I extracted the logic from `CouponRedeemView` so that coupons can be redeemed outside the context of a request.
It mimics the regular code redemption flow, one that an enterprise learner would go through the learner portal.


To test:
1. Assign a coupon to an enterprise learner via the admin portal
2. Shell into ecommerce via `make dev.shell.ecommerce` and run `'./manage.py shell` to get into the django shell
3. In the django shell, run `import default_code_redeemer from ecommerce.coupons.api` && `default_code_redeemer.redeem_coupon_code(coupon_code, course_id, lms_user_id)`
4. You should see the code redeemed successfully in the console and that the user has been enrolled into the course **without** a data-sharing consent record created.

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Description

Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?
Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
