### PR TITLE
fix: skip detect_changed_source_translations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,8 @@ update_translations: pull_translations fake_translations
 detect_changed_source_translations: requirements.tox
 	tox -e $(PYTHON_ENV)-${DJANGO_ENV_VAR}-detect_changed_translations
 
-check_translations_up_to_date: fake_translations detect_changed_source_translations
+# @FIXME: skip detect_changed_source_translations until git diff works again (REV-2737)
+check_translations_up_to_date: fake_translations # detect_changed_source_translations
 
 # Validate translations
 validate_translations: requirements.tox

--- a/e2e/test_payment.py
+++ b/e2e/test_payment.py
@@ -12,7 +12,7 @@ from selenium.webdriver.support.wait import WebDriverWait
 
 from e2e.api import DiscoveryApi, EcommerceApi, EnrollmentApi
 from e2e.config import LMS_USERNAME
-# from e2e.constants import ADDRESS_FR, ADDRESS_US
+# from e2e.constants import ADDRESS_FR, ADDRESS_US  # Can uncomment when associated test below is ready (REV-2624)
 from e2e.helpers import EcommerceHelpers, LmsHelpers
 
 log = logging.getLogger(__name__)

--- a/e2e/test_payment.py
+++ b/e2e/test_payment.py
@@ -12,7 +12,7 @@ from selenium.webdriver.support.wait import WebDriverWait
 
 from e2e.api import DiscoveryApi, EcommerceApi, EnrollmentApi
 from e2e.config import LMS_USERNAME
-from e2e.constants import ADDRESS_FR, ADDRESS_US
+# from e2e.constants import ADDRESS_FR, ADDRESS_US
 from e2e.helpers import EcommerceHelpers, LmsHelpers
 
 log = logging.getLogger(__name__)

--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -4,19 +4,20 @@
 import datetime
 import json
 from collections import Counter
+from unittest import SkipTest
 from uuid import uuid4
 
 import bleach
 import ddt
 import httpretty
 import mock
-import rules
+import rules  # pylint: disable=unused-import
 from django.conf import settings
 from django.db.models.signals import post_delete
 from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.http import urlencode
+from django.utils.http import urlencode  # pylint: disable=unused-import
 from django.utils.timezone import now
 from freezegun import freeze_time
 from oscar.core.loading import get_model
@@ -24,7 +25,7 @@ from oscar.test import factories
 from rest_framework import status
 from slumber.exceptions import SlumberHttpBaseException
 
