### PR TITLE
refactor: Added stripe flag to calls used in reveneue dashboard

### DIFF
--- a/ecommerce/extensions/checkout/mixins.py
+++ b/ecommerce/extensions/checkout/mixins.py
@@ -108,7 +108,6 @@ class EdxOrderPlacementMixin(OrderPlacementMixin, metaclass=abc.ABCMeta):
             'processor_name': self.payment_processor.NAME,
             'stripe_enabled': waffle.flag_is_active(request, ENABLE_STRIPE_PAYMENT_PROCESSOR),
         }
-        print(properties)
         # If payment didn't go through, the handle_processor_response function will raise an error. We want to
         # send the event regardless of if the payment didn't go through.
         try:

--- a/ecommerce/extensions/checkout/mixins.py
+++ b/ecommerce/extensions/checkout/mixins.py
@@ -4,6 +4,7 @@
 import abc
 import logging
 
+import crum
 import waffle
 from django.db import transaction
 from ecommerce_worker.fulfillment.v1.tasks import fulfill_order
@@ -101,11 +102,13 @@ class EdxOrderPlacementMixin(OrderPlacementMixin, metaclass=abc.ABCMeta):
         events (using add_payment_event) so they can be
         linked to the order when it is saved later on.
         """
+        request = crum.get_current_request()
         properties = {
             'basket_id': basket.id,
             'processor_name': self.payment_processor.NAME,
-            'stripe_enabled': waffle.flag_is_active(response, ENABLE_STRIPE_PAYMENT_PROCESSOR),
+            'stripe_enabled': waffle.flag_is_active(request, ENABLE_STRIPE_PAYMENT_PROCESSOR),
         }
+        print(properties)
         # If payment didn't go through, the handle_processor_response function will raise an error. We want to
         # send the event regardless of if the payment didn't go through.
         try:

--- a/ecommerce/extensions/checkout/mixins.py
+++ b/ecommerce/extensions/checkout/mixins.py
@@ -3,6 +3,7 @@
 
 import abc
 import logging
+from urllib import request
 
 import waffle
 from django.db import transaction
@@ -101,10 +102,10 @@ class EdxOrderPlacementMixin(OrderPlacementMixin, metaclass=abc.ABCMeta):
         events (using add_payment_event) so they can be
         linked to the order when it is saved later on.
         """
