### PR TITLE
feat: Added Get Smarter messaging on the receipt page

### DIFF
--- a/ecommerce/extensions/checkout/views.py
+++ b/ecommerce/extensions/checkout/views.py
@@ -197,6 +197,7 @@ class ReceiptResponseView(ThankYouView):
             'order_dashboard_url': self.get_order_dashboard_url(order),
             'explore_courses_url': get_lms_explore_courses_url(),
             'show_receipt_cta_links': True,
+            'show_get_smarter_msg': self.order_contains_executive_education_2u_product(order),
             'has_enrollment_code_product': has_enrollment_code_product,
             'disable_back_button': self.request.GET.get('disable_back_button', 0),
         })
@@ -250,6 +251,9 @@ class ReceiptResponseView(ThankYouView):
             if getattr(line.product.attr, 'credit_provider', None):
                 return True
         return False
+
+    def order_contains_executive_education_2u_product(self, order):
+        return any(line.product.is_executive_education_2u_product for line in order.lines.all())
 
     def get_order_dashboard_url(self, order):
         program_uuid = get_program_uuid(order)

--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -56,9 +56,18 @@
                   {% endblocktrans %}
                   {% interpolate_html tmsg email=order.user.email|safe link_end="</a>"|safe link_start=link_start|safe %}
               {% else %}
-                  {% blocktrans trimmed asvar tmsg %}
-                      Your order is complete. If you need a receipt, you can print this page.
-                  {% endblocktrans %}
+                  {% if show_get_smarter_msg %}
+                      {% blocktrans trimmed asvar tmsg %}
+                          Your order is complete. If you need a receipt, you can print this page.
+                          <h2><i class="fa fa-info-circle" aria-hidden="true"></i> Next Steps:</h2>
+                          1. Check your inbox for an order confirmation email from Get Smarter.<br/>
+                          2: Follow the instructions in the email to complete your registration.
+                      {% endblocktrans %}
+                  {% else %}
+                      {% blocktrans trimmed asvar tmsg %}
+                          Your order is complete. If you need a receipt, you can print this page.
+                      {% endblocktrans %}
+                  {% endif %}
                 {% interpolate_html tmsg %}
               {% endif %}
             </div>


### PR DESCRIPTION
## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

This PR modifies the messaging on the receipt page for GetSmarter courses. The following lines are added:

<img width="435" alt="image" src="https://user-images.githubusercontent.com/34648393/208706588-3249d76a-ea0b-4c05-8edb-adfe8cc11589.png">

## Supporting information

[ENT-6550](https://2u-internal.atlassian.net/browse/ENT-6550)

## Testing instructions

- Get access to Stripe
- On devstack buy a GetSmarter course with coupon that is <100% using test card number 4111 1111 1111 1111
- Review the receipt page for the additional message lines
