### PR TITLE
fix: send stripe waffle flag via url parameter in frontend

### DIFF
--- a/ecommerce/extensions/basket/constants.py
+++ b/ecommerce/extensions/basket/constants.py
@@ -12,3 +12,13 @@ PAYMENT_INTENT_ID_ATTRIBUTE = "payment_intent_id"
 # .. toggle_tickets: REV-3004
 # .. toggle_status: supported
 ENABLE_STRIPE_PAYMENT_PROCESSOR = 'enable_stripe_payment_processor'
+
+# .. toggle_name: redirect_with_waffle_testing_querystring
+# .. toggle_type: waffle_flag
+# .. toggle_default: False
+# .. toggle_description: Appends waffle flag value to MFE redirect URL's querystring
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2022-11-02
+# .. toggle_tickets: REV-3147
+# .. toggle_status: supported
+REDIRECT_WITH_WAFFLE_TESTING_QUERYSTRING = 'redirect_with_waffle_testing_querystring'

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -51,6 +51,7 @@ from ecommerce.extensions.basket.constants import EMAIL_OPT_IN_ATTRIBUTE, ENABLE
 from ecommerce.extensions.basket.exceptions import BadRequestException, RedirectException, VoucherException
 from ecommerce.extensions.basket.utils import (
     add_invalid_code_message_to_url,
+    add_stripe_flag_to_url,
     add_utm_params_to_url,
     apply_offers_on_basket,
     apply_voucher_on_basket_and_check_discount,
@@ -497,6 +498,7 @@ class BasketAddItemsView(BasketLogicMixin, APIView):
         redirect_url = get_payment_microfrontend_or_basket_url(request)
         redirect_url = add_utm_params_to_url(redirect_url, list(self.request.GET.items()))
         redirect_url = add_invalid_code_message_to_url(redirect_url, invalid_code)
+        redirect_url = add_stripe_flag_to_url(redirect_url, request)
 
         return HttpResponseRedirect(redirect_url, status=303)
 

--- a/ecommerce/extensions/payment/views/cybersource.py
+++ b/ecommerce/extensions/payment/views/cybersource.py
@@ -19,6 +19,7 @@ from rest_framework.views import APIView
 
 from ecommerce.extensions.api.serializers import OrderSerializer
 from ecommerce.extensions.basket.utils import (
+    add_stripe_flag_to_url,
     add_utm_params_to_url,
     basket_add_organization_attribute,
     get_payment_microfrontend_or_basket_url
@@ -472,6 +473,7 @@ class CybersourceAuthorizeAPIView(
     def redirect_on_transaction_declined(self):
         redirect_url = get_payment_microfrontend_or_basket_url(self.request)
         redirect_url = add_utm_params_to_url(redirect_url, list(self.request.GET.items()))
+        redirect_url = add_stripe_flag_to_url(redirect_url, self.request)
         return JsonResponse({
             'redirectTo': redirect_url,
         }, status=400)


### PR DESCRIPTION
## Description

django-waffle bins users into a waffle flag experience using a cookie or URL parameter. If a user does not have that cookie or URL parameter, django-waffle assigns one randomly using the % distribution set by the waffle flag.

This caused the Payment MFE to not be consistent in which waffle flag it uses to communicate with Ecommerce when we enabled the Ecommerce `enable_stripe_payment_processor` waffle flag for a % of users (as opposed to a list of users, or for all users).

Unfortunately, it does not look like the cookie is automatically passed along between Ecommerce and the Payment MFE like we hoped. However, wome nifty work in 9e9e54630cad055b1599ab7bac4935f5d6b55b6e shows that we used to pass flags to the frontends via URL parameters.

The Payment MFE already has a [parser](https://github.com/openedx/frontend-app-payment/blob/4c920f6b20ba98efe80c775df4ae6db3a65a89d5/src/index.jsx#L37-L46) and [interceptor](https://github.com/openedx/frontend-app-payment/blob/4c920f6b20ba98efe80c775df4ae6db3a65a89d5/src/index.jsx#L93-L103) to receive waffle flags this way.

This PR re-enables some of the old functionality to make waffle flags work.

It also adds waffle flag `redirect_with_waffle_testing_querystring`, which toggles the adding of a query string like `?dwft=enable_stripe_payment_processor=1` to the end of all redirects to the Payment MFE.

## Additional information

* Jira: [REV-3147](https://2u-internal.atlassian.net/browse/REV-3147)

## Testing instructions

* On local:
  * [X] Refreshing randomly with waffle flag at 50% doesn't trigger any capture context errors
  * [X] Test payment succeeds on local