### PR TITLE
fix: Stripe webhook decoding payload

### DIFF
--- a/ecommerce/extensions/api/v2/views/webhooks.py
+++ b/ecommerce/extensions/api/v2/views/webhooks.py
@@ -32,7 +32,7 @@ class StripeWebhooksView(APIView):
     def post(self, request):
         stripe.api_key = settings.ECOMMERCE_PAYMENT_PROCESSOR_CONFIG['edx']['stripe']['secret_key']
         endpoint_secret = settings.ECOMMERCE_PAYMENT_PROCESSOR_CONFIG['edx']['stripe']['endpoint_secret']
-        payload = request.body
+        payload = request.body.decode('utf-8')
         sig_header = request.META['HTTP_STRIPE_SIGNATURE']
         event = None
 


### PR DESCRIPTION
[REV-3238](https://2u-internal.atlassian.net/browse/REV-3238).

Decoding the request body to UTF-8, as it appears this could potentially solve the `SignatureVerificationError` seen in the prod Stripe webhook endpoint. The error is due to either an incorrect `endpoint_secret` or payload. The secret is correct in prod, so attempting this fix for the payload.

> Stripe requires the raw body of the request to perform signature verification. If you’re using a framework, make sure it doesn’t manipulate the raw body. Any manipulation to the raw body of the request causes the verification to fail. 

More details in [this comment](https://2u-internal.atlassian.net/browse/REV-3238?focusedCommentId=654540).
First PR for securing the Stripe webhook endpoint https://github.com/openedx/ecommerce/pull/3900