### PR TITLE
ENT-3849 | fix search endpoint for the admin portal coupon search

### DIFF
--- a/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -148,7 +148,8 @@ class Command(BaseCommand):
             "invoice_discount_value": 100,
             "start_datetime": str(now() - datetime.timedelta(days=10)),
             "end_datetime": str(now() + datetime.timedelta(days=10)),
-            "benefit_value": 100
+            "benefit_value": 100,
+            "sales_force_id": '006aaaaaaaaaaaaaaa',
         }
         url = '{}/enterprise/coupons/'.format(ecommerce_api_url)
         response = requests.post(url, json=request_obj, headers=self.headers)

--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -1303,14 +1303,12 @@ class EnterpriseCouponViewSetRbacTests(
         assert results[0]['code'] == voucher1.code
         assert results[0]['course_key'] is None
 
-
-    @httpretty.activate
     def test_search_results_regression_for_voucher_code(self):
         """
         Test regression for code search not returning all the expected results.
         """
         # Create coupons
-        coupon1 = self.create_coupon(
+        self.create_coupon(
             benefit_type=Benefit.PERCENTAGE,
             benefit_value=40,
             enterprise_customer=self.data['enterprise_customer']['id'],

--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -1303,6 +1303,7 @@ class EnterpriseCouponViewSetRbacTests(
         assert results[0]['code'] == voucher1.code
         assert results[0]['course_key'] is None
 
+    @httpretty.activate
     def test_search_results_regression_for_voucher_code(self):
         """
         Test regression for code search not returning all the expected results.


### PR DESCRIPTION
# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Description
This is basically a tweak of if-logic to make sure when we search for a code, that we get voucher applications back.

Previously, some code within the search view said: "if you're searching with an email address, return vouch applications (and of course, assignments)". The problem is, if you were search via code, the `user` variable would always be None, so you would never include voucher applications for the voucher being iterated over, hence things would be missing from the search results.

I've updated the code now to say:
- "hey do you have a user object? you must be searching with a user_email then. Here let me get you all the voucher applications with that user
- "hey do you have not have a user_email? that must mean you're looking with a code. I'll return to you all of the voucher applications for the voucher that matches this code.
- and then a default case of: "i noticed you didn't have a user object, but also noticed you DID have a user_email 🤔 . that must mean that you searched with a user_email, but there is no user object... which must mean you haven't applied any voucher yet, so let's skip this bit (and then we'll just see the assignments returned later in the code)

Oh also the seed devstack data command requires a salesforce id now, so I've added a bogus one in there so we can use the command

Searching by code (note the different emails):
<img width="745" alt="Screen Shot 2022-05-06 at 2 14 33 PM" src="https://user-images.githubusercontent.com/7385292/167195207-f3bb9b89-0e28-4e9c-b785-0eec1fcf3521.png">

Searching by email (note the different codes):
<img width="737" alt="Screen Shot 2022-05-06 at 2 15 22 PM" src="https://user-images.githubusercontent.com/7385292/167195263-7889ee6a-e259-4b64-8cb4-f4aeb9382189.png">

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
