### PR TITLE
fix: add waffle flag url param to url for coupon view

### DIFF
--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -27,7 +27,10 @@ from ecommerce.enterprise.utils import (
     get_enterprise_customer_data_sharing_consent_token
 )
 from ecommerce.extensions.api.serializers import CouponCodeAssignmentSerializer
-from ecommerce.extensions.basket.constants import ENABLE_STRIPE_PAYMENT_PROCESSOR, REDIRECT_WITH_WAFFLE_TESTING_QUERYSTRING
+from ecommerce.extensions.basket.constants import (
+    ENABLE_STRIPE_PAYMENT_PROCESSOR,
+    REDIRECT_WITH_WAFFLE_TESTING_QUERYSTRING
+)
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
 from ecommerce.extensions.checkout.utils import get_receipt_page_url

--- a/ecommerce/coupons/tests/test_views.py
+++ b/ecommerce/coupons/tests/test_views.py
@@ -16,6 +16,7 @@ from django.utils.timezone import now
 from factory.fuzzy import FuzzyText
 from oscar.core.loading import get_class, get_model
 from oscar.test.factories import OrderFactory, OrderLineFactory, ProductFactory, RangeFactory, VoucherFactory
+from waffle.testutils import override_flag
 
 from ecommerce.core.url_utils import get_lms_course_about_url, get_lms_url
 from ecommerce.coupons.tests.mixins import CouponMixin, DiscoveryMockMixin
@@ -26,6 +27,7 @@ from ecommerce.enterprise.utils import (
     get_enterprise_customer_data_sharing_consent_token
 )
 from ecommerce.extensions.api.serializers import CouponCodeAssignmentSerializer
+from ecommerce.extensions.basket.constants import ENABLE_STRIPE_PAYMENT_PROCESSOR, REDIRECT_WITH_WAFFLE_TESTING_QUERYSTRING
 from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
 from ecommerce.extensions.checkout.utils import get_receipt_page_url
@@ -489,6 +491,19 @@ class CouponRedeemViewTests(CouponMixin, DiscoveryTestMixin, LmsApiMockMixin, En
 
         self.create_coupon(catalog=self.catalog, code=COUPON_CODE, benefit_value=5)
         self.assert_redemption_page_redirects(self.get_coupon_redeem_success_expected_redirect_url())
+
+    @override_flag(REDIRECT_WITH_WAFFLE_TESTING_QUERYSTRING, active=True)
+    @responses.activate
+    def test_basket_redirect_discount_code_with_waffle(self):
+        """ Verify the view redirects to the basket view with waffle flag url param. """
+        self.mock_course_api_response(course=self.course)
+        self.mock_account_api(self.request, self.user.username, data={'is_active': True})
+        self.mock_access_token_response()
+
+        self.create_coupon(catalog=self.catalog, code=COUPON_CODE, benefit_value=5)
+        self.assert_redemption_page_redirects(
+            self.get_coupon_redeem_success_expected_redirect_url() + f'&dwft_{ENABLE_STRIPE_PAYMENT_PROCESSOR}=0'
+        )
 
     @responses.activate
     def test_basket_redirect_enrollment_code(self):

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -34,7 +34,7 @@ from ecommerce.enterprise.utils import (
 )
 from ecommerce.extensions.api import exceptions
 from ecommerce.extensions.basket.utils import (
-    add_flex_microform_flag_to_url,
+    add_stripe_flag_to_url,
     get_payment_microfrontend_or_basket_url,
     prepare_basket,
 )
@@ -303,7 +303,7 @@ class CouponRedeemView(EdxOrderPlacementMixin, APIView):
         # and should not display the payment form before making that determination.
         # TODO: It would be cleaner if the user could be redirected to their final destination up front.
         redirect_url = get_payment_microfrontend_or_basket_url(self.request) + "?coupon_redeem_redirect=1"
-        redirect_url = add_flex_microform_flag_to_url(redirect_url)
+        redirect_url = add_stripe_flag_to_url(redirect_url, self.request)
         return HttpResponseRedirect(redirect_url)
 
 

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -33,7 +33,11 @@ from ecommerce.enterprise.utils import (
     parse_consent_params
 )
 from ecommerce.extensions.api import exceptions
-from ecommerce.extensions.basket.utils import get_payment_microfrontend_or_basket_url, prepare_basket
+from ecommerce.extensions.basket.utils import (
+    add_flex_microform_flag_to_url,
+    get_payment_microfrontend_or_basket_url,
+    prepare_basket,
+)
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
 from ecommerce.extensions.checkout.utils import get_receipt_page_url
 from ecommerce.extensions.offer.utils import get_redirect_to_email_confirmation_if_required
@@ -299,6 +303,7 @@ class CouponRedeemView(EdxOrderPlacementMixin, APIView):
         # and should not display the payment form before making that determination.
         # TODO: It would be cleaner if the user could be redirected to their final destination up front.
         redirect_url = get_payment_microfrontend_or_basket_url(self.request) + "?coupon_redeem_redirect=1"
+        redirect_url = add_flex_microform_flag_to_url(redirect_url)
         return HttpResponseRedirect(redirect_url)
 
 

--- a/ecommerce/coupons/views.py
+++ b/ecommerce/coupons/views.py
@@ -36,7 +36,7 @@ from ecommerce.extensions.api import exceptions
 from ecommerce.extensions.basket.utils import (
     add_stripe_flag_to_url,
     get_payment_microfrontend_or_basket_url,
-    prepare_basket,
+    prepare_basket
 )
 from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
 from ecommerce.extensions.checkout.utils import get_receipt_page_url


### PR DESCRIPTION
## Description

This PR continues https://github.com/openedx/ecommerce/pull/3865. That PR should have had added the Stripe querystring to to coupon view. This PR does that.

## Additional information

* Jira: [REV-3165](https://2u-internal.atlassian.net/browse/REV-3165)