### PR TITLE
fix: Return status 400 if empty basket on stripe capture-context call

### DIFF
--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -626,7 +626,9 @@ class CaptureContextApiLogicMixin:  # pragma: no cover
             return
 
         try:
-            response['capture_context'] = payment_processor.get_capture_context(self.request)
+            capture_context = payment_processor.get_capture_context(self.request)
+            if capture_context is not None:
+                response['capture_context'] = capture_context
         except:  # pylint: disable=bare-except
             logger.exception("Error generating capture_context")
             return
@@ -772,6 +774,8 @@ class CaptureContextApiView(CaptureContextApiLogicMixin, APIView):  # pragma: no
         """
         data = {}
         self._add_capture_context(data)
+        if not data:
+            return JsonResponse(data, status=400)
         return Response(data, status=status)
 
 

--- a/ecommerce/extensions/payment/processors/stripe.py
+++ b/ecommerce/extensions/payment/processors/stripe.py
@@ -4,6 +4,7 @@
 import logging
 
 import stripe
+from django.http import JsonResponse
 from oscar.apps.payment.exceptions import GatewayError
 from oscar.core.loading import get_model
 
@@ -109,6 +110,7 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
                 basket.id,
                 basket.order_number,
             )
+            return JsonResponse({}, status=400)
         try:
             stripe_response = stripe.PaymentIntent.create(
                 **self._build_payment_intent_parameters(basket),

--- a/ecommerce/extensions/payment/processors/stripe.py
+++ b/ecommerce/extensions/payment/processors/stripe.py
@@ -4,7 +4,6 @@
 import logging
 
 import stripe
-from django.http import JsonResponse
 from oscar.apps.payment.exceptions import GatewayError
 from oscar.core.loading import get_model
 
@@ -110,7 +109,7 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
                 basket.id,
                 basket.order_number,
             )
-            return JsonResponse({}, status=400)
+            return None
         try:
             stripe_response = stripe.PaymentIntent.create(
                 **self._build_payment_intent_parameters(basket),

--- a/ecommerce/extensions/payment/tests/views/test_stripe.py
+++ b/ecommerce/extensions/payment/tests/views/test_stripe.py
@@ -261,6 +261,17 @@ class StripeCheckoutViewTests(PaymentEventsMixin, TestCase):
                 mock_retrieve.assert_called_once()
                 assert mock_retrieve.call_args.kwargs['id'] == 'pi_3LsftNIadiFyUl1x2TWxaADZ'
 
+    def test_capture_context_empty_basket(self):
+        basket = create_basket(owner=self.user, site=self.site)
+        basket.flush()
+
+        with mock.patch('stripe.PaymentIntent.create') as mock_create:
+            self.assertTrue(basket.is_empty)
+            response = self.client.get(self.capture_context_url)
+            mock_create.assert_not_called()
+            self.assertDictEqual(response.json(), {})
+            self.assertEqual(response.status_code, 400)
+
     def test_payment_error_no_basket(self):
         """
         Verify view redirects to error page if no basket exists for payment_intent_id.


### PR DESCRIPTION
[REV-3157](https://2u-internal.atlassian.net/browse/REV-3157).

Even though I separated the fetching of the basket and Stripe's client secret in the payment MFE (https://github.com/openedx/frontend-app-payment/pull/675), there is an issue where the `isEmpty` is `false` while loading the basket, but it will eventually turn `true` when the basket is done loading. So this means that the child `<Checkout>` component is rendered and the capture-context call is still done with an empty basket. A refactor needs to be done to avoid calls we don't need, but this will require more time.

Adding a fix in the backend will prevent the Payment Intent from being created with an empty basket. 