### PR TITLE
fix: prevent checkout of basket when frontend is out of sync

### DIFF
--- a/ecommerce/extensions/payment/tests/views/test_stripe.py
+++ b/ecommerce/extensions/payment/tests/views/test_stripe.py
@@ -296,9 +296,9 @@ class StripeCheckoutViewTests(PaymentEventsMixin, TestCase):
             )
             expected = (
                 "WARNING:ecommerce.extensions.payment.views.stripe:"
-                "Basket [1] SKU mismatch! request_skus "
+                "Basket [%s] SKU mismatch! request_skus "
                 "[{'totally_the_wrong_sku'}] and basket_skus [{'%s'}]."
-                % basket.lines.first().stockrecord.partner_sku
+                % basket.id, basket.lines.first().stockrecord.partner_sku
             )
             actual = log.output[0]
             assert actual == expected

--- a/ecommerce/extensions/payment/tests/views/test_stripe.py
+++ b/ecommerce/extensions/payment/tests/views/test_stripe.py
@@ -309,7 +309,7 @@ class StripeCheckoutViewTests(PaymentEventsMixin, TestCase):
                 "WARNING:ecommerce.extensions.payment.views.stripe:"
                 "Basket [%s] SKU mismatch! request_skus "
                 "[{'totally_the_wrong_sku'}] and basket_skus [{'%s'}]."
-                % basket.id, basket.lines.first().stockrecord.partner_sku
+                % (basket.id, basket.lines.first().stockrecord.partner_sku)
             )
             actual = log.output[0]
             assert actual == expected

--- a/ecommerce/extensions/payment/views/stripe.py
+++ b/ecommerce/extensions/payment/views/stripe.py
@@ -153,6 +153,34 @@ class StripeCheckoutView(EdxOrderPlacementMixin, APIView):
 
         basket = self._get_basket(payment_intent_id)
 
+        # Check if skus in basket match what the frontend has
+        # This is intended to prevent undesired behavior where a user opens up
+        # 2 tabs in their browser to buy 2 courses, attempts to purchase the
+        # course in the 1st tab, but receives the course in the 2nd tab
+        # (the 2nd course is "correctly" displayed on the receipt page).
+        # Why?
+        # The basket in ecommerce is updated with the product of the
+        # 2nd tab when it is loaded. When purchase is clicked on the 1st tab,
+        # the checkout happens for the user and the basket... but not with the
+        # course listed on the 1st tab's display.
+        # What to do?
+        # When the frontend makes a purchase, they have the product SKUs available
+        # to them. Let's hand those to the backend and verify what they think
+        # they are buying matches what we have in the basket. If not, throw
+        # an error and stop the purchase.
+        request_skus = stripe_response.get('skus')
+        if request_skus:
+            request_skus = set(request_skus.split(','))
+            basket_skus = set(basket.lines.values_list(
+                'stockrecord__partner_sku',
+                flat=True
+            ))
+            if request_skus != basket_skus:
+                print("WE GOT A PROBLEM DAWG \n\n\n\n\n\n\n\n\n")
+                raise Exception
+            else:
+                print("everything is a-ok")
+        raise Exception # <-- for testing purposes only :)
         if not basket:
             logger.info(
                 'Received Stripe payment notification for non-existent basket with payment intent id [%s].',


### PR DESCRIPTION
The intention of this PR is to see what SKUs a frontend believes they are trying to buy, so we can check against our basket to stop the purchase process if the basket and frontend get out of sync. ~Posting here to get some eyes on the approach before I write all the tests etc.~

~This will need tests.~

Tests added. This initial PR will just log when this occurs so we can have a sense for how safe of a change this is. We can add an Exception in in a follow-up PR when we've verified the frequency with which this occurs.

Companion frontend-app-payment PR here: https://github.com/openedx/frontend-app-payment/pull/685

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?
Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
