### PR TITLE
fix: Pick the right purchase from ios response

### DIFF
--- a/ecommerce/extensions/iap/api/v1/tests/test_views.py
+++ b/ecommerce/extensions/iap/api/v1/tests/test_views.py
@@ -387,7 +387,8 @@ class MobileCoursePurchaseExecutionViewTests(PaymentEventsMixin, TestCase):
                 'receipt': {
                     'in_app': [{
                         'original_transaction_id': '123456',
-                        'transaction_id': '123456'
+                        'transaction_id': '123456',
+                        'product_id': 'fake_product_id'
                     }]
                 }
             }

--- a/ecommerce/extensions/iap/processors/base_iap.py
+++ b/ecommerce/extensions/iap/processors/base_iap.py
@@ -152,7 +152,7 @@ class BaseIAP(BasePaymentProcessor):
 
     def parse_ios_response(self, response, product_id):
         """
-        iOS response have multiple receipts data, and we need to select the purchase we just made
+        iOS response has multiple receipts data, and we need to select the purchase we just made
         with the given product id.
         """
         purchases = response['receipt'].get('in_app', [])

--- a/ecommerce/extensions/iap/processors/base_iap.py
+++ b/ecommerce/extensions/iap/processors/base_iap.py
@@ -113,6 +113,9 @@ class BaseIAP(BasePaymentProcessor):
                 )
                 raise GatewayError(validation_response)
 