-        
-        properties = {'basket_id': basket.id,
+        properties = {
+            'basket_id': basket.id,
             'processor_name': self.payment_processor.NAME,
-            'stripe_enabled': waffle.flag_is_active(self.request, ENABLE_STRIPE_PAYMENT_PROCESSOR),
+            'stripe_enabled': waffle.flag_is_active(response, ENABLE_STRIPE_PAYMENT_PROCESSOR),
         }
         # If payment didn't go through, the handle_processor_response function will raise an error. We want to
         # send the event regardless of if the payment didn't go through.

--- a/ecommerce/extensions/checkout/mixins.py
+++ b/ecommerce/extensions/checkout/mixins.py
@@ -3,7 +3,6 @@
 
 import abc
 import logging
-from urllib import request
 
 import waffle
 from django.db import transaction

--- a/ecommerce/extensions/checkout/mixins.py
+++ b/ecommerce/extensions/checkout/mixins.py
@@ -13,7 +13,7 @@ from oscar.core.loading import get_class, get_model
 from ecommerce.core.models import BusinessClient
 from ecommerce.extensions.analytics.utils import audit_log, track_segment_event
 from ecommerce.extensions.api import data as data_api
-from ecommerce.extensions.basket.constants import EMAIL_OPT_IN_ATTRIBUTE
+from ecommerce.extensions.basket.constants import EMAIL_OPT_IN_ATTRIBUTE, ENABLE_STRIPE_PAYMENT_PROCESSOR
 from ecommerce.extensions.basket.utils import ORGANIZATION_ATTRIBUTE_TYPE
 from ecommerce.extensions.checkout.exceptions import BasketNotFreeError
 from ecommerce.extensions.offer.constants import OFFER_ASSIGNED, OFFER_ASSIGNMENT_REVOKED, OFFER_REDEEMED
@@ -101,7 +101,11 @@ class EdxOrderPlacementMixin(OrderPlacementMixin, metaclass=abc.ABCMeta):
         events (using add_payment_event) so they can be
         linked to the order when it is saved later on.
         """
-        properties = {'basket_id': basket.id, 'processor_name': self.payment_processor.NAME, }
+        
+        properties = {'basket_id': basket.id,
+            'processor_name': self.payment_processor.NAME,
+            'stripe_enabled': waffle.flag_is_active(self.request, ENABLE_STRIPE_PAYMENT_PROCESSOR),
+        }
         # If payment didn't go through, the handle_processor_response function will raise an error. We want to
         # send the event regardless of if the payment didn't go through.
         try:

--- a/ecommerce/extensions/checkout/signals.py
+++ b/ecommerce/extensions/checkout/signals.py
@@ -61,7 +61,6 @@ def track_completed_order(sender, order=None, **kwargs):  # pylint: disable=unus
             order_line['is_personalized_recommendation'] = is_personalized_recommendation
 
         products.append(order_line)
-
     properties = {
         'orderId': order.number,
         'total': float(order.total_excl_tax),
@@ -71,7 +70,7 @@ def track_completed_order(sender, order=None, **kwargs):  # pylint: disable=unus
         'currency': order.currency,
         'discount': float(order.total_discount_incl_tax),
         'products': products,
-        'stripe_enabled': waffle.flag_is_active(sender.request, ENABLE_STRIPE_PAYMENT_PROCESSOR),
+        'stripe_enabled': waffle.flag_is_active(sender, ENABLE_STRIPE_PAYMENT_PROCESSOR),
     }
     if order.user:
         properties['email'] = order.user.email

--- a/ecommerce/extensions/checkout/signals.py
+++ b/ecommerce/extensions/checkout/signals.py
@@ -2,7 +2,6 @@
 
 import logging
 
-import crum
 import waffle
 from django.dispatch import receiver
 from oscar.core.loading import get_class, get_model

--- a/ecommerce/extensions/checkout/signals.py
+++ b/ecommerce/extensions/checkout/signals.py
@@ -2,6 +2,7 @@
 
 import logging
 
+import crum
 import waffle
 from django.dispatch import receiver
 from oscar.core.loading import get_class, get_model
@@ -61,6 +62,7 @@ def track_completed_order(sender, order=None, **kwargs):  # pylint: disable=unus
             order_line['is_personalized_recommendation'] = is_personalized_recommendation
 
         products.append(order_line)
+    request = crum.get_current_request()
     properties = {
         'orderId': order.number,
         'total': float(order.total_excl_tax),
@@ -70,8 +72,9 @@ def track_completed_order(sender, order=None, **kwargs):  # pylint: disable=unus
         'currency': order.currency,
         'discount': float(order.total_discount_incl_tax),
         'products': products,
-        'stripe_enabled': waffle.flag_is_active(sender, ENABLE_STRIPE_PAYMENT_PROCESSOR),
+        'stripe_enabled': waffle.flag_is_active(request, ENABLE_STRIPE_PAYMENT_PROCESSOR),
     }
+    print(properties)
     if order.user:
         properties['email'] = order.user.email
 

--- a/ecommerce/extensions/checkout/signals.py
+++ b/ecommerce/extensions/checkout/signals.py
@@ -62,7 +62,7 @@ def track_completed_order(sender, order=None, **kwargs):  # pylint: disable=unus
             order_line['is_personalized_recommendation'] = is_personalized_recommendation
 
         products.append(order_line)
-    request = crum.get_current_request()
+    request = kwargs.get('request', None)
     properties = {
         'orderId': order.number,
         'total': float(order.total_excl_tax),
@@ -74,7 +74,6 @@ def track_completed_order(sender, order=None, **kwargs):  # pylint: disable=unus
         'products': products,
         'stripe_enabled': waffle.flag_is_active(request, ENABLE_STRIPE_PAYMENT_PROCESSOR),
     }
-    print(properties)
     if order.user:
         properties['email'] = order.user.email
 

--- a/ecommerce/extensions/checkout/signals.py
+++ b/ecommerce/extensions/checkout/signals.py
@@ -1,6 +1,7 @@
 
 
 import logging
+from ecommerce.extensions.basket.constants import ENABLE_STRIPE_PAYMENT_PROCESSOR
 
 import waffle
 from django.dispatch import receiver
@@ -70,6 +71,7 @@ def track_completed_order(sender, order=None, **kwargs):  # pylint: disable=unus
         'currency': order.currency,
         'discount': float(order.total_discount_incl_tax),
         'products': products,
+        'stripe_enabled': waffle.flag_is_active(sender.request, ENABLE_STRIPE_PAYMENT_PROCESSOR),
     }
     if order.user:
         properties['email'] = order.user.email

--- a/ecommerce/extensions/checkout/signals.py
+++ b/ecommerce/extensions/checkout/signals.py
@@ -1,7 +1,6 @@
 
 
 import logging
-from ecommerce.extensions.basket.constants import ENABLE_STRIPE_PAYMENT_PROCESSOR
 
 import waffle
 from django.dispatch import receiver
@@ -9,6 +8,7 @@ from oscar.core.loading import get_class, get_model
 
 from ecommerce.courses.utils import get_is_personalized_recommendation, mode_for_product
 from ecommerce.extensions.analytics.utils import silence_exceptions, track_segment_event
+from ecommerce.extensions.basket.constants import ENABLE_STRIPE_PAYMENT_PROCESSOR
 from ecommerce.extensions.checkout.utils import get_credit_provider_details, get_receipt_page_url
 from ecommerce.notifications.notifications import send_notification
 from ecommerce.programs.utils import get_program

--- a/ecommerce/extensions/checkout/tests/test_mixins.py
+++ b/ecommerce/extensions/checkout/tests/test_mixins.py
@@ -432,6 +432,7 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin,
             'total': basket.total_incl_tax,
             'success': True,
             'processor_name': DummyProcessor.NAME,
+            'stripe_enabled': False,
         }
         calls.append(mock.call(user_tracking_id, 'Payment Processor Response', properties, context=context))
 
@@ -476,6 +477,7 @@ class EdxOrderPlacementMixinTests(BusinessIntelligenceMixin, PaymentEventsMixin,
             'payment_error': 'Exception',
             'success': False,
             'processor_name': DummyProcessor.NAME,
+            'stripe_enabled': False,
         }
         calls.append(mock.call(user_tracking_id, 'Payment Processor Response', properties, context=context))
 

--- a/ecommerce/extensions/checkout/tests/test_signals.py
+++ b/ecommerce/extensions/checkout/tests/test_signals.py
@@ -253,6 +253,7 @@ class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
             'coupon': coupon,
             'discount': float(order.total_discount_incl_tax),
             'products': products,
+            'stripe_enabled': False,
         }
         if order.user:
             properties['email'] = order.user.email

--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -291,7 +291,7 @@ class BusinessIntelligenceMixin:
         completed order or refund.
         """
         self.assertEqual(
-            ['coupon', 'currency', 'discount', 'email', 'orderId', 'products', 'revenue', 'total'],
+            ['coupon', 'currency', 'discount', 'email', 'orderId', 'products', 'revenue', 'stripe_enabled', 'total'],
             sorted(event_payload.keys())
         )
         self.assertEqual(event_payload['orderId'], order_number)


### PR DESCRIPTION
[REV-3128](https://2u-internal.atlassian.net/browse/REV-3128)

Using the waffle flag ENABLE_STRIPE_PAYMENT_PROCESSOR to send in the track events to segment so new relic graphs can differentiate between a user visiting a stripe enabled flow vs a cybersource flow.

Decided to use [Django-crum](https://pythonhosted.org/django-crum/) in the call within mixins::handle_payment since a request is not always part of the arguments.  If we fins that handle_payment is not always within the scope of a request this will need to be changed to add an optional request parameter to handle_payment.

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

