### PR TITLE
fix: point enterprise learners to correct course about page

### DIFF
--- a/ecommerce/core/url_utils.py
+++ b/ecommerce/core/url_utils.py
@@ -40,19 +40,6 @@ def get_ecommerce_url(path=''):
     return site_configuration.build_ecommerce_url(path)
 
 
-def get_lms_courseware_url(course_run_id):
-    """
-    Return the courseware URL for the given course run.
-
-    Arguments:
-        course_run_id (string): The serialized course run ID.
-
-    Returns:
-        string: The courseware URL.
-    """
-    return get_lms_url('courses/{}/info'.format(course_run_id))
-
-
 def get_lms_course_about_url(course_key):
     """
     Return the courseware about URL for the given course key.

--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -17,7 +17,7 @@ from factory.fuzzy import FuzzyText
 from oscar.core.loading import get_class, get_model
 from oscar.test.factories import OrderFactory, OrderLineFactory, ProductFactory, RangeFactory, VoucherFactory
 
-from ecommerce.core.url_utils import get_lms_courseware_url, get_lms_url
+from ecommerce.core.url_utils import get_lms_course_about_url, get_lms_url
 from ecommerce.coupons.tests.mixins import CouponMixin, DiscoveryMockMixin
 from ecommerce.coupons.views import voucher_is_valid
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
@@ -669,7 +669,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         )
 
         response = self.redeem_coupon(code=code, consent_token=consent_token)
-        self.assertRedirects(response, get_lms_courseware_url(self.course.id), fetch_redirect_response=False)
+        self.assertRedirects(response, get_lms_course_about_url(self.course.id), fetch_redirect_response=False)
 
         last_request = responses.calls[-1].request
 
@@ -688,7 +688,7 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
         self.mock_enterprise_learner_post_api()
 
         response = self.client.get(self.redeem_url_with_params(code=code), follow=False)
-        self.assertRedirects(response, get_lms_courseware_url(self.course.id), fetch_redirect_response=False)
+        self.assertRedirects(response, get_lms_course_about_url(self.course.id), fetch_redirect_response=False)
 
     @responses.activate
     def test_enterprise_customer_successful_redemption_message(self):

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -18,7 +18,7 @@ from edx_rest_framework_extensions.permissions import LoginRedirectIfUnauthentic
 from oscar.core.loading import get_class, get_model
 from rest_framework.views import APIView
 
-from ecommerce.core.url_utils import absolute_redirect, get_ecommerce_url, get_lms_courseware_url
+from ecommerce.core.url_utils import absolute_redirect, get_ecommerce_url, get_lms_course_about_url
 from ecommerce.core.views import StaffOnlyMixin
 from ecommerce.coupons.decorators import login_required_for_credit
 from ecommerce.coupons.utils import is_voucher_applied
@@ -266,7 +266,7 @@ class CouponRedeemView(EdxOrderPlacementMixin, APIView):
                 order = self.place_free_order(basket)
                 if enterprise_customer:
                     return HttpResponseRedirect(
-                        get_lms_courseware_url(product.course.id)
+                        get_lms_course_about_url(product.course.id)
                     )
                 return HttpResponseRedirect(
                     get_receipt_page_url(

--- a/ecommerce/extensions/checkout/tests/test_views.py
+++ b/ecommerce/extensions/checkout/tests/test_views.py
@@ -11,7 +11,7 @@ from mock import patch
 from oscar.core.loading import get_model
 from oscar.test import factories
 
-from ecommerce.core.url_utils import get_lms_courseware_url, get_lms_program_dashboard_url
+from ecommerce.core.url_utils import get_lms_course_about_url, get_lms_program_dashboard_url
 from ecommerce.coupons.tests.mixins import DiscoveryMockMixin
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
 from ecommerce.extensions.basket.tests.test_utils import TEST_BUNDLE_ID
@@ -87,7 +87,7 @@ class FreeCheckoutViewTests(EnterpriseServiceMockMixin, TestCase):
         response = self.client.get(self.path)
         self.assertEqual(Order.objects.count(), 1)
 
-        expected_url = get_lms_courseware_url(self.course_run.id)
+        expected_url = get_lms_course_about_url(self.course_run.id)
         self.assertRedirects(response, expected_url, fetch_redirect_response=False)
 
     @responses.activate

--- a/ecommerce/extensions/checkout/views.py
+++ b/ecommerce/extensions/checkout/views.py
@@ -18,7 +18,7 @@ from requests.exceptions import ConnectionError as ReqConnectionError
 from requests.exceptions import HTTPError, Timeout
 
 from ecommerce.core.url_utils import (
-    get_lms_courseware_url,
+    get_lms_course_about_url,
     get_lms_dashboard_url,
     get_lms_explore_courses_url,
     get_lms_program_dashboard_url
@@ -76,7 +76,7 @@ class FreeCheckoutView(EdxOrderPlacementMixin, RedirectView):
                     url = get_lms_program_dashboard_url(program_uuid)
                 else:
                     course_run_id = order.lines.all()[:1].get().product.course.id
-                    url = get_lms_courseware_url(course_run_id)
+                    url = get_lms_course_about_url(course_run_id)
             else:
                 receipt_path = get_receipt_page_url(
                     order_number=order.number,


### PR DESCRIPTION
`courses/{}/info` is deprecated, point enterprise learners to `courses/{}/about` instead.

In the learner portal we direct them to the learning MFE, but will defer on that and get this out as a fix.

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?
Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
