### PR TITLE
fix: exclude redeem_url field from ent coupon usage

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -828,6 +828,19 @@ class CodeUsageSerializer(serializers.Serializer):  # pylint: disable=abstract-m
     revocation_date = serializers.SerializerMethodField()
     is_public = serializers.SerializerMethodField()
 
+    def __init__(self, *args, **kwargs):
+        """
+        Takes an optional `ignore_fields` argument that allows
+        for the dynamic exclusion of fields during serialization.
+        See: https://www.django-rest-framework.org/api-guide/serializers/#dynamically-modifying-fields
+        """
+        ignore_fields = kwargs.pop('ignore_fields', None)
+        super().__init__(*args, **kwargs)
+
+        if ignore_fields is not None:
+            for field_name in ignore_fields:
+                self.fields.pop(field_name, None)
+
     def _get_assignment(self, obj):
         assigned_to = self.get_assigned_to(obj)
         code = self.get_code(obj)

--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -34,7 +34,6 @@ from ecommerce.core.constants import (  # pylint: disable=unused-import
     SYSTEM_ENTERPRISE_OPERATOR_ROLE
 )
 from ecommerce.core.models import EcommerceFeatureRole, EcommerceFeatureRoleAssignment
-from ecommerce.core.url_utils import get_ecommerce_url
 from ecommerce.coupons.tests.mixins import CouponMixin, DiscoveryMockMixin
 from ecommerce.coupons.utils import is_coupon_available
 from ecommerce.courses.tests.factories import CourseFactory
@@ -701,10 +700,6 @@ class EnterpriseCouponViewSetRbacTests(
         for result in expected:
             expected_result = result
             expected_result['code'] = codes[result['code']]
-            expected_result['redeem_url'] = '{url}?code={code}'.format(
-                url=get_ecommerce_url('/coupons/offer/'),
-                code=expected_result['code']
-            )
             assignment = OfferAssignment.objects.filter(
                 code=expected_result['code'], user_email=expected_result['assigned_to']
             ).first()
@@ -981,8 +976,11 @@ class EnterpriseCouponViewSetRbacTests(
         # Strip out first row (headers) and last row (extra csv line)
         csv_data = csv_content[1:-1]
         # Verify headers.
-        self.assertEqual(csv_header, 'assigned_to,assignment_date,code,is_public,last_reminder_date,redeem_url,'
-                                     'redemptions.total,redemptions.used,revocation_date')
+        expected_header = (
+            'assigned_to,assignment_date,code,is_public,last_reminder_date,'
+            'redemptions.total,redemptions.used,revocation_date'
+        )
+        self.assertEqual(csv_header, expected_header)
 
         # Verify csv data.
         self.assert_coupon_codes_response(

--- a/ecommerce/extensions/api/v2/views/enterprise.py
+++ b/ecommerce/extensions/api/v2/views/enterprise.py
@@ -444,12 +444,20 @@ class EnterpriseCouponViewSet(CouponViewSet):
             raise serializers.ValidationError(
                 "visibility_filter must be specified as 'public' or 'private' received: {}".format(visibility_filter))
 
+        # Alex Dusenbery 2022-07-15: `redeem_url` is omitted because it points to a
+        # deprecated offers page for enterprise codes.
+        # https://2u-internal.atlassian.net/browse/ENT-3805
+        serializer_kwargs = {
+            'many': True,
+            'context': {'usage_type': usage_type},
+            'ignore_fields': ['redeem_url'],
+        }
         if format is None:
             page = self.paginate_queryset(queryset)
-            serializer = serializer_class(page, many=True, context={'usage_type': usage_type})
+            serializer = serializer_class(page, **serializer_kwargs)
             return self.get_paginated_response(serializer.data)
 
-        serializer = serializer_class(queryset, many=True, context={'usage_type': usage_type})
+        serializer = serializer_class(queryset, **serializer_kwargs)
         return Response(serializer.data)
 
     def _get_not_assigned_usages(self, vouchers):


### PR DESCRIPTION
Exclude this field from the Enterprise Coupon Usage view, because it points to a deprecated offers page.
https://2u-internal.atlassian.net/browse/ENT-3805