### PR TITLE
feat: Secure Stripe webhooks endpoint

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_webhooks.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_webhooks.py
@@ -112,7 +112,8 @@ class StripeWebhooksViewTests(TestCase):
     @mock.patch('stripe.Webhook.construct_event')
     @ddt.data(
         ('payment_intent.succeeded', 299, 'pi_123dummy'),
-        ('payment_intent.requires_action', 399, 'pi_456dummy')
+        ('payment_intent.requires_action', 399, 'pi_456dummy'),
+        ('payment_intent.payment_failed', 499, 'pi_789dummy'),
     )
     @ddt.unpack
     def test_handled_webhook_event(self, event_type, amount, payment_intent_id, mock_construct_event):

--- a/ecommerce/extensions/api/v2/tests/views/test_webhooks.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_webhooks.py
@@ -6,13 +6,14 @@ import ddt
 import mock
 from django.test import Client
 from django.urls import reverse
+from stripe.error import SignatureVerificationError
 from testfixtures import LogCapture
 
+from ecommerce.extensions.api.v2.tests.views import JSON_CONTENT_TYPE
 from ecommerce.tests.testcases import TestCase
 
 log = logging.getLogger(__name__)
 log_name = 'ecommerce.extensions.api.v2.views.webhooks'
-CONTENT_TYPE = 'application/json'
 
 
 @ddt.ddt
@@ -23,11 +24,25 @@ class StripeWebhooksViewTests(TestCase):
         super(StripeWebhooksViewTests, self).setUp()
         self.url = reverse("api:v2:webhooks:webhook_events")
         self.client = Client(enforce_csrf_checks=True)
+        self.mock_settings = {
+            'ECOMMERCE_PAYMENT_PROCESSOR_CONFIG': {
+                'edx': {
+                    'stripe': {
+                        'secret_key': 'sk_test_123',
+                        'endpoint_secret': 'whsec_123',
+                    }
+                }
+            },
+        }
+        self.mock_header = {
+            'HTTP_STRIPE_SIGNATURE': 't=1674755157,v1=a5e6655d0f41076ca300150ed98b125ab0203f8672ced6f7cc9c8856517727e8',
+        }
+        self.mock_stripe_event = mock.Mock()
 
-    def _build_event_data(self, **kwargs):
+    def _build_request_data(self, **kwargs):
         event_type = kwargs.get('event_type', None)
         amount = kwargs.get('amount', None)
-        event_id = kwargs.get('event_id', None)
+        payment_intent_id = kwargs.get('payment_intent_id', None)
         return {
             'id': 'evt_123dummy',
             'object': 'event',
@@ -35,14 +50,25 @@ class StripeWebhooksViewTests(TestCase):
             'created': 1673630016,
             'data': {
                 'object': {
-                    'object': 'charge',
-                    'id': event_id,
+                    'object': 'payment_intent',
+                    'id': payment_intent_id,
                     'amount': amount,
+                    'amount_received': amount,
+                    'confirmation_method': 'automatic',
                     'currency': 'usd',
-                    'last_payment_error': None,
-                    'metadata': {},
-                    'next_action': None,
+                    'description': 'EDX-10001',
+                    'metadata': {
+                        'order_number': 'EDX-10001'
+                    },
+                    'payment_method': 'pm_123dummy',
+                    'secret_key_confirmation': 'required',
+                    'status': 'succeeded',
                 },
+            },
+            'pending_webhooks': 3,
+            'request': {
+                'id': 'req_123dummy',
+                'idempotency_key': '123dummy'
             },
             'type': event_type,
         }
@@ -55,61 +81,71 @@ class StripeWebhooksViewTests(TestCase):
         response = getattr(self.client, http_method)(self.url)
         self.assertEqual(response.status_code, 405)
 
-    @mock.patch('stripe.Event.construct_from')
-    def test_exception_stripe_event_object(self, mock_stripe_construct_from):
+    def test_stripe_event_value_error(self):
         """
-        Verify an exception is raised if there is any issue with the Stripe Event object.
-        """
-        with mock.patch('ecommerce.extensions.api.v2.views.webhooks.logger.exception') as mock_logger:
-            mock_stripe_construct_from.side_effect = ValueError
-            post_data = self._build_event_data()
-            response = self.client.post(self.url, post_data, content_type=CONTENT_TYPE)
-            self.assertEqual(response.status_code, 400)
-            self.assertTrue(mock_logger.called)
-
-    def test_exception_invalid_json(self):
-        """
-        Verify an exception is raised if there is any issue with the JSON parser.
+        Verify an exception is raised if there is an issue with the Stripe Event from unexpected payload.
         """
         with mock.patch('ecommerce.extensions.api.v2.views.webhooks.logger.exception') as mock_logger:
