### PR TITLE
fix: schedule upgrade-python-requirements monthly and correct user_reviewers

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -2,7 +2,7 @@ name: Upgrade Requirements
 
 on:
   schedule:
-     - cron: "15 1 * * 4"
+     - cron: "15 1 1 * *"
   workflow_dispatch:
      inputs:
        branch:

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -13,8 +13,9 @@ jobs:
    call-upgrade-python-requirements-workflow:
     with:
        branch: ${{ github.event.inputs.branch }}
-       team_reviewers: "revenue-squad"
-       email_address: revenue-tasks@edx.org  
+       user_reviewers: edx-revenue-tasks
+       team_reviewers: ""
+       email_address: revenue-tasks@edx.org
        send_success_notification: false
     secrets:
        requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

We want the bot to send a success notification to revenue-tasks@edx.org so a ticket is created in our Jira system whenever an upgrade PR is created every month.

Previously, #3795 intended to set `send_success_notification` to true and not use @edx-revenue-tasks as a `user_reviewers`. However, that would make the created task for a successful run (which requires the followup action of a review) look very similar to a failed PR (which requires a very different followup action of investigation).

This PR changes the cadence of the GitHub Actions job in upgrade-python-requirements.yml to monthly and adds @edx-revenue-tasks as a reviewer instead of @openedx/revenue-squad.

## Supporting information

* Jira: [REV-2694](https://2u-internal.atlassian.net/browse/REV-2694)
* Corrects: https://github.com/openedx/ecommerce/pull/3795