### PR TITLE
FC-0001: Replace usages enterprise_catalogs Enterprise API V1

### DIFF
--- a/ecommerce/coupons/tests/mixins.py
+++ b/ecommerce/coupons/tests/mixins.py
@@ -1,9 +1,11 @@
 
 
 import datetime
+from urllib.parse import urljoin
 
 import mock
 import responses
+from django.conf import settings
 from django.test import RequestFactory
 from edx_django_utils.cache import TieredCache
 from oscar.core.utils import slugify
@@ -20,6 +22,8 @@ from ecommerce.tests.mixins import Applicator, Benefit, Catalog, ProductClass, S
 
 class DiscoveryMockMixin:
     """ Mocks for the Discovery service response. """
+    ENTERPRISE_CATALOG_URL = urljoin(settings.ENTERPRISE_CATALOG_API_URL, 'enterprise-catalogs/')
+
     def setUp(self):
         super(DiscoveryMockMixin, self).setUp()
         TieredCache.dangerous_clear_all_tiers()
@@ -210,7 +214,7 @@ class DiscoveryMockMixin:
         )
 
     def mock_enterprise_catalog_course_endpoint(
-            self, enterprise_api_url, enterprise_catalog_id, course_run=None, course_info=None
+            self, enterprise_catalog_id, course_run=None, course_info=None
     ):
         """
         Helper function to register a enterprise API endpoint for getting course information.
@@ -240,13 +244,9 @@ class DiscoveryMockMixin:
                     'course_runs': [],
                 }],
             }
-        enterprise_catalog_url = '{}enterprise_catalogs/{}/'.format(
-            enterprise_api_url,
-            enterprise_catalog_id
-        )
         responses.add(
             responses.GET,
-            enterprise_catalog_url,
+            url=urljoin(f'{self.ENTERPRISE_CATALOG_URL}{enterprise_catalog_id}/', 'get_content_metadata/'),
             json=course_info,
             content_type='application/json'
         )

--- a/ecommerce/enterprise/tests/test_utils.py
+++ b/ecommerce/enterprise/tests/test_utils.py
@@ -272,7 +272,7 @@ class EnterpriseUtilsTests(EnterpriseServiceMockMixin, TestCase):
         Verify that "get_enterprise_customer_catalogs" works as expected with and without caching.
         """
         enterprise_customer_uuid = str(uuid.uuid4())
-        base_url = self.LEGACY_ENTERPRISE_CATALOG_URL
+        base_url = self.ENTERPRISE_CATALOG_URL
 
         self.mock_access_token_response()
         self.mock_enterprise_catalog_api(enterprise_customer_uuid)
@@ -294,7 +294,7 @@ class EnterpriseUtilsTests(EnterpriseServiceMockMixin, TestCase):
         Verify that "get_enterprise_customer_catalogs" return default response on exception.
         """
         enterprise_customer_uuid = str(uuid.uuid4())
-        base_url = self.LEGACY_ENTERPRISE_CATALOG_URL
+        base_url = self.ENTERPRISE_CATALOG_URL
 
         self.mock_access_token_response()
         self.mock_enterprise_catalog_api(enterprise_customer_uuid, raise_exception=True)

--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -32,13 +32,10 @@ CONSENT_FAILED_PARAM = 'consent_failed'
 log = logging.getLogger(__name__)
 
 CUSTOMER_CATALOGS_DEFAULT_RESPONSE = {
-    'count': 0,
-    'num_pages': 0,
-    'current_page': 0,
-    'start': 0,
-    'next': None,
-    'previous': None,
-    'results': [],
+    "count": 0,
+    "next": None,
+    "previous": None,
+    "results": []
 }
 
 
@@ -150,6 +147,7 @@ def get_enterprise_customer_catalogs(site, endpoint_request_url, enterprise_cust
 
     Args:
         site (Site): The site which is handling the current request
+        endpoint_request_url (str): endpoint request url
         enterprise_customer_uuid (str): The uuid of the Enterprise Customer
 
     Returns:
@@ -158,35 +156,34 @@ def get_enterprise_customer_catalogs(site, endpoint_request_url, enterprise_cust
     Response will look like
 
         {
-            'count': 2,
-            'num_pages': 1,
-            'current_page': 1,
-            'results': [
+            "count": 2,
+            "next": None,
+            "previous": None,
+            "results": [
                 {
-                    'enterprise_customer': '6ae013d4-c5c4-474d-8da9-0e559b2448e2',
-                    'uuid': '869d26dd-2c44-487b-9b6a-24eee973f9a4',
-                    'title': 'batman_catalog'
+                    "uuid": "869d26dd-2c44-487b-9b6a-24eee973f9a4",
+                    "title": "batman_catalog",
+                    "enterprise_customer": "6ae013d4-c5c4-474d-8da9-0e559b2448e2",
+                    "catalog_query_uuid": None,
+                    "content_last_modified": None,
+                    "catalog_modified": "2022-05-26T12:56:20.346837Z",
+                    "query_title": None
                 },
                 {
-                    'enterprise_customer': '6ae013d4-c5c4-474d-8da9-0e559b2448e2',
-                    'uuid': '1a61de70-f8e8-4e8c-a76e-01783a930ae6',
-                    'title': 'new catalog'
+                    "uuid": "1a61de70-f8e8-4e8c-a76e-01783a930ae6",
+                    "title": "new_catalog",
+                    "enterprise_customer": "6ae013d4-c5c4-474d-8da9-0e559b2448e2",
+                    "catalog_query_uuid": None,
+                    "content_last_modified": None,
+                    "catalog_modified": "2022-05-26T12:56:20.346837Z",
+                    "query_title": None
                 }
             ],
-            'next': None,
-            'start': 0,
-            'previous': None
         }
     """
     resource = 'enterprise_catalogs'
     partner_code = site.siteconfiguration.partner.short_code
