### PR TITLE
fix: ensure updates to product attributes are persisted during updates

### DIFF
--- a/ecommerce/entitlements/tests/test_utils.py
+++ b/ecommerce/entitlements/tests/test_utils.py
@@ -23,20 +23,22 @@ class TestCourseEntitlementProductCreation(TestCase):
 
     def test_course_entitlement_update(self):
         """ Test course entitlement product update """
+        original_variant_id = '00000000-0000-0000-0000-000000000000'
         product = create_or_update_course_entitlement(
-            'verified', 100, self.partner, 'foo-bar', 'Foo Bar Entitlement')
+            'verified', 100, self.partner, 'foo-bar', 'Foo Bar Entitlement', variant_id=original_variant_id)
+        assert product.attr.variant_id == original_variant_id
         stock_record = StockRecord.objects.get(product=product, partner=self.partner)
 
         self.assertEqual(stock_record.price_excl_tax, 100)
         self.assertEqual(product.title, 'Course Foo Bar Entitlement')
 
-        variant_id = '00000000-0000-0000-0000-000000000000'
+        new_variant_id = '11111111-1111-1111-1111-11111111'
         product = create_or_update_course_entitlement(
-            'verified', 200, self.partner, 'foo-bar', 'Foo Bar Entitlement', variant_id=variant_id)
+            'verified', 200, self.partner, 'foo-bar', 'Foo Bar Entitlement', variant_id=new_variant_id)
 
         stock_record = StockRecord.objects.get(product=product, partner=self.partner)
         self.assertEqual(stock_record.price_excl_tax, 200)
         self.assertEqual(stock_record.price_excl_tax, 200)
 
         product.refresh_from_db()
-        assert product.attr.variant_id == '00000000-0000-0000-0000-000000000000'
+        assert product.attr.variant_id == new_variant_id


### PR DESCRIPTION
When a course is updated in course-discovery, it calls a publication API endpoint in ecommerce to create/update any relevant records in its DB including products (e.g., course entitlements).

For Executive Education (2U) content, we require the `variant_id` to be ingested into ecommerce's course entitlements that are created/updated.

Creates seem to be working as expected, however updates do now. When we update a `variant_id` that already exists in publisher, for example, we see it properly updates the additional metadata in course-discovery as expected, but does not update in the entitlement product within ecommerce.

It appears this is due to needing to call `.save()` on the `ProductAttributesContainer` from django-oscar (i.e., `product.attr`) for any updates to those attributes to persist in the DB.

Note this `save()` call must _only_ happen on updates, since it requires the `course_entitlement` to exist in the DB first.

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?
Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