-            with self.assertRaises(Exception):
-                post_data = {
-                    'amount': 199 * 0.99
-                }
-                response = self.client.post(self.url, post_data, content_type=CONTENT_TYPE)
+            with self.settings(**self.mock_settings):
+                response = self.client.post(
+                    self.url, 'not-expected-data', content_type=JSON_CONTENT_TYPE, **self.mock_header
+                )
                 self.assertEqual(response.status_code, 400)
                 self.assertTrue(mock_logger.called)
 
+    @mock.patch('stripe.Webhook.construct_event')
+    def test_stripe_signature_verification_error(self, mock_construct_event):
+        """
+        Verify an exception is raised if there is any issue with verifying the stripe header/endpoint secret.
+        """
+        with mock.patch('ecommerce.extensions.api.v2.views.webhooks.logger.exception') as mock_logger:
+            with self.settings(**self.mock_settings):
+                mock_construct_event.side_effect = SignatureVerificationError(
+                    'error on signature verification', self.mock_header['HTTP_STRIPE_SIGNATURE']
+                )
+                response = self.client.post(
+                    self.url, self._build_request_data(), content_type=JSON_CONTENT_TYPE, **self.mock_header
+                )
+                self.assertEqual(response.status_code, 400)
+                self.assertTrue(mock_logger.called)
+
+    @mock.patch('stripe.Webhook.construct_event')
     @ddt.data(
-        ('charge.succeeded', 199, 'ch_123dummy'),
         ('payment_intent.succeeded', 299, 'pi_123dummy'),
-        ('payment_intent.created', 399, 'pi_123dummy')
+        ('payment_intent.requires_action', 399, 'pi_456dummy')
     )
     @ddt.unpack
-    def test_handled_webhook_event(self, event_type, amount, event_id):
+    def test_handled_webhook_event(self, event_type, amount, payment_intent_id, mock_construct_event):
         """
         Verify the expected logs for the known handled event types are logged
         with the correct event type and other attributes.
         """
-        post_data = self._build_event_data(event_type=event_type, amount=amount, event_id=event_id)
+        post_data = self._build_request_data(event_type=event_type, amount=amount, payment_intent_id=payment_intent_id)
         expected_logs = [
             (
                 log_name,
                 'INFO',
                 '[Stripe webhooks] event {} with amount {} and payment intent ID [{}].'
-                .format(event_type, amount, event_id),
+                .format(event_type, amount, payment_intent_id),
             ),
         ]
-        with LogCapture(log_name) as log_capture:
-            response = self.client.post(self.url, post_data, content_type=CONTENT_TYPE)
-            self.assertEqual(response.status_code, 200)
-            log_capture.check_present(*expected_logs)
+        with self.settings(**self.mock_settings):
+            self.mock_stripe_event.type = event_type
+            self.mock_stripe_event.data.object.amount = amount
+            self.mock_stripe_event.data.object.id = payment_intent_id
+            mock_construct_event.return_value = self.mock_stripe_event
+            with LogCapture(log_name) as log_capture:
+                response = self.client.post(self.url, post_data, content_type=JSON_CONTENT_TYPE, **self.mock_header)
+                self.assertEqual(response.status_code, 200)
+                log_capture.check_present(*expected_logs)
 
-    def test_unhandled_webhook_event(self):
+    @mock.patch('stripe.Webhook.construct_event')
+    def test_unhandled_webhook_event(self, mock_construct_event):
         """
         Verify the expected logs for the unhandled event types are logged with the correct event type.
         """
-        post_data = self._build_event_data(event_type='account_updated')
+        event_type = 'account_updated'
+        post_data = self._build_request_data(event_type=event_type)
         expected_logs = [
             (
                 log_name,
@@ -117,7 +153,10 @@ class StripeWebhooksViewTests(TestCase):
                 '[Stripe webhooks] unhandled event with type [{}].'.format(post_data['type']),
             ),
         ]
