### PR TITLE
feat: Add webhooks Stripe endpoint

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_webhooks.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_webhooks.py
@@ -3,6 +3,7 @@
 import logging
 
 import ddt
+import mock
 from django.test import Client
 from django.urls import reverse
 from testfixtures import LogCapture
@@ -11,6 +12,7 @@ from ecommerce.tests.testcases import TestCase
 
 log = logging.getLogger(__name__)
 log_name = 'ecommerce.extensions.api.v2.views.webhooks'
+CONTENT_TYPE = 'application/json'
 
 
 @ddt.ddt
@@ -53,9 +55,35 @@ class StripeWebhooksViewTests(TestCase):
         response = getattr(self.client, http_method)(self.url)
         self.assertEqual(response.status_code, 405)
 
+    @mock.patch('stripe.Event.construct_from')
+    def test_exception_stripe_event_object(self, mock_stripe_construct_from):
+        """
+        Verify an exception is raised if there is any issue with the Stripe Event object.
+        """
+        with mock.patch('ecommerce.extensions.api.v2.views.webhooks.logger.exception') as mock_logger:
+            mock_stripe_construct_from.side_effect = ValueError
+            post_data = self._build_event_data()
+            response = self.client.post(self.url, post_data, content_type=CONTENT_TYPE)
+            self.assertEqual(response.status_code, 400)
+            self.assertTrue(mock_logger.called)
+
+    def test_exception_invalid_json(self):
+        """
+        Verify an exception is raised if there is any issue with the JSON parser.
+        """
+        with mock.patch('ecommerce.extensions.api.v2.views.webhooks.logger.exception') as mock_logger:
+            with self.assertRaises(Exception):
+                post_data = {
+                    'amount': 199 * 0.99
+                }
+                response = self.client.post(self.url, post_data, content_type=CONTENT_TYPE)
+                self.assertEqual(response.status_code, 400)
+                self.assertTrue(mock_logger.called)
+
     @ddt.data(
         ('charge.succeeded', 199, 'ch_123dummy'),
         ('payment_intent.succeeded', 299, 'pi_123dummy'),
+        ('payment_intent.created', 399, 'pi_123dummy')
     )
     @ddt.unpack
     def test_handled_webhook_event(self, event_type, amount, event_id):
@@ -73,7 +101,7 @@ class StripeWebhooksViewTests(TestCase):
             ),
         ]
         with LogCapture(log_name) as log_capture:
-            response = self.client.post(self.url, post_data, content_type='application/json')
+            response = self.client.post(self.url, post_data, content_type=CONTENT_TYPE)
             self.assertEqual(response.status_code, 200)
             log_capture.check_present(*expected_logs)
 
@@ -85,11 +113,11 @@ class StripeWebhooksViewTests(TestCase):
         expected_logs = [
             (
                 log_name,
-                'INFO',
+                'WARNING',
                 '[Stripe webhooks] unhandled event with type [{}].'.format(post_data['type']),
             ),
         ]
         with LogCapture(log_name) as log_capture:
-            response = self.client.post(self.url, post_data, content_type='application/json')
+            response = self.client.post(self.url, post_data, content_type=CONTENT_TYPE)
             self.assertEqual(response.status_code, 200)
             log_capture.check_present(*expected_logs)