-from ecommerce.core.constants import (
+from ecommerce.core.constants import (  # pylint: disable=unused-import
     ALL_ACCESS_CONTEXT,
     ENTERPRISE_COUPON_ADMIN_ROLE,
     SYSTEM_ENTERPRISE_ADMIN_ROLE,
@@ -38,7 +39,10 @@ from ecommerce.coupons.utils import is_coupon_available
 from ecommerce.courses.tests.factories import CourseFactory
 from ecommerce.enterprise.benefits import BENEFIT_MAP as ENTERPRISE_BENEFIT_MAP
 from ecommerce.enterprise.conditions import AssignableEnterpriseCustomerCondition
-from ecommerce.enterprise.rules import request_user_has_explicit_access_admin, request_user_has_implicit_access_admin
+from ecommerce.enterprise.rules import (  # pylint: disable=unused-import
+    request_user_has_explicit_access_admin,
+    request_user_has_implicit_access_admin
+)
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
 from ecommerce.extensions.offer.constants import (
@@ -1125,21 +1129,23 @@ class EnterpriseCouponViewSetRbacTests(
             codes
         )
 
+    # @FIXME: commenting out until test is fixed in ENT-5824
     def test_implicit_permission_coupon_overview(self):
         """
         Test that we get implicit access via role assignment
         """
-        response = self.get_response('POST', ENTERPRISE_COUPONS_LINK, self.data)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        EcommerceFeatureRoleAssignment.objects.all().delete()
-        response = self.get_response(
-            'GET',
-            reverse(
-                'api:v2:enterprise-coupons-overview',
-                kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
-            )
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        #     response = self.get_response('POST', ENTERPRISE_COUPONS_LINK, self.data)
+        #     self.assertEqual(response.status_code, status.HTTP_200_OK)
+        #     EcommerceFeatureRoleAssignment.objects.all().delete()
+        #     response = self.get_response(
+        #         'GET',
+        #         reverse(
+        #             'api:v2:enterprise-coupons-overview',
+        #             kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
+        #         )
+        #     )
+        #     self.assertEqual(response.status_code, status.HTTP_200_OK)
+        raise SkipTest("Fix in ENT-5824")
 
     def test_implicit_permission_codes_detail(self):
         """
@@ -1492,29 +1498,31 @@ class EnterpriseCouponViewSetRbacTests(
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    @override_settings(SYSTEM_TO_FEATURE_ROLE_MAPPING={SYSTEM_ENTERPRISE_ADMIN_ROLE: ['dummy-role']})
+    # @FIXME: commenting out until test is fixed in ENT-5824
+    # @override_settings(SYSTEM_TO_FEATURE_ROLE_MAPPING={SYSTEM_ENTERPRISE_ADMIN_ROLE: ['dummy-role']})
     def test_explicit_permission_coupon_overview(self):
         """
         Test that we get explicit access via role assignment
         """
-        # Re-order rules predicate to check explicit access first.
-        rules.remove_perm('enterprise.can_view_coupon')
-        rules.add_perm(
-            'enterprise.can_view_coupon',
-            request_user_has_explicit_access_admin |
-            request_user_has_implicit_access_admin
-        )
+    #     # Re-order rules predicate to check explicit access first.
+    #     rules.remove_perm('enterprise.can_view_coupon')
+    #     rules.add_perm(
+    #         'enterprise.can_view_coupon',
+    #         request_user_has_explicit_access_admin |
+    #         request_user_has_implicit_access_admin
+    #     )
 
-        response = self.get_response('POST', ENTERPRISE_COUPONS_LINK, self.data)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        response = self.get_response(
-            'GET',
-            reverse(
-                'api:v2:enterprise-coupons-overview',
-                kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
-            )
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+    #     response = self.get_response('POST', ENTERPRISE_COUPONS_LINK, self.data)
+    #     self.assertEqual(response.status_code, status.HTTP_200_OK)
+    #     response = self.get_response(
+    #         'GET',
+    #         reverse(
+    #             'api:v2:enterprise-coupons-overview',
+    #             kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
+    #         )
+    #     )
+    #     self.assertEqual(response.status_code, status.HTTP_200_OK)
+        raise SkipTest("Fix in ENT-5824")
 
     @override_settings(SYSTEM_TO_FEATURE_ROLE_MAPPING={SYSTEM_ENTERPRISE_ADMIN_ROLE: ['dummy-role']})
     def test_explicit_permission_denied_coupon_overview(self):
@@ -1553,52 +1561,56 @@ class EnterpriseCouponViewSetRbacTests(
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    # @FIXME: commenting out until test is fixed in ENT-5824
     def test_permissions_with_enterprise_openedx_operator(self):
         """
         Test that role base permissions works as expected with `enterprise_openedx_operator` role.
         """
-        self.set_jwt_cookie(system_wide_role=SYSTEM_ENTERPRISE_OPERATOR_ROLE, context=ALL_ACCESS_CONTEXT)
+    #     self.set_jwt_cookie(system_wide_role=SYSTEM_ENTERPRISE_OPERATOR_ROLE, context=ALL_ACCESS_CONTEXT)
 
-        response = self.get_response('POST', ENTERPRISE_COUPONS_LINK, self.data)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        EcommerceFeatureRoleAssignment.objects.all().delete()
+    #     response = self.get_response('POST', ENTERPRISE_COUPONS_LINK, self.data)
+    #     self.assertEqual(response.status_code, status.HTTP_200_OK)
+    #     EcommerceFeatureRoleAssignment.objects.all().delete()
 
-        response = self.get_response(
-            'GET',
-            reverse(
-                'api:v2:enterprise-coupons-overview',
-                kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
-            )
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+    #     response = self.get_response(
+    #         'GET',
+    #         reverse(
+    #             'api:v2:enterprise-coupons-overview',
+    #             kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
+    #         )
+    #     )
+    #     self.assertEqual(response.status_code, status.HTTP_200_OK)
+        raise SkipTest("Fix in ENT-5824")
 
-    @ddt.data(SYSTEM_ENTERPRISE_ADMIN_ROLE, 'role_with_no_mapped_permissions')
-    def test_permissions_with_all_access_context(self, system_wide_role):
-        """
-        Test that role base permissions works as expected with all access context.
-        """
-        # Create a feature role assignment with no enterprise id i.e it would have all access context.
-        EcommerceFeatureRoleAssignment.objects.all().delete()
-        EcommerceFeatureRoleAssignment.objects.get_or_create(
-            role=self.role,
-            user=self.user
-        )
+    # @FIXME: commenting out until test is fixed in ENT-5824
+    # @ddt.data(SYSTEM_ENTERPRISE_ADMIN_ROLE, 'role_with_no_mapped_permissions')
+    # def test_permissions_with_all_access_context(self, system_wide_role):
+        # """
+        # Test that role base permissions works as expected with all access context.
+        # """
+    #     # Create a feature role assignment with no enterprise id i.e it would have all access context.
+    #     EcommerceFeatureRoleAssignment.objects.all().delete()
+    #     EcommerceFeatureRoleAssignment.objects.get_or_create(
+    #         role=self.role,
+    #         user=self.user
+    #     )
 
-        self.set_jwt_cookie(
-            system_wide_role=system_wide_role, context=ALL_ACCESS_CONTEXT
-        )
+    #     self.set_jwt_cookie(
+    #         system_wide_role=system_wide_role, context=ALL_ACCESS_CONTEXT
+    #     )
 
-        response = self.get_response('POST', ENTERPRISE_COUPONS_LINK, self.data)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+    #     response = self.get_response('POST', ENTERPRISE_COUPONS_LINK, self.data)
+    #     self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        response = self.get_response(
-            'GET',
-            reverse(
-                'api:v2:enterprise-coupons-overview',
-                kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
-            )
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+    #     response = self.get_response(
+    #         'GET',
+    #         reverse(
+    #             'api:v2:enterprise-coupons-overview',
+    #             kwargs={'enterprise_id': self.data['enterprise_customer']['id']}
+    #         )
+    #     )
+    #     self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # raise SkipTest("Fix in ENT-5824")
 
     def test_coupon_overview_learner_access(self):
         """
@@ -1651,367 +1663,356 @@ class EnterpriseCouponViewSetRbacTests(
             codes
         )
 
-    @ddt.data(
-        (
-            '85b08dde-0877-4474-a4e9-8408fe47ce88',
-            ['coupon-1', 'coupon-2']
-        ),
-        (
-            'f5c9149f-8dce-4410-bb0f-85c0f2dda864',
-            ['coupon-3']
-        ),
-        (
-            'f5c9149f-8dce-4410-bb0f-85c0f2dda860',
-            []
-        ),
-    )
-    @ddt.unpack
-    def test_get_enterprise_coupon_overview_data(self, enterprise_id, expected_coupons):
-        """
-        Test if we get correct enterprise coupon overview data.
-        """
-        coupons_data = [{
-            'title': 'coupon-1',
-            'enterprise_customer': {'name': 'LOTRx', 'id': '85b08dde-0877-4474-a4e9-8408fe47ce88'}
-        }, {
-            'title': 'coupon-2',
-            'enterprise_customer': {'name': 'LOTRx', 'id': '85b08dde-0877-4474-a4e9-8408fe47ce88'}
-        }, {
-            'title': 'coupon-3',
-            'enterprise_customer': {'name': 'HPx', 'id': 'f5c9149f-8dce-4410-bb0f-85c0f2dda864'}
-        }]
-        EcommerceFeatureRoleAssignment.objects.all().delete()
-        EcommerceFeatureRoleAssignment.objects.get_or_create(
-            role=self.role,
-            user=self.user,
-            enterprise_id=enterprise_id
-        )
-        # Create coupons.
-        for coupon_data in coupons_data:
-            self.get_response('POST', ENTERPRISE_COUPONS_LINK, dict(self.data, **coupon_data))
+    # @ddt.data(
+    #     (
+    #         '85b08dde-0877-4474-a4e9-8408fe47ce88',
+    #         ['coupon-1', 'coupon-2']
+    #     ),
+    #     (
+    #         'f5c9149f-8dce-4410-bb0f-85c0f2dda864',
+    #         ['coupon-3']
+    #     ),
+    #     (
+    #         'f5c9149f-8dce-4410-bb0f-85c0f2dda860',
+    #         []
+    #     ),
+    # )
+    # @FIXME: commenting out until test is fixed in ENT-5824
+    # @ddt.unpack
+    # def test_get_enterprise_coupon_overview_data(self, enterprise_id, expected_coupons):
+        # """
+        # Test if we get correct enterprise coupon overview data.
+        # """
+    #     coupons_data = [{
+    #         'title': 'coupon-1',
+    #         'enterprise_customer': {'name': 'LOTRx', 'id': '85b08dde-0877-4474-a4e9-8408fe47ce88'}
+    #     }, {
+    #         'title': 'coupon-2',
+    #         'enterprise_customer': {'name': 'LOTRx', 'id': '85b08dde-0877-4474-a4e9-8408fe47ce88'}
+    #     }, {
+    #         'title': 'coupon-3',
+    #         'enterprise_customer': {'name': 'HPx', 'id': 'f5c9149f-8dce-4410-bb0f-85c0f2dda864'}
+    #     }]
+    #     EcommerceFeatureRoleAssignment.objects.all().delete()
+    #     EcommerceFeatureRoleAssignment.objects.get_or_create(
+    #         role=self.role,
+    #         user=self.user,
+    #         enterprise_id=enterprise_id
+    #     )
+    #     # Create coupons.
+    #     for coupon_data in coupons_data:
+    #         self.get_response('POST', ENTERPRISE_COUPONS_LINK, dict(self.data, **coupon_data))
+    #     # Build expected results.
+    #     expected_results = []
+    #     for coupon_title in expected_coupons:
+    #         expected_results.append(self.get_coupon_data(coupon_title))
+    #     overview_response = self.get_response_json(
+    #         'GET',
+    #         reverse(
+    #             'api:v2:enterprise-coupons-overview',
+    #             kwargs={'enterprise_id': enterprise_id}
+    #         )
+    #     )
+    #     # Verify that we get correct number of results related enterprise id.
+    #     self.assertEqual(overview_response['count'], len(expected_results))
+    #     # Verify that we get correct results.
+    #     for actual_result in overview_response['results']:
+    #         self.assertIn(actual_result, expected_results)
+        # raise SkipTest("Fix in ENT-5824")
 
-        # Build expected results.
-        expected_results = []
-        for coupon_title in expected_coupons:
-            expected_results.append(self.get_coupon_data(coupon_title))
-
-        overview_response = self.get_response_json(
-            'GET',
-            reverse(
-                'api:v2:enterprise-coupons-overview',
-                kwargs={'enterprise_id': enterprise_id}
-            )
-        )
-
-        # Verify that we get correct number of results related enterprise id.
-        self.assertEqual(overview_response['count'], len(expected_results))
-
-        # Verify that we get correct results.
-        for actual_result in overview_response['results']:
-            self.assertIn(actual_result, expected_results)
-
+    # @FIXME: commenting out until test is fixed in ENT-5824
     def test_get_enterprise_coupon_overview_data_with_active_filter(self):
         """
         Test if we get correct enterprise coupon overview data with some inactive coupons.
         """
-        enterprise_id = '85b08dde-0877-4474-a4e9-8408fe47ce88'
-        EcommerceFeatureRoleAssignment.objects.all().delete()
-        EcommerceFeatureRoleAssignment.objects.get_or_create(
-            role=self.role,
-            user=self.user,
-            enterprise_id=enterprise_id
-        )
+    #     enterprise_id = '85b08dde-0877-4474-a4e9-8408fe47ce88'
+    #     EcommerceFeatureRoleAssignment.objects.all().delete()
+    #     EcommerceFeatureRoleAssignment.objects.get_or_create(
+    #         role=self.role,
+    #         user=self.user,
+    #         enterprise_id=enterprise_id
+    #     )
+    #     active_coupon_titles = ['coupon-1', 'coupon-2', 'coupon-3']
+    #     inactive_coupon_titles = ['coupon-4', 'coupon-5']
+    #     # Create coupons.
+    #     for coupon_title in active_coupon_titles + inactive_coupon_titles:
+    #         data = dict(
+    #             self.data,
+    #             title=coupon_title,
+    #             enterprise_customer={'name': 'LOTRx', 'id': enterprise_id}
+    #         )
+    #         self.get_response('POST', ENTERPRISE_COUPONS_LINK, data)
+    #     # now set coupon inactive
+    #     for inactive_coupon_title in inactive_coupon_titles:
+    #         inactive_coupon = Product.objects.get(title=inactive_coupon_title)
+    #         inactive_coupon.attr.inactive = True
+    #         inactive_coupon.save()
+    #     overview_response = self.get_response_json(
+    #         'GET',
+    #         reverse(
+    #             'api:v2:enterprise-coupons-overview',
+    #             kwargs={'enterprise_id': enterprise_id}
+    #         )
+    #     )
+    #     # Build expected results.
+    #     expected_results = []
+    #     for coupon_title in active_coupon_titles + inactive_coupon_titles:
+    #         expected_results.append(self.get_coupon_data(coupon_title))
+    #     # Verify that we get correct results.
+    #     self.assertEqual(overview_response['count'], len(expected_results))
+    #     for actual_result in overview_response['results']:
+    #         self.assertIn(actual_result, expected_results)
+    #     overview_response = self.get_response_json(
+    #         'GET',
+    #         reverse(
+    #             'api:v2:enterprise-coupons-overview',
+    #             kwargs={'enterprise_id': enterprise_id},
+    #         ),
+    #         data={'filter': 'active'}
+    #     )
+    #     # Build expected results.
+    #     expected_results = [result for result in expected_results if result['title'] in active_coupon_titles]
+    #     # Verify that we get correct results.
+    #     self.assertEqual(overview_response['count'], len(expected_results))
+    #     for actual_result in overview_response['results']:
+    #         self.assertIn(actual_result, expected_results)
+        raise SkipTest("Fix in ENT-5824")
 
-        active_coupon_titles = ['coupon-1', 'coupon-2', 'coupon-3']
-        inactive_coupon_titles = ['coupon-4', 'coupon-5']
+    # @ddt.data(
+    #     (
+    #         '85b08dde-0877-4474-a4e9-8408fe47ce88',
+    #         ['coupon-1', 'coupon-2']
+    #     ),
+    #     (
+    #         'f5c9149f-8dce-4410-bb0f-85c0f2dda864',
+    #         ['coupon-3']
+    #     ),
+    # )
 
-        # Create coupons.
-        for coupon_title in active_coupon_titles + inactive_coupon_titles:
-            data = dict(
-                self.data,
-                title=coupon_title,
-                enterprise_customer={'name': 'LOTRx', 'id': enterprise_id}
-            )
-            self.get_response('POST', ENTERPRISE_COUPONS_LINK, data)
+    # @FIXME: commenting out until test is fixed in ENT-5824
+    # @ddt.unpack
+    # def test_get_single_enterprise_coupon_overview_data(self, enterprise_id, expected_coupons):
+        # """
+        # Test if we get correct enterprise coupon overview data for a single coupon.
+        # """
+    #     coupons_data = [{
+    #         'title': 'coupon-1',
+    #         'enterprise_customer': {'name': 'LOTRx', 'id': '85b08dde-0877-4474-a4e9-8408fe47ce88'}
+    #     }, {
+    #         'title': 'coupon-2',
+    #         'enterprise_customer': {'name': 'LOTRx', 'id': '85b08dde-0877-4474-a4e9-8408fe47ce88'}
+    #     }, {
+    #         'title': 'coupon-3',
+    #         'enterprise_customer': {'name': 'HPx', 'id': 'f5c9149f-8dce-4410-bb0f-85c0f2dda864'}
+    #     }]
+    #     EcommerceFeatureRoleAssignment.objects.all().delete()
+    #     EcommerceFeatureRoleAssignment.objects.get_or_create(
+    #         role=self.role,
+    #         user=self.user,
+    #         enterprise_id=enterprise_id
+    #     )
+    #     # Create coupons.
+    #     for coupon_data in coupons_data:
+    #         self.get_response('POST', ENTERPRISE_COUPONS_LINK, dict(self.data, **coupon_data))
+    #     # Build expected results for all coupons.
+    #     expected_results = []
+    #     for coupon_title in expected_coupons:
+    #         expected_results.append(self.get_coupon_data(coupon_title))
+    #     # Build request URL with `coupon_id` query parameter
+    #     base_url = reverse(
+    #         'api:v2:enterprise-coupons-overview',
+    #         kwargs={'enterprise_id': enterprise_id}
+    #     )
+    #     coupon_id = expected_results[0].get('id')
+    #     request_url = '{}?{}'.format(base_url, urlencode({'coupon_id': coupon_id}))
+    #     # Fetch single coupon overview data
+    #     overview_response = self.get_response_json('GET', request_url)
+    #     self.assertEqual(overview_response, expected_results[0])
+        # raise SkipTest("Fix in ENT-5824")
 
-        # now set coupon inactive
-        for inactive_coupon_title in inactive_coupon_titles:
-            inactive_coupon = Product.objects.get(title=inactive_coupon_title)
-            inactive_coupon.attr.inactive = True
-            inactive_coupon.save()
-
-        overview_response = self.get_response_json(
-            'GET',
-            reverse(
-                'api:v2:enterprise-coupons-overview',
-                kwargs={'enterprise_id': enterprise_id}
-            )
-        )
-
-        # Build expected results.
-        expected_results = []
-        for coupon_title in active_coupon_titles + inactive_coupon_titles:
-            expected_results.append(self.get_coupon_data(coupon_title))
-
-        # Verify that we get correct results.
-        self.assertEqual(overview_response['count'], len(expected_results))
-        for actual_result in overview_response['results']:
-            self.assertIn(actual_result, expected_results)
-
-        overview_response = self.get_response_json(
-            'GET',
-            reverse(
-                'api:v2:enterprise-coupons-overview',
-                kwargs={'enterprise_id': enterprise_id},
-            ),
-            data={'filter': 'active'}
-        )
-        # Build expected results.
-        expected_results = [result for result in expected_results if result['title'] in active_coupon_titles]
-        # Verify that we get correct results.
-        self.assertEqual(overview_response['count'], len(expected_results))
-        for actual_result in overview_response['results']:
-            self.assertIn(actual_result, expected_results)
-
-    @ddt.data(
-        (
-            '85b08dde-0877-4474-a4e9-8408fe47ce88',
-            ['coupon-1', 'coupon-2']
-        ),
-        (
-            'f5c9149f-8dce-4410-bb0f-85c0f2dda864',
-            ['coupon-3']
-        ),
-    )
-    @ddt.unpack
-    def test_get_single_enterprise_coupon_overview_data(self, enterprise_id, expected_coupons):
-        """
-        Test if we get correct enterprise coupon overview data for a single coupon.
-        """
-        coupons_data = [{
-            'title': 'coupon-1',
-            'enterprise_customer': {'name': 'LOTRx', 'id': '85b08dde-0877-4474-a4e9-8408fe47ce88'}
-        }, {
-            'title': 'coupon-2',
-            'enterprise_customer': {'name': 'LOTRx', 'id': '85b08dde-0877-4474-a4e9-8408fe47ce88'}
-        }, {
-            'title': 'coupon-3',
-            'enterprise_customer': {'name': 'HPx', 'id': 'f5c9149f-8dce-4410-bb0f-85c0f2dda864'}
-        }]
-        EcommerceFeatureRoleAssignment.objects.all().delete()
-        EcommerceFeatureRoleAssignment.objects.get_or_create(
-            role=self.role,
-            user=self.user,
-            enterprise_id=enterprise_id
-        )
-        # Create coupons.
-        for coupon_data in coupons_data:
-            self.get_response('POST', ENTERPRISE_COUPONS_LINK, dict(self.data, **coupon_data))
-
-        # Build expected results for all coupons.
-        expected_results = []
-        for coupon_title in expected_coupons:
-            expected_results.append(self.get_coupon_data(coupon_title))
-
-        # Build request URL with `coupon_id` query parameter
-        base_url = reverse(
-            'api:v2:enterprise-coupons-overview',
-            kwargs={'enterprise_id': enterprise_id}
-        )
-        coupon_id = expected_results[0].get('id')
-        request_url = '{}?{}'.format(base_url, urlencode({'coupon_id': coupon_id}))
-
-        # Fetch single coupon overview data
-        overview_response = self.get_response_json('GET', request_url)
-
-        self.assertEqual(overview_response, expected_results[0])
-
-    @ddt.data(
-        {
-            'voucher_type': Voucher.SINGLE_USE,
-            'quantity': 3,
-            'max_uses': None,
-            'code_assignments': [0, 0, 0],
-            'code_redemptions': [0, 0, 0],
-            'expected_response': {'max_uses': 3, 'num_codes': 3, 'num_unassigned': 3, 'num_uses': 0, 'errors': []}
-        },
-        {
-            'voucher_type': Voucher.SINGLE_USE,
-            'quantity': 3,
-            'max_uses': None,
-            'code_assignments': [1, 0, 0],
-            'code_redemptions': [0, 1, 0],
-            'expected_response': {'max_uses': 3, 'num_codes': 3, 'num_unassigned': 1, 'num_uses': 1, 'errors': []}
-        },
-        {
-            'voucher_type': Voucher.SINGLE_USE,
-            'quantity': 3,
-            'max_uses': None,
-            'code_assignments': [1, 1, 1],
-            'code_redemptions': [0, 1, 1],
-            'assignment_has_error': True,
-            'expected_response': {'max_uses': 3, 'num_codes': 3, 'num_unassigned': 0, 'num_uses': 2, 'errors': True}
-        },
-        {
-            'voucher_type': Voucher.MULTI_USE_PER_CUSTOMER,
-            'quantity': 3,
-            'max_uses': 2,
-            'code_assignments': [0, 0, 0],
-            'code_redemptions': [0, 0, 0],
-            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 6, 'num_uses': 0, 'errors': []}
-        },
-        {
-            'voucher_type': Voucher.MULTI_USE_PER_CUSTOMER,
-            'quantity': 3,
-            'max_uses': 2,
-            'code_assignments': [1, 0, 0],
-            'code_redemptions': [0, 1, 0],
-            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 2, 'num_uses': 1, 'errors': []}
-        },
-        {
-            'voucher_type': Voucher.MULTI_USE_PER_CUSTOMER,
-            'quantity': 3,
-            'max_uses': 2,
-            'code_assignments': [1, 1, 0],
-            'code_redemptions': [0, 2, 0],
-            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 2, 'num_uses': 2, 'errors': []}
-        },
-        {
-            'voucher_type': Voucher.MULTI_USE_PER_CUSTOMER,
-            'quantity': 3,
-            'max_uses': 2,
-            'code_assignments': [1, 1, 1],
-            'code_redemptions': [0, 1, 2],
-            'assignment_has_error': True,
-            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 0, 'num_uses': 3, 'errors': True}
-        },
-        {
-            'voucher_type': Voucher.MULTI_USE,
-            'quantity': 3,
-            'max_uses': 2,
-            'code_assignments': [1, 0, 0],
-            'code_redemptions': [0, 1, 0],
-            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 4, 'num_uses': 1, 'errors': []}
-        },
-        {
-            'voucher_type': Voucher.MULTI_USE,
-            'quantity': 3,
-            'max_uses': 2,
-            'code_assignments': [2, 0, 0],
-            'code_redemptions': [0, 2, 0],
-            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 2, 'num_uses': 2, 'errors': []}
-        },
-        {
-            'voucher_type': Voucher.MULTI_USE,
-            'quantity': 3,
-            'max_uses': 2,
-            'code_assignments': [2, 1, 1],
-            'code_redemptions': [2, 0, 1],
-            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 1, 'num_uses': 3, 'errors': []}
-        },
-        {
-            'voucher_type': Voucher.MULTI_USE,
-            'quantity': 3,
-            'max_uses': 2,
-            'code_assignments': [2, 2, 2],
-            'code_redemptions': [0, 0, 0],
-            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 0, 'num_uses': 0, 'errors': []}
-        },
-        {
-            'voucher_type': Voucher.MULTI_USE,
-            'quantity': 1,
-            'max_uses': None,
-            'code_assignments': [1],
-            'code_redemptions': [1],
-            'assignment_has_error': True,
-            'expected_response': {
-                'max_uses': 10000, 'num_codes': 1, 'num_unassigned': 9998, 'num_uses': 1, 'errors': True
-            }
-        },
-        {
-            'voucher_type': Voucher.ONCE_PER_CUSTOMER,
-            'quantity': 3,
-            'max_uses': 2,
-            'code_assignments': [0, 0, 0],
-            'code_redemptions': [0, 0, 0],
-            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 6, 'num_uses': 0, 'errors': []}
-        },
-        {
-            'voucher_type': Voucher.ONCE_PER_CUSTOMER,
-            'quantity': 3,
-            'max_uses': 2,
-            'code_assignments': [2, 1, 0],
-            'code_redemptions': [0, 0, 1],
-            'assignment_has_error': True,
-            'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 2, 'num_uses': 1, 'errors': True}
-        },
-    )
-    @ddt.unpack
-    def test_coupon_overview_fields(
-            self,
-            voucher_type,
-            quantity,
-            max_uses,
-            code_assignments,
-            code_redemptions,
-            expected_response,
-            assignment_has_error=False):
-        """
-        Tests coupon overview endpoint returns correct value for calculated fields.
-        """
-        enterprise_id = '85b08dde-0877-4474-a4e9-8408fe47ce88'
-        coupon_data = {
-            'max_uses': max_uses,
-            'quantity': quantity,
-            'voucher_type': voucher_type,
-            'enterprise_customer': {'name': 'LOTRx', 'id': enterprise_id}
-        }
-        EcommerceFeatureRoleAssignment.objects.all().delete()
-        EcommerceFeatureRoleAssignment.objects.get_or_create(
-            role=self.role,
-            user=self.user,
-            enterprise_id=enterprise_id
-        )
-        coupon_response = self.get_response('POST', ENTERPRISE_COUPONS_LINK, dict(self.data, **coupon_data))
-        coupon = coupon_response.json()
-        coupon_id = coupon['coupon_id']
-        vouchers = Product.objects.get(id=coupon_id).attr.coupon_vouchers.vouchers.all()
-
-        # code assignments.
-        self.assign_coupon_codes(coupon_id, vouchers, code_assignments)
-
-        # Should we update assignment with error
-        if assignment_has_error:
-            assignment = OfferAssignment.objects.filter(code=vouchers[0].code).first()
-            if assignment:
-                assignment.status = OFFER_ASSIGNMENT_EMAIL_BOUNCED
-                assignment.save()
-
-        for i, voucher in enumerate(vouchers):
-            for _ in range(0, code_redemptions[i]):
-                self.use_voucher(voucher, self.create_user())
-
-        coupon_overview_response = self.get_response_json(
-            'GET',
-            reverse(
-                'api:v2:enterprise-coupons-overview',
-                kwargs={'enterprise_id': enterprise_id}
-            )
-        )
-
-        # Verify that we get correct results.
-        for field, value in expected_response.items():
-            if assignment_has_error and field == 'errors':
-                assignment_with_errors = OfferAssignment.objects.filter(status=OFFER_ASSIGNMENT_EMAIL_BOUNCED)
-                value = [
-                    {
-                        'id': assignment.id,
-                        'code': assignment.code,
-                        'user_email': assignment.user_email
-                    }
-                    for assignment in assignment_with_errors
-                ]
-            self.assertEqual(coupon_overview_response['results'][0][field], value)
+    # @ddt.data(
+    #     {
+    #         'voucher_type': Voucher.SINGLE_USE,
+    #         'quantity': 3,
+    #         'max_uses': None,
+    #         'code_assignments': [0, 0, 0],
+    #         'code_redemptions': [0, 0, 0],
+    #         'expected_response': {'max_uses': 3, 'num_codes': 3, 'num_unassigned': 3, 'num_uses': 0, 'errors': []}
+    #     },
+    #     {
+    #         'voucher_type': Voucher.SINGLE_USE,
+    #         'quantity': 3,
+    #         'max_uses': None,
+    #         'code_assignments': [1, 0, 0],
+    #         'code_redemptions': [0, 1, 0],
+    #         'expected_response': {'max_uses': 3, 'num_codes': 3, 'num_unassigned': 1, 'num_uses': 1, 'errors': []}
+    #     },
+    #     {
+    #         'voucher_type': Voucher.SINGLE_USE,
+    #         'quantity': 3,
+    #         'max_uses': None,
+    #         'code_assignments': [1, 1, 1],
+    #         'code_redemptions': [0, 1, 1],
+    #         'assignment_has_error': True,
+    #         'expected_response': {'max_uses': 3, 'num_codes': 3, 'num_unassigned': 0, 'num_uses': 2, 'errors': True}
+    #     },
+    #     {
+    #         'voucher_type': Voucher.MULTI_USE_PER_CUSTOMER,
+    #         'quantity': 3,
+    #         'max_uses': 2,
+    #         'code_assignments': [0, 0, 0],
+    #         'code_redemptions': [0, 0, 0],
+    #         'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 6, 'num_uses': 0, 'errors': []}
+    #     },
+    #     {
+    #         'voucher_type': Voucher.MULTI_USE_PER_CUSTOMER,
+    #         'quantity': 3,
+    #         'max_uses': 2,
+    #         'code_assignments': [1, 0, 0],
+    #         'code_redemptions': [0, 1, 0],
+    #         'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 2, 'num_uses': 1, 'errors': []}
+    #     },
+    #     {
+    #         'voucher_type': Voucher.MULTI_USE_PER_CUSTOMER,
+    #         'quantity': 3,
+    #         'max_uses': 2,
+    #         'code_assignments': [1, 1, 0],
+    #         'code_redemptions': [0, 2, 0],
+    #         'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 2, 'num_uses': 2, 'errors': []}
+    #     },
+    #     {
+    #         'voucher_type': Voucher.MULTI_USE_PER_CUSTOMER,
+    #         'quantity': 3,
+    #         'max_uses': 2,
+    #         'code_assignments': [1, 1, 1],
+    #         'code_redemptions': [0, 1, 2],
+    #         'assignment_has_error': True,
+    #         'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 0, 'num_uses': 3, 'errors': True}
+    #     },
+    #     {
+    #         'voucher_type': Voucher.MULTI_USE,
+    #         'quantity': 3,
+    #         'max_uses': 2,
+    #         'code_assignments': [1, 0, 0],
+    #         'code_redemptions': [0, 1, 0],
+    #         'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 4, 'num_uses': 1, 'errors': []}
+    #     },
+    #     {
+    #         'voucher_type': Voucher.MULTI_USE,
+    #         'quantity': 3,
+    #         'max_uses': 2,
+    #         'code_assignments': [2, 0, 0],
+    #         'code_redemptions': [0, 2, 0],
+    #         'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 2, 'num_uses': 2, 'errors': []}
+    #     },
+    #     {
+    #         'voucher_type': Voucher.MULTI_USE,
+    #         'quantity': 3,
+    #         'max_uses': 2,
+    #         'code_assignments': [2, 1, 1],
+    #         'code_redemptions': [2, 0, 1],
+    #         'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 1, 'num_uses': 3, 'errors': []}
+    #     },
+    #     {
+    #         'voucher_type': Voucher.MULTI_USE,
+    #         'quantity': 3,
+    #         'max_uses': 2,
+    #         'code_assignments': [2, 2, 2],
+    #         'code_redemptions': [0, 0, 0],
+    #         'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 0, 'num_uses': 0, 'errors': []}
+    #     },
+    #     {
+    #         'voucher_type': Voucher.MULTI_USE,
+    #         'quantity': 1,
+    #         'max_uses': None,
+    #         'code_assignments': [1],
+    #         'code_redemptions': [1],
+    #         'assignment_has_error': True,
+    #         'expected_response': {
+    #             'max_uses': 10000, 'num_codes': 1, 'num_unassigned': 9998, 'num_uses': 1, 'errors': True
+    #         }
+    #     },
+    #     {
+    #         'voucher_type': Voucher.ONCE_PER_CUSTOMER,
+    #         'quantity': 3,
+    #         'max_uses': 2,
+    #         'code_assignments': [0, 0, 0],
+    #         'code_redemptions': [0, 0, 0],
+    #         'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 6, 'num_uses': 0, 'errors': []}
+    #     },
+    #     {
+    #         'voucher_type': Voucher.ONCE_PER_CUSTOMER,
+    #         'quantity': 3,
+    #         'max_uses': 2,
+    #         'code_assignments': [2, 1, 0],
+    #         'code_redemptions': [0, 0, 1],
+    #         'assignment_has_error': True,
+    #         'expected_response': {'max_uses': 6, 'num_codes': 3, 'num_unassigned': 2, 'num_uses': 1, 'errors': True}
+    #     },
+    # )
+    # @FIXME: commenting out until test is fixed in ENT-5824
+    # @ddt.unpack
+    # def test_coupon_overview_fields(
+    #         self,
+    #         voucher_type,
+    #         quantity,
+    #         max_uses,
+    #         code_assignments,
+    #         code_redemptions,
+    #         expected_response,
+    #         assignment_has_error=False):
+        # """
+        # Tests coupon overview endpoint returns correct value for calculated fields.
+        # """
+    #     enterprise_id = '85b08dde-0877-4474-a4e9-8408fe47ce88'
+    #     coupon_data = {
+    #         'max_uses': max_uses,
+    #         'quantity': quantity,
+    #         'voucher_type': voucher_type,
+    #         'enterprise_customer': {'name': 'LOTRx', 'id': enterprise_id}
+    #     }
+    #     EcommerceFeatureRoleAssignment.objects.all().delete()
+    #     EcommerceFeatureRoleAssignment.objects.get_or_create(
+    #         role=self.role,
+    #         user=self.user,
+    #         enterprise_id=enterprise_id
+    #     )
+    #     coupon_response = self.get_response('POST', ENTERPRISE_COUPONS_LINK, dict(self.data, **coupon_data))
+    #     coupon = coupon_response.json()
+    #     coupon_id = coupon['coupon_id']
+    #     vouchers = Product.objects.get(id=coupon_id).attr.coupon_vouchers.vouchers.all()
+    #     # code assignments.
+    #     self.assign_coupon_codes(coupon_id, vouchers, code_assignments)
+    #     # Should we update assignment with error
+    #     if assignment_has_error:
+    #         assignment = OfferAssignment.objects.filter(code=vouchers[0].code).first()
+    #         if assignment:
+    #             assignment.status = OFFER_ASSIGNMENT_EMAIL_BOUNCED
+    #             assignment.save()
+    #     for i, voucher in enumerate(vouchers):
+    #         for _ in range(0, code_redemptions[i]):
+    #             self.use_voucher(voucher, self.create_user())
+    #     coupon_overview_response = self.get_response_json(
+    #         'GET',
+    #         reverse(
+    #             'api:v2:enterprise-coupons-overview',
+    #             kwargs={'enterprise_id': enterprise_id}
+    #         )
+    #     )
+    #     # Verify that we get correct results.
+    #     for field, value in expected_response.items():
+    #         if assignment_has_error and field == 'errors':
+    #             assignment_with_errors = OfferAssignment.objects.filter(status=OFFER_ASSIGNMENT_EMAIL_BOUNCED)
+    #             value = [
+    #                 {
+    #                     'id': assignment.id,
+    #                     'code': assignment.code,
+    #                     'user_email': assignment.user_email
+    #                 }
+    #                 for assignment in assignment_with_errors
+    #             ]
+    #         self.assertEqual(coupon_overview_response['results'][0][field], value)
+        # raise SkipTest("Fix in ENT-5824")
 
     @staticmethod
     def _create_nudge_email_templates():
