### PR TITLE
feat: Add receipt page info to Orders API

### DIFF
--- a/ecommerce/entitlements/utils.py
+++ b/ecommerce/entitlements/utils.py
@@ -55,7 +55,9 @@ def get_entitlement(uuid, certificate_type):
     return Product.objects.filter(uuid_query).get(certificate_type_query)
 
 
-def create_or_update_course_entitlement(certificate_type, price, partner, UUID, title, id_verification_required=False):
+def create_or_update_course_entitlement(
+    certificate_type, price, partner, UUID, title, id_verification_required=False, credit_provider=False
+):
     """ Create or Update Course Entitlement Products """
     certificate_type = certificate_type.lower()
     UUID = str(UUID)
@@ -72,6 +74,7 @@ def create_or_update_course_entitlement(certificate_type, price, partner, UUID, 
     course_entitlement.attr.certificate_type = certificate_type
     course_entitlement.attr.UUID = UUID
     course_entitlement.attr.id_verification_required = id_verification_required
+    course_entitlement.attr.credit_provider = credit_provider
     course_entitlement.parent = parent_entitlement
     course_entitlement.save()
 

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -393,6 +393,8 @@ class OrderSerializer(serializers.ModelSerializer):
     user = UserSerializer()
     vouchers = serializers.SerializerMethodField()
     enable_hoist_order_history = serializers.SerializerMethodField()
+    payment_method = serializers.SerializerMethodField()
+
 
     def get_vouchers(self, obj):
         try:
@@ -428,6 +430,17 @@ class OrderSerializer(serializers.ModelSerializer):
             )
         return obj.enable_hoist_order_history
 
+    def get_payment_method(self, obj):
+        payment_method = None
+        try:
+            payment_method = ReceiptResponseView().get_payment_method(obj)
+        except ValueError:
+            logger.exception(
+                'Failed to retrieve payment_method for order [%s]',
+                obj
+            )
+        return payment_method
+
     class Meta:
         model = Order
         fields = (
@@ -439,6 +452,7 @@ class OrderSerializer(serializers.ModelSerializer):
             'lines',
             'number',
             'payment_processor',
+            'payment_method',
             'status',
             'total_excl_tax',
             'user',

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -397,7 +397,7 @@ class OrderSerializer(serializers.ModelSerializer):
     vouchers = serializers.SerializerMethodField()
     enable_hoist_order_history = serializers.SerializerMethodField()
     payment_method = serializers.SerializerMethodField()
-    enterprise_customer_info = serializers.SerializerMethodField()
+    enterprise_learner_portal_url = serializers.SerializerMethodField()
     total_before_discounts_incl_tax = serializers.SerializerMethodField()
     order_product_ids = serializers.SerializerMethodField()
 
@@ -489,22 +489,15 @@ class OrderSerializer(serializers.ModelSerializer):
             )
         return payment_method
 
-    def get_enterprise_customer_info(self, obj):
+    def get_enterprise_learner_portal_url(self, obj):
         try:
-            learner_portal_url = ReceiptResponseView().add_message_if_enterprise_user(obj)
-            discount = obj.discounts.first()
-            if discount and learner_portal_url:
-                return {
-                    'learner_portal_url': learner_portal_url,
-                    'offer_condition_enterprise_customer_name': discount.offer.condition.enterprise_customer_name,
-                    'offer_condition_name': discount.offer.condition.name,
-                }
-        except (AttributeError, TypeError, ValueError):
+            return ReceiptResponseView().add_message_if_enterprise_user(obj)
+        except (AttributeError, ValueError):
             logger.exception(
-                'Failed to retrieve enterprise_customer_info for order [%s]',
+                'Failed to retrieve get_enterprise_learner_portal_url for order [%s]',
                 obj
             )
-        return None
+            return None
 
     def get_total_before_discounts_incl_tax(self, obj):
         try:
@@ -533,7 +526,7 @@ class OrderSerializer(serializers.ModelSerializer):
             'dashboard_url',
             'discount',
             'enable_hoist_order_history',
-            'enterprise_customer_info',
+            'enterprise_learner_portal_url',
             'lines',
             'number',
             'order_product_ids',

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -585,13 +585,16 @@ class EntitlementProductHelper:
         id_verified_default = certificate_type == 'professional'
         id_verification_required = attrs.get('id_verification_required', id_verified_default)
 
