### PR TITLE
fix: account for refunds in exec ed 2u redemption flow

### DIFF
--- a/ecommerce/extensions/executive_education_2u/utils.py
+++ b/ecommerce/extensions/executive_education_2u/utils.py
@@ -32,8 +32,10 @@ def get_executive_education_2u_product(partner, sku):
 
 
 def get_previous_order_for_user(user, product):
-    # TODO: figure out if users can place orders multiple times
-    return Order.objects.filter(user=user, lines__product=product).first()
+    """
+    Find previous non-refunded order for product from user.
+    """
+    return Order.objects.prefetch_related('refunds').filter(user=user, lines__product=product, refunds__isnull=True).first()
 
 
 def get_learner_portal_url(request):

--- a/ecommerce/extensions/executive_education_2u/utils.py
+++ b/ecommerce/extensions/executive_education_2u/utils.py
@@ -37,7 +37,8 @@ def get_previous_order_for_user(user, product):
     """
     return Order.objects \
         .prefetch_related('refunds') \
-        .filter(user=user, lines__product=product, refunds__isnull=True).first()
+        .filter(user=user, lines__product=product, refunds__isnull=True) \
+        .exists()
 
 
 def get_learner_portal_url(request):

--- a/ecommerce/extensions/executive_education_2u/utils.py
+++ b/ecommerce/extensions/executive_education_2u/utils.py
@@ -35,7 +35,9 @@ def get_previous_order_for_user(user, product):
     """
     Find previous non-refunded order for product from user.
     """
-    return Order.objects.prefetch_related('refunds').filter(user=user, lines__product=product, refunds__isnull=True).first()
+    return Order.objects \
+        .prefetch_related('refunds') \
+        .filter(user=user, lines__product=product, refunds__isnull=True).first()
 
 
 def get_learner_portal_url(request):

--- a/ecommerce/extensions/executive_education_2u/utils.py
+++ b/ecommerce/extensions/executive_education_2u/utils.py
@@ -8,6 +8,7 @@ from oscar.core.loading import get_model
 from ecommerce.courses.constants import CertificateType
 from ecommerce.enterprise.api import get_enterprise_id_for_user
 from ecommerce.enterprise.utils import get_enterprise_customer
+from ecommerce.extensions.refund.status import REFUND
 
 Product = get_model('catalogue', 'Product')
 Order = get_model('order', 'Order')
@@ -36,8 +37,9 @@ def get_previous_order_for_user(user, product):
     Find previous non-refunded order for product from user.
     """
     return Order.objects \
+        .filter(user=user, lines__product=product) \
         .prefetch_related('refunds') \
-        .filter(user=user, lines__product=product, refunds__isnull=True) \
+        .filter(Q(refunds__isnull=True) | ~Q(refunds__status=REFUND.COMPLETE)) \
         .first()
 
 

--- a/ecommerce/extensions/executive_education_2u/utils.py
+++ b/ecommerce/extensions/executive_education_2u/utils.py
@@ -38,7 +38,7 @@ def get_previous_order_for_user(user, product):
     return Order.objects \
         .prefetch_related('refunds') \
         .filter(user=user, lines__product=product, refunds__isnull=True) \
-        .exists()
+        .first()
 
 
 def get_learner_portal_url(request):

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -670,7 +670,7 @@ ENTERPRISE_SERVICE_URL = 'http://localhost:8000/enterprise/'
 # Cache enterprise response from Enterprise API.
 ENTERPRISE_API_CACHE_TIMEOUT = 300  # Value is in seconds
 
-ENTERPRISE_CATALOG_SERVICE_URL = 'http://localhost:18160/'
+ENTERPRISE_CATALOG_SERVICE_URL = 'http://enterprise.catalog.app:18160/'
 
 ENTERPRISE_ANALYTICS_API_URL = 'http://localhost:19001'
 


### PR DESCRIPTION
# Description

The Executive Education 2U redemption flow does not account for refunds when retrieving previous orders for the user + product (exec ed course). This PR ensures we only query for orders that have not been refunded.

## Testing Instructions
1. Ingest exec ed course(s) into course-discovery / ecommerce.
2. Ensure offer is created for enterprise customer and catalog containing exec ed course(s).
3. Simulate clicking on the `enrollment_url` from enterprise-catalog's `get_content_metadata` API endpoint to enter into the redemption flow.
4. Place an order for the exec ed course.
5. Repeat step 3. Observe you go straight to receipt page, not the LP.
6. In the ecommerce dashboard, create a refund for the order just placed. Observe the credit is added back to the learner credit.
7. Repeat step 3. Observe you now go to the LP to place another order.

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?
Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