@@ -2032,500 +2033,503 @@ class EnterpriseCouponViewSetRbacTests(
         else:
             assert CodeAssignmentNudgeEmails.objects.filter(code=code, user_email=user_email).count() == 0
 
-    @ddt.data(
-        (Voucher.SINGLE_USE, 2, None, [{'email': 't1@exam.com'}, {'email': 'test2@exam.com'}], [1], True, True),
-        (Voucher.SINGLE_USE, 2, None, [{'email': 't1@exam.com'}, {'email': 'test2@exam.com'}], [1], False, False),
-        (Voucher.MULTI_USE_PER_CUSTOMER, 2, 3, [{'email': 't1@exam.com'}, {'email': 't2@exam.com'}], [3], False, True),
-        (Voucher.MULTI_USE, 1, None, [{'email': 't1@example.com'}, {'email': 'test2@example.com'}], [2], True, True),
-        (
-            Voucher.MULTI_USE,
-            2,
-            3,
-            [{'email': 't1@exam.com'}, {'email': 't2@exam.com'}, {'email': 't3@exam.com'}, {'email': 't4@exam.com'}],
-            [3, 1],
-            True,
-            True
-        ),
-        (Voucher.ONCE_PER_CUSTOMER, 2, 2, [{'email': 't1@exam.com'}, {'email': 't2@exam.com'}], [2], False, False),
-    )
-    @ddt.unpack
-    def test_coupon_codes_assign_success1(
-            self,
-            voucher_type,
-            quantity,
-            max_uses,
-            users,
-            assignments_per_code,
-            create_nudge_email_templates,
-            enable_nudge_emails
-    ):
-        """Test assigning codes to users."""
-        coupon_post_data = dict(self.data, voucher_type=voucher_type, quantity=quantity, max_uses=max_uses)
-        coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
-        if create_nudge_email_templates:
-            self._create_nudge_email_templates()
-        coupon = coupon.json()
-        coupon_id = coupon['coupon_id']
-        with mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email.delay') as mock_send_email:
-            with mock.patch(UPLOAD_FILES_TO_S3_PATH) as mock_file_uploader:
-                mock_file_uploader.return_value = [
-                    {'name': 'def.png', 'size': 456, 'url': 'https://www.example.com/def-png'}
-                ]
-                response = self.get_response(
-                    'POST',
-                    '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
-                    {
-                        'template': 'Test template',
-                        'template_subject': TEMPLATE_SUBJECT,
-                        'template_greeting': TEMPLATE_GREETING,
-                        'template_closing': TEMPLATE_CLOSING,
-                        'template_files': TEMPLATE_FILES_MIXED,
-                        'users': users,
-                        'enable_nudge_emails': enable_nudge_emails
-                    }
-                )
-                mock_file_uploader.assert_called_once_with(
-                    [{'name': 'def.png', 'size': 456, 'contents': '1,2,3', 'type': 'image/png'}])
-        response = response.json()
-        assert mock_send_email.call_count == len(users)
-        for i, user in enumerate(users):
-            if voucher_type != Voucher.MULTI_USE_PER_CUSTOMER:
-                assert response['offer_assignments'][i]['user_email'] == user['email']
-            else:
-                for j in range(max_uses):
-                    assert response['offer_assignments'][(i * max_uses) + j]['user_email'] == user['email']
+    # @ddt.data(
+    #     (Voucher.SINGLE_USE, 2, None, [{'email': 't1@exam.com'}, {'email': 'test2@exam.com'}], [1], True, True),
+    #     (Voucher.SINGLE_USE, 2, None, [{'email': 't1@exam.com'}, {'email': 'test2@exam.com'}], [1], False, False),
+    #  (Voucher.MULTI_USE_PER_CUSTOMER, 2, 3, [{'email': 't1@exam.com'}, {'email': 't2@exam.com'}], [3], False, True),
+    #     (Voucher.MULTI_USE, 1, None, [{'email': 't1@example.com'}, {'email': 'test2@example.com'}], [2], True, True),
+    #     (
+    #         Voucher.MULTI_USE,
+    #         2,
+    #         3,
+    #         [{'email': 't1@exam.com'}, {'email': 't2@exam.com'}, {'email': 't3@exam.com'}, {'email': 't4@exam.com'}],
+    #         [3, 1],
+    #         True,
+    #         True
+    #     ),
+    #     (Voucher.ONCE_PER_CUSTOMER, 2, 2, [{'email': 't1@exam.com'}, {'email': 't2@exam.com'}], [2], False, False),
+    # )
 
-        assigned_codes = []
-        for assignment in response['offer_assignments']:
-            if assignment['code'] not in assigned_codes:
-                assigned_codes.append(assignment['code'])
-                self._assert_nudge_email_data(
-                    assignment['code'],
-                    assignment['user_email'],
-                    enable_nudge_emails,
-                    create_nudge_email_templates
-                )
+    # @FIXME: commenting out until test is fixed in ENT-5824
+    # @ddt.unpack
+    # def test_coupon_codes_assign_success1(
+    #         self,
+    #         voucher_type,
+    #         quantity,
+    #         max_uses,
+    #         users,
+    #         assignments_per_code,
+    #         create_nudge_email_templates,
+    #         enable_nudge_emails
+    # ):
+        # """Test assigning codes to users."""
+    #     coupon_post_data = dict(self.data, voucher_type=voucher_type, quantity=quantity, max_uses=max_uses)
+    #     coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
+    #     if create_nudge_email_templates:
+    #         self._create_nudge_email_templates()
+    #     coupon = coupon.json()
+    #     coupon_id = coupon['coupon_id']
+    #     with mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email.delay') as mock_send_email:
+    #         with mock.patch(UPLOAD_FILES_TO_S3_PATH) as mock_file_uploader:
+    #             mock_file_uploader.return_value = [
+    #                 {'name': 'def.png', 'size': 456, 'url': 'https://www.example.com/def-png'}
+    #             ]
+    #             response = self.get_response(
+    #                 'POST',
+    #                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
+    #                 {
+    #                     'template': 'Test template',
+    #                     'template_subject': TEMPLATE_SUBJECT,
+    #                     'template_greeting': TEMPLATE_GREETING,
+    #                     'template_closing': TEMPLATE_CLOSING,
+    #                     'template_files': TEMPLATE_FILES_MIXED,
+    #                     'users': users,
+    #                     'enable_nudge_emails': enable_nudge_emails
+    #                 }
+    #             )
+    #             mock_file_uploader.assert_called_once_with(
+    #                 [{'name': 'def.png', 'size': 456, 'contents': '1,2,3', 'type': 'image/png'}])
+    #     response = response.json()
+    #     assert mock_send_email.call_count == len(users)
+    #     for i, user in enumerate(users):
+    #         if voucher_type != Voucher.MULTI_USE_PER_CUSTOMER:
+    #             assert response['offer_assignments'][i]['user_email'] == user['email']
+    #         else:
+    #             for j in range(max_uses):
+    #                 assert response['offer_assignments'][(i * max_uses) + j]['user_email'] == user['email']
+    #     assigned_codes = []
+    #     for assignment in response['offer_assignments']:
+    #         if assignment['code'] not in assigned_codes:
+    #             assigned_codes.append(assignment['code'])
+    #             self._assert_nudge_email_data(
+    #                 assignment['code'],
+    #                 assignment['user_email'],
+    #                 enable_nudge_emails,
+    #                 create_nudge_email_templates
+    #             )
+    #     for code in assigned_codes:
+    #         assert OfferAssignment.objects.filter(code=code).count() in assignments_per_code
+    #    raise SkipTest("Fix in ENT-5824")
 
-        for code in assigned_codes:
-            assert OfferAssignment.objects.filter(code=code).count() in assignments_per_code
-
+    # @FIXME: commenting out until test is fixed in ENT-5824
     def test_coupon_codes_assign_success_with_codes_filter(self):
-        coupon_post_data = dict(self.data, voucher_type=Voucher.SINGLE_USE, quantity=5)
-        coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
-        coupon = coupon.json()
-        coupon_id = coupon['coupon_id']
+        #     coupon_post_data = dict(self.data, voucher_type=Voucher.SINGLE_USE, quantity=5)
+        #     coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
+        #     coupon = coupon.json()
+        #     coupon_id = coupon['coupon_id']
+        #     vouchers = Product.objects.get(id=coupon_id).attr.coupon_vouchers.vouchers.all()
+        #     codes = [voucher.code for voucher in vouchers]
+        #     codes_param = codes[3:]
+        #     users = [{'email': 't1@example.com'}, {'email': 't2@example.com'}]
+        #     with mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email.delay') as mock_send_email:
+        #         with mock.patch(UPLOAD_FILES_TO_S3_PATH) as mock_file_uploader:
+        #             mock_file_uploader.return_value = [
+        #                 {'name': 'def.png', 'size': 456, 'url': 'https://www.example.com/def-png'}
+        #             ]
+        #             response = self.get_response(
+        #                 'POST',
+        #                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
+        #                 {
+        #                     'template': 'Test template',
+        #                     'template_subject': TEMPLATE_SUBJECT,
+        #                     'template_greeting': TEMPLATE_GREETING,
+        #                     'template_closing': TEMPLATE_CLOSING,
+        #                     'template_files': TEMPLATE_FILES_MIXED,
+        #                     'users': users,
+        #                     'codes': codes_param
+        #                 }
+        #             )
+        #             mock_file_uploader.assert_called_once_with(
+        #                 [{'name': 'def.png', 'size': 456, 'contents': '1,2,3', 'type': 'image/png'}])
+        #     response = response.json()
+        #     assert mock_send_email.call_count == len(users)
+        #     for i, user in enumerate(users):
+        #         assert response['offer_assignments'][i]['user_email'] == user['email']
+        #         assert response['offer_assignments'][i]['code'] in codes_param
+        #     for code in codes:
+        #         if code not in codes_param:
+        #             assert OfferAssignment.objects.filter(code=code).count() == 0
+        #         else:
+        #             assert OfferAssignment.objects.filter(code=code).count() == 1
+        raise SkipTest("Fix in ENT-5824")
 
-        vouchers = Product.objects.get(id=coupon_id).attr.coupon_vouchers.vouchers.all()
-        codes = [voucher.code for voucher in vouchers]
-        codes_param = codes[3:]
-
-        users = [{'email': 't1@example.com'}, {'email': 't2@example.com'}]
-        with mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email.delay') as mock_send_email:
-            with mock.patch(UPLOAD_FILES_TO_S3_PATH) as mock_file_uploader:
-                mock_file_uploader.return_value = [
-                    {'name': 'def.png', 'size': 456, 'url': 'https://www.example.com/def-png'}
-                ]
-                response = self.get_response(
-                    'POST',
-                    '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
-                    {
-                        'template': 'Test template',
-                        'template_subject': TEMPLATE_SUBJECT,
-                        'template_greeting': TEMPLATE_GREETING,
-                        'template_closing': TEMPLATE_CLOSING,
-                        'template_files': TEMPLATE_FILES_MIXED,
-                        'users': users,
-                        'codes': codes_param
-                    }
-                )
-                mock_file_uploader.assert_called_once_with(
-                    [{'name': 'def.png', 'size': 456, 'contents': '1,2,3', 'type': 'image/png'}])
-        response = response.json()
-        assert mock_send_email.call_count == len(users)
-        for i, user in enumerate(users):
-            assert response['offer_assignments'][i]['user_email'] == user['email']
-            assert response['offer_assignments'][i]['code'] in codes_param
-
-        for code in codes:
-            if code not in codes_param:
-                assert OfferAssignment.objects.filter(code=code).count() == 0
-            else:
-                assert OfferAssignment.objects.filter(code=code).count() == 1
-
+    # @FIXME: commenting out until test is fixed in ENT-5824
     def test_coupon_codes_assign_success_exclude_used_codes(self):
-        coupon_post_data = dict(self.data, voucher_type=Voucher.SINGLE_USE, quantity=5)
-        coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
-        coupon = coupon.json()
-        coupon_id = coupon['coupon_id']
+        #     coupon_post_data = dict(self.data, voucher_type=Voucher.SINGLE_USE, quantity=5)
+        #     coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
+        #     coupon = coupon.json()
+        #     coupon_id = coupon['coupon_id']
+        #     vouchers = Product.objects.get(id=coupon_id).attr.coupon_vouchers.vouchers.all()
+        #     # Use some of the vouchers
+        #     used_codes = []
+        #     for voucher in vouchers[:3]:
+        #         self.use_voucher(voucher, self.create_user())
+        #         used_codes.append(voucher.code)
+        #     unused_codes = [voucher.code for voucher in vouchers[3:]]
+        #     users = [{'email': 't1@example.com'}, {'email': 't2@example.com'}]
+        #     with mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email.delay') as mock_send_email:
+        #         with mock.patch(UPLOAD_FILES_TO_S3_PATH) as mock_file_uploader:
+        #             mock_file_uploader.return_value = [
+        #                 {'name': 'def.png', 'size': 456, 'url': 'https://www.example.com/def-png'}
+        #             ]
+        #             response = self.get_response(
+        #                 'POST',
+        #                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
+        #                 {
+        #                     'template': 'Test template',
+        #                     'template_subject': TEMPLATE_SUBJECT,
+        #                     'template_greeting': TEMPLATE_GREETING,
+        #                     'template_closing': TEMPLATE_CLOSING,
+        #                     'template_files': TEMPLATE_FILES_MIXED,
+        #                     'users': users
+        #                 }
+        #             )
+        #             mock_file_uploader.assert_called_once_with(
+        #                 [{'name': 'def.png', 'size': 456, 'contents': '1,2,3', 'type': 'image/png'}])
+        #     response = response.json()
+        #     assert mock_send_email.call_count == len(users)
+        #     for i, user in enumerate(users):
+        #         assert response['offer_assignments'][i]['user_email'] == user['email']
+        #         assert response['offer_assignments'][i]['code'] in unused_codes
+        #     for code in used_codes:
+        #         assert OfferAssignment.objects.filter(code=code).count() == 0
+        #     for code in unused_codes:
+        #         assert OfferAssignment.objects.filter(code=code).count() == 1
+        raise SkipTest("Fix in ENT-5824")
 
-        vouchers = Product.objects.get(id=coupon_id).attr.coupon_vouchers.vouchers.all()
-        # Use some of the vouchers
-        used_codes = []
-        for voucher in vouchers[:3]:
-            self.use_voucher(voucher, self.create_user())
-            used_codes.append(voucher.code)
-        unused_codes = [voucher.code for voucher in vouchers[3:]]
-        users = [{'email': 't1@example.com'}, {'email': 't2@example.com'}]
-        with mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email.delay') as mock_send_email:
-            with mock.patch(UPLOAD_FILES_TO_S3_PATH) as mock_file_uploader:
-                mock_file_uploader.return_value = [
-                    {'name': 'def.png', 'size': 456, 'url': 'https://www.example.com/def-png'}
-                ]
-                response = self.get_response(
-                    'POST',
-                    '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
-                    {
-                        'template': 'Test template',
-                        'template_subject': TEMPLATE_SUBJECT,
-                        'template_greeting': TEMPLATE_GREETING,
-                        'template_closing': TEMPLATE_CLOSING,
-                        'template_files': TEMPLATE_FILES_MIXED,
-                        'users': users
-                    }
-                )
-                mock_file_uploader.assert_called_once_with(
-                    [{'name': 'def.png', 'size': 456, 'contents': '1,2,3', 'type': 'image/png'}])
-        response = response.json()
-        assert mock_send_email.call_count == len(users)
-        for i, user in enumerate(users):
-            assert response['offer_assignments'][i]['user_email'] == user['email']
-            assert response['offer_assignments'][i]['code'] in unused_codes
-
-        for code in used_codes:
-            assert OfferAssignment.objects.filter(code=code).count() == 0
-        for code in unused_codes:
-            assert OfferAssignment.objects.filter(code=code).count() == 1
-
+    # @FIXME: commenting out until test is fixed in ENT-5824
     def test_code_visibility(self):
-        coupon_post_data = dict(self.data, voucher_type=Voucher.SINGLE_USE, quantity=5)
-        coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
-        coupon = coupon.json()
-        coupon_id = coupon['coupon_id']
-        vouchers = Product.objects.get(id=coupon_id).attr.coupon_vouchers.vouchers.all()
-        code_ids = []
-        for voucher in vouchers:
-            assert not voucher.is_public  # Defaults to False for
-            code_ids.append(voucher.code)
+        #     coupon_post_data = dict(self.data, voucher_type=Voucher.SINGLE_USE, quantity=5)
+        #     coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
+        #     coupon = coupon.json()
+        #     coupon_id = coupon['coupon_id']
+        #     vouchers = Product.objects.get(id=coupon_id).attr.coupon_vouchers.vouchers.all()
+        #     code_ids = []
+        #     for voucher in vouchers:
+        #         assert not voucher.is_public  # Defaults to False for
+        #         code_ids.append(voucher.code)
+        #     response = self.get_response(
+        #         'POST',
+        #         '/api/v2/enterprise/coupons/{}/visibility/'.format(coupon_id),
+        #         {}
+        #     )
+        #     assert response.status_code == 400
+        #     response = self.get_response(
+        #         'POST',
+        #         '/api/v2/enterprise/coupons/{}/visibility/'.format(coupon_id),
+        #         {
+        #             'code_ids': code_ids,
+        #             'is_public': True,
+        #         }
+        #     )
+        #     assert response.status_code == 200
+        #     for voucher in Product.objects.get(id=coupon_id).attr.coupon_vouchers.vouchers.all():
+        #         assert voucher.is_public
+        raise SkipTest("Fix in ENT-5824")
 
-        response = self.get_response(
-            'POST',
-            '/api/v2/enterprise/coupons/{}/visibility/'.format(coupon_id),
-            {}
-        )
-        assert response.status_code == 400
-
-        response = self.get_response(
-            'POST',
-            '/api/v2/enterprise/coupons/{}/visibility/'.format(coupon_id),
-            {
-                'code_ids': code_ids,
-                'is_public': True,
-            }
-        )
-        assert response.status_code == 200
-        for voucher in Product.objects.get(id=coupon_id).attr.coupon_vouchers.vouchers.all():
-            assert voucher.is_public
-
+    # @FIXME: commenting out until test is fixed in ENT-5824
     def test_coupon_codes_assign_once_per_customer_with_used_codes(self):
-        coupon_post_data = dict(self.data, voucher_type=Voucher.ONCE_PER_CUSTOMER, quantity=3)
-        coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
-        coupon = coupon.json()
-        coupon_id = coupon['coupon_id']
+        #     coupon_post_data = dict(self.data, voucher_type=Voucher.ONCE_PER_CUSTOMER, quantity=3)
+        #     coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
+        #     coupon = coupon.json()
+        #     coupon_id = coupon['coupon_id']
+        #     vouchers = Product.objects.get(id=coupon_id).attr.coupon_vouchers.vouchers.all()
+        #     # Redeem and assign two of the vouchers
+        #     already_redeemed_voucher = vouchers[0]
+        #     already_assigned_voucher = vouchers[1]
+        #     unused_voucher = vouchers[2]
+        #     redeemed_user = self.create_user(email='t1@example.com')
+        #     self.use_voucher(already_redeemed_voucher, redeemed_user)
+        #     OfferAssignment.objects.create(
+        #         code=already_assigned_voucher.code,
+        #         offer=already_assigned_voucher.enterprise_offer,
+        #         user_email='t2@example.com',
+        #     )
+        #     users = [{'email': 't1@example.com'}, {'email': 't2@example.com'}, {'email': 't3@example.com'}]
+        #     with mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email.delay') as mock_send_email:
+        #         with mock.patch(UPLOAD_FILES_TO_S3_PATH) as mock_file_uploader:
+        #             mock_file_uploader.return_value = [
+        #                 {'name': 'def.png', 'size': 456, 'url': 'https://www.example.com/def-png'}
+        #             ]
+        #             response = self.get_response(
+        #                 'POST',
+        #                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
+        #                 {
+        #                     'template': 'Test template',
+        #                     'template_subject': TEMPLATE_SUBJECT,
+        #                     'template_greeting': TEMPLATE_GREETING,
+        #                     'template_closing': TEMPLATE_CLOSING,
+        #                     'template_files': TEMPLATE_FILES_MIXED,
+        #                     'users': users
+        #                 }
+        #             )
+        #             mock_file_uploader.assert_called_once_with(
+        #                 [{'name': 'def.png', 'size': 456, 'contents': '1,2,3', 'type': 'image/png'}])
+        #     response = response.json()
+        #     assert mock_send_email.call_count == len(users)
+        #     for i, user in enumerate(users):
+        #         assert response['offer_assignments'][i]['user_email'] == user['email']
+        #         assert response['offer_assignments'][i]['code'] == unused_voucher.code
+        #     assert OfferAssignment.objects.filter(code=unused_voucher.code).count() == 3
+        #     assert OfferAssignment.objects.filter(code=already_assigned_voucher.code).count() == 1
+        #     assert OfferAssignment.objects.filter(code=already_redeemed_voucher.code).count() == 0
+        raise SkipTest("Fix in ENT-5824")
 
-        vouchers = Product.objects.get(id=coupon_id).attr.coupon_vouchers.vouchers.all()
-        # Redeem and assign two of the vouchers
-        already_redeemed_voucher = vouchers[0]
-        already_assigned_voucher = vouchers[1]
-        unused_voucher = vouchers[2]
-        redeemed_user = self.create_user(email='t1@example.com')
-        self.use_voucher(already_redeemed_voucher, redeemed_user)
-        OfferAssignment.objects.create(
-            code=already_assigned_voucher.code,
-            offer=already_assigned_voucher.enterprise_offer,
-            user_email='t2@example.com',
-        )
-        users = [{'email': 't1@example.com'}, {'email': 't2@example.com'}, {'email': 't3@example.com'}]
-        with mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email.delay') as mock_send_email:
-            with mock.patch(UPLOAD_FILES_TO_S3_PATH) as mock_file_uploader:
-                mock_file_uploader.return_value = [
-                    {'name': 'def.png', 'size': 456, 'url': 'https://www.example.com/def-png'}
-                ]
-                response = self.get_response(
-                    'POST',
-                    '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
-                    {
-                        'template': 'Test template',
-                        'template_subject': TEMPLATE_SUBJECT,
-                        'template_greeting': TEMPLATE_GREETING,
-                        'template_closing': TEMPLATE_CLOSING,
-                        'template_files': TEMPLATE_FILES_MIXED,
-                        'users': users
-                    }
-                )
-                mock_file_uploader.assert_called_once_with(
-                    [{'name': 'def.png', 'size': 456, 'contents': '1,2,3', 'type': 'image/png'}])
-        response = response.json()
-        assert mock_send_email.call_count == len(users)
-        for i, user in enumerate(users):
-            assert response['offer_assignments'][i]['user_email'] == user['email']
-            assert response['offer_assignments'][i]['code'] == unused_voucher.code
-
-        assert OfferAssignment.objects.filter(code=unused_voucher.code).count() == 3
-        assert OfferAssignment.objects.filter(code=already_assigned_voucher.code).count() == 1
-        assert OfferAssignment.objects.filter(code=already_redeemed_voucher.code).count() == 0
-
+    # @FIXME: commenting out until test is fixed in ENT-5824
     def test_coupon_codes_assign_once_per_customer_with_revoked_code(self):
-        coupon_post_data = dict(self.data, voucher_type=Voucher.ONCE_PER_CUSTOMER, quantity=1)
-        coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
-        coupon = coupon.json()
-        coupon_id = coupon['coupon_id']
+        #     coupon_post_data = dict(self.data, voucher_type=Voucher.ONCE_PER_CUSTOMER, quantity=1)
+        #     coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
+        #     coupon = coupon.json()
+        #     coupon_id = coupon['coupon_id']
+        #     vouchers = Product.objects.get(id=coupon_id).attr.coupon_vouchers.vouchers.all()
+        #     voucher = vouchers[0]
+        #     user = {'email': 't1@example.com'}
+        #     # Assign the code to the user.
+        #     with mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email.delay') as mock_send_email:
+        #         with mock.patch(UPLOAD_FILES_TO_S3_PATH) as mock_file_uploader:
+        #             mock_file_uploader.return_value = [
+        #                 {'name': 'def.png', 'size': 456, 'url': 'https://www.example.com/def-png'}
+        #             ]
+        #             response = self.get_response(
+        #                 'POST',
+        #                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
+        #                 {
+        #                     'template': 'Test template',
+        #                     'template_subject': TEMPLATE_SUBJECT,
+        #                     'template_greeting': TEMPLATE_GREETING,
+        #                     'template_closing': TEMPLATE_CLOSING,
+        #                     'template_files': TEMPLATE_FILES_MIXED,
+        #                     'users': [user]
+        #                 }
+        #             )
+        #             mock_file_uploader.assert_called_once_with(
+        #                 [{'name': 'def.png', 'size': 456, 'contents': '1,2,3', 'type': 'image/png'}])
+        #     response = response.json()
+        #     assert mock_send_email.call_count == 1
+        #     assert response['offer_assignments'][0]['user_email'] == user['email']
+        #     assert response['offer_assignments'][0]['code'] == voucher.code
+        #     # Revoke the code from the user.
+        #     with mock.patch('ecommerce.extensions.offer.utils.send_offer_update_email.delay') as mock_send_email:
+        #         response = self.get_response(
+        #             'POST',
+        #             '/api/v2/enterprise/coupons/{}/revoke/'.format(coupon_id),
+        #             {'assignments': [{'user': user, 'code': voucher.code}], 'do_not_email': False}
+        #         )
+        #     response = response.json()
+        #     assert response == [{'code': voucher.code, 'user': user, 'detail': 'success', 'do_not_email': False}]
+        #     # Assign the same code to the user again.
+        #     with mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email.delay') as mock_send_email:
+        #         with mock.patch(UPLOAD_FILES_TO_S3_PATH) as mock_file_uploader:
+        #             mock_file_uploader.return_value = [
+        #                 {'name': 'def.png', 'size': 456, 'url': 'https://www.example.com/def-png'}
+        #             ]
+        #             response = self.get_response(
+        #                 'POST',
+        #                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
+        #                 {
+        #                     'template': 'Test template',
+        #                     'template_subject': TEMPLATE_SUBJECT,
+        #                     'template_greeting': TEMPLATE_GREETING,
+        #                     'template_closing': TEMPLATE_CLOSING,
+        #                     'template_files': TEMPLATE_FILES_MIXED,
+        #                     'users': [user]
+        #                 }
+        #             )
+        #             mock_file_uploader.assert_called_once_with(
+        #                 [{'name': 'def.png', 'size': 456, 'contents': '1,2,3', 'type': 'image/png'}])
+        #     response = response.json()
+        #     assert mock_send_email.call_count == 1
+        #     assert response['offer_assignments'][0]['user_email'] == user['email']
+        #     assert response['offer_assignments'][0]['code'] == voucher.code
+        raise SkipTest("Fix in ENT-5824")
 
-        vouchers = Product.objects.get(id=coupon_id).attr.coupon_vouchers.vouchers.all()
-        voucher = vouchers[0]
-        user = {'email': 't1@example.com'}
-        # Assign the code to the user.
-        with mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email.delay') as mock_send_email:
-            with mock.patch(UPLOAD_FILES_TO_S3_PATH) as mock_file_uploader:
-                mock_file_uploader.return_value = [
-                    {'name': 'def.png', 'size': 456, 'url': 'https://www.example.com/def-png'}
-                ]
-                response = self.get_response(
-                    'POST',
-                    '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
-                    {
-                        'template': 'Test template',
-                        'template_subject': TEMPLATE_SUBJECT,
-                        'template_greeting': TEMPLATE_GREETING,
-                        'template_closing': TEMPLATE_CLOSING,
-                        'template_files': TEMPLATE_FILES_MIXED,
-                        'users': [user]
-                    }
-                )
-                mock_file_uploader.assert_called_once_with(
-                    [{'name': 'def.png', 'size': 456, 'contents': '1,2,3', 'type': 'image/png'}])
+    # @ddt.data(
+    #     (Voucher.SINGLE_USE, 1, None, [{'email': 'test1@example.com'}, {'email': 'test2@example.com'}]),
+    #     (Voucher.MULTI_USE_PER_CUSTOMER, 1, 3, [{'email': 'test1@example.com'}, {'email': 'test2@example.com'}]),
+    #     (
+    #         Voucher.MULTI_USE,
+    #         1,
+    #         3,
+    #         [{'email': 't1@exam.com'}, {'email': 't3@exam.com'}, {'email': 't3@exam.com'}, {'email': 't4@exam.com'}]
+    #     ),
+    # )
 
-        response = response.json()
-        assert mock_send_email.call_count == 1
-        assert response['offer_assignments'][0]['user_email'] == user['email']
-        assert response['offer_assignments'][0]['code'] == voucher.code
+    # @FIXME: commenting out until test is fixed in ENT-5824
+    # @ddt.unpack
+    # def test_coupon_codes_assign_failure(self, voucher_type, quantity, max_uses, users):
+        #     coupon_post_data = dict(self.data, voucher_type=voucher_type, quantity=quantity, max_uses=max_uses)
+        #     coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
+        #     coupon = coupon.json()
+        #     coupon_id = coupon['coupon_id']
+        #     with mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email.delay') as mock_send_email:
+        #         with mock.patch(UPLOAD_FILES_TO_S3_PATH) as mock_file_uploader:
+        #             mock_file_uploader.return_value = [
+        #                 {'name': 'def.png', 'size': 456, 'url': 'https://www.example.com/def-png'}
+        #             ]
+        #             with mock.patch('ecommerce.extensions.api.v2.views.enterprise.delete_file_from_s3_with_key')\
+        #                     as mock_file_deleter:
+        #                 response = self.get_response(
+        #                     'POST',
+        #                     '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
+        #                     {
+        #                         'template': 'Test template',
+        #                         'template_subject': TEMPLATE_SUBJECT,
+        #                         'template_greeting': TEMPLATE_GREETING,
+        #                         'template_closing': TEMPLATE_CLOSING,
+        #                         'template_files': TEMPLATE_FILES_MIXED,
+        #                         'users': users
+        #                     }
+        #                 )
+        #                 mock_file_deleter.assert_called_once_with('def.png')
+        #             mock_file_uploader.assert_called_once_with(
+        #                 [{'name': 'def.png', 'size': 456, 'contents': '1,2,3', 'type': 'image/png'}])
+        #         response = response.json()
+        #     assert response['non_field_errors'] == ['Not enough available codes for assignment!']
+        #     assert mock_send_email.call_count == 0
+        # raise SkipTest("Fix in ENT-5824")
 
-        # Revoke the code from the user.
-        with mock.patch('ecommerce.extensions.offer.utils.send_offer_update_email.delay') as mock_send_email:
-            response = self.get_response(
-                'POST',
-                '/api/v2/enterprise/coupons/{}/revoke/'.format(coupon_id),
-                {'assignments': [{'user': user, 'code': voucher.code}], 'do_not_email': False}
-            )
+    # @ddt.data(
+    #     (Voucher.SINGLE_USE, 2, None, [{'email': 'test1@example.com'}, {'email': 'test2@example.com'}], [1]),
+    #     (Voucher.MULTI_USE_PER_CUSTOMER, 2, 3, [{'email': 'test1@example.com'}, {'email': 'test2@example.com'}], [3]),
+    #     (Voucher.MULTI_USE, 1, None, [{'email': 'test1@example.com'}, {'email': 'test2@example.com'}], [2]),
+    #     (
+    #         Voucher.MULTI_USE,
+    #         2,
+    #         3,
+    #         [{'email': 't1@exam.com'}, {'email': 't2@exam.com'}, {'email': 't3@exam.com'}, {'email': 't3@exam.com'}],
+    #         [3, 1]
+    #     ),
+    #     (Voucher.ONCE_PER_CUSTOMER, 2, 2, [{'email': 'test1@example.com'}, {'email': 'test2@example.com'}], [2]),
+    # )
 
-        response = response.json()
-        assert response == [{'code': voucher.code, 'user': user, 'detail': 'success', 'do_not_email': False}]
+    # @FIXME: commenting out until test is fixed in ENT-5824
+    # @ddt.unpack
+    # def test_codes_assignment_email_failure(self, voucher_type, quantity, max_uses, users, assignments_per_code):
+        # """Test assigning codes to users."""
+        #     coupon_post_data = dict(self.data, voucher_type=voucher_type, quantity=quantity, max_uses=max_uses)
+        #     coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
+        #     coupon = coupon.json()
+        #     coupon_id = coupon['coupon_id']
+        #     with mock.patch(
+        #             'ecommerce.extensions.offer.utils.send_offer_assignment_email.delay',
+        #             side_effect=Exception()) as mock_send_email:
+        #         with mock.patch(
+        #                 UPLOAD_FILES_TO_S3_PATH) as mock_file_uploader:
+        #             mock_file_uploader.return_value = [
+        #                 {'name': 'def.png', 'size': 456, 'url': 'https://www.example.com/def-png'}
+        #             ]
+        #             response = self.get_response(
+        #                 'POST',
+        #                 '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
+        #                 {
+        #                     'template': 'Test template',
+        #                     'template_subject': TEMPLATE_SUBJECT,
+        #                     'template_greeting': TEMPLATE_GREETING,
+        #                     'template_closing': TEMPLATE_CLOSING,
+        #                     'template_files': TEMPLATE_FILES_MIXED,
+        #                     'users': users
+        #                 }
+        #             )
+        #             mock_file_uploader.assert_called_once_with(
+        #                 [{'name': 'def.png', 'size': 456, 'contents': '1,2,3', 'type': 'image/png'}])
+        #     response = response.json()
+        #     assert mock_send_email.call_count == len(users)
+        #     for i, user in enumerate(users):
+        #         if voucher_type != Voucher.MULTI_USE_PER_CUSTOMER:
+        #             assert response['offer_assignments'][i]['user_email'] == user['email']
+        #         else:
+        #             for j in range(max_uses):
+        #                 assert response['offer_assignments'][(i * max_uses) + j]['user_email'] == user['email']
+        #     assigned_codes = []
+        #     for assignment in response['offer_assignments']:
+        #         if assignment['code'] not in assigned_codes:
+        #             assigned_codes.append(assignment['code'])
+        #     for code in assigned_codes:
+        #         assert OfferAssignment.objects.filter(code=code).count() in assignments_per_code
+    #    raise SkipTest("Fix in ENT-5824")
 
-        # Assign the same code to the user again.
-        with mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email.delay') as mock_send_email:
-            with mock.patch(UPLOAD_FILES_TO_S3_PATH) as mock_file_uploader:
-                mock_file_uploader.return_value = [
-                    {'name': 'def.png', 'size': 456, 'url': 'https://www.example.com/def-png'}
-                ]
-                response = self.get_response(
-                    'POST',
-                    '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
-                    {
-                        'template': 'Test template',
-                        'template_subject': TEMPLATE_SUBJECT,
-                        'template_greeting': TEMPLATE_GREETING,
-                        'template_closing': TEMPLATE_CLOSING,
-                        'template_files': TEMPLATE_FILES_MIXED,
-                        'users': [user]
-                    }
-                )
-                mock_file_uploader.assert_called_once_with(
-                    [{'name': 'def.png', 'size': 456, 'contents': '1,2,3', 'type': 'image/png'}])
-        response = response.json()
-        assert mock_send_email.call_count == 1
-        assert response['offer_assignments'][0]['user_email'] == user['email']
-        assert response['offer_assignments'][0]['code'] == voucher.code
+    # @ddt.data(
+    #     (Voucher.SINGLE_USE, 2, None, status.HTTP_200_OK),
+    #     (Voucher.MULTI_USE_PER_CUSTOMER, 2, 3, status.HTTP_400_BAD_REQUEST),
+    #     (Voucher.MULTI_USE, 2, 3, status.HTTP_400_BAD_REQUEST),
+    #     (Voucher.ONCE_PER_CUSTOMER, 2, 2, status.HTTP_400_BAD_REQUEST)
+    # )
 
-    @ddt.data(
-        (Voucher.SINGLE_USE, 1, None, [{'email': 'test1@example.com'}, {'email': 'test2@example.com'}]),
-        (Voucher.MULTI_USE_PER_CUSTOMER, 1, 3, [{'email': 'test1@example.com'}, {'email': 'test2@example.com'}]),
-        (
-            Voucher.MULTI_USE,
-            1,
-            3,
-            [{'email': 't1@exam.com'}, {'email': 't3@exam.com'}, {'email': 't3@exam.com'}, {'email': 't4@exam.com'}]
-        ),
-    )
-    @ddt.unpack
-    def test_coupon_codes_assign_failure(self, voucher_type, quantity, max_uses, users):
-        coupon_post_data = dict(self.data, voucher_type=voucher_type, quantity=quantity, max_uses=max_uses)
-        coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
-        coupon = coupon.json()
-        coupon_id = coupon['coupon_id']
-        with mock.patch('ecommerce.extensions.offer.utils.send_offer_assignment_email.delay') as mock_send_email:
-            with mock.patch(UPLOAD_FILES_TO_S3_PATH) as mock_file_uploader:
-                mock_file_uploader.return_value = [
-                    {'name': 'def.png', 'size': 456, 'url': 'https://www.example.com/def-png'}
-                ]
-                with mock.patch('ecommerce.extensions.api.v2.views.enterprise.delete_file_from_s3_with_key')\
-                        as mock_file_deleter:
-                    response = self.get_response(
-                        'POST',
-                        '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
-                        {
-                            'template': 'Test template',
-                            'template_subject': TEMPLATE_SUBJECT,
-                            'template_greeting': TEMPLATE_GREETING,
-                            'template_closing': TEMPLATE_CLOSING,
-                            'template_files': TEMPLATE_FILES_MIXED,
-                            'users': users
-                        }
-                    )
-                    mock_file_deleter.assert_called_once_with('def.png')
-                mock_file_uploader.assert_called_once_with(
-                    [{'name': 'def.png', 'size': 456, 'contents': '1,2,3', 'type': 'image/png'}])
-            response = response.json()
-        assert response['non_field_errors'] == ['Not enough available codes for assignment!']
-        assert mock_send_email.call_count == 0
+    # @FIXME: commenting out until test is fixed in ENT-5824
+    # @ddt.unpack
+    # def test_create_refunded_voucher(self, voucher_type, quantity, max_uses, response_status):
+        #     """ Test create refunded voucher with different type of vouchers."""
+        #     coupon_post_data = dict(self.data, voucher_type=voucher_type, quantity=quantity, max_uses=max_uses)
+        #     coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
+        #     coupon = coupon.json()
+        #     coupon_id = coupon['coupon_id']
+        #     vouchers = Product.objects.get(id=coupon_id).attr.coupon_vouchers.vouchers.all()
+        #     voucher = vouchers.first()
+        #     order = self.use_voucher(voucher, self.user)
+        #     existing_offer_assignment_count = OfferAssignment.objects.count()
+        #     existing_vouchers_count = vouchers.count()
+        #     with mock.patch(
+        #             'ecommerce.extensions.offer.utils.send_offer_assignment_email.delay',
+        #             side_effect=Exception()) as mock_send_email:
+        #         response = self.get_response(
+        #             'POST',
+        #             '/api/v2/enterprise/coupons/create_refunded_voucher/',
+        #             {
+        #                 "order": order.number
+        #             }
+        #         )
+        #     if response_status == status.HTTP_200_OK:
+        #         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        #         response = response.json()
+        #         self.assertDictContainsSubset({"order": str(order)}, response)
+        #         self.assertEqual(vouchers.count(), existing_vouchers_count + 1)
+        #         self.assertEqual(OfferAssignment.objects.count(), existing_offer_assignment_count + 1)
+        #         self.assertEqual(mock_send_email.call_count, 1)
+        #     else:
+        #         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        #         response = response.json()
+        #         self.assertIn(
+        #             "'{}' coupon are not supported to refund.".format(voucher_type),
+        #             response['non_field_errors'][0]
+        #         )
+        #         self.assertEqual(vouchers.count(), existing_vouchers_count)
+        #         self.assertEqual(OfferAssignment.objects.count(), existing_offer_assignment_count)
+        #         self.assertEqual(mock_send_email.call_count, 0)
+        # raise SkipTest("Fix in ENT-5824")
 
-    @ddt.data(
-        (Voucher.SINGLE_USE, 2, None, [{'email': 'test1@example.com'}, {'email': 'test2@example.com'}], [1]),
-        (Voucher.MULTI_USE_PER_CUSTOMER, 2, 3, [{'email': 'test1@example.com'}, {'email': 'test2@example.com'}], [3]),
-        (Voucher.MULTI_USE, 1, None, [{'email': 'test1@example.com'}, {'email': 'test2@example.com'}], [2]),
-        (
-            Voucher.MULTI_USE,
-            2,
-            3,
-            [{'email': 't1@exam.com'}, {'email': 't2@exam.com'}, {'email': 't3@exam.com'}, {'email': 't3@exam.com'}],
-            [3, 1]
-        ),
-        (Voucher.ONCE_PER_CUSTOMER, 2, 2, [{'email': 'test1@example.com'}, {'email': 'test2@example.com'}], [2]),
-    )
-    @ddt.unpack
-    def test_codes_assignment_email_failure(self, voucher_type, quantity, max_uses, users, assignments_per_code):
-        """Test assigning codes to users."""
-        coupon_post_data = dict(self.data, voucher_type=voucher_type, quantity=quantity, max_uses=max_uses)
-        coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
-        coupon = coupon.json()
-        coupon_id = coupon['coupon_id']
-        with mock.patch(
-                'ecommerce.extensions.offer.utils.send_offer_assignment_email.delay',
-                side_effect=Exception()) as mock_send_email:
-            with mock.patch(
-                    UPLOAD_FILES_TO_S3_PATH) as mock_file_uploader:
-                mock_file_uploader.return_value = [
-                    {'name': 'def.png', 'size': 456, 'url': 'https://www.example.com/def-png'}
-                ]
-                response = self.get_response(
-                    'POST',
-                    '/api/v2/enterprise/coupons/{}/assign/'.format(coupon_id),
-                    {
-                        'template': 'Test template',
-                        'template_subject': TEMPLATE_SUBJECT,
-                        'template_greeting': TEMPLATE_GREETING,
-                        'template_closing': TEMPLATE_CLOSING,
-                        'template_files': TEMPLATE_FILES_MIXED,
-                        'users': users
-                    }
-                )
-                mock_file_uploader.assert_called_once_with(
-                    [{'name': 'def.png', 'size': 456, 'contents': '1,2,3', 'type': 'image/png'}])
-        response = response.json()
-        assert mock_send_email.call_count == len(users)
-        for i, user in enumerate(users):
-            if voucher_type != Voucher.MULTI_USE_PER_CUSTOMER:
-                assert response['offer_assignments'][i]['user_email'] == user['email']
-            else:
-                for j in range(max_uses):
-                    assert response['offer_assignments'][(i * max_uses) + j]['user_email'] == user['email']
-
-        assigned_codes = []
-        for assignment in response['offer_assignments']:
-            if assignment['code'] not in assigned_codes:
-                assigned_codes.append(assignment['code'])
-
-        for code in assigned_codes:
-            assert OfferAssignment.objects.filter(code=code).count() in assignments_per_code
-
-    @ddt.data(
-        (Voucher.SINGLE_USE, 2, None, status.HTTP_200_OK),
-        (Voucher.MULTI_USE_PER_CUSTOMER, 2, 3, status.HTTP_400_BAD_REQUEST),
-        (Voucher.MULTI_USE, 2, 3, status.HTTP_400_BAD_REQUEST),
-        (Voucher.ONCE_PER_CUSTOMER, 2, 2, status.HTTP_400_BAD_REQUEST)
-    )
-    @ddt.unpack
-    def test_create_refunded_voucher(self, voucher_type, quantity, max_uses, response_status):
-        """ Test create refunded voucher with different type of vouchers."""
-        coupon_post_data = dict(self.data, voucher_type=voucher_type, quantity=quantity, max_uses=max_uses)
-        coupon = self.get_response('POST', ENTERPRISE_COUPONS_LINK, coupon_post_data)
-        coupon = coupon.json()
-        coupon_id = coupon['coupon_id']
-        vouchers = Product.objects.get(id=coupon_id).attr.coupon_vouchers.vouchers.all()
-        voucher = vouchers.first()
-        order = self.use_voucher(voucher, self.user)
-
-        existing_offer_assignment_count = OfferAssignment.objects.count()
-        existing_vouchers_count = vouchers.count()
-
-        with mock.patch(
-                'ecommerce.extensions.offer.utils.send_offer_assignment_email.delay',
-                side_effect=Exception()) as mock_send_email:
-            response = self.get_response(
-                'POST',
-                '/api/v2/enterprise/coupons/create_refunded_voucher/',
-                {
-                    "order": order.number
-                }
-            )
-
-        if response_status == status.HTTP_200_OK:
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-            response = response.json()
-            self.assertDictContainsSubset({"order": str(order)}, response)
-            self.assertEqual(vouchers.count(), existing_vouchers_count + 1)
-            self.assertEqual(OfferAssignment.objects.count(), existing_offer_assignment_count + 1)
-            self.assertEqual(mock_send_email.call_count, 1)
-        else:
-            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-            response = response.json()
-            self.assertIn(
-                "'{}' coupon are not supported to refund.".format(voucher_type),
-                response['non_field_errors'][0]
-            )
-            self.assertEqual(vouchers.count(), existing_vouchers_count)
-            self.assertEqual(OfferAssignment.objects.count(), existing_offer_assignment_count)
-            self.assertEqual(mock_send_email.call_count, 0)
-
+    # @FIXME: commenting out until test is fixed in ENT-5824
     def test_email_record_created_after_new_code_assignment(self):
         """
         Test that create refunded voucher successfully records an email info to OfferAssignmentEmailSentRecord when
         an automated assignment email is sent.
         """
-        self.get_response('POST', ENTERPRISE_COUPONS_LINK, dict(self.data))
-        coupon = Product.objects.get(title=self.data['title'])
-        voucher = self.get_coupon_voucher(coupon)
-        order = self.use_voucher(voucher, self.user)
+        # self.get_response('POST', ENTERPRISE_COUPONS_LINK, dict(self.data))
+        # coupon = Product.objects.get(title=self.data['title'])
+        # voucher = self.get_coupon_voucher(coupon)
+        # order = self.use_voucher(voucher, self.user)
 
-        # Verify that no record have been created yet
-        assert OfferAssignmentEmailSentRecord.objects.count() == 0
-        with mock.patch(
-                'ecommerce.extensions.offer.utils.send_offer_assignment_email.delay',
-                side_effect=Exception()):
-            response = self.get_response(
-                'POST',
-                '/api/v2/enterprise/coupons/create_refunded_voucher/',
-                {
-                    "order": order.number
-                }
-            )
+        # # Verify that no record have been created yet
+        # assert OfferAssignmentEmailSentRecord.objects.count() == 0
+        # with mock.patch(
+        #         'ecommerce.extensions.offer.utils.send_offer_assignment_email.delay',
+        #         side_effect=Exception()):
+        #     response = self.get_response(
+        #         'POST',
+        #         '/api/v2/enterprise/coupons/create_refunded_voucher/',
+        #         {
+        #             "order": order.number
+        #         }
+        #     )
 
-        if response.status_code == status.HTTP_200_OK:
-            # Verify that a new record was created
-            assert OfferAssignmentEmailSentRecord.objects.filter(email_type=ASSIGN).count() == 1
-            record = OfferAssignmentEmailSentRecord.objects.get(email_type=ASSIGN)
-            # Verify that the record was created with correct values
-            assert record.code == response.data['code']
-            assert record.user_email == self.user.email
-            assert str(record.enterprise_customer) == self.data['enterprise_customer']['id']
+        # if response.status_code == status.HTTP_200_OK:
+        #     # Verify that a new record was created
+        #     assert OfferAssignmentEmailSentRecord.objects.filter(email_type=ASSIGN).count() == 1
+        #     record = OfferAssignmentEmailSentRecord.objects.get(email_type=ASSIGN)
+        #     # Verify that the record was created with correct values
+        #     assert record.code == response.data['code']
+        #     assert record.user_email == self.user.email
+        #     assert str(record.enterprise_customer) == self.data['enterprise_customer']['id']
+        raise SkipTest("Fix in ENT-5824")
 
     def test_create_refunded_voucher_with_coupon_could_not_assign(self):
         """ Test create refunded voucher when created successfully but failed at assign serializer."""

--- a/ecommerce/extensions/refund/models.py
+++ b/ecommerce/extensions/refund/models.py
@@ -196,13 +196,11 @@ class Refund(StatusMixin, TimeStampedModel):
     def _issue_credit_for_enterprise_offer(self):
         """
         Credits the enterprise offers used for the order, if applicable.
-        """
 
-        """
         This is an edge case that we won't deal with for now. This happens when there were multiple lines in
         an order but not all lines were refunded. We have no good way to determine how much of the discount was
-        applied to each line. We also don't know if partial refunds count as 1 application & order. Note that there has not been
-        an order with partial refund that uses enterprise offers currently.
+        applied to each line. We also don't know if partial refunds count as 1 application & order.
+        Note that there has not been an order with partial refund that uses enterprise offers currently.
         """
         if self.lines.count() != self.order.lines.count():
             logger.error(
@@ -235,7 +233,7 @@ class Refund(StatusMixin, TimeStampedModel):
                     )
 
                     offer.save()
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             logger.exception("[Enterprise Offer Refund] Failed to credit enterprise offer for refund %d.", self.id)
 
     def _revoke_lines(self):

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,19 +37,19 @@
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
     "node_modules/abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+      "integrity": "sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==",
       "dev": true
     },
     "node_modules/accepts": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-      "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+      "integrity": "sha512-AOPopplFOUlmUugwiZUCDpOwmqvSgdCyE8iJVLWI4NcB7qfMKQN34dn5xYtlUU03XGG5egRWW4NW5gIxpa5hEA==",
       "dev": true,
       "dependencies": {
         "mime-types": "~2.1.11",
@@ -74,7 +74,7 @@
     "node_modules/acorn-jsx": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "integrity": "sha512-AU7pnZkguthwBjKgCg6998ByQNIMjbuDQZ8bb78QAFZwPfmKia8AIzgY/gWgqCjnht8JLdXmB4YxA0KaV60ncQ==",
       "dev": true,
       "dependencies": {
         "acorn": "^3.0.4"
@@ -83,7 +83,7 @@
     "node_modules/acorn-jsx/node_modules/acorn": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+      "integrity": "sha512-OLUyIIZ7mF5oaAUT1w0TFqQS81q3saT46x8t7ukpPjMNk+nbs4ZHhs7ToV8EWnLYLepjETXd4XaCE4uxkMeqUw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -95,7 +95,7 @@
     "node_modules/adm-zip": {
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
-      "integrity": "sha1-hgbCy/HEJs6MjsABdER/1Jtur8E=",
+      "integrity": "sha512-QHVQ6ekddFaGr9r2hBUC4gPw2wLqMZioXojt9BydQPbSh8us7+Q5xcUCUq+hnh4zAdauV3wqoY0quApjKqrhbA==",
       "dev": true,
       "engines": {
         "node": ">=0.3.0"
@@ -104,13 +104,13 @@
     "node_modules/after": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
+      "integrity": "sha512-QbJ0NTQ/I9DI3uSJA4cbexiwQeRAfjPScqIbSjUDd9TOrcg6pTkdgziesOqxBMBzit8vFCTwrP27t13vFOORRA==",
       "dev": true
     },
     "node_modules/ajv": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "integrity": "sha512-I/bSHSNEcFFqXLf91nchoNB9D1Kie3QKcWdchYUaoIg1+1bdWDkdfdlvdIOJbi9U8xR0y+MWc5D+won9v95WlQ==",
       "dev": true,
       "dependencies": {
         "co": "^4.6.0",
@@ -120,7 +120,7 @@
     "node_modules/ajv-keywords": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "integrity": "sha512-vuBv+fm2s6cqUyey2A7qYcvsik+GMDJsw8BARP2sDE76cqmaZVarsvHf7Vx6VJ0Xk8gLl+u3MoAPf6gKzJefeA==",
       "dev": true,
       "peerDependencies": {
         "ajv": ">=4.10.0"
@@ -129,7 +129,7 @@
     "node_modules/amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
       "dev": true,
       "optional": true,
       "engines": {
@@ -151,7 +151,7 @@
     "node_modules/ansi-escapes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "integrity": "sha512-wiXutNjDUlNEDWHcYH3jtZUhd3c4/VojassD8zHdHCY13xbZy2XbW+NKQwA0tWGBVzDA9qEzYwfoSsWmviidhw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -160,7 +160,7 @@
     "node_modules/ansi-gray": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
-      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "integrity": "sha512-HrgGIZUl8h2EHuZaU9hTR/cU5nhKxpVE1V6kdGsQ8e4zirElJ5fvtfc8N7Q1oq1aatO275i8pUFUCpNWCAnVWw==",
       "dev": true,
       "dependencies": {
         "ansi-wrap": "0.1.0"
@@ -172,7 +172,7 @@
     "node_modules/ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -181,7 +181,7 @@
     "node_modules/ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -190,7 +190,7 @@
     "node_modules/ansi-wrap": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "integrity": "sha512-ZyznvL8k/FZeQHr2T6LzcJ/+vBApDnMNZvfVFy3At0knswWd6rJ3/0Hhmpu8oqa6C92npmozs890sX9Dl6q+Qw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -221,7 +221,7 @@
     "node_modules/append-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
-      "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
+      "integrity": "sha512-WLbYiXzD3y/ATLZFufV/rZvWdZOs+Z/+5v1rBZ463Jn398pa6kcde27cvozYnBoxXblGZTFfoPpsaEw0orU5BA==",
       "dev": true,
       "dependencies": {
         "buffer-equal": "^1.0.0"
@@ -233,13 +233,13 @@
     "node_modules/apple-pay-js-stubs": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/apple-pay-js-stubs/-/apple-pay-js-stubs-1.0.4.tgz",
-      "integrity": "sha1-2VDRtTUh2M7x2FIPto/bEJS4fW0=",
+      "integrity": "sha512-XNvvvKTOyn4NWQ2KpwPtmtBgXbxcR+QnrZjw/huLDnXzDThA9AkhFt+4inOqcQhymFLimZr2O2SKeZc8oXMcRA==",
       "dev": true
     },
     "node_modules/archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true
     },
     "node_modules/argparse": {
@@ -254,7 +254,7 @@
     "node_modules/arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -263,7 +263,7 @@
     "node_modules/arr-filter": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
-      "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
+      "integrity": "sha512-A2BETWCqhsecSvCkWAeVBFLH6sXEUGASuzkpjL3GR1SlL/PWL6M3J8EAAld2Uubmh39tvkJTqC9LeLHCUKmFXA==",
       "dev": true,
       "dependencies": {
         "make-iterator": "^1.0.0"
@@ -284,7 +284,7 @@
     "node_modules/arr-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
-      "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
+      "integrity": "sha512-tVqVTHt+Q5Xb09qRkbu+DidW1yYzz5izWS2Xm2yFm7qJnmUfz4HPzNxbHkdRJbz2lrqI7S+z17xNYdFcBBO8Hw==",
       "dev": true,
       "dependencies": {
         "make-iterator": "^1.0.0"
@@ -296,7 +296,7 @@
     "node_modules/arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -305,7 +305,7 @@
     "node_modules/array-differ": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+      "integrity": "sha512-LeZY+DZDRnvP7eMuQ6LHfCzUGxAAIViUBliK24P3hWXL6y4SortgR6Nim6xrkfSLlmH0+k+9NYNwVC2s53ZrYQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -314,7 +314,7 @@
     "node_modules/array-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
-      "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
+      "integrity": "sha512-zHjL5SZa68hkKHBFBK6DJCTtr9sfTCPCaph/L7tMSLcTFgy+zX7E+6q5UArbtOtMBCtxdICpfTCspRse+ywyXA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -323,21 +323,21 @@
     "node_modules/array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/array-includes": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
-      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
+      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5",
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       },
@@ -351,7 +351,7 @@
     "node_modules/array-initial": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/array-initial/-/array-initial-1.1.0.tgz",
-      "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
+      "integrity": "sha512-BC4Yl89vneCYfpLrs5JU2aAu9/a+xWbeKhvISg9PT7eWFB9UlRvI+rKEtk6mgxWr3dSkk9gQ8hCrdqt06NXPdw==",
       "dev": true,
       "dependencies": {
         "array-slice": "^1.0.0",
@@ -403,7 +403,7 @@
     "node_modules/array-slice": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-      "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
+      "integrity": "sha512-rlVfZW/1Ph2SNySXwR9QYkChp8EkOEiTMO5Vwx60usw04i4nWemkm9RXmQqgkQFaLHsqLuADvjp6IfgL9l2M8Q==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -426,7 +426,7 @@
     "node_modules/array-uniq": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -435,7 +435,7 @@
     "node_modules/array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -462,13 +462,13 @@
     "node_modules/arraybuffer.slice": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
-      "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco=",
+      "integrity": "sha512-6ZjfQaBSy6CuIH0+B0NrxMfDE5VIOCP/5gOqSpEIsaAZx9/giszzrXg6PZ7G51U/n88UmlAgYLNQ9wAnII7PJA==",
       "dev": true
     },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -477,7 +477,7 @@
     "node_modules/async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
       "dev": true
     },
     "node_modules/async-done": {
@@ -504,7 +504,7 @@
     "node_modules/async-settle": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
-      "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
+      "integrity": "sha512-VPXfB4Vk49z1LHHodrEQ6Xf7W4gg1w0dAPROHngx7qgDjqmIQ+fXmwgGXTW/ITLai0YLSvWepJOP9EVpMnEAcw==",
       "dev": true,
       "dependencies": {
         "async-done": "^1.2.2"
@@ -528,7 +528,7 @@
     "node_modules/babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
       "dev": true,
       "dependencies": {
         "chalk": "^1.1.3",
@@ -539,7 +539,7 @@
     "node_modules/bach": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
-      "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
+      "integrity": "sha512-bZOOfCb3gXBXbTFXq3OZtGR88LwGeJvzu6szttaIzymOTS4ZttBNOWSv7aLZja2EMycKtRYV0Oa8SNKH/zkxvg==",
       "dev": true,
       "dependencies": {
         "arr-filter": "^1.1.1",
@@ -559,7 +559,7 @@
     "node_modules/backo2": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+      "integrity": "sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==",
       "dev": true
     },
     "node_modules/balanced-match": {
@@ -601,7 +601,7 @@
     "node_modules/base64-arraybuffer": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
+      "integrity": "sha512-437oANT9tP582zZMwSvZGy2nmSeAb8DW2me3y+Uv1Wp2Rulr8Mqlyrv3E7MLxmsiaPSMMDmiDVzgE+e8zlMx9g==",
       "dev": true,
       "engines": {
         "node": ">= 0.6.0"
@@ -610,7 +610,7 @@
     "node_modules/base64id": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
-      "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
+      "integrity": "sha512-rz8L+d/xByiB/vLVftPkyY215fqNrmasrcJsYkVcm4TgJNz+YXKrFaFAWibSaHkiKoSgMDCb+lipOIRQNGYesw==",
       "dev": true,
       "engines": {
         "node": ">= 0.4.0"
@@ -619,7 +619,7 @@
     "node_modules/beeper": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+      "integrity": "sha512-3vqtKL1N45I5dV0RdssXZG7X6pCqQrWPNOlBPZPrd+QkE2HEhR57Z04m0KtpbsZH73j+a3F8UD1TQnn+ExTvIA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -628,7 +628,7 @@
     "node_modules/better-assert": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+      "integrity": "sha512-bYeph2DFlpK1XmGs6fvlLRUN29QISM3GBuUwSFsMY2XRx4AvC0WNCS57j4c/xGrK2RS24C1w3YoBOsw9fT46tQ==",
       "dev": true,
       "dependencies": {
         "callsite": "1.0.0"
@@ -659,13 +659,13 @@
     "node_modules/blob": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
+      "integrity": "sha512-YRc9zvVz4wNaxcXmiSgb9LAg7YYwqQ2xd0Sj6osfA7k/PKmIGVlnOYs3wOFdkRC9/JpQu8sGt/zHgJV7xzerfg==",
       "dev": true
     },
     "node_modules/block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "integrity": "sha512-OorbnJVPII4DuUKbjARAe8u8EfqOmkEEaSFIyoQ7OjTHn6kafxWl0wLgoZ2rXaYd7MyLcDaU4TmhfxtwgcccMQ==",
       "dev": true,
       "dependencies": {
         "inherits": "~2.0.0"
@@ -677,7 +677,7 @@
     "node_modules/bluebird": {
       "version": "3.4.6",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz",
-      "integrity": "sha1-AdqNgh2HgT0ViWfnQ9X+bGLPjA8=",
+      "integrity": "sha512-YvvhuCEE6vHQVlxe+ZTuZyXiA9RIXLz1X8YamApVDYf410Y/K0tBTpZ2bTVNsnPVSRviN/mfu2W42BnRfSXA2A==",
       "dev": true
     },
     "node_modules/body-parser": {
@@ -766,7 +766,7 @@
     "node_modules/buffer-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
-      "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+      "integrity": "sha512-tcBWO2Dl4e7Asr9hTGcpVrCe+F7DubpmqWCTbj4FHLmjqO2hIaC383acQubWtRJhdceqs5uBHs6Es+Sk//RKiQ==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -775,7 +775,7 @@
     "node_modules/buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
       "dev": true
     },
     "node_modules/buffer-from": {
@@ -841,7 +841,7 @@
     "node_modules/caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "integrity": "sha512-UJiE1otjXPF5/x+T3zTnSFiTOEmJoGTD9HmBoxnCUwho61a2eSNn/VwtwuIBDAo2SEOv1AJ7ARI5gCmohFLu/g==",
       "dev": true,
       "dependencies": {
         "callsites": "^0.2.0"
@@ -853,7 +853,7 @@
     "node_modules/callsite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+      "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -862,7 +862,7 @@
     "node_modules/callsites": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "integrity": "sha512-Zv4Dns9IbXXmPkgRRUjAaJQgfN4xX5p6+RQFhWUqscdvvK2xK/ZL8b3IXIJsj+4sD+f24NwnWy2BY8AJ82JB0A==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -871,7 +871,7 @@
     "node_modules/camelcase": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+      "integrity": "sha512-4nhGqUkc4BqbBBB4Q6zLuD7lzzrHYrjKGeYaEji/3tFR5VdJu9v+LilhGIVe8wxEJPPOeWo7eg8dwY13TZ1BNg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -880,7 +880,7 @@
     "node_modules/camelcase-keys": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "integrity": "sha512-bA/Z/DERHKqoEOrp+qeGKw1QlvEQkGZSc0XaY6VnTxZr+Kv1G5zFwttpjv8qxZ/sBPT4nthwZaAcsAZTJlSKXQ==",
       "dev": true,
       "dependencies": {
         "camelcase": "^2.0.0",
@@ -893,7 +893,7 @@
     "node_modules/camelcase-keys/node_modules/camelcase": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "integrity": "sha512-DLIsRzJVBQu72meAKPkWQOLcujdXT32hwdfnkI1frSiSRMK1MofjKHf+MEx0SB6fjEFXL8fBDv1dKymBlOp4Qw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -911,7 +911,7 @@
     "node_modules/chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "dev": true,
       "dependencies": {
         "ansi-styles": "^2.2.1",
@@ -1046,7 +1046,7 @@
     "node_modules/cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "integrity": "sha512-25tABq090YNKkF6JH7lcwO0zFJTRke4Jcq9iX2nr/Sz0Cjjv4gckmwlW6Ty/aoyFd6z3ysR2hMGC2GFugmBo6A==",
       "dev": true,
       "dependencies": {
         "restore-cursor": "^1.0.1"
@@ -1064,7 +1064,7 @@
     "node_modules/cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
       "dev": true,
       "dependencies": {
         "string-width": "^1.0.1",
@@ -1075,7 +1075,7 @@
     "node_modules/clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
       "dev": true,
       "engines": {
         "node": ">=0.8"
@@ -1084,7 +1084,7 @@
     "node_modules/clone-buffer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+      "integrity": "sha512-KLLTJWrvwIP+OPfMn0x2PheDEP20RPUcGXj/ERegTgdmPEZylALQldygiqrPPu8P45uNuPs7ckmReLY6v/iA5g==",
       "dev": true,
       "engines": {
         "node": ">= 0.10"
@@ -1093,7 +1093,7 @@
     "node_modules/clone-stats": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+      "integrity": "sha512-dhUqc57gSMCo6TX85FLfe51eC/s+Im2MLkAgJwfaRRexR2tA4dd3eLEW4L6efzHc2iNorrRRXITifnDLlRrhaA==",
       "dev": true
     },
     "node_modules/cloneable-readable": {
@@ -1110,7 +1110,7 @@
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true,
       "engines": {
         "iojs": ">= 1.0.0",
@@ -1120,7 +1120,7 @@
     "node_modules/code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1129,7 +1129,7 @@
     "node_modules/collection-map": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-map/-/collection-map-1.0.0.tgz",
-      "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
+      "integrity": "sha512-5D2XXSpkOnleOI21TG7p3T0bGAsZ/XknZpKBmGYyluO8pw4zA3K8ZlrBIbC4FXg3m6z/RNFiUFfT2sQK01+UHA==",
       "dev": true,
       "dependencies": {
         "arr-map": "^2.0.2",
@@ -1143,7 +1143,7 @@
     "node_modules/collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "integrity": "sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==",
       "dev": true,
       "dependencies": {
         "map-visit": "^1.0.0",
@@ -1174,7 +1174,7 @@
     "node_modules/combine-lists": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/combine-lists/-/combine-lists-1.0.1.tgz",
-      "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
+      "integrity": "sha512-4Mi0V7N48B9KzC8Zl/U7wiWuxMFEHf44N3/PSoAvWDu8IOPrddNo1y1tC/kXbP7IvVMhgCFMMNzgKb0pWoin9w==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.5.0"
@@ -1189,7 +1189,7 @@
     "node_modules/component-bind": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
+      "integrity": "sha512-WZveuKPeKAG9qY+FkYDeADzdHyTYdIboXS59ixDeRJL5ZhxpqUnxSOwop4FQjMsiYm3/Or8cegVbpAHNA7pHxw==",
       "dev": true
     },
     "node_modules/component-emitter": {
@@ -1201,13 +1201,13 @@
     "node_modules/component-inherit": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
+      "integrity": "sha512-w+LhYREhatpVqTESyGFg3NlP6Iu0kEKUHETY9GoZP/pQyW4mHFZuFWRUCIqVPZ36ueVLtoOEZaAqbCF2RDndaA==",
       "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "node_modules/concat-stream": {
@@ -1267,7 +1267,7 @@
     "node_modules/cookie": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "integrity": "sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -1276,7 +1276,7 @@
     "node_modules/copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1309,7 +1309,7 @@
     "node_modules/create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "integrity": "sha512-gYTKKexFO3kh200H1Nit76sRwRtOY32vQd3jpAQKpLtZqyNsSQNfI4N7o3eP2wUjV35pTWKRYqFUDBvUha/Pkw==",
       "dev": true,
       "dependencies": {
         "capture-stack-trace": "^1.0.0"
@@ -1321,7 +1321,7 @@
     "node_modules/currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "integrity": "sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==",
       "dev": true,
       "dependencies": {
         "array-find-index": "^1.0.1"
@@ -1333,7 +1333,7 @@
     "node_modules/custom-event": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
-      "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
+      "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
       "dev": true
     },
     "node_modules/d": {
@@ -1349,7 +1349,7 @@
     "node_modules/dateformat": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
+      "integrity": "sha512-GODcnWq3YGoTnygPfi02ygEiRxqUxpJwuRHjdhJYuxpcZmDq4rjBiXYmbCCzStxo176ixfLT6i4NPwQooRySnw==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -1367,7 +1367,7 @@
     "node_modules/decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1376,7 +1376,7 @@
     "node_modules/decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
       "dev": true,
       "engines": {
         "node": ">=0.10"
@@ -1403,22 +1403,26 @@
     "node_modules/default-resolution": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
-      "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
+      "integrity": "sha512-2xaP6GiwVwOEbXCGoJ4ufgC76m8cj805jrghScewJC2ZDsb9U0b4BIrba+xt/Uytyd0HvQ6+WymSRTfnYj59GQ==",
       "dev": true,
       "engines": {
         "node": ">= 0.10"
       }
     },
     "node_modules/define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
       "dev": true,
       "dependencies": {
-        "object-keys": "^1.0.12"
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/define-property": {
@@ -1605,13 +1609,13 @@
     "node_modules/engine.io-client/node_modules/component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "integrity": "sha512-jPatnhd33viNplKjqXKRkGU345p263OIWzDL2wH3LGIGp5Kojo+uXizHmOADRvhGFFTnJqX3jBAKP6vvmSDKcA==",
       "dev": true
     },
     "node_modules/engine.io-client/node_modules/debug": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-      "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+      "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
       "dev": true,
       "dependencies": {
         "ms": "0.7.2"
@@ -1650,7 +1654,7 @@
     "node_modules/engine.io/node_modules/debug": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-      "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+      "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
       "dev": true,
       "dependencies": {
         "ms": "0.7.2"
@@ -1688,17 +1692,19 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-      "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
         "is-callable": "^1.2.4",
@@ -1710,9 +1716,10 @@
         "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "regexp.prototype.flags": "^1.4.3",
+        "string.prototype.trimend": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.5",
+        "unbox-primitive": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1748,9 +1755,9 @@
       }
     },
     "node_modules/es5-ext": {
-      "version": "0.10.60",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.60.tgz",
-      "integrity": "sha512-jpKNXIt60htYG59/9FGf2PYT3pwMpnEbNKysU+k/4FGwyGtMotOvcZOuW+EmXXYASRqYSXQfGL5cVIthOTgbkg==",
+      "version": "0.10.61",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
+      "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2219,7 +2226,7 @@
     "node_modules/expand-braces/node_modules/array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2228,7 +2235,7 @@
     "node_modules/expand-braces/node_modules/braces": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
-      "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
+      "integrity": "sha512-EIMHIv2UXHWFY2xubUGKz+hq9hNkENj4Pjvr7h58cmJgpkK2yMlKA8I484f7MSttkzVAy/lL7X9xDaILd6avzA==",
       "dev": true,
       "dependencies": {
         "expand-range": "^0.1.0"
@@ -2673,9 +2680,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
       "dev": true,
       "funding": [
         {
@@ -2806,6 +2813,33 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/geckodriver": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-1.6.1.tgz",
@@ -2895,15 +2929,15 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -3269,9 +3303,9 @@
       }
     },
     "node_modules/has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3317,6 +3351,18 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -3661,9 +3707,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -4558,7 +4604,7 @@
     "node_modules/karma-coverage/node_modules/dateformat": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-      "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+      "integrity": "sha512-5sFRfAAmbHdIts+eKjR9kYJoF0ViCMVX9yqLu5A7S/v+nd077KgCITOMiirmyCBiZpKLDXbBOkYm6tu7rX/TKg==",
       "dev": true,
       "dependencies": {
         "get-stdin": "^4.0.1",
@@ -4647,7 +4693,7 @@
     "node_modules/karma-spec-reporter/node_modules/colors": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+      "integrity": "sha512-OsSVtHK8Ir8r3+Fxw/b4jS1ZLPXkV6ZxDRJQzeD7qo0SqMXWrHDM71DgYzPMHY8SFJ0Ao+nNU2p1MmwdzKqPrw==",
       "dev": true,
       "engines": {
         "node": ">=0.1.90"
@@ -4666,7 +4712,7 @@
     "node_modules/karma/node_modules/arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "integrity": "sha512-dtXTVMkh6VkEEA7OhXnN1Ecb8aAGFdZ1LFxtOCoqj4qkyOJMt7+qs6Ahdy6p/NQCPYsRSXXivhSB/J5E9jmYKA==",
       "dev": true,
       "dependencies": {
         "arr-flatten": "^1.0.1"
@@ -4678,7 +4724,7 @@
     "node_modules/karma/node_modules/array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4687,7 +4733,7 @@
     "node_modules/karma/node_modules/braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "integrity": "sha512-xU7bpz2ytJl1bH9cgIurjpg/n8Gohy9GTw81heDYLJQ4RU60dlyJsa+atVF2pI0yMMvKxI9HkKwjePCj5XI1hw==",
       "dev": true,
       "dependencies": {
         "expand-range": "^1.8.1",
@@ -4701,7 +4747,7 @@
     "node_modules/karma/node_modules/chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "integrity": "sha512-mk8fAWcRUOxY7btlLtitj3A45jOwSAxH4tOFOoEGbVsl6cL6pPMWUy7dwZ/canfj3QEdP6FHSnf/l1c6/WkzVg==",
       "deprecated": "Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.",
       "dev": true,
       "dependencies": {
@@ -5590,9 +5636,9 @@
       "dev": true
     },
     "node_modules/nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
       "dev": true,
       "optional": true
     },
@@ -5870,9 +5916,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6796,6 +6842,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/remove-bom-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
@@ -7102,7 +7165,7 @@
     "node_modules/selenium-webdriver/node_modules/adm-zip": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz",
-      "integrity": "sha1-ph7VrmkFw66lizplfSUDMJEFJzY=",
+      "integrity": "sha512-SYIiqLfr6QvmEM0yw89mD8ba2HjK+duf7oVPEw79+NPDqyQScAU8IgDPZzFt9CVdD2yaAuWJqFQGLkongB6cJQ==",
       "dev": true,
       "engines": {
         "node": ">=0.3.0"
@@ -7414,7 +7477,7 @@
     "node_modules/socket.io-adapter/node_modules/debug": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-      "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+      "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
       "dev": true,
       "dependencies": {
         "ms": "0.7.2"
@@ -7448,13 +7511,13 @@
     "node_modules/socket.io-client/node_modules/component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "integrity": "sha512-jPatnhd33viNplKjqXKRkGU345p263OIWzDL2wH3LGIGp5Kojo+uXizHmOADRvhGFFTnJqX3jBAKP6vvmSDKcA==",
       "dev": true
     },
     "node_modules/socket.io-client/node_modules/debug": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-      "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+      "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
       "dev": true,
       "dependencies": {
         "ms": "0.7.2"
@@ -7481,13 +7544,13 @@
     "node_modules/socket.io-parser/node_modules/component-emitter": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-      "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM=",
+      "integrity": "sha512-YhIbp3PJiznERfjlIkK0ue4obZxt2S60+0W8z24ZymOHT8sHloOqWOqZRU2eN5OlY8U08VFsP02letcu26FilA==",
       "dev": true
     },
     "node_modules/socket.io-parser/node_modules/debug": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
       "dev": true,
       "dependencies": {
         "ms": "0.7.1"
@@ -7508,7 +7571,7 @@
     "node_modules/socket.io/node_modules/debug": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-      "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+      "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
       "dev": true,
       "dependencies": {
         "ms": "0.7.2"
@@ -7802,26 +7865,28 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7992,7 +8057,7 @@
     "node_modules/tar.gz/node_modules/bluebird": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
+      "integrity": "sha512-UfFSr22dmHPQqPP9XWHRhq+gWnHCYguQGkXQlbyPtW5qTnhFWA8/iXg765tH0cAjy7l/zPJ1aBTO0g5XgA7kvQ==",
       "dev": true
     },
     "node_modules/text-encoding": {
@@ -8261,9 +8326,9 @@
       "dev": true
     },
     "node_modules/uglify-js": {
-      "version": "3.15.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
-      "integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
+      "version": "3.15.5",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.5.tgz",
+      "integrity": "sha512-hNM5q5GbBRB5xB+PMqVRcgYe4c8jbyZ1pzZhS6jbq54/4F2gFK869ZheiE5A8/t+W5jtTNpWef/5Q9zk639FNQ==",
       "dev": true,
       "optional": true,
       "bin": {
@@ -8280,14 +8345,14 @@
       "dev": true
     },
     "node_modules/unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       },
       "funding": {
@@ -8304,9 +8369,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
-      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.3.tgz",
+      "integrity": "sha512-QvjkYpiD+dJJraRA8+dGAU4i7aBbb2s0S3jA45TFOvg2VgqvdCDd/3N6CqA8gluk1W91GLoXg5enMUx560QzuA==",
       "dev": true
     },
     "node_modules/undertaker": {
@@ -8587,7 +8652,7 @@
     "node_modules/vinyl-fs/node_modules/clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
       "dev": true,
       "engines": {
         "node": ">=0.8"
@@ -8596,7 +8661,7 @@
     "node_modules/vinyl-fs/node_modules/clone-stats": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-      "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+      "integrity": "sha512-au6ydSpg6nsrigcZ4m8Bc9hxjeW+GJ8xh5G3BJCMt4WXe1H10UNaVOamqQTmrx1kjVuxAHIQSNU6hY4Nsn9/ag==",
       "dev": true
     },
     "node_modules/vinyl-fs/node_modules/replace-ext": {
@@ -8646,7 +8711,7 @@
     "node_modules/vinyl-sourcemap/node_modules/clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
       "dev": true,
       "engines": {
         "node": ">=0.8"
@@ -8655,7 +8720,7 @@
     "node_modules/vinyl-sourcemap/node_modules/clone-stats": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-      "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+      "integrity": "sha512-au6ydSpg6nsrigcZ4m8Bc9hxjeW+GJ8xh5G3BJCMt4WXe1H10UNaVOamqQTmrx1kjVuxAHIQSNU6hY4Nsn9/ag==",
       "dev": true
     },
     "node_modules/vinyl-sourcemap/node_modules/normalize-path": {
@@ -8892,19 +8957,19 @@
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+      "integrity": "sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==",
       "dev": true
     },
     "accepts": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-      "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+      "integrity": "sha512-AOPopplFOUlmUugwiZUCDpOwmqvSgdCyE8iJVLWI4NcB7qfMKQN34dn5xYtlUU03XGG5egRWW4NW5gIxpa5hEA==",
       "dev": true,
       "requires": {
         "mime-types": "~2.1.11",
@@ -8920,7 +8985,7 @@
     "acorn-jsx": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "integrity": "sha512-AU7pnZkguthwBjKgCg6998ByQNIMjbuDQZ8bb78QAFZwPfmKia8AIzgY/gWgqCjnht8JLdXmB4YxA0KaV60ncQ==",
       "dev": true,
       "requires": {
         "acorn": "^3.0.4"
@@ -8929,7 +8994,7 @@
         "acorn": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "integrity": "sha512-OLUyIIZ7mF5oaAUT1w0TFqQS81q3saT46x8t7ukpPjMNk+nbs4ZHhs7ToV8EWnLYLepjETXd4XaCE4uxkMeqUw==",
           "dev": true
         }
       }
@@ -8937,19 +9002,19 @@
     "adm-zip": {
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
-      "integrity": "sha1-hgbCy/HEJs6MjsABdER/1Jtur8E=",
+      "integrity": "sha512-QHVQ6ekddFaGr9r2hBUC4gPw2wLqMZioXojt9BydQPbSh8us7+Q5xcUCUq+hnh4zAdauV3wqoY0quApjKqrhbA==",
       "dev": true
     },
     "after": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
+      "integrity": "sha512-QbJ0NTQ/I9DI3uSJA4cbexiwQeRAfjPScqIbSjUDd9TOrcg6pTkdgziesOqxBMBzit8vFCTwrP27t13vFOORRA==",
       "dev": true
     },
     "ajv": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "integrity": "sha512-I/bSHSNEcFFqXLf91nchoNB9D1Kie3QKcWdchYUaoIg1+1bdWDkdfdlvdIOJbi9U8xR0y+MWc5D+won9v95WlQ==",
       "dev": true,
       "requires": {
         "co": "^4.6.0",
@@ -8959,14 +9024,14 @@
     "ajv-keywords": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "integrity": "sha512-vuBv+fm2s6cqUyey2A7qYcvsik+GMDJsw8BARP2sDE76cqmaZVarsvHf7Vx6VJ0Xk8gLl+u3MoAPf6gKzJefeA==",
       "dev": true,
       "requires": {}
     },
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
       "dev": true,
       "optional": true
     },
@@ -8982,13 +9047,13 @@
     "ansi-escapes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "integrity": "sha512-wiXutNjDUlNEDWHcYH3jtZUhd3c4/VojassD8zHdHCY13xbZy2XbW+NKQwA0tWGBVzDA9qEzYwfoSsWmviidhw==",
       "dev": true
     },
     "ansi-gray": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
-      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "integrity": "sha512-HrgGIZUl8h2EHuZaU9hTR/cU5nhKxpVE1V6kdGsQ8e4zirElJ5fvtfc8N7Q1oq1aatO275i8pUFUCpNWCAnVWw==",
       "dev": true,
       "requires": {
         "ansi-wrap": "0.1.0"
@@ -8997,19 +9062,19 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
       "dev": true
     },
     "ansi-wrap": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "integrity": "sha512-ZyznvL8k/FZeQHr2T6LzcJ/+vBApDnMNZvfVFy3At0knswWd6rJ3/0Hhmpu8oqa6C92npmozs890sX9Dl6q+Qw==",
       "dev": true
     },
     "anymatch": {
@@ -9036,7 +9101,7 @@
     "append-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
-      "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
+      "integrity": "sha512-WLbYiXzD3y/ATLZFufV/rZvWdZOs+Z/+5v1rBZ463Jn398pa6kcde27cvozYnBoxXblGZTFfoPpsaEw0orU5BA==",
       "dev": true,
       "requires": {
         "buffer-equal": "^1.0.0"
@@ -9045,13 +9110,13 @@
     "apple-pay-js-stubs": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/apple-pay-js-stubs/-/apple-pay-js-stubs-1.0.4.tgz",
-      "integrity": "sha1-2VDRtTUh2M7x2FIPto/bEJS4fW0=",
+      "integrity": "sha512-XNvvvKTOyn4NWQ2KpwPtmtBgXbxcR+QnrZjw/huLDnXzDThA9AkhFt+4inOqcQhymFLimZr2O2SKeZc8oXMcRA==",
       "dev": true
     },
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true
     },
     "argparse": {
@@ -9066,13 +9131,13 @@
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
       "dev": true
     },
     "arr-filter": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/arr-filter/-/arr-filter-1.1.2.tgz",
-      "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
+      "integrity": "sha512-A2BETWCqhsecSvCkWAeVBFLH6sXEUGASuzkpjL3GR1SlL/PWL6M3J8EAAld2Uubmh39tvkJTqC9LeLHCUKmFXA==",
       "dev": true,
       "requires": {
         "make-iterator": "^1.0.0"
@@ -9087,7 +9152,7 @@
     "arr-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
-      "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
+      "integrity": "sha512-tVqVTHt+Q5Xb09qRkbu+DidW1yYzz5izWS2Xm2yFm7qJnmUfz4HPzNxbHkdRJbz2lrqI7S+z17xNYdFcBBO8Hw==",
       "dev": true,
       "requires": {
         "make-iterator": "^1.0.0"
@@ -9096,36 +9161,36 @@
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
       "dev": true
     },
     "array-differ": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+      "integrity": "sha512-LeZY+DZDRnvP7eMuQ6LHfCzUGxAAIViUBliK24P3hWXL6y4SortgR6Nim6xrkfSLlmH0+k+9NYNwVC2s53ZrYQ==",
       "dev": true
     },
     "array-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
-      "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
+      "integrity": "sha512-zHjL5SZa68hkKHBFBK6DJCTtr9sfTCPCaph/L7tMSLcTFgy+zX7E+6q5UArbtOtMBCtxdICpfTCspRse+ywyXA==",
       "dev": true
     },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
       "dev": true
     },
     "array-includes": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
-      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
+      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5",
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       }
@@ -9133,7 +9198,7 @@
     "array-initial": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/array-initial/-/array-initial-1.1.0.tgz",
-      "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
+      "integrity": "sha512-BC4Yl89vneCYfpLrs5JU2aAu9/a+xWbeKhvISg9PT7eWFB9UlRvI+rKEtk6mgxWr3dSkk9gQ8hCrdqt06NXPdw==",
       "dev": true,
       "requires": {
         "array-slice": "^1.0.0",
@@ -9174,7 +9239,7 @@
     "array-slice": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-      "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
+      "integrity": "sha512-rlVfZW/1Ph2SNySXwR9QYkChp8EkOEiTMO5Vwx60usw04i4nWemkm9RXmQqgkQFaLHsqLuADvjp6IfgL9l2M8Q==",
       "dev": true
     },
     "array-sort": {
@@ -9191,13 +9256,13 @@
     "array-uniq": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
       "dev": true
     },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
       "dev": true
     },
     "array.prototype.flat": {
@@ -9215,19 +9280,19 @@
     "arraybuffer.slice": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
-      "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco=",
+      "integrity": "sha512-6ZjfQaBSy6CuIH0+B0NrxMfDE5VIOCP/5gOqSpEIsaAZx9/giszzrXg6PZ7G51U/n88UmlAgYLNQ9wAnII7PJA==",
       "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
       "dev": true
     },
     "async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
       "dev": true
     },
     "async-done": {
@@ -9251,7 +9316,7 @@
     "async-settle": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
-      "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
+      "integrity": "sha512-VPXfB4Vk49z1LHHodrEQ6Xf7W4gg1w0dAPROHngx7qgDjqmIQ+fXmwgGXTW/ITLai0YLSvWepJOP9EVpMnEAcw==",
       "dev": true,
       "requires": {
         "async-done": "^1.2.2"
@@ -9266,7 +9331,7 @@
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
       "dev": true,
       "requires": {
         "chalk": "^1.1.3",
@@ -9277,7 +9342,7 @@
     "bach": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
-      "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
+      "integrity": "sha512-bZOOfCb3gXBXbTFXq3OZtGR88LwGeJvzu6szttaIzymOTS4ZttBNOWSv7aLZja2EMycKtRYV0Oa8SNKH/zkxvg==",
       "dev": true,
       "requires": {
         "arr-filter": "^1.1.1",
@@ -9294,7 +9359,7 @@
     "backo2": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+      "integrity": "sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==",
       "dev": true
     },
     "balanced-match": {
@@ -9332,25 +9397,25 @@
     "base64-arraybuffer": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
+      "integrity": "sha512-437oANT9tP582zZMwSvZGy2nmSeAb8DW2me3y+Uv1Wp2Rulr8Mqlyrv3E7MLxmsiaPSMMDmiDVzgE+e8zlMx9g==",
       "dev": true
     },
     "base64id": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
-      "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
+      "integrity": "sha512-rz8L+d/xByiB/vLVftPkyY215fqNrmasrcJsYkVcm4TgJNz+YXKrFaFAWibSaHkiKoSgMDCb+lipOIRQNGYesw==",
       "dev": true
     },
     "beeper": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+      "integrity": "sha512-3vqtKL1N45I5dV0RdssXZG7X6pCqQrWPNOlBPZPrd+QkE2HEhR57Z04m0KtpbsZH73j+a3F8UD1TQnn+ExTvIA==",
       "dev": true
     },
     "better-assert": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+      "integrity": "sha512-bYeph2DFlpK1XmGs6fvlLRUN29QISM3GBuUwSFsMY2XRx4AvC0WNCS57j4c/xGrK2RS24C1w3YoBOsw9fT46tQ==",
       "dev": true,
       "requires": {
         "callsite": "1.0.0"
@@ -9375,13 +9440,13 @@
     "blob": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
+      "integrity": "sha512-YRc9zvVz4wNaxcXmiSgb9LAg7YYwqQ2xd0Sj6osfA7k/PKmIGVlnOYs3wOFdkRC9/JpQu8sGt/zHgJV7xzerfg==",
       "dev": true
     },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "integrity": "sha512-OorbnJVPII4DuUKbjARAe8u8EfqOmkEEaSFIyoQ7OjTHn6kafxWl0wLgoZ2rXaYd7MyLcDaU4TmhfxtwgcccMQ==",
       "dev": true,
       "requires": {
         "inherits": "~2.0.0"
@@ -9390,7 +9455,7 @@
     "bluebird": {
       "version": "3.4.6",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz",
-      "integrity": "sha1-AdqNgh2HgT0ViWfnQ9X+bGLPjA8=",
+      "integrity": "sha512-YvvhuCEE6vHQVlxe+ZTuZyXiA9RIXLz1X8YamApVDYf410Y/K0tBTpZ2bTVNsnPVSRviN/mfu2W42BnRfSXA2A==",
       "dev": true
     },
     "body-parser": {
@@ -9465,13 +9530,13 @@
     "buffer-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
-      "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+      "integrity": "sha512-tcBWO2Dl4e7Asr9hTGcpVrCe+F7DubpmqWCTbj4FHLmjqO2hIaC383acQubWtRJhdceqs5uBHs6Es+Sk//RKiQ==",
       "dev": true
     },
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
       "dev": true
     },
     "buffer-from": {
@@ -9525,7 +9590,7 @@
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "integrity": "sha512-UJiE1otjXPF5/x+T3zTnSFiTOEmJoGTD9HmBoxnCUwho61a2eSNn/VwtwuIBDAo2SEOv1AJ7ARI5gCmohFLu/g==",
       "dev": true,
       "requires": {
         "callsites": "^0.2.0"
@@ -9534,25 +9599,25 @@
     "callsite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+      "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
       "dev": true
     },
     "callsites": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "integrity": "sha512-Zv4Dns9IbXXmPkgRRUjAaJQgfN4xX5p6+RQFhWUqscdvvK2xK/ZL8b3IXIJsj+4sD+f24NwnWy2BY8AJ82JB0A==",
       "dev": true
     },
     "camelcase": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+      "integrity": "sha512-4nhGqUkc4BqbBBB4Q6zLuD7lzzrHYrjKGeYaEji/3tFR5VdJu9v+LilhGIVe8wxEJPPOeWo7eg8dwY13TZ1BNg==",
       "dev": true
     },
     "camelcase-keys": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "integrity": "sha512-bA/Z/DERHKqoEOrp+qeGKw1QlvEQkGZSc0XaY6VnTxZr+Kv1G5zFwttpjv8qxZ/sBPT4nthwZaAcsAZTJlSKXQ==",
       "dev": true,
       "requires": {
         "camelcase": "^2.0.0",
@@ -9562,7 +9627,7 @@
         "camelcase": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "integrity": "sha512-DLIsRzJVBQu72meAKPkWQOLcujdXT32hwdfnkI1frSiSRMK1MofjKHf+MEx0SB6fjEFXL8fBDv1dKymBlOp4Qw==",
           "dev": true
         }
       }
@@ -9576,7 +9641,7 @@
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "dev": true,
       "requires": {
         "ansi-styles": "^2.2.1",
@@ -9689,7 +9754,7 @@
     "cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "integrity": "sha512-25tABq090YNKkF6JH7lcwO0zFJTRke4Jcq9iX2nr/Sz0Cjjv4gckmwlW6Ty/aoyFd6z3ysR2hMGC2GFugmBo6A==",
       "dev": true,
       "requires": {
         "restore-cursor": "^1.0.1"
@@ -9704,7 +9769,7 @@
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
       "dev": true,
       "requires": {
         "string-width": "^1.0.1",
@@ -9715,19 +9780,19 @@
     "clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
       "dev": true
     },
     "clone-buffer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+      "integrity": "sha512-KLLTJWrvwIP+OPfMn0x2PheDEP20RPUcGXj/ERegTgdmPEZylALQldygiqrPPu8P45uNuPs7ckmReLY6v/iA5g==",
       "dev": true
     },
     "clone-stats": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+      "integrity": "sha512-dhUqc57gSMCo6TX85FLfe51eC/s+Im2MLkAgJwfaRRexR2tA4dd3eLEW4L6efzHc2iNorrRRXITifnDLlRrhaA==",
       "dev": true
     },
     "cloneable-readable": {
@@ -9744,19 +9809,19 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
       "dev": true
     },
     "collection-map": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-map/-/collection-map-1.0.0.tgz",
-      "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
+      "integrity": "sha512-5D2XXSpkOnleOI21TG7p3T0bGAsZ/XknZpKBmGYyluO8pw4zA3K8ZlrBIbC4FXg3m6z/RNFiUFfT2sQK01+UHA==",
       "dev": true,
       "requires": {
         "arr-map": "^2.0.2",
@@ -9767,7 +9832,7 @@
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "integrity": "sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==",
       "dev": true,
       "requires": {
         "map-visit": "^1.0.0",
@@ -9789,7 +9854,7 @@
     "combine-lists": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/combine-lists/-/combine-lists-1.0.1.tgz",
-      "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
+      "integrity": "sha512-4Mi0V7N48B9KzC8Zl/U7wiWuxMFEHf44N3/PSoAvWDu8IOPrddNo1y1tC/kXbP7IvVMhgCFMMNzgKb0pWoin9w==",
       "dev": true,
       "requires": {
         "lodash": "^4.5.0"
@@ -9804,7 +9869,7 @@
     "component-bind": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
+      "integrity": "sha512-WZveuKPeKAG9qY+FkYDeADzdHyTYdIboXS59ixDeRJL5ZhxpqUnxSOwop4FQjMsiYm3/Or8cegVbpAHNA7pHxw==",
       "dev": true
     },
     "component-emitter": {
@@ -9816,13 +9881,13 @@
     "component-inherit": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
+      "integrity": "sha512-w+LhYREhatpVqTESyGFg3NlP6Iu0kEKUHETY9GoZP/pQyW4mHFZuFWRUCIqVPZ36ueVLtoOEZaAqbCF2RDndaA==",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "concat-stream": {
@@ -9875,13 +9940,13 @@
     "cookie": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "integrity": "sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw==",
       "dev": true
     },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
       "dev": true
     },
     "copy-props": {
@@ -9909,7 +9974,7 @@
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "integrity": "sha512-gYTKKexFO3kh200H1Nit76sRwRtOY32vQd3jpAQKpLtZqyNsSQNfI4N7o3eP2wUjV35pTWKRYqFUDBvUha/Pkw==",
       "dev": true,
       "requires": {
         "capture-stack-trace": "^1.0.0"
@@ -9918,7 +9983,7 @@
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "integrity": "sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==",
       "dev": true,
       "requires": {
         "array-find-index": "^1.0.1"
@@ -9927,7 +9992,7 @@
     "custom-event": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
-      "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
+      "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
       "dev": true
     },
     "d": {
@@ -9943,7 +10008,7 @@
     "dateformat": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
+      "integrity": "sha512-GODcnWq3YGoTnygPfi02ygEiRxqUxpJwuRHjdhJYuxpcZmDq4rjBiXYmbCCzStxo176ixfLT6i4NPwQooRySnw==",
       "dev": true
     },
     "debug": {
@@ -9958,13 +10023,13 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
       "dev": true
     },
     "deep-is": {
@@ -9985,16 +10050,17 @@
     "default-resolution": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
-      "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
+      "integrity": "sha512-2xaP6GiwVwOEbXCGoJ4ufgC76m8cj805jrghScewJC2ZDsb9U0b4BIrba+xt/Uytyd0HvQ6+WymSRTfnYj59GQ==",
       "dev": true
     },
     "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
       "dev": true,
       "requires": {
-        "object-keys": "^1.0.12"
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       }
     },
     "define-property": {
@@ -10138,7 +10204,7 @@
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
           "dev": true,
           "requires": {
             "ms": "0.7.2"
@@ -10185,13 +10251,13 @@
         "component-emitter": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+          "integrity": "sha512-jPatnhd33viNplKjqXKRkGU345p263OIWzDL2wH3LGIGp5Kojo+uXizHmOADRvhGFFTnJqX3jBAKP6vvmSDKcA==",
           "dev": true
         },
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
           "dev": true,
           "requires": {
             "ms": "0.7.2"
@@ -10245,17 +10311,19 @@
       }
     },
     "es-abstract": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-      "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
         "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
         "is-callable": "^1.2.4",
@@ -10267,9 +10335,10 @@
         "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "regexp.prototype.flags": "^1.4.3",
+        "string.prototype.trimend": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.5",
+        "unbox-primitive": "^1.0.2"
       }
     },
     "es-shim-unscopables": {
@@ -10293,9 +10362,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.60",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.60.tgz",
-      "integrity": "sha512-jpKNXIt60htYG59/9FGf2PYT3pwMpnEbNKysU+k/4FGwyGtMotOvcZOuW+EmXXYASRqYSXQfGL5cVIthOTgbkg==",
+      "version": "0.10.61",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.61.tgz",
+      "integrity": "sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==",
       "dev": true,
       "requires": {
         "es6-iterator": "^2.0.3",
@@ -10686,13 +10755,13 @@
         "array-unique": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg==",
           "dev": true
         },
         "braces": {
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
-          "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
+          "integrity": "sha512-EIMHIv2UXHWFY2xubUGKz+hq9hNkENj4Pjvr7h58cmJgpkK2yMlKA8I484f7MSttkzVAy/lL7X9xDaILd6avzA==",
           "dev": true,
           "requires": {
             "expand-range": "^0.1.0"
@@ -11066,9 +11135,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
       "dev": true
     },
     "for-in": {
@@ -11158,6 +11227,24 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      }
+    },
+    "functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true
+    },
     "geckodriver": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-1.6.1.tgz",
@@ -11228,15 +11315,15 @@
       "dev": true
     },
     "glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -11532,9 +11619,9 @@
       }
     },
     "has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true
     },
     "has-binary": {
@@ -11573,6 +11660,15 @@
       "dev": true,
       "requires": {
         "sparkles": "^1.0.0"
+      }
+    },
+    "has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.1"
       }
     },
     "has-symbols": {
@@ -11845,9 +11941,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -12374,7 +12470,7 @@
         "arr-diff": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "integrity": "sha512-dtXTVMkh6VkEEA7OhXnN1Ecb8aAGFdZ1LFxtOCoqj4qkyOJMt7+qs6Ahdy6p/NQCPYsRSXXivhSB/J5E9jmYKA==",
           "dev": true,
           "requires": {
             "arr-flatten": "^1.0.1"
@@ -12383,13 +12479,13 @@
         "array-unique": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg==",
           "dev": true
         },
         "braces": {
           "version": "1.8.5",
           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "integrity": "sha512-xU7bpz2ytJl1bH9cgIurjpg/n8Gohy9GTw81heDYLJQ4RU60dlyJsa+atVF2pI0yMMvKxI9HkKwjePCj5XI1hw==",
           "dev": true,
           "requires": {
             "expand-range": "^1.8.1",
@@ -12400,7 +12496,7 @@
         "chokidar": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-          "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+          "integrity": "sha512-mk8fAWcRUOxY7btlLtitj3A45jOwSAxH4tOFOoEGbVsl6cL6pPMWUy7dwZ/canfj3QEdP6FHSnf/l1c6/WkzVg==",
           "dev": true,
           "requires": {
             "anymatch": "^1.3.0",
@@ -12569,7 +12665,7 @@
         "dateformat": {
           "version": "1.0.12",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-          "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+          "integrity": "sha512-5sFRfAAmbHdIts+eKjR9kYJoF0ViCMVX9yqLu5A7S/v+nd077KgCITOMiirmyCBiZpKLDXbBOkYm6tu7rX/TKg==",
           "dev": true,
           "requires": {
             "get-stdin": "^4.0.1",
@@ -12779,7 +12875,7 @@
         "colors": {
           "version": "0.6.2",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+          "integrity": "sha512-OsSVtHK8Ir8r3+Fxw/b4jS1ZLPXkV6ZxDRJQzeD7qo0SqMXWrHDM71DgYzPMHY8SFJ0Ao+nNU2p1MmwdzKqPrw==",
           "dev": true
         }
       }
@@ -13395,9 +13491,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
       "dev": true,
       "optional": true
     },
@@ -13621,9 +13717,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true
     },
     "object-keys": {
@@ -14354,6 +14450,17 @@
         }
       }
     },
+    "regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      }
+    },
     "remove-bom-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
@@ -14583,7 +14690,7 @@
         "adm-zip": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz",
-          "integrity": "sha1-ph7VrmkFw66lizplfSUDMJEFJzY=",
+          "integrity": "sha512-SYIiqLfr6QvmEM0yw89mD8ba2HjK+duf7oVPEw79+NPDqyQScAU8IgDPZzFt9CVdD2yaAuWJqFQGLkongB6cJQ==",
           "dev": true
         },
         "tmp": {
@@ -14832,7 +14939,7 @@
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
           "dev": true,
           "requires": {
             "ms": "0.7.2"
@@ -14865,7 +14972,7 @@
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
           "dev": true,
           "requires": {
             "ms": "0.7.2"
@@ -14901,13 +15008,13 @@
         "component-emitter": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+          "integrity": "sha512-jPatnhd33viNplKjqXKRkGU345p263OIWzDL2wH3LGIGp5Kojo+uXizHmOADRvhGFFTnJqX3jBAKP6vvmSDKcA==",
           "dev": true
         },
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "integrity": "sha512-dCHp4G+F11zb+RtEu7BE2U8R32AYmM/4bljQfut8LipH3PdwsVBVGh083MXvtKkB7HSQUzSwiXz53c4mzJvYfw==",
           "dev": true,
           "requires": {
             "ms": "0.7.2"
@@ -14936,13 +15043,13 @@
         "component-emitter": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-          "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM=",
+          "integrity": "sha512-YhIbp3PJiznERfjlIkK0ue4obZxt2S60+0W8z24ZymOHT8sHloOqWOqZRU2eN5OlY8U08VFsP02letcu26FilA==",
           "dev": true
         },
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
           "dev": true,
           "requires": {
             "ms": "0.7.1"
@@ -15195,23 +15302,25 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       }
     },
     "strip-ansi": {
@@ -15340,7 +15449,7 @@
         "bluebird": {
           "version": "2.11.0",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
+          "integrity": "sha512-UfFSr22dmHPQqPP9XWHRhq+gWnHCYguQGkXQlbyPtW5qTnhFWA8/iXg765tH0cAjy7l/zPJ1aBTO0g5XgA7kvQ==",
           "dev": true
         }
       }
@@ -15563,9 +15672,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.15.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
-      "integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
+      "version": "3.15.5",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.5.tgz",
+      "integrity": "sha512-hNM5q5GbBRB5xB+PMqVRcgYe4c8jbyZ1pzZhS6jbq54/4F2gFK869ZheiE5A8/t+W5jtTNpWef/5Q9zk639FNQ==",
       "dev": true,
       "optional": true
     },
@@ -15576,14 +15685,14 @@
       "dev": true
     },
     "unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
     },
@@ -15594,9 +15703,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
-      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.3.tgz",
+      "integrity": "sha512-QvjkYpiD+dJJraRA8+dGAU4i7aBbb2s0S3jA45TFOvg2VgqvdCDd/3N6CqA8gluk1W91GLoXg5enMUx560QzuA==",
       "dev": true
     },
     "undertaker": {
@@ -15827,13 +15936,13 @@
         "clone": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+          "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
           "dev": true
         },
         "clone-stats": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+          "integrity": "sha512-au6ydSpg6nsrigcZ4m8Bc9hxjeW+GJ8xh5G3BJCMt4WXe1H10UNaVOamqQTmrx1kjVuxAHIQSNU6hY4Nsn9/ag==",
           "dev": true
         },
         "replace-ext": {
@@ -15876,13 +15985,13 @@
         "clone": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+          "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
           "dev": true
         },
         "clone-stats": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+          "integrity": "sha512-au6ydSpg6nsrigcZ4m8Bc9hxjeW+GJ8xh5G3BJCMt4WXe1H10UNaVOamqQTmrx1kjVuxAHIQSNU6hY4Nsn9/ag==",
           "dev": true
         },
         "normalize-path": {


### PR DESCRIPTION
[REV-2737](https://2u-internal.atlassian.net/browse/REV-2737)

Starting 4/19 there's a github [issue](https://support.github.com/ticket/personal/0/1636121) preventing git diff from working during our detect_changed_translations test. As a result our quality-and-jobs github action fails (without running many of the tests), and changes can only be merged to ecommerce by admins. Let's skip this one test to allow the other working checks to run properly. 

Since quality-and-jobs wasn't able to run fully for the last few updates: 
- there are a bunch of failing tests in test_enterprise.py that weren't noticed (including 25 in ENT-5824, see Brian Beggs' approval below since his team plans on fixing those)- I'm disabling those and other failing enterprise tests until they can be fixed so they no longer block these checks. 
- I've fixed pylint spacing issues as well
- along the way there had been a package/dependency issue, so I also did 'make upgrade' which resolved that message, and I didn't see any major version updates in the updated package-lock.json
- Now the only check failing is that code coverage has decreased with the skipped/commented tests

## Required Testing
- [x] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)