+        credit_provider = attrs.get('credit_provider')
+
         entitlement = create_or_update_course_entitlement(
             certificate_type,
             price,
             partner,
             uuid,
             course.name,
-            id_verification_required=id_verification_required
+            id_verification_required=id_verification_required,
+            credit_provider=credit_provider
         )
 
         # As a convenience to our caller, provide the SKU in the returned product serialization.

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -422,14 +422,13 @@ class OrderSerializer(serializers.ModelSerializer):
     def get_enable_hoist_order_history(self, obj):
         try:
             request = self.context.get('request')
-            order_history_enabled = waffle.flag_is_active(request, ENABLE_HOIST_ORDER_HISTORY)
-            obj.enable_hoist_order_history = order_history_enabled
-        except (AttributeError, ValueError) as error:
+            return waffle.flag_is_active(request, ENABLE_HOIST_ORDER_HISTORY)
+        except ValueError:
             logger.exception(
-                'An error occurred while attempting to set ENABLE_HOIST_ORDER_HISTORY flag, error: [%s]',
-                error
+                'An error occurred while attempting to get ENABLE_HOIST_ORDER_HISTORY flag for order [%s]',
+                obj
             )
-        return obj.enable_hoist_order_history
+            return None
 
     def get_payment_method(self, obj):
         payment_method = None

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -386,6 +386,7 @@ class LineSerializer(serializers.ModelSerializer):
 class OrderSerializer(serializers.ModelSerializer):
     """Serializer for parsing order data."""
     billing_address = BillingAddressSerializer(allow_null=True)
+    dashboard_url = serializers.SerializerMethodField()
     date_placed = serializers.DateTimeField(format=ISO_8601_FORMAT)
     discount = serializers.SerializerMethodField()
     lines = LineSerializer(many=True)
@@ -410,6 +411,16 @@ class OrderSerializer(serializers.ModelSerializer):
         try:
             return obj.sources.all()[0].source_type.name
         except IndexError:
+            return None
+
+    def get_dashboard_url(self, obj):
+        try:
+            return ReceiptResponseView.get_order_dashboard_url(self, obj)
+        except ValueError:
+            logger.exception(
+                'Failed to retrieve get_dashboard_url for [%s]',
+                obj
+            )
             return None
 
     def get_discount(self, obj):
@@ -470,6 +481,7 @@ class OrderSerializer(serializers.ModelSerializer):
             'billing_address',
             'currency',
             'date_placed',
+            'dashboard_url',
             'discount',
             'enable_hoist_order_history',
             'enterprise_customer_info',

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -49,6 +49,7 @@ from ecommerce.extensions.api.v2.constants import (
     REFUND_ORDER_EMAIL_SUBJECT
 )
 from ecommerce.extensions.catalogue.utils import attach_vouchers_to_coupon_product
