### PR TITLE
feat: update segment event property

### DIFF
--- a/ecommerce/courses/utils.py
+++ b/ecommerce/courses/utils.py
@@ -154,9 +154,15 @@ def get_certificate_type_display_value(certificate_type):
     return display_values[certificate_type]
 
 
-def get_is_personalized_recommendation(course, request):
+def is_course_recommended_on_user_dashboard(course, request):
     """
-    Returns the personalized recommendation value from the cookie.
+    Tells whether the course was recommended on the user dashboard.
+
+    Return values:
+        Personalized recommendation: Returns whether the course was recommended on user dashboard
+        Control group: Returns the user segmentation group a user belonged in. This is useful when we
+                       show different recommendations based on the group a user belongs in i.e general
+                       vs personalized.
     """
     if request and course:
         recommendations = request.COOKIES.get('edx-user-personalized-recommendation', None)
@@ -165,6 +171,6 @@ def get_is_personalized_recommendation(course, request):
             course_key = CourseKey.from_string(course.id)
             course_key = f'{course_key.org}+{course_key.course}'
             if course_key in recommendations['course_keys']:
-                return recommendations['is_personalized_recommendation']
+                return True, recommendations.get('is_control')
 
-    return None
+    return False, None

--- a/ecommerce/extensions/checkout/signals.py
+++ b/ecommerce/extensions/checkout/signals.py
@@ -6,7 +6,7 @@ import waffle
 from django.dispatch import receiver
 from oscar.core.loading import get_class, get_model
 
-from ecommerce.courses.utils import get_is_personalized_recommendation, mode_for_product
+from ecommerce.courses.utils import is_course_recommended_on_user_dashboard, mode_for_product
 from ecommerce.extensions.analytics.utils import silence_exceptions, track_segment_event
 from ecommerce.extensions.basket.constants import ENABLE_STRIPE_PAYMENT_PROCESSOR
 from ecommerce.extensions.checkout.utils import get_credit_provider_details, get_receipt_page_url
@@ -54,11 +54,11 @@ def track_completed_order(sender, order=None, **kwargs):  # pylint: disable=unus
 
         # VAN-987: Adding segment event property 'is_personalized_recommendation'
         # for the course recommendations.
-        is_personalized_recommendation = get_is_personalized_recommendation(
+        is_recommended_course, control_group = is_course_recommended_on_user_dashboard(
             line.product.course, kwargs.get('request', None)
         )
-        if is_personalized_recommendation is not None:
-            order_line['is_personalized_recommendation'] = is_personalized_recommendation
+        if is_recommended_course:
+            order_line['dashboard_recommendations_group'] = control_group
 
         products.append(order_line)
     request = kwargs.get('request', None)

--- a/ecommerce/extensions/checkout/tests/test_signals.py
+++ b/ecommerce/extensions/checkout/tests/test_signals.py
@@ -242,7 +242,7 @@ class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
                 course_key = CourseKey.from_string(line.product.course.id)
                 course_key = f'{course_key.org}+{course_key.course}'
                 if recommendations and course_key in recommendations['course_keys']:
-                    order_line['is_personalized_recommendation'] = recommendations['is_personalized_recommendation']
+                    order_line['dashboard_recommendations_group'] = recommendations['is_control']
             products.append(order_line)
 
         properties = {
@@ -285,7 +285,7 @@ class SignalTests(ProgramTestMixin, CouponMixin, TestCase):
                 course_keys.append(course_key)
         return {
             'course_keys': course_keys,
-            'is_personalized_recommendation': True
+            'is_control': True
         }
 
     def test_track_completed_order(self):


### PR DESCRIPTION
Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Description

A change to the segment event property related to the recommendations shown on the learner dashboard. The property now picks the control group value the user was added to by Amplitude.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

[VAN-1250](https://2u-internal.atlassian.net/browse/VAN-1250)
