### PR TITLE
fix: add checkbox to pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,10 @@ Use this template as a guide. Omit sections that don't apply. You may link to in
 
 ## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.
 
+## Required Testing
+[ ] Before deploying this change, complete a purchase in the stage environment. 
+(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)
+
 ## Description
 
 Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?


### PR DESCRIPTION
Due to the blockages getting test_verified_seat_payment_with_credit_card_payment_page (REV-2624) to run successfully, we'd like developers to perform an order manually when making a change to ecommerce. I'm adding a checkbox to the pull request template to this effect. 

Note: we have a known failure in the `quality-and-jobs` build check, so I've confirmed in ecommerce-shell that 'make validate' (which contains a large overlap with quality-and-jobs) has no new failures. 