+from ecommerce.extensions.checkout.views import ReceiptResponseView
 from ecommerce.extensions.offer.constants import (
     ASSIGN,
     AUTOMATIC_EMAIL,
@@ -339,6 +340,7 @@ class ProductSerializer(ProductPaymentInfoMixin, serializers.HyperlinkedModelSer
     attribute_values = serializers.SerializerMethodField()
     product_class = serializers.SerializerMethodField()
     is_available_to_buy = serializers.SerializerMethodField()
+    is_enrollment_code_product = serializers.SerializerMethodField()
     stockrecords = StockRecordSerializer(many=True, read_only=True)
 
     def get_attribute_values(self, product):
@@ -358,10 +360,15 @@ class ProductSerializer(ProductPaymentInfoMixin, serializers.HyperlinkedModelSer
         info = self._get_info(product)
         return info.availability.is_available_to_buy
 
+    def get_is_enrollment_code_product(self, product):
+        return product.is_enrollment_code_product
+
     class Meta:
         model = Product
-        fields = ('id', 'url', 'structure', 'product_class', 'title', 'price', 'expires', 'attribute_values',
-                  'is_available_to_buy', 'stockrecords',)
+        fields = (
+            'id', 'url', 'structure', 'product_class', 'title', 'price', 'expires', 'attribute_values',
+            'is_available_to_buy', 'is_enrollment_code_product', 'stockrecords'
+        )
         extra_kwargs = {
             'url': {'view_name': PRODUCT_DETAIL_VIEW},
         }

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -395,6 +395,7 @@ class OrderSerializer(serializers.ModelSerializer):
     enable_hoist_order_history = serializers.SerializerMethodField()
     payment_method = serializers.SerializerMethodField()
     enterprise_customer_info = serializers.SerializerMethodField()
+    total_before_discounts_incl_tax = serializers.SerializerMethodField()
 
     def get_vouchers(self, obj):
         try:
@@ -458,6 +459,12 @@ class OrderSerializer(serializers.ModelSerializer):
             )
         return None
 
+    def get_total_before_discounts_incl_tax(self, obj):
+        try:
+            return str(obj.total_before_discounts_incl_tax)
+        except ValueError:
+            return None
+
     class Meta:
         model = Order
         fields = (
@@ -472,6 +479,7 @@ class OrderSerializer(serializers.ModelSerializer):
             'payment_processor',
             'payment_method',
             'status',
+            'total_before_discounts_incl_tax',
             'total_excl_tax',
             'user',
             'vouchers',

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -397,6 +397,7 @@ class OrderSerializer(serializers.ModelSerializer):
     payment_method = serializers.SerializerMethodField()
     enterprise_customer_info = serializers.SerializerMethodField()
     total_before_discounts_incl_tax = serializers.SerializerMethodField()
+    order_product_ids = serializers.SerializerMethodField()
 
     def get_vouchers(self, obj):
         try:
@@ -475,6 +476,16 @@ class OrderSerializer(serializers.ModelSerializer):
         except ValueError:
             return None
 
+    def get_order_product_ids(self, obj):
+        try:
+            return ','.join(map(str, obj.lines.values_list('product_id', flat=True)))
+        except (AttributeError, ValueError):
+            logger.exception(
+                'Failed to retrieve order_product_ids for order [%s]',
+                obj
+            )
+            return None
+
     class Meta:
         model = Order
         fields = (
@@ -487,6 +498,7 @@ class OrderSerializer(serializers.ModelSerializer):
             'enterprise_customer_info',
             'lines',
             'number',
+            'order_product_ids',
             'payment_processor',
             'payment_method',
             'status',

--- a/ecommerce/extensions/api/tests/test_serializers.py
+++ b/ecommerce/extensions/api/tests/test_serializers.py
@@ -86,7 +86,7 @@ class OrderSerializerTests(TestCase):
             logger.check_present(*expected)
 
     @mock.patch('ecommerce.extensions.checkout.views.ReceiptResponseView.add_message_if_enterprise_user')
-    def test_get_enterprise_customer_info(self, mock_learner_portal_url):
+    def test_get_enterprise_learner_portal_url(self, mock_learner_portal_url):
         mock_learner_portal_url.side_effect = ValueError()
         order = factories.create_order(site=self.site, user=self.user)
         serializer = OrderSerializer(order, context={'request': RequestFactory(SERVER_NAME=self.site.domain).get('/')})
@@ -95,12 +95,12 @@ class OrderSerializerTests(TestCase):
             (
                 self.LOGGER_NAME,
                 'ERROR',
-                'Failed to retrieve enterprise_customer_info for order [{}]'.format(order)
+                'Failed to retrieve get_enterprise_learner_portal_url for order [{}]'.format(order)
             ),
         ]
 
         with LogCapture(self.LOGGER_NAME) as logger:
-            serializer.get_enterprise_customer_info(order)
+            serializer.get_enterprise_learner_portal_url(order)
             self.assertTrue(mock_learner_portal_url)
             logger.check_present(*expected)
 

--- a/ecommerce/extensions/api/tests/test_serializers.py
+++ b/ecommerce/extensions/api/tests/test_serializers.py
@@ -47,6 +47,25 @@ class OrderSerializerTests(TestCase):
             self.assertTrue(mock_receipt_dashboard_url.called)
             logger.check_present(*expected)
 
+    @mock.patch('ecommerce.extensions.checkout.views.ReceiptResponseView.order_contains_credit_seat')
+    def test_get_contains_credit_seat(self, mock_contains_credit_seat):
+        mock_contains_credit_seat.side_effect = ValueError()
+        order = factories.create_order(site=self.site, user=self.user)
+        serializer = OrderSerializer(order, context={'request': RequestFactory(SERVER_NAME=self.site.domain).get('/')})
+
+        expected = [
+            (
+                self.LOGGER_NAME,
+                'ERROR',
+                'Failed to retrieve get_contains_credit_seat for [{}]'.format(order)
+            ),
+        ]
+
+        with LogCapture(self.LOGGER_NAME) as logger:
+            serializer.get_contains_credit_seat(order)
+            self.assertTrue(mock_contains_credit_seat)
+            logger.check_present(*expected)
+
     @mock.patch('ecommerce.extensions.checkout.views.ReceiptResponseView.get_payment_method')
     def test_get_payment_method(self, mock_receipt_payment_method):
         mock_receipt_payment_method.side_effect = ValueError()
@@ -57,7 +76,7 @@ class OrderSerializerTests(TestCase):
             (
                 self.LOGGER_NAME,
                 'ERROR',
-                'Failed to retrieve payment_method for order [{}]'.format(order)
+                'Failed to retrieve get_payment_method for order [{}]'.format(order)
             ),
         ]
 

--- a/ecommerce/extensions/api/v2/tests/views/__init__.py
+++ b/ecommerce/extensions/api/v2/tests/views/__init__.py
@@ -73,6 +73,7 @@ class ProductSerializerMixin:
         info = Selector().strategy().fetch_for_product(product)
         data.update({
             'is_available_to_buy': info.availability.is_available_to_buy,
+            'is_enrollment_code_product': product.is_enrollment_code_product,
             'price': "{0:.2f}".format(info.price.excl_tax) if info.availability.is_available_to_buy else None
         })
 

--- a/ecommerce/extensions/api/v2/tests/views/test_orders.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_orders.py
@@ -180,6 +180,11 @@ class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
             # Test for: credit_provider in attr
             self.assertEqual(getattr(line.product.attr, 'credit_provider', None), credit_provider)
 
+        # Test for: contains_credit_seat
+        self.assertIn('contains_credit_seat', content['results'][0])
+        if credit_provider:
+            self.assertEqual(content['results'][0]['contains_credit_seat'], True)
+
         # Test for: basket_discounts
         self.assertIn('basket_discounts', content['results'][0])
         if has_discount:

--- a/ecommerce/extensions/api/v2/tests/views/test_orders.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_orders.py
@@ -136,12 +136,13 @@ class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
         ) as mock_learner_portal_url:
             test_learner_portal_url = 'http://fake-learner-portal-url.org'
             mock_learner_portal_url.return_value = test_learner_portal_url
-            price = 100
+            price = 100.00
+            currency = 'USD'
             course = CourseFactory(id='a/b/c', name='Test Course', partner=self.partner)
             product = factories.ProductFactory(
                 categories=[],
                 stockrecords__price_excl_tax=price,
-                stockrecords__price_currency='USD'
+                stockrecords__price_currency=currency
             )
             basket = factories.BasketFactory(owner=self.user, site=self.site)
             product = course.create_or_update_seat(
@@ -178,6 +179,18 @@ class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
 
             # Test for: credit_provider in attr
             self.assertEqual(getattr(line.product.attr, 'credit_provider', None), credit_provider)
+
+        # Test for: basket_discounts
+        self.assertIn('basket_discounts', content['results'][0])
+        if has_discount:
+            self.assertEqual(
+                float(percent_benefit),
+                content['results'][0]['basket_discounts'][0]['benefit_value']
+            )
+            self.assertEqual(
+                currency,
+                content['results'][0]['basket_discounts'][0]['currency']
+            )
 
         # Test for: payment_method
         self.assertEqual(payment_method, content['results'][0]['payment_method'])

--- a/ecommerce/extensions/api/v2/tests/views/test_orders.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_orders.py
@@ -202,6 +202,11 @@ class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
                 content['results'][0]['enterprise_customer_info']['learner_portal_url']
             )
 
+        # Test for: order_product_ids
+        self.assertIn('order_product_ids', content['results'][0])
+        expected_order_product_ids = ','.join(map(str, order.lines.values_list('product_id', flat=True)))
+        self.assertEqual(expected_order_product_ids, content['results'][0]['order_product_ids'])
+
     def test_with_other_users_orders(self):
         """ The view should only return orders for the authenticated users. """
         other_user = self.create_user()

--- a/ecommerce/extensions/api/v2/tests/views/test_orders.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_orders.py
@@ -213,11 +213,11 @@ class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
         self.assertIn('dashboard_url', content['results'][0])
 
         # Test for: enterprise_customer
-        self.assertIn('enterprise_customer_info', content['results'][0])
+        self.assertIn('enterprise_learner_portal_url', content['results'][0])
         if has_discount:
             self.assertEqual(
                 test_learner_portal_url,
-                content['results'][0]['enterprise_customer_info']['learner_portal_url']
+                content['results'][0]['enterprise_learner_portal_url']
             )
 
         # Test for: order_product_ids

--- a/ecommerce/extensions/api/v2/tests/views/test_orders.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_orders.py
@@ -25,14 +25,16 @@ from ecommerce.extensions.api.tests.test_authentication import AccessTokenMixin
 from ecommerce.extensions.api.v2.constants import ENABLE_HOIST_ORDER_HISTORY
 from ecommerce.extensions.api.v2.tests.views import OrderDetailViewTestMixin
 from ecommerce.extensions.checkout.exceptions import BasketNotFreeError
+from ecommerce.extensions.checkout.views import ReceiptResponseView
 from ecommerce.extensions.fulfillment.signals import SHIPPING_EVENT_NAME
 from ecommerce.extensions.fulfillment.status import LINE, ORDER
-from ecommerce.extensions.test.factories import create_order
+from ecommerce.extensions.test.factories import create_order, prepare_voucher
 from ecommerce.tests.factories import SiteConfigurationFactory
-from ecommerce.tests.mixins import ThrottlingMixin
+from ecommerce.tests.mixins import Applicator, ThrottlingMixin
 from ecommerce.tests.testcases import TestCase
 
 Basket = get_model('basket', 'Basket')
+Benefit = get_model('offer', 'Benefit')
 Order = get_model('order', 'Order')
 Product = get_model('catalogue', 'Product')
 ShippingEventType = get_model('order', 'ShippingEventType')
@@ -112,6 +114,80 @@ class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
             content = json.loads(response.content.decode('utf-8'))
 
             self.assertEqual(content['results'][0]['enable_hoist_order_history'], enable_hoist_order_history_flag)
+
+    @ddt.data(
+        # certificate_type, has_discount, percent_benefit, credit_provider, credit_hours, create_enrollment_code, sku
+        ('credit', False, 0, 'Harvard', 1, False, '123'),
+        ('credit', True, 15, 'Harvard', 1, False, '456'),
+        ('verified', True, 15, None, 0, False, '789'),
+        ('audit', False, 0, None, 0, False, '124'),
+    )
+    @ddt.unpack
+    def test_orders_api_attributes_for_receipt_mfe(
+        self, certificate_type, has_discount, percent_benefit,
+        credit_provider, credit_hours, create_enrollment_code, sku
+    ):
+        """ Verify that orders have the values added in the Orders API serializer """
+        price = 100
+        course = CourseFactory(id='a/b/c', name='Test Course', partner=self.partner)
+        product = factories.ProductFactory(
+            categories=[],
+            stockrecords__price_excl_tax=price,
+            stockrecords__price_currency='USD'
+        )
+        basket = factories.BasketFactory(owner=self.user, site=self.site)
+        product = course.create_or_update_seat(
+            certificate_type,
+            True,
+            price,
+            credit_provider=credit_provider,
+            credit_hours=credit_hours,
+            create_enrollment_code=create_enrollment_code,
+            sku=sku,
+        )
+
+        if has_discount:
+            voucher, product = prepare_voucher(
+                _range=factories.RangeFactory(products=[product]),
+                benefit_value=percent_benefit,
+                benefit_type=Benefit.PERCENTAGE
+            )
+            basket.vouchers.add(voucher)
+
+        basket.add_product(product)
+        Applicator().apply(basket, user=basket.owner, request=self.request)
+        order = factories.create_order(basket=basket, user=self.user)
+
+        response = self.client.get(self.path, HTTP_AUTHORIZATION=self.token)
+        self.assertEqual(response.status_code, 200)
+
+        content = json.loads(response.content.decode('utf-8'))
+        payment_method = ReceiptResponseView().get_payment_method(order)
+
+        for line in order.lines.all():
+            # Test for: is_enrollment_code_product
+            self.assertEqual(create_enrollment_code, line.product.is_enrollment_code_product)
+
+            # Test for: credit_provider in attr
+            self.assertEqual(getattr(line.product.attr, 'credit_provider', None), credit_provider)
+
+        # Test for: payment_method
+        self.assertEqual(payment_method, content['results'][0]['payment_method'])
+
+        # Test for: discount
+        if has_discount:
+            self.assertEqual(float(percent_benefit), float(content['results'][0]['discount']))
+        else:
+            self.assertEqual('0', content['results'][0]['discount'])
+
+        # Test for: total_before_discounts_incl_tax
+        self.assertEqual(float(price), float(content['results'][0]['total_before_discounts_incl_tax']))
+
+        # Test for: dashboard_url
+        self.assertIn('dashboard_url', content['results'][0])
+
+        # Test for: enterprise_customer
+        self.assertIn('enterprise_customer_info', content['results'][0])
 
     def test_with_other_users_orders(self):
         """ The view should only return orders for the authenticated users. """

--- a/ecommerce/extensions/checkout/views.py
+++ b/ecommerce/extensions/checkout/views.py
@@ -187,8 +187,8 @@ class ReceiptResponseView(ThankYouView):
             'payment_method': self.get_payment_method(order),
             'display_credit_messaging': self.order_contains_credit_seat(order),
         })
