### PR TITLE
chore: add logging to include fulfillment details upon GEAG allocation exception

### DIFF
--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -1029,8 +1029,8 @@ class ExecutiveEducation2UFulfillmentModule(BaseFulfillmentModule):
                     pass
 
                 logger.exception(
-                    'Fulfillment of line [%d] on order [%s] failed. Reason: %s.',
-                    line.id, order.number, reason
+                    '[ExecutiveEducation2UFulfillmentModule] Fulfillment of line [%d] on order [%s] failed. Reason: %s. Fulfillment details: %s',
+                    line.id, order.number, reason, fulfillment_details,
                 )
                 line.set_status(LINE.FULFILLMENT_SERVER_ERROR)
             else:

--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -1029,7 +1029,8 @@ class ExecutiveEducation2UFulfillmentModule(BaseFulfillmentModule):
                     pass
 
                 logger.exception(
-                    '[ExecutiveEducation2UFulfillmentModule] Fulfillment of line [%d] on order [%s] failed. Reason: %s. Fulfillment details: %s',
+                    '[ExecutiveEducation2UFulfillmentModule] Fulfillment of line [%d] on '
+                    'order [%s] failed. Reason: %s. Fulfillment details: %s.',
                     line.id, order.number, reason, fulfillment_details,
                 )
                 line.set_status(LINE.FULFILLMENT_SERVER_ERROR)


### PR DESCRIPTION
# Description

In [ENT-6839](https://2u-internal.atlassian.net/browse/ENT-6839), we continue to see failed fulfillment attempts due to the following error returned by the GEAG allocations API:

```
2023-03-03 16:55:08,004 ERROR 523265 [ecommerce.extensions.fulfillment.modules] /edx/app/ecommerce/ecommerce/ecommerce/extensions/fulfillment/modules.py:1031 - Fulfillment of line [32113486] on order [EDX-54232556] failed. Reason: {'errors': [{'code': 30112, 'message': 'email not a valid email'}]}.
Traceback (most recent call last):
  File "/edx/app/ecommerce/ecommerce/ecommerce/extensions/fulfillment/modules.py", line 1023, in fulfill_product
    self.get_smarter_client.create_enterprise_allocation(**allocation_payload)
  File "/edx/app/ecommerce/venvs/ecommerce/lib/python3.8/site-packages/getsmarter_api_clients/geag.py", line 253, in create_enterprise_allocation
```

However, on the failed order, it does appear the associated order note has a valid email in its message, so it's unclear why GEAG is throwing a validation error. Logging the `fulfillment_details` which includes the `user_details` should help us debug the  `email not a valid email` error further.

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?
Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
