### PR TITLE
feat: adhere to enable_integrated_customer_learner_portal_search on legacy receipt page

### DIFF
--- a/ecommerce/enterprise/api.py
+++ b/ecommerce/enterprise/api.py
@@ -12,7 +12,10 @@ from requests.exceptions import ConnectionError as ReqConnectionError
 from requests.exceptions import HTTPError, Timeout
 
 from ecommerce.core.utils import get_cache_key
-from ecommerce.enterprise.utils import get_enterprise_id_for_current_request_user_from_jwt
+from ecommerce.enterprise.utils import (
+    find_active_enterprise_customer_user,
+    get_enterprise_id_for_current_request_user_from_jwt,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -196,10 +199,7 @@ def get_enterprise_id_for_user(site, user):
         logger.info('Unable to retrieve enterprise learner data for User: %s, Exception: %s', user, exc)
         return None
 
-    active_enterprise_customer_user = next(
-        (ecu for ecu in enterprise_learner_response['results'] if ecu['active'] is True),
-        None,
-    )
+    active_enterprise_customer_user = find_active_enterprise_customer_user(enterprise_learner_response['results'])
     if active_enterprise_customer_user:
         return active_enterprise_customer_user['enterprise_customer']['uuid']
     return None

--- a/ecommerce/enterprise/api.py
+++ b/ecommerce/enterprise/api.py
@@ -14,7 +14,7 @@ from requests.exceptions import HTTPError, Timeout
 from ecommerce.core.utils import get_cache_key
 from ecommerce.enterprise.utils import (
     find_active_enterprise_customer_user,
-    get_enterprise_id_for_current_request_user_from_jwt,
+    get_enterprise_id_for_current_request_user_from_jwt
 )
 
 logger = logging.getLogger(__name__)

--- a/ecommerce/enterprise/api.py
+++ b/ecommerce/enterprise/api.py
@@ -196,9 +196,10 @@ def get_enterprise_id_for_user(site, user):
         logger.info('Unable to retrieve enterprise learner data for User: %s, Exception: %s', user, exc)
         return None
 
-    try:
-        return enterprise_learner_response['results'][0]['enterprise_customer']['uuid']
-    except IndexError:
-        pass
-
+    active_enterprise_customer_user = next(
+        (ecu for ecu in enterprise_learner_response['results'] if ecu['active'] is True),
+        None,
+    )
+    if active_enterprise_customer_user:
+        return active_enterprise_customer_user['enterprise_customer']['uuid']
     return None

--- a/ecommerce/enterprise/tests/mixins.py
+++ b/ecommerce/enterprise/tests/mixins.py
@@ -217,6 +217,7 @@ class EnterpriseServiceMockMixin:
             'results': [
                 {
                     'id': learner_id,
+                    'active': True,
                     'enterprise_customer': {
                         'uuid': enterprise_customer_uuid,
                         'name': 'BigEnterprise',

--- a/ecommerce/enterprise/tests/test_api.py
+++ b/ecommerce/enterprise/tests/test_api.py
@@ -247,12 +247,14 @@ class EnterpriseAPITests(EnterpriseServiceMockMixin, DiscoveryTestMixin, TestCas
         mock_fetch.return_value = {
             'results': [
                 {
+                    'id': 1,
                     'enterprise_customer': {
                         'uuid': 'my-uuid',
                     },
                     'active': True,
                 },
                 {
+                    'id': 2,
                     'enterprise_customer': {
                         'uuid': 'my-uuid-2',
                     },

--- a/ecommerce/enterprise/tests/test_api.py
+++ b/ecommerce/enterprise/tests/test_api.py
@@ -248,9 +248,16 @@ class EnterpriseAPITests(EnterpriseServiceMockMixin, DiscoveryTestMixin, TestCas
             'results': [
                 {
                     'enterprise_customer': {
-                        'uuid': 'my-uuid'
-                    }
-                }
+                        'uuid': 'my-uuid',
+                    },
+                    'active': True,
+                },
+                {
+                    'enterprise_customer': {
+                        'uuid': 'my-uuid-2',
+                    },
+                    'active': False,
+                },
             ]
         }
         assert enterprise_api.get_enterprise_id_for_user('some-site', self.learner) == 'my-uuid'

--- a/ecommerce/enterprise/tests/test_utils.py
+++ b/ecommerce/enterprise/tests/test_utils.py
@@ -19,6 +19,7 @@ from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
 from ecommerce.enterprise.utils import (
     CUSTOMER_CATALOGS_DEFAULT_RESPONSE,
     enterprise_customer_user_needs_consent,
+    find_active_enterprise_customer_user,
     get_enterprise_catalog,
     get_enterprise_customer,
     get_enterprise_customer_catalogs,
@@ -422,3 +423,16 @@ class EnterpriseUtilsTests(EnterpriseServiceMockMixin, TestCase):
         mock_request2 = RequestFactory().get('/any')
         parsed = parse_consent_params(mock_request2)
         assert parsed is None
+
+    def test_find_active_enterprise_customer_user(self):
+        """
+        Verify `find_active_enterprise_customer_user` returns the enterprise customer user that is
+        marked as `active=True`.
+        """
+        example_enterprise_customer_users = [
+            {'id': 1, 'active': False},
+            {'id': 2, 'active': True},
+            {'id': 3, 'active': False},
+        ]
+        active_enterprise_customer_user = find_active_enterprise_customer_user(example_enterprise_customer_users)
+        assert active_enterprise_customer_user['id'] == 2

--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -753,3 +753,27 @@ def generate_offer_display_name(conditional_offer):
     if enterprise_name and start_date:
         return "{} - {}".format(enterprise_name, start_date)
     return None
+
+
+def find_active_enterprise_customer_user(enterprise_customer_users):
+    """
+    Finds and returns the metadata for the active enterprise customer user.
+
+    Arguments:
+        enterprise_customer_users: List of dictionaries representing enterprise customer users, with an `active` field.
+    """
+    active_ecus = list(filter(lambda ecu: ecu.get('active', False) is True, enterprise_customer_users))
+    total_active_ecus = len(active_ecus)
+    if total_active_ecus == 0:
+        return None
+    
+    if total_active_ecus > 0:
+        # while there is supposed to be, at most, 1 active enterprise customer
+        # user record per learner, log when there isn't for monitoring.
+        log.warning(
+            'More than one active enterprise customer user record provided '
+            'with the following EnterpriseCustomerUser ids: %s',
+            ', '.join([str(ecu['id']) for ecu in active_ecus if ecu.get('id') is not None]),
+        )
+
+    return active_ecus[0]

--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -766,7 +766,7 @@ def find_active_enterprise_customer_user(enterprise_customer_users):
     total_active_ecus = len(active_ecus)
     if total_active_ecus == 0:
         return None
-    
+
     if total_active_ecus > 0:
         # while there is supposed to be, at most, 1 active enterprise customer
         # user record per learner, log when there isn't for monitoring.

--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -762,18 +762,17 @@ def find_active_enterprise_customer_user(enterprise_customer_users):
     Arguments:
         enterprise_customer_users: List of dictionaries representing enterprise customer users, with an `active` field.
     """
-    active_ecus = list(filter(lambda ecu: ecu.get('active', False) is True, enterprise_customer_users))
-    total_active_ecus = len(active_ecus)
-    if total_active_ecus == 0:
+    active_ecus = [ecu for ecu in enterprise_customer_users if ecu.get('active', False) is True]
+    if not active_ecus:
         return None
 
-    if total_active_ecus > 0:
+    if len(active_ecus) > 1:
         # while there is supposed to be, at most, 1 active enterprise customer
         # user record per learner, log when there isn't for monitoring.
         log.warning(
             'More than one active enterprise customer user record provided '
             'with the following EnterpriseCustomerUser ids: %s',
-            ', '.join([str(ecu['id']) for ecu in active_ecus if ecu.get('id') is not None]),
+            ', '.join(str(ecu['id']) for ecu in active_ecus if ecu.get('id')),
         )
 
     return active_ecus[0]

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -510,7 +510,14 @@ class OrderSerializer(serializers.ModelSerializer):
     def get_enterprise_learner_portal_url(self, obj):
         try:
             request = self.context['request']
-            return ReceiptResponseView().add_message_if_enterprise_user(request)
+            enterprise_customer_user = ReceiptResponseView().get_metadata_for_enterprise_user(request)
+            if not enterprise_customer_user:
+                return None
+            enterprise_customer = enterprise_customer_user['enterprise_customer']
+            learner_portal_url = ReceiptResponseView().get_enterprise_learner_portal_url(
+                request, enterprise_customer
+            )
+            return learner_portal_url
         except (AttributeError, ValueError):
             logger.exception(
                 '[Receipt MFE] Failed to retrieve enterprise learner portal URL for order [%s]',

--- a/ecommerce/extensions/api/tests/test_serializers.py
+++ b/ecommerce/extensions/api/tests/test_serializers.py
@@ -85,9 +85,9 @@ class OrderSerializerTests(TestCase):
             self.assertTrue(mock_receipt_payment_method)
             logger.check_present(*expected)
 
-    @mock.patch('ecommerce.extensions.checkout.views.ReceiptResponseView.add_message_if_enterprise_user')
-    def test_get_enterprise_learner_portal_url(self, mock_learner_portal_url):
-        mock_learner_portal_url.side_effect = ValueError()
+    @mock.patch('ecommerce.extensions.checkout.views.ReceiptResponseView.get_metadata_for_enterprise_user')
+    def test_get_enterprise_learner_portal_url(self, mock_enterprise_user):
+        mock_enterprise_user.side_effect = ValueError()
         order = factories.create_order(site=self.site, user=self.user)
         serializer = OrderSerializer(order, context={'request': RequestFactory(SERVER_NAME=self.site.domain).get('/')})
 
@@ -101,7 +101,7 @@ class OrderSerializerTests(TestCase):
 
         with LogCapture(self.LOGGER_NAME) as logger:
             serializer.get_enterprise_learner_portal_url(order)
-            self.assertTrue(mock_learner_portal_url)
+            self.assertTrue(mock_enterprise_user)
             logger.check_present(*expected)
 
     @mock.patch('ecommerce.extensions.checkout.views.ReceiptResponseView.add_product_tracking')

--- a/ecommerce/extensions/api/v2/tests/views/test_orders.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_orders.py
@@ -137,6 +137,7 @@ class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
         """
         test_learner_portal_url = 'http://fake-learner-portal-url.org'
         mock_get_metadata_for_enterprise_user.return_value = {
+            'id': 1,
             'active': True,
             'enterprise_customer': {'slug': 'fake-enterprise'},
         }

--- a/ecommerce/extensions/api/v2/tests/views/test_orders.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_orders.py
@@ -124,56 +124,60 @@ class OrderListViewTests(AccessTokenMixin, ThrottlingMixin, TestCase):
         ('audit', False, 0, None, 0, False, '124'),
     )
     @ddt.unpack
+    @mock.patch('ecommerce.extensions.checkout.views.ReceiptResponseView.get_enterprise_learner_portal_url')
+    @mock.patch('ecommerce.extensions.checkout.views.ReceiptResponseView.get_metadata_for_enterprise_user')
     def test_orders_api_attributes_for_receipt_mfe(
         self, certificate_type, has_discount, percent_benefit,
-        credit_provider, credit_hours, create_enrollment_code, sku
+        credit_provider, credit_hours, create_enrollment_code, sku,
+        mock_get_metadata_for_enterprise_user, mock_get_enterprise_learner_portal_url,
     ):
         """
         Verify that orders have the values added in the Orders API serializer
         to be utilized in the receipt page in ecommerce MFE.
         """
-        with mock.patch(
-                'ecommerce.extensions.checkout.views.ReceiptResponseView.add_message_if_enterprise_user'
-        ) as mock_learner_portal_url:
-            test_learner_portal_url = 'http://fake-learner-portal-url.org'
-            mock_learner_portal_url.return_value = test_learner_portal_url
-            price = 100.00
-            currency = 'USD'
-            course_id = 'a/b/c'
-            course = CourseFactory(id=course_id, name='Test Course', partner=self.partner)
-            product = factories.ProductFactory(
-                categories=[],
-                stockrecords__price_excl_tax=price,
-                stockrecords__price_currency=currency
+        test_learner_portal_url = 'http://fake-learner-portal-url.org'
+        mock_get_metadata_for_enterprise_user.return_value = {
+            'active': True,
+            'enterprise_customer': {'slug': 'fake-enterprise'},
+        }
+        mock_get_enterprise_learner_portal_url.return_value = test_learner_portal_url
+        price = 100.00
+        currency = 'USD'
+        course_id = 'a/b/c'
+        course = CourseFactory(id=course_id, name='Test Course', partner=self.partner)
+        product = factories.ProductFactory(
+            categories=[],
+            stockrecords__price_excl_tax=price,
+            stockrecords__price_currency=currency
+        )
+        basket = factories.BasketFactory(owner=self.user, site=self.site)
+        product = course.create_or_update_seat(
+            certificate_type,
+            True,
+            price,
+            credit_provider=credit_provider,
+            credit_hours=credit_hours,
+            create_enrollment_code=create_enrollment_code,
+            sku=sku,
+        )
+
+        if has_discount:
+            voucher, product = prepare_voucher(
+                _range=factories.RangeFactory(products=[product]),
+                benefit_value=percent_benefit,
+                benefit_type=Benefit.PERCENTAGE
             )
-            basket = factories.BasketFactory(owner=self.user, site=self.site)
-            product = course.create_or_update_seat(
-                certificate_type,
-                True,
-                price,
-                credit_provider=credit_provider,
-                credit_hours=credit_hours,
-                create_enrollment_code=create_enrollment_code,
-                sku=sku,
-            )
+            basket.vouchers.add(voucher)
 
-            if has_discount:
-                voucher, product = prepare_voucher(
-                    _range=factories.RangeFactory(products=[product]),
-                    benefit_value=percent_benefit,
-                    benefit_type=Benefit.PERCENTAGE
-                )
-                basket.vouchers.add(voucher)
+        basket.add_product(product)
+        Applicator().apply(basket, user=basket.owner, request=self.request)
+        order = factories.create_order(basket=basket, user=self.user)
 
-            basket.add_product(product)
-            Applicator().apply(basket, user=basket.owner, request=self.request)
-            order = factories.create_order(basket=basket, user=self.user)
+        response = self.client.get(self.path, HTTP_AUTHORIZATION=self.token)
+        self.assertEqual(response.status_code, 200)
 
-            response = self.client.get(self.path, HTTP_AUTHORIZATION=self.token)
-            self.assertEqual(response.status_code, 200)
-
-            content = json.loads(response.content.decode('utf-8'))
-            payment_method = ReceiptResponseView().get_payment_method(order)
+        content = json.loads(response.content.decode('utf-8'))
+        payment_method = ReceiptResponseView().get_payment_method(order)
 
         for line in order.lines.all():
             # Test for: is_enrollment_code_product

--- a/ecommerce/extensions/checkout/tests/test_views.py
+++ b/ecommerce/extensions/checkout/tests/test_views.py
@@ -194,6 +194,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         # Note: actual response is far more rich. Just including the bits relevant to us
         self.enterprise_learner_data_no_portal = {
             'results': [{
+                'id': 1,
                 'enterprise_customer': {
                     'name': 'Test Company',
                     'slug': 'test-company',
@@ -205,6 +206,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         }
         self.enterprise_learner_data_with_portal = {
             'results': [{
+                'id': 1,
                 'enterprise_customer': {
                     'name': 'Test Company',
                     'slug': 'test-company',
@@ -216,6 +218,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         }
         self.enterprise_learner_data_with_portal_no_search = {
             'results': [{
+                'id': 1,
                 'enterprise_customer': {
                     'name': 'Test Company',
                     'slug': 'test-company',

--- a/ecommerce/extensions/checkout/tests/test_views.py
+++ b/ecommerce/extensions/checkout/tests/test_views.py
@@ -554,7 +554,6 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         {'is_integrated_learner_portal_search_enabled': True},
         {'is_integrated_learner_portal_search_enabled': False},
     )
-    @ddt.unpack
     def test_no_enterprise_learner_dashboard_link_in_messages(self,
                                                               is_integrated_learner_portal_search_enabled,
                                                               mock_learner_data):

--- a/ecommerce/extensions/checkout/tests/test_views.py
+++ b/ecommerce/extensions/checkout/tests/test_views.py
@@ -615,7 +615,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         The "Go to dashboard" and "Find more courses" CTA links at the bottom of the receipt
         page should be hidden when the integrated learner portal search configuration is disabled.
         """
-        mock_learner_data.return_value = self.enterprise_learner_data_with_portal
+        mock_learner_data.return_value = self.enterprise_learner_data_with_portal_no_search
         order = self._create_order_for_receipt()
         BasketAttribute.objects.update_or_create(
             basket=order.basket,

--- a/ecommerce/extensions/checkout/views.py
+++ b/ecommerce/extensions/checkout/views.py
@@ -24,7 +24,10 @@ from ecommerce.core.url_utils import (
     get_lms_program_dashboard_url
 )
 from ecommerce.enterprise.api import fetch_enterprise_learner_data
-from ecommerce.enterprise.utils import has_enterprise_offer
+from ecommerce.enterprise.utils import (
+    find_active_enterprise_customer_user,
+    has_enterprise_offer,
+)
 from ecommerce.extensions.checkout.exceptions import BasketNotFreeError
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
 from ecommerce.extensions.checkout.utils import get_receipt_page_url
@@ -273,7 +276,7 @@ class ReceiptResponseView(ThankYouView):
                      'User: %s, Exception: %s', request.user, exc)
             return None
 
-        active_enterprise_customer_user = next((ecu for ecu in learner_data['results'] if ecu['active'] is True), None)
+        active_enterprise_customer_user = find_active_enterprise_customer_user(learner_data['results'])
         return active_enterprise_customer_user
 
     def get_enterprise_learner_portal_url(self, request, enterprise_customer):

--- a/ecommerce/extensions/checkout/views.py
+++ b/ecommerce/extensions/checkout/views.py
@@ -24,10 +24,7 @@ from ecommerce.core.url_utils import (
     get_lms_program_dashboard_url
 )
 from ecommerce.enterprise.api import fetch_enterprise_learner_data
-from ecommerce.enterprise.utils import (
-    find_active_enterprise_customer_user,
-    has_enterprise_offer,
-)
+from ecommerce.enterprise.utils import find_active_enterprise_customer_user, has_enterprise_offer
 from ecommerce.extensions.checkout.exceptions import BasketNotFreeError
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
 from ecommerce.extensions.checkout.utils import get_receipt_page_url

--- a/ecommerce/extensions/checkout/views.py
+++ b/ecommerce/extensions/checkout/views.py
@@ -168,9 +168,15 @@ class ReceiptResponseView(ThankYouView):
                 'order_history_url': request.site.siteconfiguration.build_lms_url('account/settings'),
             }
             return self.render_to_response(context=context, status=404)
-        learner_portal_url = self.add_message_if_enterprise_user(request)
-        if learner_portal_url:
-            response.context_data['order_dashboard_url'] = learner_portal_url
+        enterprise_customer_user = self.get_metadata_for_enterprise_user(request)
+        if enterprise_customer_user:
+            enterprise_customer = enterprise_customer_user['enterprise_customer']
+            learner_portal_url = self.get_enterprise_learner_portal_url(request, enterprise_customer)
+            if learner_portal_url:
+                self.add_message_if_enterprise_user(request, enterprise_customer, learner_portal_url)
+                response.context_data['order_dashboard_url'] = learner_portal_url
+            else:
+                response.context_data['show_receipt_cta_links'] = False
         return response
 
     def get_context_data(self, **kwargs):  # pylint: disable=arguments-differ
@@ -190,6 +196,7 @@ class ReceiptResponseView(ThankYouView):
         context.update({
             'order_dashboard_url': self.get_order_dashboard_url(order),
             'explore_courses_url': get_lms_explore_courses_url(),
+            'show_receipt_cta_links': True,
             'has_enrollment_code_product': has_enrollment_code_product,
             'disable_back_button': self.request.GET.get('disable_back_button', 0),
         })
@@ -252,7 +259,12 @@ class ReceiptResponseView(ThankYouView):
             order_dashboard_url = get_lms_dashboard_url()
         return order_dashboard_url
 
-    def add_message_if_enterprise_user(self, request):
+    def get_metadata_for_enterprise_user(self, request):
+        """
+        Retrieves metadata about the authenticated user's linked enterprise customers. Returns the metadata
+        for the `EnterpriseCustomerUser` record marked as active (i.e., there is only one active at a time) for
+        the current Django session.
+        """
         try:
             # If enterprise feature is enabled return all the enterprise_customer associated with user.
             learner_data = fetch_enterprise_learner_data(request.site, request.user)
@@ -261,22 +273,49 @@ class ReceiptResponseView(ThankYouView):
                      'User: %s, Exception: %s', request.user, exc)
             return None
 
-        try:
-            enterprise_customer = learner_data['results'][0]['enterprise_customer']
-        except (IndexError, KeyError):
-            # If enterprise feature is enabled and user is not associated to any enterprise
-            return None
+        active_enterprise_customer_user = next((ecu for ecu in learner_data['results'] if ecu['active'] is True), None)
+        return active_enterprise_customer_user
 
+    def get_enterprise_learner_portal_url(self, request, enterprise_customer):
+        """
+        Returns an enterprise learner portal URL string given a request and the metadata
+        for an enterprise customer, or None if the specified enterprise customer is not
+        configured for a learner portal URL.
+
+        The enterprise customer must have a `slug`, and the `enable_learner_portal` and
+        `enable_integrated_customer_learner_portal_search` fields turned on.
+
+        Arguments:
+            request: A request object
+            enterprise_customer: Dictionary containing the following properties:
+                - enable_learner_portal
+                - enable_integrated_customer_learner_portal_search
+                - slug
+
+        """
         enable_learner_portal = enterprise_customer.get('enable_learner_portal')
+        enable_integrated_customer_learner_portal_search = enterprise_customer.get(
+            'enable_integrated_customer_learner_portal_search',
+        )
         enterprise_learner_portal_slug = enterprise_customer.get('slug')
-        if enable_learner_portal and enterprise_learner_portal_slug:
+
+        if enable_learner_portal and enterprise_learner_portal_slug and enable_integrated_customer_learner_portal_search:  # pylint: disable=line-too-long
             learner_portal_url = '{scheme}://{hostname}/{slug}'.format(
                 scheme=request.scheme,
                 hostname=settings.ENTERPRISE_LEARNER_PORTAL_HOSTNAME,
                 slug=enterprise_learner_portal_slug,
             )
+            return learner_portal_url
+        return None
+
+    def add_message_if_enterprise_user(self, request, enterprise_customer, learner_portal_url):
+        """
+        Adds a info message alert informing the user of their enterprise learner portal dashboard. The message
+        will only appear if the learner is linked to an enterprise customer with a valid learner portal URL.
+        """
+        if enterprise_customer and learner_portal_url:
             message = (
-                'Your company, {enterprise_customer_name}, has a dedicated page where '
+                'Your organization, {enterprise_customer_name}, has a dedicated page where '
                 'you can see all of your sponsored courses. '
                 'Go to <a href="{url}">your learner portal</a>.'
             ).format(
@@ -284,5 +323,3 @@ class ReceiptResponseView(ThankYouView):
                 url=learner_portal_url
             )
             messages.add_message(request, messages.INFO, message, extra_tags='safe')
-            return learner_portal_url
-        return None

--- a/ecommerce/extensions/executive_education_2u/utils.py
+++ b/ecommerce/extensions/executive_education_2u/utils.py
@@ -1,4 +1,8 @@
+from datetime import datetime
+
+import pytz
 from django.conf import settings
+from django.db.models import Q
 from oscar.core.loading import get_model
 
 from ecommerce.courses.constants import CertificateType
@@ -51,8 +55,12 @@ def get_enterprise_offers_for_catalogs(enterprise_id, catalog_list):
     """
     Return enterprise offers filtered by the user's enterprise.
     """
+    cutoff = datetime.now(pytz.UTC)
     ConditionalOffer = get_model('offer', 'ConditionalOffer')
-    offers = ConditionalOffer.active.filter(
+    offers = ConditionalOffer.objects.filter(
+        Q(end_datetime__gte=cutoff) | Q(end_datetime=None),
+        Q(start_datetime__lte=cutoff) | Q(start_datetime=None),
+    ).filter(
         offer_type=ConditionalOffer.SITE,
         condition__enterprise_customer_catalog_uuid__in=catalog_list,
         condition__enterprise_customer_uuid=enterprise_id,

--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -193,16 +193,18 @@
         {% endif %}
       </div>
 
-      <div id="cta-nav-links" class="row">
-        <div class="col-xs-12 text-right">
-          <a class="dashboard-link nav-link" href="{{ order_dashboard_url }}">
-            {% trans "Go to dashboard" as tmsg %}{{ tmsg | force_escape }}
-          </a>
-          <a class="find-more-courses-link nav-link" href="{{ explore_courses_url }}">
-            {% trans "Find more courses" as tmsg %}{{ tmsg | force_escape }}
-          </a>
+      {% if show_receipt_cta_links %}
+        <div id="cta-nav-links" class="row">
+          <div class="col-xs-12 text-right">
+            <a class="dashboard-link nav-link" href="{{ order_dashboard_url }}">
+              {% trans "Go to dashboard" as tmsg %}{{ tmsg | force_escape }}
+            </a>
+            <a class="find-more-courses-link nav-link" href="{{ explore_courses_url }}">
+              {% trans "Find more courses" as tmsg %}{{ tmsg | force_escape }}
+            </a>
+          </div>
         </div>
-      </div>
+      {% endif %}
     </div>
   </div>
 {% endblock content %}


### PR DESCRIPTION
# Description

For customers with the learner portal enabled, but with the "Integrated learner portal search" flag disabled, we shouldn't show any messaging/links that direct the user to the enterprise learner portal because accessing it isn't relevant for those customers as much of the learner portal functionality is disabled with that setting unchecked.

For the ecommerce receipt page, the blue alert banner and the CTA links at the bottom are removed when honoring the "Integrated learner portal search" flag on the enterprise customer.

## Before

![image](https://user-images.githubusercontent.com/2828721/192568422-b2266e6a-dad7-4178-b036-c66d38262e6b.png)

## After

![image](https://user-images.githubusercontent.com/2828721/192568466-ea30a96a-6509-4552-a097-88ab9f01d1c4.png)

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?
Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
