### PR TITLE
Revert "temp: add project-zebra to branches that should run ci (#3824)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master, project-zebra]
+    branches: [master]
   pull_request:
-    branches: [master, project-zebra]
+    branches: [master]
 
 jobs:
   build:


### PR DESCRIPTION
## Description

Now that we are pushing the Project Zebra code to master, we no longer need the CI to run on that branch.

This PR is a reminder to remove the CI for that branch once we're done with Project Zebra.

Note that the target branch of this PR may need to be adjusted depending on when this PR is merged.

## Additional information

* Jira: [REV-3146](https://2u-internal.atlassian.net/browse/REV-3146) Cleanup: Remove project-zebra branch from CI