### PR TITLE
fix: add waffle flag ENABLE_STRIPE_PAYMENT_PROCESSOR to get_client_side_payment_processor_class()

### DIFF
--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -583,7 +583,7 @@ class BasketSummaryView(BasketLogicMixin, BasketView):
             basket view context needs to be updated with.
         """
         site_configuration = self.request.site.siteconfiguration
-        payment_processor_class = site_configuration.get_client_side_payment_processor_class()
+        payment_processor_class = site_configuration.get_client_side_payment_processor_class(self.request)
 
         if payment_processor_class:
             payment_processor = payment_processor_class(self.request.site)
@@ -615,7 +615,8 @@ class CaptureContextApiLogicMixin:  # pragma: no cover
     Business logic for the capture context API.
     """
     def _add_capture_context(self, response):
-        payment_processor_class = self.request.site.siteconfiguration.get_client_side_payment_processor_class()
+        site_configuration = self.request.site.siteconfiguration
+        payment_processor_class = site_configuration.get_client_side_payment_processor_class(self.request)
         if not payment_processor_class:
             return
         payment_processor = payment_processor_class(self.request.site)

--- a/ecommerce/extensions/payment/views/apple_pay.py
+++ b/ecommerce/extensions/payment/views/apple_pay.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 class ApplePayMerchantDomainAssociationView(View):
     def get(self, request, *args, **kwargs):  # pylint: disable=unused-argument
         site_configuration = self.request.site.siteconfiguration
-        payment_processor_class = site_configuration.get_client_side_payment_processor_class()
+        payment_processor_class = site_configuration.get_client_side_payment_processor_class(self.request)
         payment_processor = payment_processor_class(self.request.site)
         content = payment_processor.apple_pay_merchant_id_domain_association
         status_code = 200


### PR DESCRIPTION
## Description

The client-side payment processor decides which payment processor Ecommerce will use when generating the capture context for a payment.

This PR forces the client-side payment processor to be 'stripe' when the waffle flag `enable_stripe_payment_processor` is on in Ecommerce.

## Supporting information

* Jira: [REV-3131](https://2u-internal.atlassian.net/browse/REV-3131) Create a waffle flag that allows engineers to set a rollout %

## Testing information

* On local:
  * Payment MFE loaded (using Ecommerce's capture context) with Stripe components...
    * [X] ...with site configuration client-side payment processor set to `cybersource` and waffle flag on
    * [X] ...with site configuration client-side payment processor set to `stripe` and waffle flag on
    * [X] ...with site configuration client-side payment processor set to `stripe` and waffle flag off
  * Payment MFE loaded (using Ecommerce's capture context) with Cybersource components...
    * [X] ...with site configuration client-side payment processor set to `cybersource` and waffle flag off
* On stage & prod:
  * [X] Scheduled for testing by QA team.