### PR TITLE
fix: Handle exceptions in Orders API serializer for new Receipt Page

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -409,13 +409,14 @@ class OrderSerializer(serializers.ModelSerializer):
                 for discount in discounts:
                     basket_discount = {
                         'amount': discount.amount,
-                        'benefit_value': discount.voucher.benefit.value,
+                        'benefit_value': discount.voucher.benefit.value if discount.voucher else None,
                         'code': discount.voucher_code,
-                        'condition_name': discount.offer.condition.name,
+                        'condition_name': discount.offer.condition.name if discount.offer else None,
                         'contains_offer': bool(discount.offer),
                         'currency': obj.currency,
-                        'enterprise_customer_name': discount.offer.condition.enterprise_customer_name,
-                        'offer_type': discount.offer.offer_type,
+                        'enterprise_customer_name':
+                            discount.offer.condition.enterprise_customer_name if discount.offer else None,
+                        'offer_type': discount.offer.offer_type if discount.offer else None,
                     }
                     basket_discounts.append(basket_discount)
         except (AttributeError, TypeError, ValueError):

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -492,7 +492,8 @@ class OrderSerializer(serializers.ModelSerializer):
 
     def get_enterprise_learner_portal_url(self, obj):
         try:
-            return ReceiptResponseView().add_message_if_enterprise_user(obj)
+            request = self.context['request']
+            return ReceiptResponseView().add_message_if_enterprise_user(request)
         except (AttributeError, ValueError):
             logger.exception(
                 'Failed to retrieve get_enterprise_learner_portal_url for order [%s]',


### PR DESCRIPTION
[REV-2788](https://2u-internal.atlassian.net/browse/REV-2788).

Addressing some exceptions seen in Splunk from merged PR https://github.com/openedx/ecommerce/pull/3748
Link to Splunk job: https://splunk.edx.org/en-US/app/search/search?sid=1659640001.4985951

**This PR fixes**:

Exception in `basket_discounts` `benefit_value`: looks like checking for `discounts` is not enough

> `2022-08-04 14:40:58,676 ERROR 1298 [ecommerce.extensions.api.serializers] /edx/app/ecommerce/ecommerce/ecommerce/extensions/api/serializers.py:422 - Failed to retrieve get_basket_discounts for [#EDX-32251794]
> Traceback (most recent call last):
>   File "/edx/app/ecommerce/ecommerce/ecommerce/extensions/api/serializers.py", line 412, in get_basket_discounts
>     'benefit_value': discount.voucher.benefit.value,
> AttributeError: 'NoneType' object has no attribute 'benefit'`

(I've added a check for other values that could lead to a similar exception).

Exception in `enterprise_learner_portal_url`:

> `Aug  4 14:41:36 ip-10-2-117-95 [service_variant=ecommerce][ecommerce.extensions.api.serializers] ERROR [ip-10-2-117-95  1297] [/edx/app/ecommerce/ecommerce/ecommerce/extensions/api/serializers.py:496] - Failed to retrieve get_enterprise_learner_portal_url for order [#EDX-51452862]
> Traceback (most recent call last):
>   File "/edx/app/ecommerce/ecommerce/ecommerce/extensions/api/serializers.py", line 494, in get_enterprise_learner_portal_url
>     return ReceiptResponseView().add_message_if_enterprise_user(obj)
>   File "/edx/app/ecommerce/ecommerce/ecommerce/extensions/checkout/views.py", line 274, in add_message_if_enterprise_user
>     scheme=request.scheme,
> AttributeError: 'Order' object has no attribute 'scheme'`