### PR TITLE
feat: pass enterprise customer uuid to geag

### DIFF
--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -946,8 +946,13 @@ class ExecutiveEducation2UFulfillmentModule(BaseFulfillmentModule):
         # A variant_id attribute must exist on the product
         variant_id = getattr(line.product.attr, 'variant_id')
 
+        # This will be the offer that was applied. We will let an error be thrown if this doesn't exist.
+        discount = order.discounts.first()
+        enterprise_customer_uuid = str(discount.offer.condition.enterprise_customer_uuid)
+
         return {
             'payment_reference': order.number,
+            'enterprise_customer_uuid': enterprise_customer_uuid,
             'currency': currency,
             'order_items': [
                 {

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -50,7 +50,11 @@ from ecommerce.extensions.fulfillment.modules import (
 from ecommerce.extensions.fulfillment.status import LINE
 from ecommerce.extensions.fulfillment.tests.mixins import FulfillmentTestMixin
 from ecommerce.extensions.payment.models import EnterpriseContractMetadata
-from ecommerce.extensions.test.factories import create_order
+from ecommerce.extensions.test.factories import (
+    EnterpriseOfferFactory,
+    EnterprisePercentageDiscountBenefitFactory,
+    create_order
+)
 from ecommerce.extensions.voucher.models import OrderLineVouchers
 from ecommerce.extensions.voucher.utils import create_vouchers
 from ecommerce.programs.tests.mixins import ProgramTestMixin
@@ -1212,7 +1216,16 @@ class ExecutiveEducation2UFulfillmentModuleTests(
         basket.add_product(self.exec_ed_2u_course_entitlement_2, 1)
         basket.add_product(self.non_exec_ed_2u_course_entitlement, 1)
         self.order = create_order(number=1, basket=basket, user=self.user)
-
+        # Create enterprise offer for order
+        offer = EnterpriseOfferFactory(
+            partner=self.partner,
+            benefit=EnterprisePercentageDiscountBenefitFactory(value=100)
+        )
+        factories.OrderDiscountFactory(
+            order=self.order,
+            offer_id=offer.id,
+            amount=100
+        )
         order_lines = self.order.lines.all()
         self.exec_ed_2u_entitlement_line = order_lines[0]
         self.exec_ed_2u_entitlement_line_2 = order_lines[1]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -254,7 +254,7 @@ funcsigs==1.0.2
     # via cybersource-rest-client-python
 future==0.18.2
     # via pyjwkest
-getsmarter-api-clients==0.3.1
+getsmarter-api-clients==0.4.1
     # via -r requirements/base.in
 idna==2.7
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -364,7 +364,7 @@ future==0.18.2
     # via
     #   -r requirements/test.txt
     #   pyjwkest
-getsmarter-api-clients==0.3.1
+getsmarter-api-clients==0.4.1
     # via -r requirements/test.txt
 gitdb==4.0.9
     # via gitpython

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -259,7 +259,7 @@ funcsigs==1.0.2
     # via cybersource-rest-client-python
 future==0.18.2
     # via pyjwkest
-getsmarter-api-clients==0.3.1
+getsmarter-api-clients==0.4.1
     # via -r requirements/base.in
 gunicorn==19.7.1
     # via -r requirements/production.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -369,7 +369,7 @@ future==0.18.2
     # via
     #   -r requirements/base.txt
     #   pyjwkest
-getsmarter-api-clients==0.3.1
+getsmarter-api-clients==0.4.1
     # via -r requirements/base.txt
 idna==2.7
     # via


### PR DESCRIPTION
GetSmarter will add a new field for enterprise_customer_uuid on their api endpoint. Assuming that change goes through as planned, these changes will have to be merged to pass the enterprise_customer_uuid.

Merge after releasing https://github.com/edx/getsmarter-api-clients/pull/7. 

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?
Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
