### PR TITLE
feat: use enterprise_allocation endpoint for exec_ed 2u fulfillment

### DIFF
--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -936,7 +936,7 @@ class ExecutiveEducation2UFulfillmentModule(BaseFulfillmentModule):
         """
         return [line for line in lines if self.supports_line(line)]
 
-    def _create_allocation_payload(
+    def _create_enterprise_allocation_payload(
         self,
         order,
         line,
@@ -1008,14 +1008,14 @@ class ExecutiveEducation2UFulfillmentModule(BaseFulfillmentModule):
         for line in lines:
             product = line.product
 
-            allocation_payload = self._create_allocation_payload(
+            allocation_payload = self._create_enterprise_allocation_payload(
                 order=order,
                 line=line,
                 fulfillment_details=fulfillment_details
             )
 
             try:
-                self.get_smarter_client.create_allocation(**allocation_payload)
+                self.get_smarter_client.create_enterprise_allocation(**allocation_payload)
             except Exception as ex:  # pylint: disable=broad-except
                 reason = ''
                 try:

--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -946,8 +946,13 @@ class ExecutiveEducation2UFulfillmentModule(BaseFulfillmentModule):
         # A variant_id attribute must exist on the product
         variant_id = getattr(line.product.attr, 'variant_id')
 
+        # This will be the offer that was applied. We will let an error be thrown if this doesn't exist.
+        discount = order.discounts.first()
+        enterprise_customer_uuid = str(discount.offer.condition.enterprise_customer_uuid)
+
         return {
             'payment_reference': order.number,
+            'enterprise_customer_uuid': enterprise_customer_uuid,
             'currency': currency,
             'order_items': [
                 {

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -1293,14 +1293,16 @@ class ExecutiveEducation2UFulfillmentModuleTests(
     @mock.patch('ecommerce.extensions.fulfillment.modules.GetSmarterEnterpriseApiClient')
     def test_fulfill_product_success(self, mock_geag_client):
         with self.settings(**self.mock_settings):
-            mock_create_allocation = mock.MagicMock()
-            mock_geag_client.return_value = mock.MagicMock(create_allocation=mock_create_allocation)
+            mock_create_enterprise_allocation = mock.MagicMock()
+            mock_geag_client.return_value = mock.MagicMock(
+                create_enterprise_allocation=mock_create_enterprise_allocation
+            )
             self.order.notes.create(message=self.fulfillment_details, note_type='Fulfillment Details')
             ExecutiveEducation2UFulfillmentModule().fulfill_product(
                 self.order,
                 [self.exec_ed_2u_entitlement_line, self.exec_ed_2u_entitlement_line_2]
             )
-            self.assertEqual(mock_create_allocation.call_count, 2)
+            self.assertEqual(mock_create_enterprise_allocation.call_count, 2)
             self.assertEqual(self.exec_ed_2u_entitlement_line.status, LINE.COMPLETE)
             self.assertEqual(self.exec_ed_2u_entitlement_line_2.status, LINE.COMPLETE)
             self.assertFalse(self.order.notes.exists())
@@ -1308,15 +1310,17 @@ class ExecutiveEducation2UFulfillmentModuleTests(
     @mock.patch('ecommerce.extensions.fulfillment.modules.GetSmarterEnterpriseApiClient')
     def test_fulfill_product_error(self, mock_geag_client):
         with self.settings(**self.mock_settings):
-            mock_create_allocation = mock.MagicMock()
-            mock_create_allocation.side_effect = [None, Exception("Uh oh.")]
-            mock_geag_client.return_value = mock.MagicMock(create_allocation=mock_create_allocation)
+            mock_create_enterprise_allocation = mock.MagicMock()
+            mock_create_enterprise_allocation.side_effect = [None, Exception("Uh oh.")]
+            mock_geag_client.return_value = mock.MagicMock(
+                create_enterprise_allocation=mock_create_enterprise_allocation
+            )
             self.order.notes.create(message=self.fulfillment_details, note_type='Fulfillment Details')
             ExecutiveEducation2UFulfillmentModule().fulfill_product(
                 self.order,
                 [self.exec_ed_2u_entitlement_line, self.exec_ed_2u_entitlement_line_2]
             )
-            self.assertEqual(mock_create_allocation.call_count, 2)
+            self.assertEqual(mock_create_enterprise_allocation.call_count, 2)
             self.assertEqual(self.exec_ed_2u_entitlement_line.status, LINE.COMPLETE)
             self.assertEqual(self.exec_ed_2u_entitlement_line_2.status, LINE.FULFILLMENT_SERVER_ERROR)
             self.assertTrue(self.order.notes.exists())

--- a/ecommerce/extensions/fulfillment/tests/test_modules.py
+++ b/ecommerce/extensions/fulfillment/tests/test_modules.py
@@ -50,7 +50,11 @@ from ecommerce.extensions.fulfillment.modules import (
 from ecommerce.extensions.fulfillment.status import LINE
 from ecommerce.extensions.fulfillment.tests.mixins import FulfillmentTestMixin
 from ecommerce.extensions.payment.models import EnterpriseContractMetadata
-from ecommerce.extensions.test.factories import create_order
+from ecommerce.extensions.test.factories import (
+    EnterpriseOfferFactory,
+    EnterprisePercentageDiscountBenefitFactory,
+    create_order
+)
 from ecommerce.extensions.voucher.models import OrderLineVouchers
 from ecommerce.extensions.voucher.utils import create_vouchers
 from ecommerce.programs.tests.mixins import ProgramTestMixin
@@ -1213,6 +1217,16 @@ class ExecutiveEducation2UFulfillmentModuleTests(
         basket.add_product(self.non_exec_ed_2u_course_entitlement, 1)
         self.order = create_order(number=1, basket=basket, user=self.user)
 
+        # Create enterprise offer for order
+        offer = EnterpriseOfferFactory(
+            partner=self.partner,
+            benefit=EnterprisePercentageDiscountBenefitFactory(value=100)
+        )
+        factories.OrderDiscountFactory(
+            order=self.order,
+            offer_id=offer.id,
+            amount=100
+        )
         order_lines = self.order.lines.all()
         self.exec_ed_2u_entitlement_line = order_lines[0]
         self.exec_ed_2u_entitlement_line_2 = order_lines[1]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -254,7 +254,7 @@ funcsigs==1.0.2
     # via cybersource-rest-client-python
 future==0.18.2
     # via pyjwkest
-getsmarter-api-clients==0.3.1
+getsmarter-api-clients==0.4.0
     # via -r requirements/base.in
 idna==2.7
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -364,7 +364,7 @@ future==0.18.2
     # via
     #   -r requirements/test.txt
     #   pyjwkest
-getsmarter-api-clients==0.3.1
+getsmarter-api-clients==0.4.0
     # via -r requirements/test.txt
 gitdb==4.0.9
     # via gitpython

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -259,7 +259,7 @@ funcsigs==1.0.2
     # via cybersource-rest-client-python
 future==0.18.2
     # via pyjwkest
-getsmarter-api-clients==0.3.1
+getsmarter-api-clients==0.4.0
     # via -r requirements/base.in
 gunicorn==19.7.1
     # via -r requirements/production.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -369,7 +369,7 @@ future==0.18.2
     # via
     #   -r requirements/base.txt
     #   pyjwkest
-getsmarter-api-clients==0.3.1
+getsmarter-api-clients==0.4.0
     # via -r requirements/base.txt
 idna==2.7
     # via


### PR DESCRIPTION
# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

- Updating enterprise exec_ed 2U fulfillment to use a new enterprise_allocations endpoint.
- This cannot be merged before https://github.com/edx/getsmarter-api-clients/pull/8 merges and is on PyPI
- You'll need to run make upgrade to get the latest version of getsmarter-api-clients once it is merged

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
