### PR TITLE
chore: add logging to debug ent-6954

### DIFF
--- a/ecommerce/extensions/executive_education_2u/views.py
+++ b/ecommerce/extensions/executive_education_2u/views.py
@@ -118,7 +118,8 @@ class ExecutiveEducation2UViewSet(viewsets.ViewSet, ExecutiveEducation2UOrderPla
         try:
             # logger 1 for debugging ent-6954
             logger.info(
-                '[ExecutiveEducation2UViewSet] checkout_failure_reason  1: Checking if user [%s] has purchased product [%s] previously from basket [%s].',
+                '[ExecutiveEducation2UViewSet] checkout_failure_reason  1: Checking if user [%s] has '
+                'purchased product [%s] previously from basket [%s].',
                 request.user.id, product, basket)
             enterprise_id = get_enterprise_id_for_user(request.site, request.user)
             course_info = get_course_info_from_catalog(request.site, product)
@@ -126,7 +127,8 @@ class ExecutiveEducation2UViewSet(viewsets.ViewSet, ExecutiveEducation2UOrderPla
 
             # logger 2 for debugging ent-6954
             logger.info(
-                '[ExecutiveEducation2UViewSet] checkout_failure_reason step 2: User [%s] is attempting to checkout for course [%s] with enterprise id [%s]',
+                '[ExecutiveEducation2UViewSet] checkout_failure_reason step 2: User [%s] is attempting '
+                'to checkout for course [%s] with enterprise id [%s]',
                 request.user.id,
                 course_key,
                 enterprise_id,
@@ -139,7 +141,8 @@ class ExecutiveEducation2UViewSet(viewsets.ViewSet, ExecutiveEducation2UOrderPla
 
             # logger 3 for debugging ent-6954
             logger.info(
-                '[ExecutiveEducation2UViewSet] checkout_failure_reason step 3: User [%s] is attempting to checkout for course [%s] with enterprise id [%s] and catalog list [%s]',
+                '[ExecutiveEducation2UViewSet] checkout_failure_reason step 3: User [%s] is attempting '
+                'to checkout for course [%s] with enterprise id [%s] and catalog list [%s]',
                 request.user.id,
                 course_key,
                 enterprise_id,
@@ -149,7 +152,9 @@ class ExecutiveEducation2UViewSet(viewsets.ViewSet, ExecutiveEducation2UOrderPla
 
             # logger 4 for debugging ent-6954
             logger.info(
-                '[ExecutiveEducation2UViewSet] checkout_failure_reason step 4: User [%s] is attempting to checkout for course [%s] with enterprise id [%s] and catalog list [%s] and enterprise offers [%s]',
+                '[ExecutiveEducation2UViewSet] checkout_failure_reason step 4: User [%s] is attempting '
+                'to checkout for course [%s] with enterprise id [%s] and catalog list [%s] and enterprise '
+                'offers [%s]',
                 request.user.id,
                 course_key,
                 enterprise_id,
@@ -168,7 +173,9 @@ class ExecutiveEducation2UViewSet(viewsets.ViewSet, ExecutiveEducation2UOrderPla
 
             # logger 5 for debugging ent-6954
             logger.info(
-                '[ExecutiveEducation2UViewSet] checkout_failure_reason step 5: User [%s] is attempting to checkout for course [%s] with enterprise id [%s] and catalog list [%s] and enterprise offers [%s] and offers with remaining balance [%s]',
+                '[ExecutiveEducation2UViewSet] checkout_failure_reason step 5: User [%s] is attempting '
+                'to checkout for course [%s] with enterprise id [%s] and catalog list [%s] and enterprise '
+                'offers [%s] and offers with remaining balance [%s]',
                 request.user.id,
                 course_key,
                 enterprise_id,
@@ -231,7 +238,8 @@ class ExecutiveEducation2UViewSet(viewsets.ViewSet, ExecutiveEducation2UOrderPla
 
             # logger 2 for debugging ent-6954
             logger.info(
-                '[ExecutiveEducation2UViewSet] User [%s] is attempting to checkout for product [%s] with sku [%s] and course_uuid [%s] with query params [%s]',
+                '[ExecutiveEducation2UViewSet] User [%s] is attempting to checkout for product [%s] with ',
+                'sku [%s] and course_uuid [%s] with query params [%s]',
                 request.user.id,
                 product,
                 sku,
@@ -252,7 +260,8 @@ class ExecutiveEducation2UViewSet(viewsets.ViewSet, ExecutiveEducation2UOrderPla
             if basket.total_excl_tax != 0:
                 # logger 4 for debugging ent-6954
                 logger.info(
-                    '[ExecutiveEducation2UViewSet] User [%s] is attempting to checkout for product [%s] with sku [%s] and course_uuid [%s] with query params [%s] and basket total [%s]',
+                    '[ExecutiveEducation2UViewSet] User [%s] is attempting to checkout for product [%s] with '
+                    'sku [%s] and course_uuid [%s] with query params [%s] and basket total [%s]',
                     request.user.id,
                     product,
                     sku,
@@ -263,7 +272,11 @@ class ExecutiveEducation2UViewSet(viewsets.ViewSet, ExecutiveEducation2UOrderPla
                 failure_reason = self._get_checkout_failure_reason(request, basket, product)
 
                 # logger 5 for debugging ent-6954
-                logger.info('[ExecutiveEducation2UViewSet] User [%s] encountered a failure_reason: %s', request.user.id, failure_reason)
+                logger.info(
+                    '[ExecutiveEducation2UViewSet] User [%s] encountered a failure_reason: %s',
+                    request.user.id,
+                    failure_reason,
+                )
 
                 query_params.update({
                     'failure_reason': failure_reason

--- a/ecommerce/extensions/executive_education_2u/views.py
+++ b/ecommerce/extensions/executive_education_2u/views.py
@@ -116,17 +116,46 @@ class ExecutiveEducation2UViewSet(viewsets.ViewSet, ExecutiveEducation2UOrderPla
 
     def _get_checkout_failure_reason(self, request, basket, product):
         try:
+            # logger 1 for debugging ent-6954
+            logger.info(
+                '[ExecutiveEducation2UViewSet] checkout_failure_reason  1: Checking if user [%s] has purchased product [%s] previously from basket [%s].',
+                request.user.id, product, basket)
             enterprise_id = get_enterprise_id_for_user(request.site, request.user)
             course_info = get_course_info_from_catalog(request.site, product)
             course_key = course_info['key']
 
+            # logger 2 for debugging ent-6954
+            logger.info(
+                '[ExecutiveEducation2UViewSet] checkout_failure_reason step 2: User [%s] is attempting to checkout for course [%s] with enterprise id [%s]',
+                request.user.id,
+                course_key,
+                enterprise_id,
+            )
             catalog_list = fetch_enterprise_catalogs_for_content_items(
                 request.site,
                 course_key,
                 enterprise_id
             )
 
+            # logger 3 for debugging ent-6954
+            logger.info(
+                '[ExecutiveEducation2UViewSet] checkout_failure_reason step 3: User [%s] is attempting to checkout for course [%s] with enterprise id [%s] and catalog list [%s]',
+                request.user.id,
+                course_key,
+                enterprise_id,
+                catalog_list,
+            )
             enterprise_offers = get_enterprise_offers_for_catalogs(enterprise_id, catalog_list)
+
+            # logger 4 for debugging ent-6954
+            logger.info(
+                '[ExecutiveEducation2UViewSet] checkout_failure_reason step 4: User [%s] is attempting to checkout for course [%s] with enterprise id [%s] and catalog list [%s] and enterprise offers [%s]',
+                request.user.id,
+                course_key,
+                enterprise_id,
+                catalog_list,
+                enterprise_offers,
+            )
             if not enterprise_offers:
                 return ExecutiveEducation2UCheckoutFailureReason.NO_OFFER_AVAILABLE
 
@@ -136,6 +165,18 @@ class ExecutiveEducation2UViewSet(viewsets.ViewSet, ExecutiveEducation2UOrderPla
                     basket, offer
                 )
             ]
+
+            # logger 5 for debugging ent-6954
+            logger.info(
+                '[ExecutiveEducation2UViewSet] checkout_failure_reason step 5: User [%s] is attempting to checkout for course [%s] with enterprise id [%s] and catalog list [%s] and enterprise offers [%s] and offers with remaining balance [%s]',
+                request.user.id,
+                course_key,
+                enterprise_id,
+                catalog_list,
+                enterprise_offers,
+                offers_with_remaining_balance,
+            )
+
             if not offers_with_remaining_balance:
                 return ExecutiveEducation2UCheckoutFailureReason.NO_OFFER_WITH_ENOUGH_BALANCE
 
@@ -171,6 +212,13 @@ class ExecutiveEducation2UViewSet(viewsets.ViewSet, ExecutiveEducation2UOrderPla
             return HttpResponseNotFound(f'No Executive Education (2U) product found for SKU {sku}.')
 
         try:
+            # logger 1 for debugging ent-6954
+            logger.info(
+                '[ExecutiveEducation2UViewSet] User [%s] is attempting to checkout for product [%s] with sku [%s]',
+                request.user.id,
+                product,
+                sku,
+            )
             # Create basket and see if total cost is $0
             basket = self._prepare_basket(request, product)
             course_uuid = getattr(product.attr, 'UUID', '')
@@ -181,18 +229,53 @@ class ExecutiveEducation2UViewSet(viewsets.ViewSet, ExecutiveEducation2UOrderPla
                 'sku': sku
             }
 
+            # logger 2 for debugging ent-6954
+            logger.info(
+                '[ExecutiveEducation2UViewSet] User [%s] is attempting to checkout for product [%s] with sku [%s] and course_uuid [%s] with query params [%s]',
+                request.user.id,
+                product,
+                sku,
+                course_uuid,
+                query_params,
+            )
+
             referer = request.headers.get('referer', '')
+
+            # logger 3 for debugging ent-6954
+            logger.info('[ExecutiveEducation2UViewSet] HTTP Referer: %s', referer)
+
             if referer:
                 query_params.update({'http_referer': referer})
 
             failure_reason = None
             # Users cannot purchase Exec Ed 2U products directly
             if basket.total_excl_tax != 0:
+                # logger 4 for debugging ent-6954
+                logger.info(
+                    '[ExecutiveEducation2UViewSet] User [%s] is attempting to checkout for product [%s] with sku [%s] and course_uuid [%s] with query params [%s] and basket total [%s]',
+                    request.user.id,
+                    product,
+                    sku,
+                    course_uuid,
+                    query_params,
+                    basket.total_excl_tax,
+                )
                 failure_reason = self._get_checkout_failure_reason(request, basket, product)
+
+                # logger 5 for debugging ent-6954
+                logger.info('[ExecutiveEducation2UViewSet] User [%s] encountered a failure_reason: %s', request.user.id, failure_reason)
+
                 query_params.update({
                     'failure_reason': failure_reason
                 })
                 basket.flush()
+
+                # logger 6 for debugging ent-6954
+                logger.info(
+                    '[ExecutiveEducation2UViewSet] flushed basket [%s] for user [%s]',
+                    basket,
+                    request.user.id,
+                )
 
             # Redirect users to learner portals for terms & policies or error display
             learner_portal_url = get_learner_portal_url(request)

--- a/ecommerce/extensions/executive_education_2u/views.py
+++ b/ecommerce/extensions/executive_education_2u/views.py
@@ -228,6 +228,7 @@ class ExecutiveEducation2UViewSet(viewsets.ViewSet, ExecutiveEducation2UOrderPla
             )
             # Create basket and see if total cost is $0
             basket = self._prepare_basket(request, product)
+
             course_uuid = getattr(product.attr, 'UUID', '')
 
             # Create the query params that will be used by the learner portal
@@ -238,9 +239,12 @@ class ExecutiveEducation2UViewSet(viewsets.ViewSet, ExecutiveEducation2UOrderPla
 
             # logger 2 for debugging ent-6954
             logger.info(
-                '[ExecutiveEducation2UViewSet] User [%s] is attempting to checkout for product [%s] with '
-                'sku [%s] and course_uuid [%s] with query params [%s]',
+                '[ExecutiveEducation2UViewSet] User [%s] is attempting to checkout '
+                'basket [%s] (price: [%s]) for product [%s] with sku [%s] and course_uuid [%s] with '
+                'query params [%s]',
                 request.user.id,
+                basket.id,
+                basket.total_excl_tax,
                 product,
                 sku,
                 course_uuid,

--- a/ecommerce/extensions/executive_education_2u/views.py
+++ b/ecommerce/extensions/executive_education_2u/views.py
@@ -238,7 +238,7 @@ class ExecutiveEducation2UViewSet(viewsets.ViewSet, ExecutiveEducation2UOrderPla
 
             # logger 2 for debugging ent-6954
             logger.info(
-                '[ExecutiveEducation2UViewSet] User [%s] is attempting to checkout for product [%s] with ',
+                '[ExecutiveEducation2UViewSet] User [%s] is attempting to checkout for product [%s] with '
                 'sku [%s] and course_uuid [%s] with query params [%s]',
                 request.user.id,
                 product,


### PR DESCRIPTION
# Description

Opens a PR for Hamzah since he can't push to ecommerce (needs to be a member of https://github.com/orgs/openedx/teams/ecommerce-maintainers/members).

Adds logging to help debug ENT-6954 (issues with Exec Ed enrollment/fulfillment with GEAG).

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?
Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
