### PR TITLE
feat: add get smarter api client

### DIFF
--- a/ecommerce/extensions/api_client/get_smarter.py
+++ b/ecommerce/extensions/api_client/get_smarter.py
@@ -1,0 +1,106 @@
+
+import datetime
+import logging
+
+import pytz
+import requests
+from django.conf import settings
+from edx_django_utils.cache import TieredCache
+from oauthlib.oauth2 import BackendApplicationClient
+from requests_oauthlib import OAuth2Session
+
+logger = logging.getLogger(__name__)
+
+
+class GetSmarterEnterpriseApiClient:
+    """
+    Client to interface with the GetSmarter Enterprise API Gateway(GEAG).
+    """
+
+    def __init__(self):
+        required_settings = [
+            'GET_SMARTER_OAUTH2_KEY',
+            'GET_SMARTER_OAUTH2_SECRET',
+            'GET_SMARTER_OAUTH2_PROVIDER_URL',
+            'GET_SMARTER_API_URL'
+        ]
+
+        for setting in required_settings:
+            if not getattr(settings, setting, None):
+                logger.error('Failed to initialize GetSmarterEnterpriseApiClient, missing %s.', setting)
+                raise ValueError('Missing {setting}.')
+
+        self.oauth_client_id = settings.GET_SMARTER_OAUTH2_KEY
+        self.oauth_client_secret = settings.GET_SMARTER_OAUTH2_SECRET
+        self.oauth_provider_url = settings.GET_SMARTER_OAUTH2_PROVIDER_URL
+        self.api_url = settings.GET_SMARTER_API_URL
+        self.session = requests.Session()
+
+    @property
+    def oauth_token_url(self):
+        return self.oauth_provider_url + '/oauth2/token'
+
+    @property
+    def access_token_cache_key(self):
+        return 'get_smart_enterprise_gateway.access_token.{}'.format(self.oauth_client_id)
+
+    def _get_cached_access_token(self):
+        """
+        Return the cached access token if it is not expired.
+        """
+        cached_response = TieredCache.get_cached_response(self.access_token_cache_key)
+
+        if cached_response.is_found:
+            cached_value = cached_response.value
+            expires_at = cached_value['expires_at']
+            if datetime.datetime.now(pytz.utc).timestamp() < expires_at:
+                return cached_value['access_token']
+
+        return None
+
+    def _get_access_token(self):
+        """
+        Return the access token required for making calls to Get Smarter API Gateway.
+        """
+        cached_token = self._get_cached_access_token()
+        if cached_token:
+            return cached_token
+
+        try:
+            client = BackendApplicationClient(client_id=self.oauth_client_id)
+            oauth = OAuth2Session(client=client)
+            token_response = oauth.fetch_token(
+                token_url=self.oauth_token_url,
+                client_secret=self.oauth_client_secret
+            )
+            TieredCache.set_all_tiers(self.access_token_cache_key, token_response, token_response['expires_in'])
+            return token_response['access_token']
+        except Exception as ex:  # pylint: disable=broad-except
+            logger.exception(ex)
+            return None
+
+    def _ensure_authentication(self):
+        """
+        Add the required headers for authentication.
+        """
+        headers = {
+            'User-Agent': 'Mozilla/5.0',  # GEAG blocks the python-requests user agent for certain requests
+            'Authorization': 'Bearer ' + self._get_access_token(),
+        }
+        self.session.headers.update(headers)
+
+    def get_terms_and_conditions(self):
+        """
+        Fetch and return the terms and conditions from GEAG.
+        """
+        url = self.api_url + '/terms'
+        self._ensure_authentication()
+        response = self.session.get(url)
+        response.raise_for_status()
+        return response.json()
+
+    def create_allocation(self):
+        """
+        Create an allocation (enrollment) through GEAG.
+        """
+        return NotImplementedError()

