### PR TITLE
Fix/hardcoded currency 135

### DIFF
--- a/ecommerce/core/context_processors.py
+++ b/ecommerce/core/context_processors.py
@@ -1,5 +1,8 @@
 
 
+from babel.numbers import get_currency_symbol
+from django.conf import settings
+
 from ecommerce.core.url_utils import get_favicon_url, get_lms_dashboard_url, get_lms_url, get_logo_url
 
 
@@ -15,4 +18,20 @@ def core(request):
         'logo_url': get_logo_url(),
         'favicon_url': get_favicon_url(),
         'optimizely_snippet_src': site_configuration.optimizely_snippet_src,
+    }
+
+def localization(_request):
+    defaults = getattr(settings, "COURSE_MODE_DEFAULTS", {})
+    default_currency = defaults.get("currency")
+    registration_currency = getattr(settings, "PAID_COURSE_REGISTRATION_CURRENCY", None)
+    currency_code = registration_currency or default_currency or "USD"
+
+    if not isinstance(currency_code, str):
+        raise ValueError(f"Currency code must be a string; currently: {currency_code}")
+
+    return {
+        # Note: babel returns code if not found
+        # get_currency_symbol("XYZ") => "XYZ"
+        "currency_symbol_": get_currency_symbol(currency_code),
+        "currency_code_": currency_code,
     }

--- a/ecommerce/core/context_processors.py
+++ b/ecommerce/core/context_processors.py
@@ -20,6 +20,7 @@ def core(request):
         'optimizely_snippet_src': site_configuration.optimizely_snippet_src,
     }
 
+
 def localization(_request):
     defaults = getattr(settings, "COURSE_MODE_DEFAULTS", {})
     default_currency = defaults.get("currency")

--- a/ecommerce/courses/tests/test_views.py
+++ b/ecommerce/courses/tests/test_views.py
@@ -134,6 +134,25 @@ class CourseAppViewTests(TestCase):
         )
 
     @responses.activate
+    def test_currency_localization(self):
+        """Verify the currency symbol is localized based on settings"""
+        self._create_and_login_staff_user()
+        self.mock_access_token_response()
+        __ = self.mock_credit_api_providers()
+
+        response = self.client.get(self.path)
+        self.assertEqual(response.status_code, 200)
+        # default is USD
+        self.assertEqual(response.context["currency_symbol_"], "$")
+        self.assertEqual(response.context["currency_code_"], "USD")
+
+        with self.settings(PAID_COURSE_REGISTRATION_CURRENCY="GBP"):
+            response = self.client.get(self.path)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.context["currency_symbol_"], "£")
+            self.assertEqual(response.context["currency_code_"], "GBP")
+
+    @responses.activate
     def test_credit_providers_in_context_cached(self):
         """ Verify the cached context data includes a list of credit providers. """
         self._create_and_login_staff_user()

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -208,6 +208,7 @@ TEMPLATES = [
                 'oscar.apps.communication.notifications.context_processors.notifications',
                 'oscar.core.context_processors.metadata',
                 'ecommerce.core.context_processors.core',
+                "ecommerce.core.context_processors.localization",
                 'ecommerce.extensions.analytics.context_processors.analytics',
             ),
             'debug': True,  # Django will only display debug pages if the global DEBUG setting is set to True.