--- a/ecommerce/extensions/api/v2/tests/views/test_webhooks.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_webhooks.py
@@ -1,0 +1,95 @@
+
+
+import logging
+
+import ddt
+from django.test import Client
+from django.urls import reverse
+from testfixtures import LogCapture
+
+from ecommerce.tests.testcases import TestCase
+
+log = logging.getLogger(__name__)
+log_name = 'ecommerce.extensions.api.v2.views.webhooks'
+
+
+@ddt.ddt
+class StripeWebhooksViewTests(TestCase):
+    """ Tests StripeWebhooksView """
+
+    def setUp(self):
+        super(StripeWebhooksViewTests, self).setUp()
+        self.url = reverse("api:v2:webhooks:webhook_events")
+        self.client = Client(enforce_csrf_checks=True)
+
+    def _build_event_data(self, **kwargs):
+        event_type = kwargs.get('event_type', None)
+        amount = kwargs.get('amount', None)
+        event_id = kwargs.get('event_id', None)
+        return {
+            'id': 'evt_123dummy',
+            'object': 'event',
+            'api_version': '2022-08-01',
+            'created': 1673630016,
+            'data': {
+                'object': {
+                    'object': 'charge',
+                    'id': event_id,
+                    'amount': amount,
+                    'currency': 'usd',
+                    'last_payment_error': None,
+                    'metadata': {},
+                    'next_action': None,
+                },
+            },
+            'type': event_type,
+        }
+
+    @ddt.data('get', 'put', 'patch', 'head')
+    def test_method_not_allowed(self, http_method):
+        """
+        Verify the view only accepts POST HTTP method.
+        """
+        response = getattr(self.client, http_method)(self.url)
+        self.assertEqual(response.status_code, 405)
+
+    @ddt.data(
+        ('charge.succeeded', 199, 'ch_123dummy'),
+        ('payment_intent.succeeded', 299, 'pi_123dummy'),
+    )
+    @ddt.unpack
+    def test_handled_webhook_event(self, event_type, amount, event_id):
+        """
+        Verify the expected logs for the known handled event types are logged
+        with the correct event type and other attributes.
+        """
+        post_data = self._build_event_data(event_type=event_type, amount=amount, event_id=event_id)
+        expected_logs = [
+            (
+                log_name,
+                'INFO',
+                '[Stripe webhooks] event {} with amount {} and payment intent ID [{}].'
+                .format(event_type, amount, event_id),
+            ),
+        ]
+        with LogCapture(log_name) as log_capture:
+            response = self.client.post(self.url, post_data, content_type='application/json')
+            self.assertEqual(response.status_code, 200)
+            log_capture.check_present(*expected_logs)
+
+    def test_unhandled_webhook_event(self):
+        """
+        Verify the expected logs for the unhandled event types are logged with the correct event type.
+        """
+        post_data = self._build_event_data(event_type='account_updated')
+        expected_logs = [
+            (
+                log_name,
+                'INFO',
+                '[Stripe webhooks] unhandled event with type [{}].'.format(post_data['type']),
+            ),
+        ]
+        with LogCapture(log_name) as log_capture:
+            response = self.client.post(self.url, post_data, content_type='application/json')
+            self.assertEqual(response.status_code, 200)
+            log_capture.check_present(*expected_logs)

--- a/ecommerce/extensions/api/v2/urls.py
+++ b/ecommerce/extensions/api/v2/urls.py
@@ -23,6 +23,7 @@ from ecommerce.extensions.api.v2.views import retirement as retirement_views
 from ecommerce.extensions.api.v2.views import stockrecords as stockrecords_views
 from ecommerce.extensions.api.v2.views import user_management as user_management_views
 from ecommerce.extensions.api.v2.views import vouchers as voucher_views
+from ecommerce.extensions.api.v2.views import webhooks as webhooks_views
 from ecommerce.extensions.voucher.views import CouponReportCSVView
 
 ORDER_NUMBER_PATTERN = r'(?P<number>[-\w]+)'