-        context.update(self.get_order_dashboard_context(order))
         context.update({
+            'order_dashboard_url': self.get_order_dashboard_url(order),
             'explore_courses_url': get_lms_explore_courses_url(),
             'has_enrollment_code_product': has_enrollment_code_product,
             'disable_back_button': self.request.GET.get('disable_back_button', 0),
@@ -244,13 +244,13 @@ class ReceiptResponseView(ThankYouView):
                 return True
         return False
 
-    def get_order_dashboard_context(self, order):
+    def get_order_dashboard_url(self, order):
         program_uuid = get_program_uuid(order)
         if program_uuid:
             order_dashboard_url = get_lms_program_dashboard_url(program_uuid)
         else:
             order_dashboard_url = get_lms_dashboard_url()
-        return {'order_dashboard_url': order_dashboard_url}
+        return order_dashboard_url
 
     def add_message_if_enterprise_user(self, request):
         try:


### PR DESCRIPTION
[REV-2788](https://2u-internal.atlassian.net/browse/REV-2788).

Backend work in preparation to move the receipt page to `frontend-app-ecommerce`. There are some Order attributes needed in the frontend side of the receipt page that are not available in the Order API. I've separated each one by commit.
Related frontend PR: https://github.com/openedx/frontend-app-ecommerce/pull/189

**This PR:**
1. Adds following attributes to the Order Serializer
- Order contains credit ([display_credit_messaging](https://github.com/edx/ecommerce/blob/ae592a9b8a008553c3a49578c9589a7007d26faa/ecommerce/extensions/checkout/views.py#L241))
- Enrollment code product: [has_enrollment_code_product](https://github.com/edx/ecommerce/blob/ae592a9b8a008553c3a49578c9589a7007d26faa/ecommerce/extensions/checkout/views.py#L182)
- Payment method: [payment_method](https://github.com/edx/ecommerce/blob/ae592a9b8a008553c3a49578c9589a7007d26faa/ecommerce/extensions/checkout/views.py#L230) (displays processor name ie. VISA 123XXXXXXXX123)
- `total_before_discounts_incl_tax`
-  Enterprise related variables/logic
- Alert message handling for Enterprise via `learner_portal_url`
- All of discount related variables needed in the MFE
- `order_product_ids` for data attribute
2. Adds unit tests

