### PR TITLE
fix: [VAN-1021] Update order completed event property

### DIFF
--- a/ecommerce/courses/utils.py
+++ b/ecommerce/courses/utils.py
@@ -162,7 +162,9 @@ def get_is_personalized_recommendation(course, request):
         recommendations = request.COOKIES.get('edx-user-personalized-recommendation', None)
         if recommendations:
             recommendations = json.loads(unquote(recommendations))
-            if course.id in recommendations['course_keys']:
+            course_key = CourseKey.from_string(course.id)
+            course_key = f'{course_key.org}+{course_key.course}'
+            if course_key in recommendations['course_keys']:
                 return recommendations['is_personalized_recommendation']
 
     return None


### PR DESCRIPTION
- Setting course_key instead of course_run_key in LMS cookies for personalized recommendations.
- Now getting course_key instead of course_run_key for event property.

VAN-1021