### PR TITLE
fix: enterprise offer discount not showing on receipt page

### DIFF
--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -137,7 +137,7 @@
                       {% endwith %}
                     {% else %}
                         <span class="discount">
-                            {% if offer.condition.enterprise_customer_name %}
+                            {% if discount.offer.condition.enterprise_customer_name %}
                               {% filter force_escape %}
                                 {% blocktrans trimmed with type=discount.offer.offer_type enterprise_name=discount.offer.condition.enterprise_customer_name %}
                                     Discount of type {{ type }} provided by {{ enterprise_name }}


### PR DESCRIPTION
offer was not defined so enterprise offer discounts were not showing up properly on the receipt page.

![Screen Shot 2022-08-25 at 2 46 14 PM](https://user-images.githubusercontent.com/17792243/186744386-ae20357a-a1a5-488c-88fc-17de39bd29af.png)
