### PR TITLE
fix: remove email sentence for learner flow

### DIFF
--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -58,10 +58,8 @@
               {% else %}
                   {% blocktrans trimmed asvar tmsg %}
                       Your order is complete. If you need a receipt, you can print this page.
-                      You will also receive a confirmation message with this information at
-                      {link_start}{email}{link_end}.
                   {% endblocktrans %}
-                {% interpolate_html tmsg email=order.user.email|safe link_end="</a>"|safe link_start=link_start|safe %}
+                {% interpolate_html tmsg %}
               {% endif %}
             </div>
 


### PR DESCRIPTION
[REV-2789](https://2u-internal.atlassian.net/browse/REV-2789)

From [CR-3540](https://2u-internal.atlassian.net/browse/CR-3540): we no longer send confirmation emails, but the receipt page says we will so learners expect it and contact support when they don’t get it. For the regular learner flow*, remove that last sentence about confirmation email: 

`Your order is complete. If you need a receipt, you can print this page. You will also receive a confirmation message with this information at [user@gmail.com](mailto:sara.durai@gmail.com).`

*not the path for buying enrollment codes

## Before
<img width="1445" alt="receipt_before" src="https://user-images.githubusercontent.com/5384216/172918747-00e56740-8c97-4a19-b839-b0da98bdabde.png">

## After
![receipt_after](https://user-images.githubusercontent.com/5384216/172918863-91a9d3e8-b949-4467-a4b0-81d0b76a60e4.png)

## Testing instructions
Place a local order and look at the receipt

## Other information
Note: this page also has a path for purchasing enrollment codes, and the email may still go out for this, so I've left that in place. I'm not sure how to perform that case locally (or elsewhere) to confirm that it stays intact, but that code is in its own block. (if has_enrollment_code_product)
