### PR TITLE
feat: Add product tracking value to Order API serializer

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -386,7 +386,7 @@ class LineSerializer(serializers.ModelSerializer):
                 return CourseKey.from_string(line.product.course.id).org
         except (AttributeError, TypeError, ValueError):
             logger.exception(
-                'Failed to retrieve get_course_organization for line [%s]',
+                '[Receipt MFE] Failed to retrieve course organization for line [%s]',
                 line
             )
         return None
@@ -438,7 +438,7 @@ class OrderSerializer(serializers.ModelSerializer):
                     basket_discounts.append(basket_discount)
         except (AttributeError, TypeError, ValueError):
             logger.exception(
-                'Failed to retrieve get_basket_discounts for [%s]',
+                '[Receipt MFE] Failed to retrieve basket discounts for [%s]',
                 obj
             )
         return basket_discounts
@@ -463,7 +463,7 @@ class OrderSerializer(serializers.ModelSerializer):
             return ReceiptResponseView.get_order_dashboard_url(self, obj)
         except ValueError:
             logger.exception(
-                'Failed to retrieve get_dashboard_url for [%s]',
+                '[Receipt MFE] Failed to retrieve dashboard URL for [%s]',
                 obj
             )
             return None
@@ -480,7 +480,7 @@ class OrderSerializer(serializers.ModelSerializer):
             return ReceiptResponseView().order_contains_credit_seat(obj)
         except ValueError:
             logger.exception(
-                'Failed to retrieve get_contains_credit_seat for [%s]',
+                '[Receipt MFE] Failed to retrieve credit seat value for [%s]',
                 obj
             )
             return None
@@ -502,7 +502,7 @@ class OrderSerializer(serializers.ModelSerializer):
             payment_method = ReceiptResponseView().get_payment_method(obj)
         except ValueError:
             logger.exception(
-                'Failed to retrieve get_payment_method for order [%s]',
+                '[Receipt MFE] Failed to retrieve payment method for order [%s]',
                 obj
             )
         return payment_method
@@ -513,7 +513,7 @@ class OrderSerializer(serializers.ModelSerializer):
             return ReceiptResponseView().add_message_if_enterprise_user(request)
         except (AttributeError, ValueError):
             logger.exception(
-                'Failed to retrieve get_enterprise_learner_portal_url for order [%s]',
+                '[Receipt MFE] Failed to retrieve enterprise learner portal URL for order [%s]',
                 obj
             )
             return None
@@ -529,7 +529,7 @@ class OrderSerializer(serializers.ModelSerializer):
             return ','.join(map(str, obj.lines.values_list('product_id', flat=True)))
         except (AttributeError, ValueError):
             logger.exception(
-                'Failed to retrieve get_order_product_ids for order [%s]',
+                '[Receipt MFE] Failed to retrieve order product IDs for order [%s]',
                 obj
             )
             return None
@@ -540,7 +540,7 @@ class OrderSerializer(serializers.ModelSerializer):
                 return ReceiptResponseView.add_product_tracking(self, obj)
         except (AttributeError, ValueError):
             logger.exception(
-                'Failed to retrieve get_product_tracking for order [%s]',
+                '[Receipt MFE] Failed to retrieve AWIN product tracking for order [%s]',
                 obj
             )
         return None

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -393,6 +393,7 @@ class OrderSerializer(serializers.ModelSerializer):
     discount = serializers.SerializerMethodField()
     lines = LineSerializer(many=True)
     payment_processor = serializers.SerializerMethodField()
+    product_tracking = serializers.SerializerMethodField()
     user = UserSerializer()
     vouchers = serializers.SerializerMethodField()
     enable_hoist_order_history = serializers.SerializerMethodField()
@@ -517,6 +518,17 @@ class OrderSerializer(serializers.ModelSerializer):
             )
             return None
 
+    def get_product_tracking(self, obj):
+        try:
+            if settings.AWIN_ADVERTISER_ID and obj.lines:
+                return ReceiptResponseView.add_product_tracking(self, obj)
+        except (AttributeError, ValueError):
+            logger.exception(
+                'Failed to retrieve get_product_tracking for order [%s]',
+                obj
+            )
+        return None
+
     class Meta:
         model = Order
         fields = (
@@ -534,6 +546,7 @@ class OrderSerializer(serializers.ModelSerializer):
             'order_product_ids',
             'payment_processor',
             'payment_method',
+            'product_tracking',
             'status',
             'total_before_discounts_incl_tax',
             'total_excl_tax',

--- a/ecommerce/extensions/api/tests/test_serializers.py
+++ b/ecommerce/extensions/api/tests/test_serializers.py
@@ -38,7 +38,7 @@ class OrderSerializerTests(TestCase):
             (
                 self.LOGGER_NAME,
                 'ERROR',
-                'Failed to retrieve get_dashboard_url for [{}]'.format(order)
+                '[Receipt MFE] Failed to retrieve dashboard URL for [{}]'.format(order)
             ),
         ]
 
@@ -57,7 +57,7 @@ class OrderSerializerTests(TestCase):
             (
                 self.LOGGER_NAME,
                 'ERROR',
-                'Failed to retrieve get_contains_credit_seat for [{}]'.format(order)
+                '[Receipt MFE] Failed to retrieve credit seat value for [{}]'.format(order)
             ),
         ]
 
