### PR TITLE
 fix: Stripe billing address line2 default to empty if null

### DIFF
--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -603,7 +603,7 @@ def get_billing_address_from_payment_intent_data(payment_intent):
         first_name=billing_details['name'],  # Stripe only has a single name field
         last_name='',
         line1=customer_address['line1'],
-        line2=customer_address.get('line2', ''),  # line2 is optional, default to '' if not provided
+        line2='' if not customer_address['line2'] else customer_address['line2'],  # line2 is optional, default to '' if not provided
         line4=customer_address['city'],  # Oscar uses line4 for city
         postcode=customer_address['postal_code'],
         state=customer_address['state'],


### PR DESCRIPTION
[REV-3068](https://2u-internal.atlassian.net/browse/REV-3069).

Second fix for the optional `line2` in the billing address, the previous fix done here https://github.com/openedx/ecommerce/pull/3833 does not default to `''` since the key still exists, even if the value is null.

Made a successful payment and the receipt page rendered (before it would not because it caused an error in `line2` that it cannot be null.

<img width="1157" alt="Screen Shot 2022-10-05 at 1 50 06 PM" src="https://user-images.githubusercontent.com/13632680/194127754-a1ac6b65-eae5-4745-83b1-e31f9ec2eb5f.png">
