### PR TITLE
fix: Get billing address line2 default empty

### DIFF
--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -599,12 +599,11 @@ def get_billing_address_from_payment_intent_data(payment_intent):
     """
     billing_details = payment_intent['charges']['data'][0]['billing_details']
     customer_address = billing_details['address']
-
     address = BillingAddress(
-        first_name=billing_details['name'],    # Stripe only has a single name field
+        first_name=billing_details['name'],  # Stripe only has a single name field
         last_name='',
         line1=customer_address['line1'],
-        line2=customer_address['line2'],
+        line2=customer_address.get('line2', ''),  # line2 is optional, default to '' if not provided
         line4=customer_address['city'],  # Oscar uses line4 for city
         postcode=customer_address['postal_code'],
         state=customer_address['state'],

--- a/ecommerce/extensions/payment/views/stripe.py
+++ b/ecommerce/extensions/payment/views/stripe.py
@@ -148,7 +148,7 @@ class StripeCheckoutView(EdxOrderPlacementMixin, BasePaymentSubmitView):
                 user=self.request.user,
                 billing_address=billing_address
             )
-        except Exception as err:
+        except Exception as err:  # pylint: disable=broad-except
             logger.exception('Error creating billing address for basket [%d]: %s', basket.id, err)
             billing_address = None
 


### PR DESCRIPTION
[REV-3069](https://2u-internal.atlassian.net/browse/REV-3069).
We're getting the billing address from Stripe's Payment Intent. `line2` is the apt/unit field, and this can be empty sometimes (not a required field on the FE validation), which was causing the below error -
`edx.devstack.ecommerce  | django.db.utils.IntegrityError: (1048, "Column 'line2' cannot be null")
`

Solution is to use `.get()` instead to get the key/value and default to `''` if there's no key/value for `line2`
Bug was found while debugging with @christopappas while testing FE work on [REV-3034](https://2u-internal.atlassian.net/browse/REV-3034).