-        with LogCapture(log_name) as log_capture:
-            response = self.client.post(self.url, post_data, content_type=CONTENT_TYPE)
-            self.assertEqual(response.status_code, 200)
-            log_capture.check_present(*expected_logs)
+        with self.settings(**self.mock_settings):
+            self.mock_stripe_event.type = event_type
+            mock_construct_event.return_value = self.mock_stripe_event
+            with LogCapture(log_name) as log_capture:
+                response = self.client.post(self.url, post_data, content_type=JSON_CONTENT_TYPE, **self.mock_header)
+                self.assertEqual(response.status_code, 200)
+                log_capture.check_present(*expected_logs)

--- a/ecommerce/extensions/api/v2/views/webhooks.py
+++ b/ecommerce/extensions/api/v2/views/webhooks.py
@@ -60,6 +60,13 @@ class StripeWebhooksView(APIView):
             )
             # TODO: define and call a method to handle the successful payment intent.
             # handle_payment_intent_succeeded(payment_intent)
+        elif event.type == 'payment_intent.payment_failed':
+            logger.info(
+                '[Stripe webhooks] event payment_intent.payment_failed with amount %d and payment intent ID [%s].',
+                payment_intent.amount,
+                payment_intent.id,
+            )
+            # TODO: define and call a method to handle failed payment intent.
         elif event.type == 'payment_intent.requires_action':
             logger.info(
                 '[Stripe webhooks] event payment_intent.requires_action with amount %d and payment intent ID [%s].',

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -821,8 +821,9 @@ ECOMMERCE_PAYMENT_PROCESSOR_CONFIG = {
             'max_network_retries': 0,
             'proxy': None,
             'publishable_key': 'SET-ME-PLEASE',
-            'receipt_url': '/checkout/receipt/',
             'secret_key': 'SET-ME-PLEASE',
+            'endpoint_secret': 'SET-ME-PLEASE',
+            'receipt_url': '/checkout/receipt/',
         },
     }
 }

--- a/ecommerce/settings/devstack.py
+++ b/ecommerce/settings/devstack.py
@@ -102,6 +102,7 @@ PAYMENT_PROCESSOR_CONFIG = {
             'proxy': None,
             'publishable_key': 'SET-ME-PLEASE',
             'secret_key': 'SET-ME-PLEASE',
+            'endpoint_secret': 'SET-ME-PLEASE',
             'error_path': PAYMENT_PROCESSOR_ERROR_PATH,
             'cancel_checkout_path': PAYMENT_PROCESSOR_CANCEL_PATH,
             'receipt_url': PAYMENT_PROCESSOR_RECEIPT_PATH,

--- a/ecommerce/settings/local.py
+++ b/ecommerce/settings/local.py
@@ -140,6 +140,7 @@ PAYMENT_PROCESSOR_CONFIG = {
             'proxy': None,
             'publishable_key': 'SET-ME-PLEASE',
             'secret_key': 'SET-ME-PLEASE',
+            'endpoint_secret': 'SET-ME-PLEASE',
         },
     },
 }


### PR DESCRIPTION
[REV-3238](https://2u-internal.atlassian.net/browse/REV-3238).

Following the creation of the webhooks Stripe endpoint, we're securing the endpoint to make sure that the request we receive are from Stripe. We'll now use `stripe.Webhook.construct_event()` which verifies the webhook signature and constructs an event if the signature is correct.

This PR should be merged with `edx-internal` PR - https://github.com/edx/edx-internal/pull/7698

Successfully tested locally using the Stripe CLI:
<img width="1394" alt="Screen Shot 2023-01-24 at 4 28 35 PM" src="https://user-images.githubusercontent.com/13632680/214422839-3d11d0bf-e0d5-4cdc-903a-f57f3e07f2b8.png">
Event in `edX Local/Dev` account - https://dashboard.stripe.com/test/events/evt_3MTu2EH4caH7G0X11kBn3mn9


**This PR:**
- Secures the endpoint by using the endpoint secret and checking for the request headers.
- Removes the `charge.succeeded` event type, which is not needed as per [Q51](https://2u-internal.atlassian.net/wiki/spaces/RS/pages/192446522/Q+A+with+Stripe+Tech+Rep#51) in the Stripe Q&A.
- Added the `payment_intent.requires_action` for 3DS work. We won't be listening to this event yet in the Stripe dashboard.
- Updates tests.
