### PR TITLE
REV-2736: Omit failing test from e2e pipeline step

### DIFF
--- a/e2e/test_payment.py
+++ b/e2e/test_payment.py
@@ -208,15 +208,16 @@ class TestSeatPayment:
 
         assert test_run_successfully, "Unable to find a valid course run to test!"
 
-    def test_verified_seat_payment_with_credit_card_payment_page(self, selenium):
-        """
-        Using the payment microfrontend page, validates users can add a verified seat to the cart and
-        checkout with a credit card.
+    #  @FIXME: Commenting out test, pending necessary updates in REV-2624 for it to work again
+    # def test_verified_seat_payment_with_credit_card_payment_page(self, selenium):
+    #     """
+    #     Using the payment microfrontend page, validates users can add a verified seat to the cart and
+    #     checkout with a credit card.
 
-        This test requires 'disable_repeat_order_check' waffle switch turned off on stage, to run.
-        - Note: Waffle switch warning copied from original basket page test without being verified.
-        """
-        self.verified_seat_payment_with_credit_card(
-            selenium,
-            addresses=(ADDRESS_US, ADDRESS_FR,)
-        )
+    #     This test requires 'disable_repeat_order_check' waffle switch turned off on stage, to run.
+    #     - Note: Waffle switch warning copied from original basket page test without being verified.
+    #     """
+    #     self.verified_seat_payment_with_credit_card(
+    #         selenium,
+    #         addresses=(ADDRESS_US, ADDRESS_FR,)
+    #     )


### PR DESCRIPTION
[REV-2736](https://2u-internal.atlassian.net/browse/REV-2736)

One of the ecommerce e2e tests launches a web browser to complete a purchase, and there are many blocked updates needed in order for that to work again (see [REV-2624](https://2u-internal.atlassian.net/browse/REV-2624)).  

Having a continually-failing step makes it hard to detect a newly failing test, so until this can work again let's stop including that failing test. We'll also update the repo PR template to include a checkbox for manually completing a purchase throughout verification. 

Notes: in the github actions run for ecommerce builds, quality-and-jobs is known to fail (see REV-2737), and it's blocking additional checks. Instead I ran 'make validate' locally, comparing master vs this branch, and the results are the same. 