### PR TITLE
fix: Fixed html rendering for GetSmarter messaging in receipt page

### DIFF
--- a/ecommerce/templates/edx/checkout/receipt.html
+++ b/ecommerce/templates/edx/checkout/receipt.html
@@ -59,16 +59,17 @@
                   {% if show_get_smarter_msg %}
                       {% blocktrans trimmed asvar tmsg %}
                           Your order is complete. If you need a receipt, you can print this page.
-                          <h2><i class="fa fa-info-circle" aria-hidden="true"></i> Next Steps:</h2>
-                          1. Check your inbox for an order confirmation email from Get Smarter.<br/>
+                          {next_start} Next Steps:{next_end}
+                          1. Check your inbox for an order confirmation email from Get Smarter.{next_line}
                           2: Follow the instructions in the email to complete your registration.
                       {% endblocktrans %}
+                      {% interpolate_html tmsg next_start='<h2><i class="fa fa-info-circle" aria-hidden="true"></i>'|safe next_end='</h2>'|safe next_line='<br/>'|safe %}
                   {% else %}
                       {% blocktrans trimmed asvar tmsg %}
                           Your order is complete. If you need a receipt, you can print this page.
                       {% endblocktrans %}
+                      {% interpolate_html tmsg %}
                   {% endif %}
-                {% interpolate_html tmsg %}
               {% endif %}
             </div>
 


### PR DESCRIPTION
## Description

This PR fixes the html rendering for GetSmarter messaging in the receipt page

## Supporting information

JIRA: [ENT-6550](https://2u-internal.atlassian.net/browse/ENT-6550)
Related PR: https://github.com/openedx/ecommerce/pull/3883