--- a/ecommerce/extensions/api_client/tests/test_get_smarter.py
+++ b/ecommerce/extensions/api_client/tests/test_get_smarter.py
@@ -1,0 +1,108 @@
+import json
+from datetime import datetime
+from unittest import mock
+
+import ddt
+import pytz
+import responses
+from django.test import TestCase
+
+from ecommerce.extensions.api_client.get_smarter import GetSmarterEnterpriseApiClient
+
+
+@ddt.ddt
+class TestGetSmarterEnterpriseApiClient(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.mock_settings = {
+            'GET_SMARTER_OAUTH2_PROVIDER_URL': 'https://provider-url.com',
+            'GET_SMARTER_OAUTH2_KEY': 'key',
+            'GET_SMARTER_OAUTH2_SECRET': 'secret',
+            'GET_SMARTER_API_URL': 'https://api-url.com',
+        }
+
+    def mock_access_token(
+        self,
+        token='abcd',
+    ):
+        responses.add(
+            responses.POST,
+            self.mock_settings['GET_SMARTER_OAUTH2_PROVIDER_URL'] + '/oauth2/token',
+            body=json.dumps({
+                'access_token': token,
+                'expires_in': 300,
+                'expires_at': datetime.now(pytz.utc).timestamp() + 300
+            }),
+            status=200,
+        )
+
+    def test_init_missing_setting(self):
+        """
+        Test that an error is raise if a required setting is missing.
+        """
+        with self.settings(**{**self.mock_settings, 'GET_SMARTER_OAUTH2_SECRET': None}):
+            self.assertRaises(ValueError, GetSmarterEnterpriseApiClient)
+
+    def test_init_success(self):
+        with self.settings(**self.mock_settings):
+            client = GetSmarterEnterpriseApiClient()
+            self.assertEqual(client.oauth_client_secret, self.mock_settings['GET_SMARTER_OAUTH2_SECRET'])
+
+    @responses.activate
+    def test_get_access_token(self):
+        """
+        Test that the client can get an access token using the credentials in the settings.
+        """
+        with self.settings(**self.mock_settings):
+            self.mock_access_token('abcd')
+            client = GetSmarterEnterpriseApiClient()
+            access_token = client._get_access_token()
+            self.assertEqual(access_token, 'abcd')
+
+    @ddt.data(
+        (False, 'bcde'),
+        (True, 'abcd'),
+    )
+    @ddt.unpack
+    @mock.patch('ecommerce.extensions.api_client.get_smarter.TieredCache')
+    @responses.activate
+    def test_cached_access_token(self, is_expired, expected_token, mock_tiered_cache):
+        """
+        Test that the cached token is used if it's not expired.
+        """
+
+        mock_tiered_cache.get_cached_response.return_value = mock.MagicMock(
+            value={
+                'access_token': 'bcde',
+                'expires_in': 60,
+                'expires_at': datetime.now(pytz.utc).timestamp() + (-60 if is_expired else 60)
+            },
+            is_found=True
+        )
+
+        with self.settings(**self.mock_settings):
+            self.mock_access_token('abcd')
+            client = GetSmarterEnterpriseApiClient()
+            access_token = client._get_access_token()
+            self.assertEqual(access_token, expected_token)
+
+    @responses.activate
+    def test_get_terms_and_conditions(self):
+        terms_and_conditions = {
+            'privacyPolicy': 'abcd',
+            'websiteTermsOfUse': 'efgh',
+        }
+
+        with self.settings(**self.mock_settings):
+            self.mock_access_token('abcd')
+            responses.add(
+                responses.GET,
+                self.mock_settings['GET_SMARTER_API_URL'] + '/terms',
+                body=json.dumps(terms_and_conditions),
+                status=200,
+            )
+
+            client = GetSmarterEnterpriseApiClient()
+            response = client.get_terms_and_conditions()
+            self.assertEqual(terms_and_conditions, response)


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-6090

Adds a client to interface with the get smarter api gateway.

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?
Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and 
- 
- "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
