### PR TITLE
temp: Log if Stripe keys are unset

### DIFF
--- a/ecommerce/extensions/api/v2/views/webhooks.py
+++ b/ecommerce/extensions/api/v2/views/webhooks.py
@@ -39,14 +39,14 @@ class StripeWebhooksView(APIView):
         # Temp: remove after webhook testing in stage/prod
         if endpoint_secret == 'SET-ME-PLEASE':
             logger.info('[Stripe webhooks] TESTING endpoint_secret unset')
-        if endpoint_secret == None:
+        if endpoint_secret is None:
             logger.info('[Stripe webhooks] TESTING endpoint_secret is None')
         if endpoint_secret == '':
             logger.info('[Stripe webhooks] TESTING endpoint_secret is empty')
 
         if stripe.api_key == 'SET-ME-PLEASE':
             logger.info('[Stripe webhooks] TESTING api key unset')
-        if stripe.api_key == None:
+        if stripe.api_key is None:
             logger.info('[Stripe webhooks] TESTING api key is None')
         if stripe.api_key == '':
             logger.info('[Stripe webhooks] TESTING api key is empty')

--- a/ecommerce/extensions/api/v2/views/webhooks.py
+++ b/ecommerce/extensions/api/v2/views/webhooks.py
@@ -36,6 +36,21 @@ class StripeWebhooksView(APIView):
         sig_header = request.META['HTTP_STRIPE_SIGNATURE']
         event = None
 
+        # Temp: remove after webhook testing in stage/prod
+        if endpoint_secret == 'SET-ME-PLEASE':
+            logger.info('[Stripe webhooks] TESTING endpoint_secret unset')
+        if endpoint_secret == None:
+            logger.info('[Stripe webhooks] TESTING endpoint_secret is None')
+        if endpoint_secret == '':
+            logger.info('[Stripe webhooks] TESTING endpoint_secret is empty')
+
+        if stripe.api_key == 'SET-ME-PLEASE':
+            logger.info('[Stripe webhooks] TESTING api key unset')
+        if stripe.api_key == None:
+            logger.info('[Stripe webhooks] TESTING api key is None')
+        if stripe.api_key == '':
+            logger.info('[Stripe webhooks] TESTING api key is empty')
+
         try:
             event = stripe.Webhook.construct_event(
                 payload, sig_header, endpoint_secret


### PR DESCRIPTION
[REV-3238](https://2u-internal.atlassian.net/browse/REV-3238).

Debugging for the `SignatureVerificationError` seen in the webhook endpoint, logging the Stripe API Key and endpoint_secret if they're empty or not set.