-    cache_key = u'{site_domain}_{partner_code}_{resource}_{uuid}_{page}'.format(
-        site_domain=site.domain,
-        partner_code=partner_code,
-        resource=resource,
-        uuid=enterprise_customer_uuid,
-        page=page,
-    )
+    cache_key = f'{site.domain}_{partner_code}_{resource}_{enterprise_customer_uuid}_{page}'
     cache_key = hashlib.md5(cache_key.encode('utf-8')).hexdigest()
 
     cached_response = TieredCache.get_cached_response(cache_key)
@@ -195,7 +192,7 @@ def get_enterprise_customer_catalogs(site, endpoint_request_url, enterprise_cust
 
     api_client = site.siteconfiguration.oauth_api_client
     enterprise_api_url = urljoin(
-        f"{site.siteconfiguration.enterprise_api_url}/", f"{resource}/"
+        f"{site.siteconfiguration.enterprise_catalog_api_url}/", "enterprise-catalogs/"
     )
 
     try:
@@ -527,31 +524,89 @@ def has_enterprise_offer(basket):
     return False
 
 
-def get_enterprise_catalog(site, enterprise_catalog, limit, page, endpoint_request_url=None):
+# pylint: disable=line-too-long
+def get_enterprise_catalog(site, enterprise_catalog, page_size, page, endpoint_request_url=None):
     """
-    Get the EnterpriseCustomerCatalog for a given catalog uuid.
+    Get the EnterpriseCatalog for a given catalog uuid.
 
     Args:
         site (Site): The site which is handling the current request
         enterprise_catalog (str): The uuid of the Enterprise Catalog
-        limit (int): The number of results to return per page.
+        page_size (int): The number of results to return per page.
         page (int): The page number to fetch.
         endpoint_request_url (str): This is used to replace the lms url with ecommerce url
 
     Returns:
         dict: The result set containing the content objects associated with the Enterprise Catalog.
         NoneType: Return None if no catalog with that uuid is found.
+
+    Response will look like
+
+        {
+            "count": 1,
+            "next": null,
+            "previous": null,
+            "uuid": "5589518b-f858-4459-a8c3-e44df4fc7af6",
+            "title": "All Course Runs",
+            "enterprise_customer": "caf06525-701b-4cf4-a05f-2c78659c4cb7",
+            "results": [
+                {
+                "aggregation_key": "courserun:edX+DemoX",
+                "content_type": "courserun",
+                "authoring_organization_uuids": [
+                    "7aeefb23-e236-41e3-92a2-bed343ec8bfe"
+                ],
+                "availability": "Current",
+                "end": null,
+                "enrollment_end": null,
+                "enrollment_start": null,
+                "first_enrollable_paid_seat_sku": "8CF08E5",
+                "first_enrollable_paid_seat_price": 149,
+                "full_description": null,
+                "go_live_date": null,
+                "has_enrollable_seats": true,
+                "image_url": null,
+                "is_enrollable": true,
+                "key": "course-v1:edX+DemoX+Demo_Course",
+                "language": null,
+                "level_type": null,
+                "logo_image_urls": [],
+                "marketing_url": "course/demonstration-course-course-v1edxdemoxdemo_course?utm_medium=enterprise&utm_source=test-enterprise",
+                "max_effort": null,
+                "min_effort": null,
+                "mobile_available": false,
+                "number": "DemoX",
+                "org": "edX",
+                "pacing_type": "instructor_paced",
+                "partner": "edx",
+                "program_types": [
+                    "MicroMasters"
+                ],
+                "published": false,
+                "seat_types": [
+                    "verified",
+                    "audit"
+                ],
+                "skill_names": [],
+                "skills": [],
+                "short_description": null,
+                "staff_uuids": [],
+                "start": "2013-02-05T05:00:00Z",
+                "subject_uuids": [],
+                "title": "Demonstration Course",
+                "transcript_languages": [],
+                "type": "verified",
+                "weeks_to_complete": null,
+                "content_last_modified": "2022-06-08T15:24:08.020654Z",
+                "enrollment_url": "http://localhost:8734/test-enterprise/course/edX+DemoX?course_run_key=course-v1%3AedX%2BDemoX%2BDemo_Course&utm_medium=enterprise&utm_source=test-enterprise",
+                "xapi_activity_id": "http://edx.devstack.lms:18000/xapi/activities/courserun/course-v1:edX+DemoX+Demo_Course"
+                }
+            ]
+        }
     """
     resource = 'enterprise_catalogs'
     partner_code = site.siteconfiguration.partner.short_code
-    cache_key = u'{site_domain}_{partner_code}_{resource}_{catalog}_{limit}_{page}'.format(
-        site_domain=site.domain,
-        partner_code=partner_code,
-        resource=resource,
-        catalog=enterprise_catalog,
-        limit=limit,
-        page=page
-    )
+    cache_key = f'{site.domain}_{partner_code}_{resource}_{enterprise_catalog}_{page_size}_{page}'
     cache_key = hashlib.md5(cache_key.encode('utf-8')).hexdigest()
 
     cached_response = TieredCache.get_cached_response(cache_key)
@@ -560,14 +615,14 @@ def get_enterprise_catalog(site, enterprise_catalog, limit, page, endpoint_reque
 
     api_client = site.siteconfiguration.oauth_api_client
     enterprise_api_url = urljoin(
-        f"{site.siteconfiguration.enterprise_api_url}/",
-        f"{resource}/{str(enterprise_catalog)}/"
+        f"{site.siteconfiguration.enterprise_catalog_api_url}/",
+        f"enterprise-catalogs/{str(enterprise_catalog)}/get_content_metadata/"
     )
 
     response = api_client.get(
         enterprise_api_url,
         params={
-            "limit": limit,
+            "page_size": page_size,
             "page": page,
         }
     )

--- a/ecommerce/extensions/api/v2/tests/views/test_vouchers.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_vouchers.py
@@ -485,7 +485,7 @@ class VoucherViewOffersEndpointTests(DiscoveryMockMixin, CouponMixin, DiscoveryT
         course, seat = self.create_course_and_seat()
         enterprise_catalog_id = str(uuid4())
         self.mock_enterprise_catalog_course_endpoint(
-            self.site_configuration.enterprise_api_url, enterprise_catalog_id, course_run=course
+            enterprise_catalog_id, course_run=course
         )
         new_range, __ = Range.objects.get_or_create(
             catalog_query='*:*',
@@ -526,7 +526,7 @@ class VoucherViewOffersEndpointTests(DiscoveryMockMixin, CouponMixin, DiscoveryT
         enterprise_customer_id = str(uuid4())
         enterprise_catalog_id = str(uuid4())
         self.mock_enterprise_catalog_course_endpoint(
-            self.site_configuration.enterprise_api_url, enterprise_catalog_id, course_run=course
+            enterprise_catalog_id, course_run=course
         )
         voucher = prepare_enterprise_voucher(
             benefit_value=10,

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -128,7 +128,7 @@ class EnterpriseCustomerCatalogsViewSet(ViewSet):
             catalog = get_enterprise_catalog(
                 site=request.site,
                 enterprise_catalog=kwargs.get('enterprise_catalog_uuid'),
-                limit=request.GET.get('limit', DEFAULT_CATALOG_PAGE_SIZE),
+                page_size=request.GET.get('limit', DEFAULT_CATALOG_PAGE_SIZE),
                 page=request.GET.get('page', '1'),
                 endpoint_request_url=endpoint_request_url
             )

--- a/ecommerce/extensions/api/v2/views/vouchers.py
+++ b/ecommerce/extensions/api/v2/views/vouchers.py
@@ -256,7 +256,7 @@ class VoucherViewSet(NonDestroyableModelViewSet):
             response = get_enterprise_catalog(
                 site=request.site,
                 enterprise_catalog=enterprise_catalog,
-                limit=request.GET.get('limit', DEFAULT_CATALOG_PAGE_SIZE),
+                page_size=request.GET.get('limit', DEFAULT_CATALOG_PAGE_SIZE),
                 page=request.GET.get('page'),
             )
         elif catalog_query:


### PR DESCRIPTION
(1 of 5) for closes https://github.com/openedx/public-engineering/issues/61
##### Latest: https://github.com/openedx/edx-enterprise/pull/1582
## Description:

Replace these [usages1](https://github.com/openedx/ecommerce/blob/master/ecommerce/enterprise/utils.py#L152) [usages2](https://github.com/openedx/ecommerce/blob/master/ecommerce/enterprise/utils.py#L515-L560) with corresponding to the enterprise-catalog service