### PR TITLE
fix: move logging statement to remove noise

### DIFF
--- a/ecommerce/extensions/refund/models.py
+++ b/ecommerce/extensions/refund/models.py
@@ -202,21 +202,23 @@ class Refund(StatusMixin, TimeStampedModel):
         applied to each line. We also don't know if partial refunds count as 1 application & order.
         Note that there has not been an order with partial refund that uses enterprise offers currently.
         """
-        if self.lines.count() != self.order.lines.count():
-            logger.error(
-                "[Enterprise Offer Refund] Refund %d has %d lines, but order %d has %d lines,"
-                "enterprise offer cannot be automatically credited.",
-                self.id,
-                self.lines.count(),
-                self.order.id,
-                self.order.lines.count()
-            )
-            return
-
         try:
             for discount in self.order.discounts.all():
                 offer = discount.offer
+
                 if offer.offer_type == ConditionalOffer.SITE and offer.condition.enterprise_customer_uuid:
+
+                    if self.lines.count() != self.order.lines.count():
+                        logger.error(
+                            "[Enterprise Offer Refund] Refund %d has %d lines, but order %d has %d lines,"
+                            "enterprise offer cannot be automatically credited.",
+                            self.id,
+                            self.lines.count(),
+                            self.order.id,
+                            self.order.lines.count()
+                        )
+                        return
+
                     amount_discounted = discount.amount
                     frequency = discount.frequency
 


### PR DESCRIPTION
This error was getting logged for refunds that do not involve enterprise offers, creating noise. Moved the logging and return statement to when we find a relevant enterprise offer.

`test_issue_credit_for_enterprise_offer_no_partial_credit` covers these changes.


# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?
Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
