### PR TITLE
fix: update team_reviewers for update-python-requirements job to @revenue-squad

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -13,7 +13,7 @@ jobs:
    call-upgrade-python-requirements-workflow:
     with:
        branch: ${{ github.event.inputs.branch }}
-       team_reviewers: revenue-squad
+       team_reviewers: "revenue-squad"
        email_address: revenue-tasks@edx.org  
        send_success_notification: false
     secrets:

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -13,7 +13,7 @@ jobs:
    call-upgrade-python-requirements-workflow:
     with:
        branch: ${{ github.event.inputs.branch }}
-       team_reviewers: "ecommerce"
+       team_reviewers: revenue-squad
        email_address: revenue-tasks@edx.org  
        send_success_notification: false
     secrets:


### PR DESCRIPTION
## Description
openedx/revenue-squad owns the responsibility of making sure ecommerce is up-to-date.

## Supporting information

* Jira: [REV-2694](https://2u-internal.atlassian.net/browse/REV-2694)