### PR TITLE
fix: Update create_order in enable_hoist_order_history test

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_orders.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_orders.py
@@ -106,8 +106,7 @@ class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
     def test_enable_hoist_order_history(self, enable_hoist_order_history_flag):
         """ Verify that orders contain the Order History flag value """
         with override_flag(ENABLE_HOIST_ORDER_HISTORY, active=enable_hoist_order_history_flag):
-            site = SiteConfigurationFactory().site
-            create_order(site=site, user=self.user)
+            create_order(site=self.site, user=self.user)
             response = self.client.get(self.path, HTTP_AUTHORIZATION=self.token)
             self.assertEqual(response.status_code, 200)
             content = json.loads(response.content.decode('utf-8'))


### PR DESCRIPTION
Fixing the enable_hoist_order_history test that is failing after pylint issues were fixed here https://github.com/openedx/ecommerce/pull/3712/commits/61d3503c09bf9730c7ee2d31b486ebbebc710ae0

Orignal PR: 
https://github.com/openedx/ecommerce/pull/3685