--- a/ecommerce/static/templates/_course_credit_seats.html
+++ b/ecommerce/static/templates/_course_credit_seats.html
@@ -21,7 +21,7 @@
                 <% _.each(creditSeats, function (seat) { %>
                     <tr class="course-seat">
                         <td class="seat-credit-provider"><%= seat.get('credit_provider_display_name') %></td>
-                        <td class="seat-price"><%= '$' +  Number(seat.get('price')).toLocaleString() %></td>
+                        <td class="seat-price"><%= currencySymbol +  Number(seat.get('price')).toLocaleString() %></td>
                         <td class="seat-credit-hours"><%= seat.get('credit_hours') %></td>
                         <td class="seat-expires"><% var expires = seat.get('expires');
                             if (expires) {

--- a/ecommerce/static/templates/_course_seat.html
+++ b/ecommerce/static/templates/_course_seat.html
@@ -3,7 +3,7 @@
         <div class="seat-type"><%= seat.getSeatTypeDisplayName() %></div>
     </div>
     <div class="col-sm-4">
-        <div class="seat-price"><%= gettext('Price:') + ' $' + Number(seat.get('price')).toLocaleString() %></div>
+        <div class="seat-price"><%= gettext('Price:') + ' ' + currencySymbol + Number(seat.get('price')).toLocaleString() %></div>
         <% var expires = seat.get('expires');
         if(expires) {
         print(gettext('Upgrade Deadline:') + ' ' + moment.utc(expires).format('lll z'));

--- a/ecommerce/static/templates/_offer_course_list.html
+++ b/ecommerce/static/templates/_offer_course_list.html
@@ -52,12 +52,12 @@
                             <% } else { %>
                             <div class="pull-left">
                                 <p class="course-price">
-                                    <span>$<%= course.attributes.stockrecords.price_excl_tax %></span>
+                                    <span>{{ currency_symbol_ }}<%= course.attributes.stockrecords.price_excl_tax %></span>
                                 </p>
                             </div>
                             <div class="pull-left">
                                 <p class="course-new-price">
-                                    <span><%- gettext('Now') %> $<%= course.attributes.new_price %></span>
+                                    <span><%- gettext('Now') %> {{ currency_symbol_ }}<%= course.attributes.new_price %></span>
                                 </p>
                             </div>
                             <% } %>

--- a/ecommerce/static/templates/audit_course_seat_form_field.html
+++ b/ecommerce/static/templates/audit_course_seat_form_field.html
@@ -2,7 +2,7 @@
     <div class="seat-type"><%= gettext('Audit') %></div>
 </div>
 <div class="col-sm-4">
-    <span class="price-label"><%= gettext('Price (in USD)') %>:</span> <span class="seat-price">$0.00</span>
+    <span class="price-label"><%= gettext('Price (in USD)') %>:</span> <span class="seat-price">{{ currency_symbol_ }}0.00</span>
     <input type="hidden" name="price" value="0">
     <input type="hidden" name="certificate_type">
     <input type="hidden" name="id_verification_required" value="false">

--- a/ecommerce/static/templates/coupon_form.html
+++ b/ecommerce/static/templates/coupon_form.html
@@ -1,249 +1,510 @@
 <div class="row">
-    <div class="fields col-md-6">
-        <div class="form-group">
-            <label for="title"><%= gettext('Coupon Name') %> *</label>
-            <input id="title" type="text" class="form-control" name="title" maxlength="30">
-            <p class="help-block"></p>
+  <div class="fields col-md-6">
+    <div class="form-group">
+      <label for="title"><%= gettext('Coupon Name') %> *</label>
+      <input
+        id="title"
+        type="text"
+        class="form-control"
+        name="title"
+        maxlength="30"
+      />
+      <p class="help-block"></p>
+    </div>
+    <div class="form-group">
+      <label for="code-type"><%= gettext('Code Type') %></label>
+      <select
+        id="code-type"
+        class="form-control non-editable"
+        name="code_type"
+      ></select>
+      <p class="help-block"></p>
+    </div>
+    <div class="form-group">
+      <label for="category"><%= gettext('Category') %></label>
+      <select id="category" class="form-control" name="category"></select>
+      <p class="help-block"></p>
+    </div>
+
+    <div class="row">
+      <div class="form-group col-md-6">
+        <label for="start-date"><%= gettext('Valid from') %> *</label>
+        <div class="input-group">
+          <div class="input-group-addon">
+            <i class="fa fa-calendar" aria-hidden="true"></i>
+          </div>
+          <input
+            id="start-date"
+            placeholder="<%- gettext('YYYY-MM-DDTHH:mm:ss') %>"
+            class="form-control add-pikaday"
+            name="start_date"
+          />
         </div>
-        <div class="form-group">
-            <label for="code-type"><%= gettext('Code Type') %></label>
-            <select id="code-type" class="form-control non-editable" name="code_type"></select>
-            <p class="help-block"></p>
-        </div>
-      <div class="form-group">
-        <label for="category"><%= gettext('Category') %></label>
-        <select id="category" class="form-control" name="category"></select>
         <p class="help-block"></p>
       </div>
-
-        <div class="row">
-            <div class="form-group col-md-6">
-                <label for="start-date"><%= gettext('Valid from') %> *</label>
-                <div class="input-group">
-                    <div class="input-group-addon"><i class="fa fa-calendar" aria-hidden="true"></i></div>
-                    <input id="start-date" placeholder="<%- gettext('YYYY-MM-DDTHH:mm:ss') %>" class="form-control add-pikaday" name="start_date">
-                </div>
-                <p class="help-block"></p>
-            </div>
-            <div class="form-group col-md-6">
-                <label for="end-date"><%= gettext('Valid until') %> *</label>
-                <div class="input-group">
-                    <div class="input-group-addon"><i class="fa fa-calendar" aria-hidden="true"></i></div>
-                    <input id="end-date" placeholder="<%- gettext('YYYY-MM-DDTHH:mm:ss') %>" class="form-control add-pikaday" name="end_date">
-                </div>
-                <p class="help-block"></p>
-            </div>
+      <div class="form-group col-md-6">
+        <label for="end-date"><%= gettext('Valid until') %> *</label>
+        <div class="input-group">
+          <div class="input-group-addon">
+            <i class="fa fa-calendar" aria-hidden="true"></i>
+          </div>
+          <input
+            id="end-date"
+            placeholder="<%- gettext('YYYY-MM-DDTHH:mm:ss') %>"
+            class="form-control add-pikaday"
+            name="end_date"
+          />
         </div>
-
-        <div class="form-group">
-            <label for="voucher-type"><%= gettext('Usage Limitations') %></label>
-            <select id="voucher-type" class="form-control non-editable" name="voucher_type"></select>
-            <p class="help-block"></p>
-        </div>
-
-        <div class="form-group">
-            <label for="code"><%= gettext('Code') %></label>
-            <input id="code" type="text" class="form-control non-editable" name="code" placeholder="<%= gettext('optional') %>">
-            <p class="help-block"></p>
-        </div>
-
-        <div class="form-group">
-            <label for="quantity"><%= gettext('Number of Codes') %> *</label>
-            <input id="quantity" type="number" step="1" class="form-control non-editable" name="quantity" value="1" min="1" max="5000">
-            <p class="help-block"></p>
-        </div>
-
-        <div class="form-group">
-            <label for="max-uses"><%= gettext('Maximum Number of Uses') %></label>
-            <input id="max-uses" type="number" step="1" class="form-control" name="max_uses" value="1" min="1" placeholder="Defaults to 10000">
-            <p class="help-block"></p>
-        </div>
-
-        <div class="form-group">
-            <label for="benefit-value"><%= gettext('Discount Value') %> *</label>
-            <div class="input-group">
-                <div class="benefit-addon input-group-addon"></div>
-                <input id="benefit-value" type="number" step="0.01" class="form-control benefit-value" name="benefit_value">
-            </div>
-            <div class="form-inline benefit-type">
-                <input id="benefit-percent" type="radio" class="non-editable" name="benefit_type" value="Percentage">
-                <label for="benefit-percent" class="normal-font-weight"><%= gettext('Percent') %></label>
-                <input id="benefit-fixed" type="radio" class="non-editable" name="benefit_type" value="Absolute">
-                <label for="benefit-fixed" class="normal-font-weight"><%= gettext('Fixed ($USD)') %></label>
-            </div>
-            <p class="help-block"></p>
-        </div>
-
-        <div class="form-group">
-            <label for="client"><%= gettext('Client') %> *</label>
-            <input id="client" type="text" class="form-control" name="client" maxlength="50">
-            <p class="help-block"></p>
-        </div>
-        <hr>
-
-        <div class="form-group">
-            <label><%= gettext('Invoice Type') %> *</label>
-            <div class="invoice-type row">
-                <div class="form-inline col-md-4">
-                    <input id="already-invoiced" type="radio" name="invoice_type" value="Prepaid">
-                    <label for="already-invoiced" class="normal-font-weight"><%= gettext('Already invoiced') %></label>
-                </div>
-                <div class="form-inline col-md-6">
-                    <input id="invoice-after-redemption" type="radio" name="invoice_type" value="Postpaid">
-                    <label for="invoice-after-redemption" class="normal-font-weight"><%= gettext('Invoice after redemption') %></label>
-                </div>
-                <div class="form-inline col-md-2">
-                    <input id="not-applicable" type="radio" name="invoice_type" value="Not-Applicable">
-                    <label for="not-applicable" class="normal-font-weight"><%= gettext('N/A') %></label>
-                </div>
-            </div>
-        </div>
-
-        <div class="form-group">
-            <label for="invoice-number"><%= gettext('Invoice Number') %> *</label>
-            <input id="invoice-number" class="form-control" type="text" name="invoice_number">
-            <p class="help-block"></p>
-        </div>
-
-        <div class="form-group">
-            <label for="price"><%= gettext('Invoiced Amount') %> *</label>
-            <div class="input-group">
-                <div class="input-group-addon">$</div>
-                <input id="price" type="number" step="0.01" min="0" class="form-control" name="price">
-            </div>
-            <p class="help-block"></p>
-        </div>
-
-        <div class="form-group">
-            <label for="invoice-payment-date"><%= gettext('Payment Date') %> *</label>
-            <div class="input-group">
-                <div class="input-group-addon"><span class="fa fa-calendar" aria-hidden="true"></span></div>
-                <input id="invoice-payment-date" placeholder="<%- gettext('YYYY-MM-DDTHH:mm:ss') %>" class="form-control add-pikaday" name="invoice_payment_date">
-            </div>
-            <p class="help-block"></p>
-        </div>
-
-        <div class="form-group hidden">
-            <label for="invoice-discount-value"><%= gettext('Discount per Code') %> *</label>
-            <div class="input-group">
-                <div class="invoice-discount-addon input-group-addon"></div>
-                <input id="invoice-discount-value" type="number" step="0.01" class="form-control invoice-discount-value" name="invoice_discount_value">
-            </div>
-            <div class="form-inline invoice-discount-type">
-                <input id="invoice-discount-percent" type="radio" name="invoice_discount_type" value="Percentage">
-                <label for="invoice-discount-percent" class="normal-font-weight"><%= gettext('Percent') %></label>
-                <input id="invoice-discount-fixed" type="radio" name="invoice_discount_type" value="Absolute">
-                <label for="invoice-discount-fixed" class="normal-font-weight"><%= gettext('Fixed ($USD)') %></label>
-            </div>
-            <p class="help-block"></p>
-        </div>
-
-        <div class="form-group">
-            <label for="tax-deducted-source"><%= gettext('Tax Deducted Source (TDS)') %></label>
-            <div class="form-inline tax-deduction">
-                <input id="tax-deducted" type="radio" name="tax_deduction" value="Yes">
-                <label for="tax-deducted" class="normal-font-weight"><%= gettext('Yes') %></label>
-                <input id="non-tax-deducted" type="radio" name="tax_deduction" value="No" checked>
-                <label for="non-tax-deducted" class="normal-font-weight"><%= gettext('No') %></label>
-            </div>
-        </div>
-
-        <div class="form-group hidden">
-            <div class="input-group tax-deducted-source-value">
-                <input id="tax-deducted-source-value" type="number" step="1" min="1" max="100" class="form-control" name="tax_deducted_source_value">
-                <div class="input-group-addon">%</div>
-            </div>
-            <p class="help-block"></p>
-        </div>
+        <p class="help-block"></p>
+      </div>
     </div>
 
-    <div class="fields col-md-6">
-        <div class="form-group">
-            <div class="form-inline catalog-type">
-                <input id="single-course" type="radio" class="non-editable" name="catalog_type" value="Single course">
-                <label for="single-course"><%= gettext('Single course') %></label>
-                <input id="multiple-courses" type="radio" name="catalog_type" value="Multiple courses">
-                <label for="multiple-courses"><%= gettext('Multiple courses') %></label>
-                <input id="catalog" type="radio" name="catalog_type" value="Catalog">
-                <label for="catalog"><%= gettext('Catalog') %></label>
-                <input id="program" type="radio" class="non-editable" name="catalog_type" value="Program">
-                <label for="program"><%= gettext('Program') %></label>
-            </div>
-            <p class="help-block"></p>
-        </div>
-        <div class="form-group">
-            <label for="course-id"><%= gettext('Course ID') %> *</label>
-            <input id="course-id" type="text" class="form-control non-editable" name="course_id">
-            <p class="help-block"></p>
-        </div>
-        <div class="form-group">
-            <label for="seat-type"><%= gettext('Seat Type') %> *</label>
-            <select id="seat-type" class="form-control non-editable" name="seat_type"></select>
-            <p class="help-block"></p>
-        </div>
-        <div class="form-group catalog-query">
-            <label for="catalog-query"><%= gettext('Query string:') %> * <a href="https://discovery.stage.edx.org/" class="external-link normal-font-weight">(query guidelines)</a></label>
-            <textarea id="catalog-query" class="form-control" name="catalog_query" rows="10"></textarea>
-            <span>Query length: <span class="query_length">0</span></span>
-            <p class="help-block"></p>
-        </div>
-        <div class="form-group course-catalog">
-            <label for="course-catalog"><%= gettext('Select from course catalogs:') %> *</label>
-            <select id="course-catalog" class="form-control" name="course_catalog"></select>
-            <p class="help-block"></p>
-        </div>
-        <div class="form-group course-seat-types">
-            <label for="course-seat-types"><%= gettext('Seat Types:') %> *</label>
-            <div class="checkboxes">
-                <div class="credit-radio">
-                    <input id="non-credit" type="radio" name="credit_radio" value="non-credit">
-                    <label for="non-credit"><%= gettext('Non-credit') %></label>
-                </div>
-                <div class="non-credit-seats">
-                    <input id="verified" type="checkbox" name="course_seat_types" value="verified">
-                    <label for="verified"><%= gettext('Verified') %></label>
-                    <input id="professional" type="checkbox" name="course_seat_types" value="professional">
-                    <label for="professional"><%= gettext('Professional') %></label>
-                </div>
-                <div class="credit-radio">
-                    <input id="credit" type="radio" name="credit_radio" value="credit">
-                    <label for="credit"><%= gettext('Credit') %></label>
-                </div>
-                <p class="help-block"></p>
-            </div>
-            <div class="catalog_buttons"></div>
-        </div>
-        <% if(editing) {%>
-            <div class="form-group enterprise-customer">
-                <label for="enterprise-customer"><%= gettext('Enterprise Customer:') %></label>
-                <input id="enterprise-customer" type="text" class="form-control non-editable" name="enterprise_customer">
-                <p class="help-block"></p>
-            </div>
-        <%}%>
-        <div class="form-group program-uuid">
-            <label for="program-uuid"><%= gettext('Program UUID') %> *</label>
-            <input id="program-uuid" type="text" class="form-control" name="program_uuid">
-            <p class="help-block"></p>
-        </div>
-        <div class="form-group email-domains">
-            <label for="email-domains"><%= gettext('Email domains:') %> </label>
-            <input id="email-domains" class="form-control" name="email_domains" maxlength="255">
-            <p class="help-block"></p>
-        </div>
-        <div class="form-group">
-            <label for="note"><%= gettext('Note') %></label>
-            <input id="note" type="text" class="form-control" name="note" maxlength="100">
-            <p class="help-block"></p>
-        </div>
-        <div class="form-group">
-            <label for="sales-force-id"><%= gettext('Salesforce Opportunity ID') %></label>
-            <input id="sales-force-id" class="form-control" type="text" name="sales_force_id">
-            <p class="help-block"></p>
-        </div>
+    <div class="form-group">
+      <label for="voucher-type"><%= gettext('Usage Limitations') %></label>
+      <select
+        id="voucher-type"
+        class="form-control non-editable"
+        name="voucher_type"
+      ></select>
+      <p class="help-block"></p>
     </div>
+
+    <div class="form-group">
+      <label for="code"><%= gettext('Code') %></label>
+      <input
+        id="code"
+        type="text"
+        class="form-control non-editable"
+        name="code"
+        placeholder="<%= gettext('optional') %>"
+      />
+      <p class="help-block"></p>
+    </div>
+
+    <div class="form-group">
+      <label for="quantity"><%= gettext('Number of Codes') %> *</label>
+      <input
+        id="quantity"
+        type="number"
+        step="1"
+        class="form-control non-editable"
+        name="quantity"
+        value="1"
+        min="1"
+        max="5000"
+      />
+      <p class="help-block"></p>
+    </div>
+
+    <div class="form-group">
+      <label for="max-uses"><%= gettext('Maximum Number of Uses') %></label>
+      <input
+        id="max-uses"
+        type="number"
+        step="1"
+        class="form-control"
+        name="max_uses"
+        value="1"
+        min="1"
+        placeholder="Defaults to 10000"
+      />
+      <p class="help-block"></p>
+    </div>
+
+    <div class="form-group">
+      <label for="benefit-value"><%= gettext('Discount Value') %> *</label>
+      <div class="input-group">
+        <div class="benefit-addon input-group-addon"></div>
+        <input
+          id="benefit-value"
+          type="number"
+          step="0.01"
+          class="form-control benefit-value"
+          name="benefit_value"
+        />
+      </div>
+      <div class="form-inline benefit-type">
+        <input
+          id="benefit-percent"
+          type="radio"
+          class="non-editable"
+          name="benefit_type"
+          value="Percentage"
+        />
+        <label for="benefit-percent" class="normal-font-weight"
+          ><%= gettext('Percent') %></label
+        >
+        <input
+          id="benefit-fixed"
+          type="radio"
+          class="non-editable"
+          name="benefit_type"
+          value="Absolute"
+        />
+        <label for="benefit-fixed" class="normal-font-weight"
+          ><%= gettext('Fixed ($USD)') %></label
+        >
+      </div>
+      <p class="help-block"></p>
+    </div>
+
+    <div class="form-group">
+      <label for="client"><%= gettext('Client') %> *</label>
+      <input
+        id="client"
+        type="text"
+        class="form-control"
+        name="client"
+        maxlength="50"
+      />
+      <p class="help-block"></p>
+    </div>
+    <hr />
+
+    <div class="form-group">
+      <label><%= gettext('Invoice Type') %> *</label>
+      <div class="invoice-type row">
+        <div class="form-inline col-md-4">
+          <input
+            id="already-invoiced"
+            type="radio"
+            name="invoice_type"
+            value="Prepaid"
+          />
+          <label for="already-invoiced" class="normal-font-weight"
+            ><%= gettext('Already invoiced') %></label
+          >
+        </div>
+        <div class="form-inline col-md-6">
+          <input
+            id="invoice-after-redemption"
+            type="radio"
+            name="invoice_type"
+            value="Postpaid"
+          />
+          <label for="invoice-after-redemption" class="normal-font-weight"
+            ><%= gettext('Invoice after redemption') %></label
+          >
+        </div>
+        <div class="form-inline col-md-2">
+          <input
+            id="not-applicable"
+            type="radio"
+            name="invoice_type"
+            value="Not-Applicable"
+          />
+          <label for="not-applicable" class="normal-font-weight"
+            ><%= gettext('N/A') %></label
+          >
+        </div>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label for="invoice-number"><%= gettext('Invoice Number') %> *</label>
+      <input
+        id="invoice-number"
+        class="form-control"
+        type="text"
+        name="invoice_number"
+      />
+      <p class="help-block"></p>
+    </div>
+
+    <div class="form-group">
+      <label for="price"><%= gettext('Invoiced Amount') %> *</label>
+      <div class="input-group">
+        <div class="input-group-addon">$</div>
+        <input
+          id="price"
+          type="number"
+          step="0.01"
+          min="0"
+          class="form-control"
+          name="price"
+        />
+      </div>
+      <p class="help-block"></p>
+    </div>
+
+    <div class="form-group">
+      <label for="invoice-payment-date"><%= gettext('Payment Date') %> *</label>
+      <div class="input-group">
+        <div class="input-group-addon">
+          <span class="fa fa-calendar" aria-hidden="true"></span>
+        </div>
+        <input
+          id="invoice-payment-date"
+          placeholder="<%- gettext('YYYY-MM-DDTHH:mm:ss') %>"
+          class="form-control add-pikaday"
+          name="invoice_payment_date"
+        />
+      </div>
+      <p class="help-block"></p>
+    </div>
+
+    <div class="form-group hidden">
+      <label for="invoice-discount-value"
+        ><%= gettext('Discount per Code') %> *</label
+      >
+      <div class="input-group">
+        <div class="invoice-discount-addon input-group-addon"></div>
+        <input
+          id="invoice-discount-value"
+          type="number"
+          step="0.01"
+          class="form-control invoice-discount-value"
+          name="invoice_discount_value"
+        />
+      </div>
+      <div class="form-inline invoice-discount-type">
+        <input
+          id="invoice-discount-percent"
+          type="radio"
+          name="invoice_discount_type"
+          value="Percentage"
+        />
+        <label for="invoice-discount-percent" class="normal-font-weight"
+          ><%= gettext('Percent') %></label
+        >
+        <input
+          id="invoice-discount-fixed"
+          type="radio"
+          name="invoice_discount_type"
+          value="Absolute"
+        />
+        <label for="invoice-discount-fixed" class="normal-font-weight"
+          ><%= gettext('Fixed ($USD)') %></label
+        >
+      </div>
+      <p class="help-block"></p>
+    </div>
+
+    <div class="form-group">
+      <label for="tax-deducted-source"
+        ><%= gettext('Tax Deducted Source (TDS)') %></label
+      >
+      <div class="form-inline tax-deduction">
+        <input
+          id="tax-deducted"
+          type="radio"
+          name="tax_deduction"
+          value="Yes"
+        />
+        <label for="tax-deducted" class="normal-font-weight"
+          ><%= gettext('Yes') %></label
+        >
+        <input
+          id="non-tax-deducted"
+          type="radio"
+          name="tax_deduction"
+          value="No"
+          checked
+        />
+        <label for="non-tax-deducted" class="normal-font-weight"
+          ><%= gettext('No') %></label
+        >
+      </div>
+    </div>
+
+    <div class="form-group hidden">
+      <div class="input-group tax-deducted-source-value">
+        <input
+          id="tax-deducted-source-value"
+          type="number"
+          step="1"
+          min="1"
+          max="100"
+          class="form-control"
+          name="tax_deducted_source_value"
+        />
+        <div class="input-group-addon">%</div>
+      </div>
+      <p class="help-block"></p>
+    </div>
+  </div>
+
+  <div class="fields col-md-6">
+    <div class="form-group">
+      <div class="form-inline catalog-type">
+        <input
+          id="single-course"
+          type="radio"
+          class="non-editable"
+          name="catalog_type"
+          value="Single course"
+        />
+        <label for="single-course"><%= gettext('Single course') %></label>
+        <input
+          id="multiple-courses"
+          type="radio"
+          name="catalog_type"
+          value="Multiple courses"
+        />
+        <label for="multiple-courses"><%= gettext('Multiple courses') %></label>
+        <input id="catalog" type="radio" name="catalog_type" value="Catalog" />
+        <label for="catalog"><%= gettext('Catalog') %></label>
+        <input
+          id="program"
+          type="radio"
+          class="non-editable"
+          name="catalog_type"
+          value="Program"
+        />
+        <label for="program"><%= gettext('Program') %></label>
+      </div>
+      <p class="help-block"></p>
+    </div>
+    <div class="form-group">
+      <label for="course-id"><%= gettext('Course ID') %> *</label>
+      <input
+        id="course-id"
+        type="text"
+        class="form-control non-editable"
+        name="course_id"
+      />
+      <p class="help-block"></p>
+    </div>
+    <div class="form-group">
+      <label for="seat-type"><%= gettext('Seat Type') %> *</label>
+      <select
+        id="seat-type"
+        class="form-control non-editable"
+        name="seat_type"
+      ></select>
+      <p class="help-block"></p>
+    </div>
+    <div class="form-group catalog-query">
+      <label for="catalog-query"
+        ><%= gettext('Query string:') %> *
+        <a
+          href="https://discovery.stage.edx.org/"
+          class="external-link normal-font-weight"
+          >(query guidelines)</a
+        ></label
+      >
+      <textarea
+        id="catalog-query"
+        class="form-control"
+        name="catalog_query"
+        rows="10"
+      ></textarea>
+      <span>Query length: <span class="query_length">0</span></span>
+      <p class="help-block"></p>
+    </div>
+    <div class="form-group course-catalog">
+      <label for="course-catalog"
+        ><%= gettext('Select from course catalogs:') %> *</label
+      >
+      <select
+        id="course-catalog"
+        class="form-control"
+        name="course_catalog"
+      ></select>
+      <p class="help-block"></p>
+    </div>
+    <div class="form-group course-seat-types">
+      <label for="course-seat-types"><%= gettext('Seat Types:') %> *</label>
+      <div class="checkboxes">
+        <div class="credit-radio">
+          <input
+            id="non-credit"
+            type="radio"
+            name="credit_radio"
+            value="non-credit"
+          />
+          <label for="non-credit"><%= gettext('Non-credit') %></label>
+        </div>
+        <div class="non-credit-seats">
+          <input
+            id="verified"
+            type="checkbox"
+            name="course_seat_types"
+            value="verified"
+          />
+          <label for="verified"><%= gettext('Verified') %></label>
+          <input
+            id="professional"
+            type="checkbox"
+            name="course_seat_types"
+            value="professional"
+          />
+          <label for="professional"><%= gettext('Professional') %></label>
+        </div>
+        <div class="credit-radio">
+          <input id="credit" type="radio" name="credit_radio" value="credit" />
+          <label for="credit"><%= gettext('Credit') %></label>
+        </div>
+        <p class="help-block"></p>
+      </div>
+      <div class="catalog_buttons"></div>
+    </div>
+    <% if(editing) {%>
+    <div class="form-group enterprise-customer">
+      <label for="enterprise-customer"
+        ><%= gettext('Enterprise Customer:') %></label
+      >
+      <input
+        id="enterprise-customer"
+        type="text"
+        class="form-control non-editable"
+        name="enterprise_customer"
+      />
+      <p class="help-block"></p>
+    </div>
+    <%}%>
+    <div class="form-group program-uuid">
+      <label for="program-uuid"><%= gettext('Program UUID') %> *</label>
+      <input
+        id="program-uuid"
+        type="text"
+        class="form-control"
+        name="program_uuid"
+      />
+      <p class="help-block"></p>
+    </div>
+    <div class="form-group email-domains">
+      <label for="email-domains"><%= gettext('Email domains:') %> </label>
+      <input
+        id="email-domains"
+        class="form-control"
+        name="email_domains"
+        maxlength="255"
+      />
+      <p class="help-block"></p>
+    </div>
+    <div class="form-group">
+      <label for="note"><%= gettext('Note') %></label>
+      <input
+        id="note"
+        type="text"
+        class="form-control"
+        name="note"
+        maxlength="100"
+      />
+      <p class="help-block"></p>
+    </div>
+    <div class="form-group">
+      <label for="sales-force-id"
+        ><%= gettext('Salesforce Opportunity ID') %></label
+      >
+      <input
+        id="sales-force-id"
+        class="form-control"
+        type="text"
+        name="sales_force_id"
+      />
+      <p class="help-block"></p>
+    </div>
+  </div>
 </div>
 
 <div class="form-actions">
-    <button type="submit" class="btn btn-primary"></button>
-    <a id="cancel-button" class="btn btn-default" href="/coupons/<% if(id){ print(id + '/'); } %>"><%= gettext('Cancel') %></a>
+  <button type="submit" class="btn btn-primary"></button>
+  <a
+    id="cancel-button"
+    class="btn btn-default"
+    href="/coupons/<% if(id){ print(id + '/'); } %>"
+    ><%= gettext('Cancel') %></a
+  >
 </div>

--- a/ecommerce/static/templates/credit_course_seat_form_field_row.html
+++ b/ecommerce/static/templates/credit_course_seat_form_field_row.html
@@ -10,7 +10,7 @@
 </td>
 <td class="price">
     <div class="input-group">
-        <div class="input-group-addon">$</div>
+        <div class="input-group-addon">{{ currency_symbol_ }}</div>
         <input type="number" class="form-control" id="price" name="price" aria-labelledby="price-label"
             min="5" step="1" pattern="\d+" value="<%= price %>">
     </div>

--- a/ecommerce/static/templates/enterprise_coupon_detail.html
+++ b/ecommerce/static/templates/enterprise_coupon_detail.html
@@ -95,7 +95,7 @@
                 <% if(coupon.contract_discount_value && coupon.contract_discount_type == 'Percentage') { %>
                     <%= coupon.contract_discount_value %>%
                 <% } else if(coupon.contract_discount_type == 'Absolute') { %>
-                    $<%= coupon.contract_discount_value && coupon.contract_discount_value %>
+                    {{ currency_symbol_ }}<%= coupon.contract_discount_value && coupon.contract_discount_value %>
                 <% } else { %>
                     -
                 <%}%>
@@ -103,7 +103,7 @@
         </div>
         <div class="info-item grid-item prepaid-invoice-amount">
             <div class="heading"><%= gettext('Prepaid Invoice Amount:') %></div>
-            <div class="value">$<%= coupon.prepaid_invoice_amount %></div>
+            <div class="value">{{ currency_symbol_ }}<%= coupon.prepaid_invoice_amount %></div>
         </div>
         <div class="info-item grid-item invoice-type">
             <div class="heading"><%= gettext('Invoice Type:') %></div>

--- a/ecommerce/static/templates/enterprise_coupon_form.html
+++ b/ecommerce/static/templates/enterprise_coupon_form.html
@@ -142,7 +142,7 @@
         <div class="form-group">
             <label for="price"><%= gettext('Invoiced Amount') %> *</label>
             <div class="input-group">
-                <div class="input-group-addon">$</div>
+                <div class="input-group-addon">{{ currency_symbol_ }}</div>
                 <input id="price" type="number" step="0.01" min="0" class="form-control" name="price">
             </div>
             <p class="help-block"></p>

--- a/ecommerce/static/templates/honor_course_seat_form_field.html
+++ b/ecommerce/static/templates/honor_course_seat_form_field.html
@@ -2,7 +2,7 @@
     <div class="seat-type"><%= gettext('Honor') %></div>
 </div>
 <div class="col-sm-4">
-    <span class="price-label"><%= gettext('Price (in USD)') %>:</span> <span class="seat-price">$0.00</span>
+    <span class="price-label"><%= gettext('Price (in USD)') %>:</span> <span class="seat-price">{{ currency_symbol_ }}0.00</span>
     <input type="hidden" name="price" value="0">
     <input type="hidden" name="certificate_type" value="honor">
     <input type="hidden" name="id_verification_required" value="false">

--- a/ecommerce/static/templates/professional_course_seat_form_field.html
+++ b/ecommerce/static/templates/professional_course_seat_form_field.html
@@ -9,7 +9,7 @@
             <label for="price"><%= gettext('Price (in USD)') %></label>
 
             <div class="input-group">
-                <div class="input-group-addon">$</div>
+                <div class="input-group-addon">{{ currency_symbol_ }}</div>
                 <input type="number" class="form-control" name="price" id="price" min="5" step="1" pattern="\d+"
                        value="<%= price %>">
             </div>

--- a/ecommerce/templates/base.html
+++ b/ecommerce/templates/base.html
@@ -35,7 +35,12 @@
       <script src="{{ optimizely_snippet_src }}"></script>
     {% endif %}
 
-    {% block extrahead %}{% endblock %}
+    {% block extrahead %}
+      <script>
+        const currencyCode = "{{ currency_code_ }}"
+        const currencySymbol = "{{ currency_symbol_ }}"
+      </script>    
+    {% endblock %}
 
     {% block tracking %}
       {# Default to using Google analytics #}


### PR DESCRIPTION
## Description
1. Adds a context processor based on the settings variables outlined in [this comment](https://github.com/openedx/build-test-release-wg/issues/135#issuecomment-1373580685).
2. Saves the localised currency code + symbol as global javascript variables in base template
3. Utilizes either django template variable or javascript variable to replace hardcoded symbol with dynamic localized symbol
4. Adds a test that context dictionary is correctly instantiated

## Supporting information
https://github.com/openedx/build-test-release-wg/issues/135

## Testing instructions
1. Change the currency code value in the configuration
2. Check that in the views the currency symbol/code has been correctly updated

## Other information
Instructions [here](https://edx.readthedocs.io/projects/open-edx-devstack/en/latest/readme.html#getting-started) for setting up the repo, didn't work for me, so I just tested the core functionality on a separate basic django project. 

Ideally, one would also want to confirm that template variables in the js templates are correctly replaced (otherwise one could use <%=currencySymbol%>)
And add a test of the above.

Lastly, there are several places in the code where `gettext('Price (USD)')` or `gettext('Fixed ($USD)')`. I could also make these dynamic, but I'm assuming this serves as a key for a translation lookup and having it dynamic may cause issues. Would a maintainer please advise on best way to handle this?

