### PR TITLE
feat: add SDN check

### DIFF
--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -601,7 +601,7 @@ def get_billing_address_from_payment_intent_data(payment_intent):
     customer_address = billing_details['address']
 
     address = BillingAddress(
-        first_name=billing_details['name'],    # Stripe only has a single name field
+        first_name=billing_details['name'],  # Stripe only has a single name field
         last_name='',
         line1=customer_address['line1'],
         line2=customer_address['line2'],

--- a/ecommerce/extensions/payment/processors/stripe.py
+++ b/ecommerce/extensions/payment/processors/stripe.py
@@ -133,7 +133,7 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
                 error_on_requires_action=True,
             )
         except stripe.error.CardError as err:
-            logger.exception(f'Card Error for basket [{basket}]: {err}')
+            logger.exception('Card Error for basket [%d]: %s}', basket.id, err)
             raise
 
         # proceed only if payment went through

--- a/ecommerce/extensions/payment/processors/stripe.py
+++ b/ecommerce/extensions/payment/processors/stripe.py
@@ -126,8 +126,6 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
         # NOTE: In the future we may want to get/create a Customer. See https://stripe.com/docs/api#customers.
         self.record_processor_response(response, transaction_id=payment_intent_id, basket=basket)
 
-        # Previously did a retrieve here, but now that we implemented SDN logic
-        # we will want to do a confirm instead
         try:
             confirm_api_response = stripe.PaymentIntent.confirm(
                 payment_intent_id,

--- a/ecommerce/extensions/payment/tests/views/test_stripe.py
+++ b/ecommerce/extensions/payment/tests/views/test_stripe.py
@@ -133,7 +133,7 @@ class StripeCheckoutViewTests(PaymentEventsMixin, TestCase):
         }
         # Response for retrieve call that should be made when getting billing address
         retrieve_resp = dict(response_dict)
-        # Response for confim call that shouls be made when handling processor response
+        # Response for confirm call that should be made when handling processor response
         confirm_resp = dict(response_dict)
         confirm_resp['status'] = 'succeeded'
 

--- a/ecommerce/extensions/payment/views/stripe.py
+++ b/ecommerce/extensions/payment/views/stripe.py
@@ -189,7 +189,7 @@ class StripeCheckoutView(EdxOrderPlacementMixin, BasePaymentSubmitView):
                 user=self.request.user,
                 billing_address=billing_address_obj
             )
-        except Exception as err:
+        except Exception as err:  # pylint: disable=broad-except
             logger.exception('Error creating billing address for basket [%d]: %s', basket.id, err)
             billing_address = None
 

--- a/ecommerce/extensions/payment/views/stripe.py
+++ b/ecommerce/extensions/payment/views/stripe.py
@@ -92,7 +92,7 @@ class StripeCheckoutView(EdxOrderPlacementMixin, BasePaymentSubmitView):
         Check that the supplied request and form data passes SDN checks.
 
         Returns:
-            JsonResponse with an error if the SDN check fails, or None if it succeeds.
+            hit_count (int) if the SDN check fails, or None if it succeeds.
         """
         hit_count = checkSDN(
             request,
@@ -106,11 +106,7 @@ class StripeCheckoutView(EdxOrderPlacementMixin, BasePaymentSubmitView):
                 request.basket.id,
                 hit_count,
             )
-            response_to_return = {
-                'error': 'There was an error submitting the basket',
-                'sdn_check_failure': {'hit_count': hit_count}}
-
-            return JsonResponse(response_to_return, status=403)
+            return hit_count
 
         logger.info(
             'SDNCheck function called for basket [%d]. It did not receive a hit.',
@@ -176,7 +172,7 @@ class StripeCheckoutView(EdxOrderPlacementMixin, BasePaymentSubmitView):
         }
         sdn_check_failure = self.check_sdn(self.request, sdn_check_data)
         if sdn_check_failure is not None:
-            return sdn_check_failure  # redirect(self.payment_processor.error_url)
+            return redirect(self.payment_processor.error_url)
 
         try:
             with transaction.atomic():

--- a/ecommerce/extensions/payment/views/stripe.py
+++ b/ecommerce/extensions/payment/views/stripe.py
@@ -13,7 +13,7 @@ from oscar.core.loading import get_class, get_model
 from ecommerce.extensions.basket.utils import basket_add_organization_attribute, basket_add_payment_intent_id_attribute
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
 from ecommerce.extensions.checkout.utils import get_receipt_page_url
-from ecommerce.extensions.payment.core.sdn import  checkSDN
+from ecommerce.extensions.payment.core.sdn import checkSDN
 from ecommerce.extensions.payment.forms import StripeSubmitForm
 from ecommerce.extensions.payment.processors.stripe import Stripe
 from ecommerce.extensions.payment.views import BasePaymentSubmitView

--- a/ecommerce/extensions/payment/views/stripe.py
+++ b/ecommerce/extensions/payment/views/stripe.py
@@ -176,14 +176,12 @@ class StripeCheckoutView(EdxOrderPlacementMixin, BasePaymentSubmitView):
         }
         sdn_check_failure = self.check_sdn(self.request, sdn_check_data)
         if sdn_check_failure is not None:
-            return sdn_check_failure
-            #redirect(self.payment_processor.error_url)
+            return sdn_check_failure  # redirect(self.payment_processor.error_url)
 
         try:
             with transaction.atomic():
                 try:
                     self.handle_payment(stripe_response, basket)
-                # may want to catch more exceptions here
                 except PaymentError:
                     return redirect(self.payment_processor.error_url)
         except:  # pylint: disable=bare-except


### PR DESCRIPTION
- Adds SDN check to stripeCheckoutView
- Makes PaymentIntent objects created in capture-context require confirmation with secret key
- Updates test to reflect new "happy path"




# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?
Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
