### PR TITLE
fix: StripeCheckoutView as a View instead of a FormView-like class

### DIFF
--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -597,7 +597,7 @@ def get_billing_address_from_payment_intent_data(payment_intent):
     Take stripes response_data dict, instantiates a BillingAddress object
     and return it.
     """
-    billing_details = payment_intent['charges']['data'][0]['billing_details']
+    billing_details = payment_intent['payment_method']['billing_details']
     customer_address = billing_details['address']
     address = BillingAddress(
         first_name=billing_details['name'],  # Stripe only has a single name field

--- a/ecommerce/extensions/payment/processors/stripe.py
+++ b/ecommerce/extensions/payment/processors/stripe.py
@@ -139,12 +139,13 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
     def handle_processor_response(self, response, basket=None):
         # pretty sure we should simply return/error if basket is None, as not
         # sure what it would mean if there
-        payment_intent_id = response['payment_intent']
+        payment_intent_id = response['payment_intent_id']
         # NOTE: In the future we may want to get/create a Customer. See https://stripe.com/docs/api#customers.
         self.record_processor_response(response, transaction_id=payment_intent_id, basket=basket)
 
         # rewrite order amount so it's updated for coupon & quantity and unchanged by the user
         stripe.PaymentIntent.modify(
+            payment_intent_id,
             **self._build_payment_intent_parameters(basket),
         )
 
@@ -205,7 +206,7 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
             BillingAddress
         """
         retrieve_kwargs = {
-            'expand': ['customer'],
+            'expand': ['payment_method'],
         }
 
         payment_intent = stripe.PaymentIntent.retrieve(

--- a/ecommerce/extensions/payment/tests/processors/test_stripe.py
+++ b/ecommerce/extensions/payment/tests/processors/test_stripe.py
@@ -116,7 +116,7 @@ class StripeTests(PaymentProcessorTestCaseMixin, TestCase):
             refund_mock.return_value = refund
             self.processor.issue_credit(order.number, order.basket, charge_reference_number, order.total_incl_tax,
                                         order.currency)
-            refund_mock.assert_called_once_with(charge=charge_reference_number)
+            refund_mock.assert_called_once_with(payment_intent=charge_reference_number)
 
         self.assert_processor_response_recorded(self.processor_name, refund.id, refund, basket=self.basket)
 

--- a/ecommerce/extensions/payment/tests/views/fixtures/test_stripe_test_payment_flow.json
+++ b/ecommerce/extensions/payment/tests/views/fixtures/test_stripe_test_payment_flow.json
@@ -1,0 +1,384 @@
+{
+  "happy_path": {
+    "confirm_resp": {
+      "id": "pi_3LsftNIadiFyUl1x2TWxaADZ",
+      "object": "payment_intent",
+      "amount": 14900,
+      "amount_capturable": 0,
+      "amount_details": {
+        "tip": {}
+      },
+      "amount_received": 14900,
+      "application": null,
+      "application_fee_amount": null,
+      "automatic_payment_methods": null,
+      "canceled_at": null,
+      "cancellation_reason": null,
+      "capture_method": "automatic",
+      "charges": {
+        "object": "list",
+        "data": [
+          {
+            "id": "ch_3LsftNIadiFyUl1x2Qh9P6Te",
+            "object": "charge",
+            "amount": 14900,
+            "amount_captured": 14900,
+            "amount_refunded": 0,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": "txn_3LsftNIadiFyUl1x2vxcOEsM",
+            "billing_details": {
+              "address": {
+                "city": "Sample",
+                "country": "US",
+                "line1": "123 Test St",
+                "line2": null,
+                "postal_code": "12345",
+                "state": "MA"
+              },
+              "email": "pshiu-dev-test-3@example.com",
+              "name": "Test User",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "WWW.EDX.ORG",
+            "captured": true,
+            "created": 1665723259,
+            "currency": "usd",
+            "customer": null,
+            "description": "EDX-100011",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_balance_transaction": null,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": {},
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "order_number": "EDX-100011"
+            },
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "network_status": "approved_by_network",
+              "reason": null,
+              "risk_level": "normal",
+              "risk_score": 6,
+              "seller_message": "Payment complete.",
+              "type": "authorized"
+            },
+            "paid": true,
+            "payment_intent": "pi_3LsftNIadiFyUl1x2TWxaADZ",
+            "payment_method": "pm_1LsfuTIadiFyUl1xcHa5WALi",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": "pass",
+                  "address_postal_code_check": "pass",
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "exp_month": 1,
+                "exp_year": 2023,
+                "fingerprint": "N2ltqpPKT2DuO8HF",
+                "funding": "credit",
+                "installments": null,
+                "last4": "1111",
+                "mandate": null,
+                "network": "visa",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xTGkyS29JYWRpRnlVbDF4KPzWo5oGMgZEeRWu5K86LBbPJHPT2KSM6XjNMXK1BnCeCX2gQYlTjBilX6VYkgohptS97JXM0Ey2L7-N",
+            "refunded": false,
+            "refunds": {},
+            "review": null,
+            "shipping": null,
+            "source": null,
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "succeeded",
+            "transfer_data": null,
+            "transfer_group": null
+          }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "/v1/charges?payment_intent=pi_3LsftNIadiFyUl1x2TWxaADZ"
+      },
+      "client_secret": "pi_3LsftNIadiFyUl1x2TWxaADZ_secret_VxRx7Y1skyp0jKtq7Gdu80Xnh",
+      "confirmation_method": "automatic",
+      "created": 1665723185,
+      "currency": "usd",
+      "customer": null,
+      "description": "EDX-100011",
+      "invoice": null,
+      "last_payment_error": null,
+      "livemode": false,
+      "metadata": {
+        "order_number": "EDX-100011"
+      },
+      "next_action": null,
+      "on_behalf_of": null,
+      "payment_method": "pm_1LsfuTIadiFyUl1xcHa5WALi",
+      "payment_method_options": {
+        "card": {
+          "installments": null,
+          "mandate_options": null,
+          "network": null,
+          "request_three_d_secure": "automatic"
+        }
+      },
+      "payment_method_types": [
+        "card"
+      ],
+      "processing": null,
+      "receipt_email": null,
+      "review": null,
+      "secret_key_confirmation": "required",
+      "setup_future_usage": null,
+      "shipping": null,
+      "source": null,
+      "statement_descriptor": null,
+      "statement_descriptor_suffix": null,
+      "status": "succeeded",
+      "transfer_data": null,
+      "transfer_group": null
+    },
+    "create_resp": {
+      "id": "pi_3LsftNIadiFyUl1x2TWxaADZ",
+      "object": "payment_intent",
+      "amount": 14900,
+      "amount_capturable": 0,
+      "amount_details": {
+        "tip": {}
+      },
+      "amount_received": 0,
+      "application": null,
+      "application_fee_amount": null,
+      "automatic_payment_methods": null,
+      "canceled_at": null,
+      "cancellation_reason": null,
+      "capture_method": "automatic",
+      "charges": {},
+      "client_secret": "pi_3LsftNIadiFyUl1x2TWxaADZ_secret_VxRx7Y1skyp0jKtq7Gdu80Xnh",
+      "confirmation_method": "automatic",
+      "created": 1665723185,
+      "currency": "usd",
+      "customer": null,
+      "description": "EDX-100011",
+      "invoice": null,
+      "last_payment_error": null,
+      "livemode": false,
+      "metadata": {
+        "order_number": "EDX-100011"
+      },
+      "next_action": null,
+      "on_behalf_of": null,
+      "payment_method": null,
+      "payment_method_options": {
+        "card": {
+          "installments": null,
+          "mandate_options": null,
+          "network": null,
+          "request_three_d_secure": "automatic"
+        }
+      },
+      "payment_method_types": [
+        "card"
+      ],
+      "processing": null,
+      "receipt_email": null,
+      "review": null,
+      "secret_key_confirmation": "required",
+      "setup_future_usage": null,
+      "shipping": null,
+      "source": null,
+      "statement_descriptor": null,
+      "statement_descriptor_suffix": null,
+      "status": "requires_payment_method",
+      "transfer_data": null,
+      "transfer_group": null
+    },
+    "modify_resp": {
+      "id": "pi_3LsftNIadiFyUl1x2TWxaADZ",
+      "object": "payment_intent",
+      "amount": 14900,
+      "amount_capturable": 0,
+      "amount_details": {
+        "tip": {}
+      },
+      "amount_received": 0,
+      "application": null,
+      "application_fee_amount": null,
+      "automatic_payment_methods": null,
+      "canceled_at": null,
+      "cancellation_reason": null,
+      "capture_method": "automatic",
+      "charges": {},
+      "client_secret": "pi_3LsftNIadiFyUl1x2TWxaADZ_secret_VxRx7Y1skyp0jKtq7Gdu80Xnh",
+      "confirmation_method": "automatic",
+      "created": 1665723185,
+      "currency": "usd",
+      "customer": null,
+      "description": "EDX-100011",
+      "invoice": null,
+      "last_payment_error": null,
+      "livemode": false,
+      "metadata": {
+        "order_number": "EDX-100011"
+      },
+      "next_action": null,
+      "on_behalf_of": null,
+      "payment_method": "pm_1LsfuTIadiFyUl1xcHa5WALi",
+      "payment_method_options": {
+        "card": {
+          "installments": null,
+          "mandate_options": null,
+          "network": null,
+          "request_three_d_secure": "automatic"
+        }
+      },
+      "payment_method_types": [
+        "card"
+      ],
+      "processing": null,
+      "receipt_email": null,
+      "review": null,
+      "secret_key_confirmation": "required",
+      "setup_future_usage": null,
+      "shipping": null,
+      "source": null,
+      "statement_descriptor": null,
+      "statement_descriptor_suffix": null,
+      "status": "requires_confirmation",
+      "transfer_data": null,
+      "transfer_group": null
+    },
+    "refund_resp": {
+      "id": "re_3LsftNIadiFyUl1x2KvTM7FO",
+      "object": "refund",
+      "amount": 14900,
+      "balance_transaction": "txn_3LsftNIadiFyUl1x2trZAzQP",
+      "charge": "ch_3LsftNIadiFyUl1x2Qh9P6Te",
+      "created": 1665723358,
+      "currency": "usd",
+      "metadata": {},
+      "payment_intent": "pi_3LsftNIadiFyUl1x2TWxaADZ",
+      "reason": null,
+      "receipt_number": null,
+      "source_transfer_reversal": null,
+      "status": "succeeded",
+      "transfer_reversal": null
+    },
+    "retrieve_addr_resp": {
+      "id": "pi_3LsftNIadiFyUl1x2TWxaADZ",
+      "object": "payment_intent",
+      "amount": 14900,
+      "amount_capturable": 0,
+      "amount_details": {
+        "tip": {}
+      },
+      "amount_received": 0,
+      "application": null,
+      "application_fee_amount": null,
+      "automatic_payment_methods": null,
+      "canceled_at": null,
+      "cancellation_reason": null,
+      "capture_method": "automatic",
+      "charges": {},
+      "client_secret": "pi_3LsftNIadiFyUl1x2TWxaADZ_secret_VxRx7Y1skyp0jKtq7Gdu80Xnh",
+      "confirmation_method": "automatic",
+      "created": 1665723185,
+      "currency": "usd",
+      "customer": null,
+      "description": "EDX-100011",
+      "invoice": null,
+      "last_payment_error": null,
+      "livemode": false,
+      "metadata": {
+        "order_number": "EDX-100011"
+      },
+      "next_action": null,
+      "on_behalf_of": null,
+      "payment_method": {
+        "id": "pm_1LsfuTIadiFyUl1xcHa5WALi",
+        "object": "payment_method",
+        "billing_details": {
+          "address": {
+            "city": "Sample",
+            "country": "US",
+            "line1": "123 Test St",
+            "line2": null,
+            "postal_code": "12345",
+            "state": "MA"
+          },
+          "email": "pshiu-dev-test-3@example.com",
+          "name": "Test User",
+          "phone": null
+        },
+        "card": {
+          "brand": "visa",
+          "checks": {
+            "address_line1_check": "unchecked",
+            "address_postal_code_check": "unchecked",
+            "cvc_check": "unchecked"
+          },
+          "country": "US",
+          "exp_month": 1,
+          "exp_year": 2023,
+          "fingerprint": "N2ltqpPKT2DuO8HF",
+          "funding": "credit",
+          "generated_from": null,
+          "last4": "1111",
+          "networks": {
+            "available": [
+              "visa"
+            ],
+            "preferred": null
+          },
+          "three_d_secure_usage": {
+            "supported": true
+          },
+          "wallet": null
+        },
+        "created": 1665723253,
+        "customer": null,
+        "livemode": false,
+        "metadata": {},
+        "type": "card"
+      },
+      "payment_method_options": {
+        "card": {
+          "installments": null,
+          "mandate_options": null,
+          "network": null,
+          "request_three_d_secure": "automatic"
+        }
+      },
+      "payment_method_types": [
+        "card"
+      ],
+      "processing": null,
+      "receipt_email": null,
+      "review": null,
+      "secret_key_confirmation": "required",
+      "setup_future_usage": null,
+      "shipping": null,
+      "source": null,
+      "statement_descriptor": null,
+      "statement_descriptor_suffix": null,
+      "status": "requires_confirmation",
+      "transfer_data": null,
+      "transfer_group": null
+    }
+  }
+}

--- a/ecommerce/extensions/payment/tests/views/test_stripe.py
+++ b/ecommerce/extensions/payment/tests/views/test_stripe.py
@@ -147,12 +147,14 @@ class StripeCheckoutViewTests(PaymentEventsMixin, TestCase):
                 mock_api_resp.return_value = self.mock_enrollment_api_resp
 
                 with mock.patch('stripe.PaymentIntent.confirm') as mock_confirm:
-                    mock_confirm.return_value = confirm_resp
-                    self.client.get(
-                        self.stripe_checkout_url,
-                        {'payment_intent': 'pi_testtesttest'},
-                    )
+                    with mock.patch('stripe.PaymentIntent.modify') as mock_modify:
+                        mock_confirm.return_value = confirm_resp
+                        self.client.post(
+                            self.stripe_checkout_url,
+                            data={'payment_intent': 'pi_testtesttest'},
+                        )
                 assert mock_retrieve.call_count == 1
+                assert mock_modify.call_count == 1
                 assert mock_confirm.call_count == 1
 
         # Verify BillingAddress was set correctly

--- a/ecommerce/extensions/payment/views/stripe.py
+++ b/ecommerce/extensions/payment/views/stripe.py
@@ -3,7 +3,7 @@
 import logging
 
 from django.contrib.auth.decorators import login_required
-from django.core.exceptions import MultipleObjectsReturned
+from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.db import transaction
 from django.http import JsonResponse
 from django.shortcuts import redirect
@@ -131,6 +131,9 @@ class StripeCheckoutView(EdxOrderPlacementMixin, View):
             basket_add_organization_attribute(basket, self.request.GET)
         except MultipleObjectsReturned:
             logger.warning(u"Duplicate payment_intent_id [%s] received from Stripe.", payment_intent_id)
+            return None
+        except ObjectDoesNotExist:
+            logger.warning(u"Could not find payment_intent_id [%s] among baskets.", payment_intent_id)
             return None
         except Exception:  # pylint: disable=broad-except
             logger.exception(u"Unexpected error during basket retrieval while executing Stripe payment.")

--- a/ecommerce/extensions/payment/views/stripe.py
+++ b/ecommerce/extensions/payment/views/stripe.py
@@ -148,13 +148,14 @@ class StripeCheckoutView(EdxOrderPlacementMixin, View):
         # ... and then potentially compare it against what our basket has?
         stripe_response = request.POST.dict()
         payment_intent_id = stripe_response.get('payment_intent_id')
-        basket = self._get_basket(payment_intent_id)
 
         logger.info(
             '%s called for payment intent id [%s].',
             self.__class__.__name__,
             request.POST.get('payment_intent_id')
         )
+
+        basket = self._get_basket(payment_intent_id)
 
         if not basket:
             return redirect(self.payment_processor.error_url)


### PR DESCRIPTION
## Description

StripeCheckoutView was previously like a FormView. This was causing errors because the StripeCheckoutView was expecting a lot more fields than what we were providing.

We could have re-used StripeSubmitForm. However, we opted to remove the overhead of Forms in lieu of trying to ensure all existing interfaces related to StripeSubmitForm were checked & implemented.

## Additional information

* Thanks to @christopappas for being my pair & helping direct approach!
* Jira: [REV-3005](https://2u-internal.atlassian.net/browse/REV-3005)

## Testing information

Tested purchase completed successfully on local using /checkout endpoint.