### PR TITLE
feat: Error if products in basket are already purchased

### DIFF
--- a/ecommerce/extensions/iap/api/v1/tests/test_utils.py
+++ b/ecommerce/extensions/iap/api/v1/tests/test_utils.py
@@ -1,0 +1,39 @@
+import mock
+
+from ecommerce.courses.tests.factories import CourseFactory
+from ecommerce.extensions.iap.api.v1.utils import products_in_basket_already_purchased
+from ecommerce.extensions.order.utils import UserAlreadyPlacedOrder
+from ecommerce.extensions.test.factories import create_basket, create_order
+from ecommerce.tests.testcases import TestCase
+
+
+class TestProductsInBasketPurchased(TestCase):
+    """ Tests for products_in_basket_already_purchased method. """
+
+    def setUp(self):
+        super(TestProductsInBasketPurchased, self).setUp()
+        self.user = self.create_user()
+        self.client.login(username=self.user.username, password=self.password)
+
+        self.course = CourseFactory(partner=self.partner)
+        product = self.course.create_or_update_seat('verified', False, 50)
+        self.basket = create_basket(
+            owner=self.user, site=self.site, price='50.0', product_class=product.product_class
+        )
+        create_order(site=self.site, user=self.user, basket=self.basket)
+
+    def test_already_purchased(self):
+        """
+        Test products in basket already purchased by user
+        """
+        with mock.patch.object(UserAlreadyPlacedOrder, 'user_already_placed_order', return_value=True):
+            return_value = products_in_basket_already_purchased(self.user, self.basket, self.site)
+            self.assertTrue(return_value)
+
+    def test_not_purchased_yet(self):
+        """
+        Test products in basket not yet purchased by user
+        """
+        with mock.patch.object(UserAlreadyPlacedOrder, 'user_already_placed_order', return_value=False):
+            return_value = products_in_basket_already_purchased(self.user, self.basket, self.site)
+            self.assertFalse(return_value)

--- a/ecommerce/extensions/iap/api/v1/utils.py
+++ b/ecommerce/extensions/iap/api/v1/utils.py
@@ -1,0 +1,19 @@
+
+
+from oscar.core.loading import get_model
+
+from ecommerce.extensions.order.utils import UserAlreadyPlacedOrder
+
+Product = get_model('catalogue', 'Product')
+
+
+def products_in_basket_already_purchased(user, basket, site):
+    """
+    Check if products in a basket are already purchased by a user.
+    """
+    products = Product.objects.filter(line__order__basket=basket)
+    for product in products:
+        if not product.is_enrollment_code_product and \
+                UserAlreadyPlacedOrder.user_already_placed_order(user=user, product=product, site=site):
+            return True
+    return False

--- a/ecommerce/extensions/iap/api/v1/views.py
+++ b/ecommerce/extensions/iap/api/v1/views.py
@@ -56,11 +56,8 @@ from ecommerce.extensions.iap.api.v1.constants import (
 )
 from ecommerce.extensions.iap.api.v1.exceptions import RefundCompletionException
 from ecommerce.extensions.iap.api.v1.serializers import MobileOrderSerializer
-<<<<<<< Updated upstream
-from ecommerce.extensions.iap.models import IAPProcessorConfiguration
-=======
 from ecommerce.extensions.iap.api.v1.utils import products_in_basket_already_purchased
->>>>>>> Stashed changes
+from ecommerce.extensions.iap.models import IAPProcessorConfiguration
 from ecommerce.extensions.iap.processors.android_iap import AndroidIAP
 from ecommerce.extensions.iap.processors.ios_iap import IOSIAP
 from ecommerce.extensions.order.exceptions import AlreadyPlacedOrderException
@@ -238,7 +235,10 @@ class MobileCheckoutView(APIView):
 
     def post(self, request):
         basket_id = request.data.get('basket_id')
-        basket = request.user.baskets.get(id=basket_id)
+        try:
+            basket = request.user.baskets.get(id=basket_id)
+        except ObjectDoesNotExist:
+            return JsonResponse({'error': ERROR_BASKET_NOT_FOUND.format(basket_id)}, status=400)
         if products_in_basket_already_purchased(request.user, basket, request.site):
             return JsonResponse({'error': _(ERROR_ALREADY_PURCHASED)}, status=406)
 

--- a/ecommerce/extensions/iap/api/v1/views.py
+++ b/ecommerce/extensions/iap/api/v1/views.py
@@ -151,15 +151,14 @@ class MobileCoursePurchaseExecutionView(EdxOrderPlacementMixin, APIView):
 
     def _get_basket(self, request, basket_id):
         """
-        Retrieve a basket using a payment ID.
+        Retrieve a basket using a basket ID.
 
         Arguments:
-            payment_id: payment_id received from PayPal.
+            basket_id: basket_id representing basket.
 
         Returns:
-            It will return related basket or log exception and return None if
-            duplicate payment_id received or any other exception occurred.
-
+            It will return related basket or raise AlreadyPlacedOrderException
+            if products in basket have already been purchased.
         """
         basket = request.user.baskets.get(id=basket_id)
         basket.strategy = request.strategy


### PR DESCRIPTION
# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description
For mobile in-app purchases.
If a user has already purchased a set of products in a basket, return an error message on the `/api/iap/v1/execute/` and `/api/iap/v1/checkout/` API.

## Supporting information

Related Jira ticket: https://2u-internal.atlassian.net/browse/LEARNER-9267

## Testing instructions

On postman, log in as a user. Then call the following apis in sequence, for a product:

- `/api/iap/v1/basket/add/?sku={{sku}}`
- `/api/iap/v1/checkout/`
- `/api/iap/v1/execute/`

## Other information

Related to Mobile in-app purchases.