@@ -76,7 +76,7 @@ class OrderSerializerTests(TestCase):
             (
                 self.LOGGER_NAME,
                 'ERROR',
-                'Failed to retrieve get_payment_method for order [{}]'.format(order)
+                '[Receipt MFE] Failed to retrieve payment method for order [{}]'.format(order)
             ),
         ]
 
@@ -95,7 +95,7 @@ class OrderSerializerTests(TestCase):
             (
                 self.LOGGER_NAME,
                 'ERROR',
-                'Failed to retrieve get_enterprise_learner_portal_url for order [{}]'.format(order)
+                '[Receipt MFE] Failed to retrieve enterprise learner portal URL for order [{}]'.format(order)
             ),
         ]
 
@@ -117,7 +117,7 @@ class OrderSerializerTests(TestCase):
                 (
                     self.LOGGER_NAME,
                     'ERROR',
-                    'Failed to retrieve get_product_tracking for order [{}]'.format(order)
+                    '[Receipt MFE] Failed to retrieve AWIN product tracking for order [{}]'.format(order)
                 ),
             ]
 

--- a/ecommerce/extensions/api/tests/test_serializers.py
+++ b/ecommerce/extensions/api/tests/test_serializers.py
@@ -104,6 +104,27 @@ class OrderSerializerTests(TestCase):
             self.assertTrue(mock_learner_portal_url)
             logger.check_present(*expected)
 
+    @mock.patch('ecommerce.extensions.checkout.views.ReceiptResponseView.add_product_tracking')
+    def test_get_product_tracking(self, mock_receipt_product_tracking):
+        with self.settings(AWIN_ADVERTISER_ID=1234):
+            mock_receipt_product_tracking.side_effect = ValueError()
+            order = factories.create_order(site=self.site, user=self.user)
+            serializer = OrderSerializer(
+                order, context={'request': RequestFactory(SERVER_NAME=self.site.domain).get('/')}
+            )
+
+            expected = [
+                (
+                    self.LOGGER_NAME,
+                    'ERROR',
+                    'Failed to retrieve get_product_tracking for order [{}]'.format(order)
+                ),
+            ]
+
+            with LogCapture(self.LOGGER_NAME) as logger:
+                serializer.get_product_tracking(order)
+                logger.check_present(*expected)
+
 
 class CouponCodeSerializerTests(CouponMixin, TestCase):
     """ Test for coupon code serializers. """

--- a/ecommerce/extensions/api/v2/tests/views/test_orders.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_orders.py
@@ -12,6 +12,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.test import RequestFactory, override_settings
 from django.urls import reverse
+from opaque_keys.edx.keys import CourseKey
 from oscar.core.loading import get_class, get_model
 from oscar.test import factories
 from rest_framework import status
@@ -138,7 +139,8 @@ class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
             mock_learner_portal_url.return_value = test_learner_portal_url
             price = 100.00
             currency = 'USD'
-            course = CourseFactory(id='a/b/c', name='Test Course', partner=self.partner)
+            course_id = 'a/b/c'
+            course = CourseFactory(id=course_id, name='Test Course', partner=self.partner)
             product = factories.ProductFactory(
                 categories=[],
                 stockrecords__price_excl_tax=price,
@@ -228,6 +230,10 @@ class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
         # Test for: product_tracking
         with self.settings(AWIN_ADVERTISER_ID=1234):
             self.assertTrue(content['results'][0]['product_tracking'])
+
+        # Test for: course_organization
+        self.assertIn('course_organization', content['results'][0]['lines'][0])
+        self.assertEqual(CourseKey.from_string(course_id).org, content['results'][0]['lines'][0]['course_organization'])
 
     def test_with_other_users_orders(self):
         """ The view should only return orders for the authenticated users. """

--- a/ecommerce/extensions/api/v2/tests/views/test_orders.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_orders.py
@@ -225,6 +225,10 @@ class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
         expected_order_product_ids = ','.join(map(str, order.lines.values_list('product_id', flat=True)))
         self.assertEqual(expected_order_product_ids, content['results'][0]['order_product_ids'])
 
+        # Test for: product_tracking
+        with self.settings(AWIN_ADVERTISER_ID=1234):
+            self.assertTrue(content['results'][0]['product_tracking'])
+
     def test_with_other_users_orders(self):
         """ The view should only return orders for the authenticated users. """
         other_user = self.create_user()


### PR DESCRIPTION
[REV-2788](https://2u-internal.atlassian.net/browse/REV-2788).

In the original PR https://github.com/openedx/ecommerce/pull/3748 to add data to the backend in preparation to move the receipt page to ecommerce MFE, this was failing several unrelated tests. I've cherry picked into this separate PR to check.

**This PR:**
- Adds product tracking data if `AWIN_ADVERTISER_ID` is set 
- Adds course organization needed in the Order table if `product.course` is not None

**Note for after deployment:**
Product tracking was added here https://github.com/openedx/ecommerce/pull/3264, will have to ask the owner/#engagement-vanguards how to verify tracking is still happening in the new page once in prod, and will be tested on the frontend side.

**Note on code coverage:**
Aiming for 85% or above coverage