### PR TITLE
feat: add optional customer uuid param for offer usage emails

### DIFF
--- a/ecommerce/enterprise/management/commands/send_enterprise_offer_limit_emails.py
+++ b/ecommerce/enterprise/management/commands/send_enterprise_offer_limit_emails.py
@@ -98,18 +98,30 @@ class Command(BaseCommand):
         }
 
     @staticmethod
-    def _get_enterprise_offers():
+    def _get_enterprise_offers(enterprise_customer_uuid=None):
         """
         Return the enterprise offers which have opted for email usage alert.
         """
-        return ConditionalOffer.objects.filter(
-            emails_for_usage_alert__isnull=False,
-            condition__enterprise_customer_uuid__isnull=False
-        ).exclude(emails_for_usage_alert='')
+        filter_kwargs = {
+            'emails_for_usage_alert__isnull': False,
+            'condition__enterprise_customer_uuid__isnull': False,
+        }
+
+        if enterprise_customer_uuid:
+            filter_kwargs['condition__enterprise_customer_uuid'] = enterprise_customer_uuid
+
+        return ConditionalOffer.objects.filter(**filter_kwargs).exclude(emails_for_usage_alert='')
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--enterprise-customer-uuid',
+            default=None,
+            help="Run command only for the given Customer's Offers",
+        )
 
     def handle(self, *args, **options):
         successful_send_count = 0
-        enterprise_offers = self._get_enterprise_offers()
+        enterprise_offers = self._get_enterprise_offers(options['enterprise_customer_uuid'])
         total_enterprise_offers_count = enterprise_offers.count()
         logger.info('[Offer Usage Alert] Total count of enterprise offers is %s.', total_enterprise_offers_count)
         for enterprise_offer in enterprise_offers:

--- a/ecommerce/enterprise/tests/test_send_enterprise_offer_limit_emails.py
+++ b/ecommerce/enterprise/tests/test_send_enterprise_offer_limit_emails.py
@@ -164,3 +164,36 @@ class SendEnterpriseOfferLimitEmailsTests(TestCase, SiteMixin, EnterpriseService
                 mock.call().get(propagate=False),
                 mock.call().successful(),
             ])
+
+    @responses.activate
+    def test_command_single_enterprise(self):
+        """
+        Test the send_enterprise_offer_limit_emails command on a single enterprise customer.
+        """
+        offer_usage_count = OfferUsageEmail.objects.all().count()
+        admin_email_1, admin_email_2 = 'example_1@example.com', 'example_2@example.com'
+        self.mock_lms_user_responses({
+            admin_email_1: 22,
+            admin_email_2: 44,
+        })
+
+        customer_uuid = self.offer_1.condition.enterprise_customer_uuid
+        self.mock_offer_analytics_response(customer_uuid, self.offer_1.id)
+
+        with mock.patch(COMMAND_PATH + '.send_offer_usage_email.delay') as mock_send_email:
+            mock_send_email.return_value = mock.Mock()
+            call_command('send_enterprise_offer_limit_emails', enterprise_customer_uuid=customer_uuid)
+            # if self.offer_with_404 had email content, this 5 would be a 6.
+            assert mock_send_email.call_count == 1
+            assert OfferUsageEmail.objects.all().count() == offer_usage_count + 1
+
+            mock_send_email.assert_has_calls([
+                mock.call(
+                    {'example_1@example.com': 22, ' example_2@example.com': 44},
+                    'Offer Usage Notification',
+                    {'percent_usage': 50.0, 'total_limit': '$10000.0', 'offer_type': 'Booking',
+                     'offer_name': self.offer_1.name, 'current_usage': '$5000.0'}
+                ),
+                mock.call().get(propagate=False),
+                mock.call().successful(),
+            ])


### PR DESCRIPTION
Allows you to run the offer usage command as 
```
./manage.py send_enterprise_offer_limit_emails --enterprise-customer-uuid=916bcb50-0162-4e3c-9e54-8fd97f87da96
```
so that the email only goes out for offers associated with this enterprise customer.