### PR TITLE
feat: add service throttle on publication endpoint and skip throttle for discovery worker

### DIFF
--- a/ecommerce/extensions/api/throttles.py
+++ b/ecommerce/extensions/api/throttles.py
@@ -11,7 +11,11 @@ class ServiceUserThrottle(UserRateThrottle):
         """Returns True if the request is coming from one of the service users
         and defaults to UserRateThrottle's configured setting otherwise.
         """
-        service_users = [settings.ECOMMERCE_SERVICE_WORKER_USERNAME, settings.PROSPECTUS_WORKER_USERNAME]
+        service_users = [
+            settings.ECOMMERCE_SERVICE_WORKER_USERNAME,
+            settings.PROSPECTUS_WORKER_USERNAME,
+            settings.DISCOVERY_WORKER_USERNAME
+        ]
         if request.user.username in service_users:
             return True
         return super(ServiceUserThrottle, self).allow_request(request, view)

--- a/ecommerce/extensions/api/v2/tests/views/test_publication.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_publication.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 
 import mock
 import pytz
+from django.conf import settings
 from django.urls import reverse
 from oscar.core.loading import get_model
 
@@ -152,7 +153,7 @@ class AtomicPublicationTests(DiscoveryTestMixin, TestCase):
             ]
         }
 
-        self.user = self.create_user(is_staff=True)
+        self.user = self.create_user(is_staff=True, username=settings.DISCOVERY_WORKER_USERNAME)
         self.client.login(username=self.user.username, password=self.password)
 
         self.publication_switch = toggle_switch('publish_course_modes_to_lms', True)

--- a/ecommerce/extensions/api/v2/views/publication.py
+++ b/ecommerce/extensions/api/v2/views/publication.py
@@ -6,6 +6,7 @@ from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 
 from ecommerce.extensions.api import serializers
+from ecommerce.extensions.api.throttles import ServiceUserThrottle
 from ecommerce.extensions.partner.shortcuts import get_partner_for_site
 
 
@@ -16,6 +17,7 @@ class AtomicPublicationView(generics.CreateAPIView, generics.UpdateAPIView):
     """
     permission_classes = (IsAuthenticated, IsAdminUser,)
     serializer_class = serializers.AtomicPublicationSerializer
+    throttle_classes = (ServiceUserThrottle,)
 
     def get_serializer_context(self):
         context = super(AtomicPublicationView, self).get_serializer_context()

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -473,6 +473,9 @@ ECOMMERCE_SERVICE_WORKER_USERNAME = 'ecommerce_worker'
 # Worker user used by prospectus to query ecommerce
 PROSPECTUS_WORKER_USERNAME = 'prospectus_worker'
 
+# Worker used by Discovery to consume ecommerce endpoints
+DISCOVERY_WORKER_USERNAME = 'discovery_worker'
+
 # Used to access the Enrollment API. Set this to the same value used by the LMS.
 EDX_API_KEY = 'PUT_YOUR_API_KEY_HERE'
 


### PR DESCRIPTION
# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

### [PROD-3012](https://2u-internal.atlassian.net/browse/PROD-3012)

### Description


- Add discovery worker username settings variable and add the username to ServiceUserThrottle's service users list
- Add ServiceUserThrottle to publication endpoint to bypass the occasional rate limit error faced when consuming ecommerce from Discovery. While it can be argued to add delay in requests in Discovery, ecommerce is already exempting certain service workers on different endpoints. I am just re-using that logic on publication endpoint. 
    - The addition of ServiceUserThrotte will not impact the regular throttling because ServiceUserThrottle is an extension of UserRateThrottle which is the default Throttle class in ecommerce [base.py settings](https://github.com/openedx/ecommerce/blob/1bcfc9c24f034e4adf0227098426fe74e26079ea/ecommerce/settings/base.py#L515)
- edx-internal PR https://github.com/edx/edx-internal/pull/7671

