### PR TITLE
fix: add -t parameter to transifex pull command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ compile_translations: requirements.tox
 fake_translations: extract_translations dummy_translations compile_translations
 
 pull_translations:
-	cd ecommerce && tx pull -a -f --mode reviewed
+	cd ecommerce && tx pull -a -f -t --mode reviewed
 
 push_translations:
 	cd ecommerce && tx push -s


### PR DESCRIPTION
### Description
- Transifex new version requires `-t` flag with  `tx pull` command.