@@ -49,6 +50,10 @@ BASKET_URLS = [
 
 PAYMENT_URLS = [
     url(r'^processors/$', payment_views.PaymentProcessorListView.as_view(), name='list_processors'),
+]
+
+WEBHOOKS_URLS = [
+    url(r'^stripe/$', webhooks_views.StripeWebhooksView.as_view(), name='webhook_events'),
 ]
 
 REFUND_URLS = [
@@ -116,6 +121,7 @@ urlpatterns = [
     url(r'^retirement/', include((RETIREMENT_URLS, 'retirement'))),
     url(r'^user_management/', include((USER_MANAGEMENT_URLS, 'user_management'))),
     url(r'^assignment-email/', include((ASSIGNMENT_EMAIL_URLS, 'assignment-email'))),
+    url(r'^webhooks/', include((WEBHOOKS_URLS, 'webhooks'))),
 ]
 
 router = SimpleRouter()

--- a/ecommerce/extensions/api/v2/views/webhooks.py
+++ b/ecommerce/extensions/api/v2/views/webhooks.py
@@ -1,0 +1,64 @@
+"""HTTP endpoints for interacting with webhooks."""
+
+
+import json
+import logging
+
+import stripe
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+logger = logging.getLogger(__name__)
+
+
+class StripeWebhooksView(APIView):
+    """
+    Endpoint for Stripe webhook events. A 200 response should be returned as soon as possible
+    since Stripe will retry the event if no response is received.
+
+    Django's default cross-site request forgery (CSRF) protection is disabled,
+    request are verified instead by the presence of request headers STRIPE_SIGNATURE.
+    This endpoint is a public endpoint however it should be used for Stripe servers only.
+    """
+    http_method_names = ['post']  # accept POST request only
+    authentication_classes = []
+    permission_classes = [AllowAny]
+
+    @csrf_exempt
+    def post(self, request):
+        event = None
+        payload = request.body
+        # TODO REV-3238: secure webhooks with endpoint_secret and stripe signature header
+        # Note: this should be done before adding any logic to this endpoint besides logs.
+        try:
+            event = stripe.Event.construct_from(json.loads(payload), stripe.api_key)
+        except ValueError as e:
+            logger.exception('StripeWebhooksView failed with %s', e)
+            return Response('Invalid payload', status=400)
+
+        # TODO REV-3296: save webhooks event data in webhooks data model. Possibly move the handling of the event
+        # to another function, and return response asap if we're listening to many events.
+
+        # Handle the event
+        payment_intent = event.data.object
+        if event.type == 'payment_intent.succeeded':
+            logger.info(
+                '[Stripe webhooks] event payment_intent.succeeded with amount %d and payment intent ID [%s].',
+                payment_intent.amount,
+                payment_intent.id,
+            )
+            # TODO: define and call a method to handle the successful payment intent.
+            # handle_payment_intent_succeeded(payment_intent)
+        elif event.type == 'charge.succeeded':
+            logger.info(
+                '[Stripe webhooks] event charge.succeeded with amount %d and payment intent ID [%s].',
+                payment_intent.amount,
+                payment_intent.id,
+            )
+        else:
+            logger.info('[Stripe webhooks] unhandled event with type [%s].', event.type)
+
+        return Response(status=status.HTTP_200_OK)

--- a/ecommerce/extensions/payment/views/stripe.py
+++ b/ecommerce/extensions/payment/views/stripe.py
@@ -155,7 +155,10 @@ class StripeCheckoutView(EdxOrderPlacementMixin, APIView):
         return basket
 
     def post(self, request):
-        """Handle an incoming user returned to us by Stripe after approving payment."""
+        """
+        Handle an incoming payment submission from the payment MFE after capture-context.
+        SDN Check and confirmation by Stripe on the payment intent is performed.
+        """
         stripe_response = request.POST.dict()
         payment_intent_id = stripe_response.get('payment_intent_id')
 


### PR DESCRIPTION
[REV-3237](https://2u-internal.atlassian.net/browse/REV-3237).

Creating a webhooks endpoint for Stripe webhook events, `/api/v2/webhooks/stripe/`. 
The endpoint is not under `/payment/` processors since we plan to use this endpoint to listen to other events not directly related to processing payment, like when a customer is created in Stripe.

_Please note_: this is a public endpoint that only has logs and does not save any event data to the `ecommerce` DB.  Only after [REV-3238](https://2u-internal.atlassian.net/browse/REV-3238) is done, which checks for the Stripe header to accept an incoming request, is when this endpoint can have any logic/saving data other than logs. For now, if the payload is not a Stripe related JSON, it will cause an exception.

Planning to merge this before REV-3238, for full testing we need to register the endpoint in the Stripe dashboard, and it cannot be a localhost endpoint.

**This PR**:
- Fixes unrelated docstring in another Stripe file.
- Adds the URLs and the `StripeWebhookView` with logs.
- Adds tests for the `StripeWebhookView`.

Confluence webhooks page created: https://2u-internal.atlassian.net/l/cp/uuKTLnNf