+        if self.NAME == 'ios-iap':
+            validation_response = self.parse_ios_response(validation_response, product_id)
+
         transaction_id = response.get('transactionId', self._get_transaction_id_from_receipt(validation_response))
         # original_transaction_id is primary identifier for a purchase on iOS
         original_transaction_id = response.get('originalTransactionId', self._get_attribute_from_receipt(
@@ -146,6 +149,21 @@ class BaseIAP(BasePaymentProcessor):
             card_number=label,
             card_type=None
         )
+
+    def parse_ios_response(self, response, product_id):
+        """
+        iOS response have multiple receipts data, and we need to select the purchase we just made
+        with the given product id.
+        """
+        purchases = response['receipt'].get('in_app', [])
+        for purchase in purchases:
+            if purchase['product_id'] == product_id and \
+                    response['receipt']['receipt_creation_date_ms'] == purchase['purchase_date_ms']:
+
+                response['receipt']['in_app'] = [purchase]
+                break
+
+        return response
 
     def record_processor_response(self, response, transaction_id=None, basket=None, original_transaction_id=None):  # pylint: disable=arguments-differ
         """

--- a/ecommerce/extensions/iap/tests/processors/test_ios_iap.py
+++ b/ecommerce/extensions/iap/tests/processors/test_ios_iap.py
@@ -54,40 +54,40 @@ class IOSIAPTests(PaymentProcessorTestCaseMixin, TestCase):
             u"IOSInAppPurchase's response was recorded in entry [{entry_id}]."
         )
         self.RETURN_DATA = {
-            'transactionId': '2000000279135357',
-            'originalTransactionId': '2000000279135357',
-            'productId': 'org.edx.mobile.integrationtest',
-            'purchaseToken': 'inapp:org.edx.mobile:ios.test.purchased',
+            'transactionId': 'test_id',
+            'originalTransactionId': 'original_test_id',
+            'productId': 'test_product_id',
+            'purchaseToken': 'inapp:test.edx.edx:ios.test.purchased',
         }
         self.mock_validation_response = {
             'environment': 'Sandbox',
             'receipt': {
-                'bundle_id': 'org.edx.mobile',
+                'bundle_id': 'test_bundle_id',
                 'in_app': [
                     {
                         'in_app_ownership_type': 'PURCHASED',
-                        'original_transaction_id': '2000000279124188',
+                        'original_transaction_id': 'very_old_purchase_id',
                         'product_id': 'org.edx.mobile.test_product1',
                         'purchase_date_ms': '1676562309000',
-                        'transaction_id': '2000000279124188'
+                        'transaction_id': 'vaery_old_purchase_id'
                     },
                     {
                         'in_app_ownership_type': 'PURCHASED',
-                        'original_transaction_id': '2000000279128532',
+                        'original_transaction_id': 'old_purchase_id',
                         'product_id': 'org.edx.mobile.test_product3',
                         'purchase_date_ms': '1676562544000',
-                        'transaction_id': '2000000279128532'
+                        'transaction_id': 'old_purchase_id'
                     },
                     {
                         'in_app_ownership_type': 'PURCHASED',
-                        'original_transaction_id': '2000000279135357',
-                        'product_id': 'org.edx.mobile.integrationtest',
+                        'original_transaction_id': 'original_test_id',
+                        'product_id': 'test_product_id',
                         'purchase_date_ms': '1676562978000',
-                        'transaction_id': '2000000279135357'
+                        'transaction_id': 'test_id'
                     }
                 ],
                 'receipt_creation_date_ms': '1676562978000',
-                }
+            }
         }
 
     def _get_receipt_url(self):

--- a/ecommerce/extensions/iap/tests/processors/test_ios_iap.py
+++ b/ecommerce/extensions/iap/tests/processors/test_ios_iap.py
@@ -54,10 +54,40 @@ class IOSIAPTests(PaymentProcessorTestCaseMixin, TestCase):
             u"IOSInAppPurchase's response was recorded in entry [{entry_id}]."
         )
         self.RETURN_DATA = {
-            'transactionId': 'transactionId.ios.test.purchased',
-            'originalTransactionId': 'originalTransactionId.ios.test.purchased',
-            'productId': 'ios.test.purchased',
+            'transactionId': '2000000279135357',
+            'originalTransactionId': '2000000279135357',
+            'productId': 'org.edx.mobile.integrationtest',
             'purchaseToken': 'inapp:org.edx.mobile:ios.test.purchased',
+        }
+        self.mock_validation_response = {
+            'environment': 'Sandbox',
+            'receipt': {
+                'bundle_id': 'org.edx.mobile',
+                'in_app': [
+                    {
+                        'in_app_ownership_type': 'PURCHASED',
+                        'original_transaction_id': '2000000279124188',
+                        'product_id': 'org.edx.mobile.test_product1',
+                        'purchase_date_ms': '1676562309000',
+                        'transaction_id': '2000000279124188'
+                    },
+                    {
+                        'in_app_ownership_type': 'PURCHASED',
+                        'original_transaction_id': '2000000279128532',
+                        'product_id': 'org.edx.mobile.test_product3',
+                        'purchase_date_ms': '1676562544000',
+                        'transaction_id': '2000000279128532'
+                    },
+                    {
+                        'in_app_ownership_type': 'PURCHASED',
+                        'original_transaction_id': '2000000279135357',
+                        'product_id': 'org.edx.mobile.integrationtest',
+                        'purchase_date_ms': '1676562978000',
+                        'transaction_id': '2000000279135357'
+                    }
+                ],
+                'receipt_creation_date_ms': '1676562978000',
+                }
         }
 
     def _get_receipt_url(self):
@@ -124,14 +154,13 @@ class IOSIAPTests(PaymentProcessorTestCaseMixin, TestCase):
         """
         Verify that appropriate PaymentError is raised in absence of originalTransactionId parameter.
         """
-        mock_ios_validator.return_value = {
-            'resource': {
-                'orderId': 'orderId.ios.test.purchased'
-            }
-        }
+        modified_validation_response = self.mock_validation_response
+        modified_validation_response['receipt']['in_app'][2].pop('original_transaction_id')
+        mock_ios_validator.return_value = modified_validation_response
         with self.assertRaises(PaymentError):
             modified_return_data = self.RETURN_DATA
             modified_return_data.pop('originalTransactionId')
+
             self.processor.handle_processor_response(modified_return_data, basket=self.basket)
 
     @mock.patch.object(BaseIAP, '_is_payment_redundant')
@@ -141,11 +170,7 @@ class IOSIAPTests(PaymentProcessorTestCaseMixin, TestCase):
         Verify that appropriate RedundantPaymentNotificationError is raised in case payment with same
         originalTransactionId exists with another user
         """
-        mock_ios_validator.return_value = {
-            'resource': {
-                'orderId': 'orderId.ios.test.purchased'
-            }
-        }
+        mock_ios_validator.return_value = self.mock_validation_response
         mock_payment_redundant.return_value = True
 
         with self.assertRaises(RedundantPaymentNotificationError):
@@ -156,11 +181,7 @@ class IOSIAPTests(PaymentProcessorTestCaseMixin, TestCase):
         """
         Verify that the processor creates the appropriate PaymentEvent and Source objects.
         """
-        mock_ios_validator.return_value = {
-            'resource': {
-                'orderId': 'orderId.ios.test.purchased'
-            }
-        }
+        mock_ios_validator.return_value = self.mock_validation_response
 
         handled_response = self.processor.handle_processor_response(self.RETURN_DATA, basket=self.basket)
         self.assertEqual(handled_response.currency, self.basket.currency)


### PR DESCRIPTION
iOS response contain multiple purchases, instead of picking the first purchase, pick the one which have given product id and latest date. LEARNER-9261

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?
Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
