### PR TITLE
fix: Update Stripe webhook endpoint secure

### DIFF
--- a/ecommerce/extensions/api/v2/views/webhooks.py
+++ b/ecommerce/extensions/api/v2/views/webhooks.py
@@ -14,6 +14,9 @@ from stripe.error import SignatureVerificationError
 
 logger = logging.getLogger(__name__)
 
+stripe.api_key = settings.ECOMMERCE_PAYMENT_PROCESSOR_CONFIG['edx']['stripe']['secret_key']
+endpoint_secret = settings.ECOMMERCE_PAYMENT_PROCESSOR_CONFIG['edx']['stripe']['endpoint_secret']
+
 
 class StripeWebhooksView(APIView):
     """
@@ -30,10 +33,8 @@ class StripeWebhooksView(APIView):
 
     @csrf_exempt
     def post(self, request):
-        stripe.api_key = settings.ECOMMERCE_PAYMENT_PROCESSOR_CONFIG['edx']['stripe']['secret_key']
-        endpoint_secret = settings.ECOMMERCE_PAYMENT_PROCESSOR_CONFIG['edx']['stripe']['endpoint_secret']
-        payload = request.body.decode('utf-8')
-        sig_header = request.META['HTTP_STRIPE_SIGNATURE']
+        payload = request.body
+        sig_header = request.headers.get('stripe-signature')
         event = None
 
         # Temp: remove after webhook testing in stage/prod

--- a/ecommerce/extensions/api/v2/views/webhooks.py
+++ b/ecommerce/extensions/api/v2/views/webhooks.py
@@ -34,7 +34,7 @@ class StripeWebhooksView(APIView):
     @csrf_exempt
     def post(self, request):
         payload = request.body
-        sig_header = request.headers.get('stripe-signature')
+        sig_header = request.META['HTTP_STRIPE_SIGNATURE']
         event = None
 
         # Temp: remove after webhook testing in stage/prod


### PR DESCRIPTION
[REV-3238](https://2u-internal.atlassian.net/browse/REV-3238).

Attempt to fix the `SignatureVerificationError` seen in Stripe for the webhook endpoint.

Verified that the `edx-internal` config for the endpoint_secret and Stripe API key is correct in prod from edx-internal, however it's not set (it's 'SET-ME-PLEASE') as seen in test logs https://github.com/openedx/ecommerce/pull/3906 -
<img width="1194" alt="Screenshot 2023-02-03 at 1 08 43 PM" src="https://user-images.githubusercontent.com/13632680/216682186-aeee9cb2-6c8d-4a44-9131-b64fc3062a82.png">

This issue was not seen using the Stripe CLI locally.