### PR TITLE
fix: Fix error in checkout api for mobile

### DIFF
--- a/ecommerce/extensions/iap/api/v1/tests/test_views.py
+++ b/ecommerce/extensions/iap/api/v1/tests/test_views.py
@@ -546,13 +546,6 @@ class TestMobileCheckoutView(TestCase):
         self.assertIn(reverse('iap:iap-execute'), response_data['payment_page_url'])
         self.assertEqual(response_data['payment_processor'], self.processor_name)
 
-    def test_already_purchased_basket(self):
-        with mock.patch.object(UserAlreadyPlacedOrder, 'user_already_placed_order', return_value=True):
-            create_order(site=self.site, user=self.user, basket=self.basket)
-            response = self.client.post(self.path, data=self.post_data)
-            self.assertEqual(response.status_code, 406)
-            self.assertEqual(response.json().get('error'), ERROR_ALREADY_PURCHASED)
-
 
 class BaseRefundTests(RefundTestMixin, AccessTokenMixin, JwtMixin, TestCase):
     MODEL_LOGGER_NAME = 'ecommerce.core.models'

--- a/ecommerce/extensions/iap/api/v1/views.py
+++ b/ecommerce/extensions/iap/api/v1/views.py
@@ -233,14 +233,6 @@ class MobileCheckoutView(APIView):
     permission_classes = (IsAuthenticated,)
 
     def post(self, request):
-        basket_id = request.data.get('basket_id')
-        try:
-            basket = request.user.baskets.get(id=basket_id)
-        except ObjectDoesNotExist:
-            return JsonResponse({'error': ERROR_BASKET_NOT_FOUND.format(basket_id)}, status=400)
-        if products_in_basket_already_purchased(request.user, basket, request.site):
-            return JsonResponse({'error': _(ERROR_ALREADY_PURCHASED)}, status=406)
-
         response = CheckoutView.as_view()(request._request)  # pylint: disable=W0212
         if response.status_code != 200:
             return JsonResponse({'error': response.content.decode()}, status=response.status_code)

--- a/ecommerce/extensions/iap/api/v1/views.py
+++ b/ecommerce/extensions/iap/api/v1/views.py
@@ -233,6 +233,7 @@ class MobileCheckoutView(APIView):
     permission_classes = (IsAuthenticated,)
 
     def post(self, request):
+        # TODO: Add check for products_in_basket_already_purchased
         response = CheckoutView.as_view()(request._request)  # pylint: disable=W0212
         if response.status_code != 200:
             return JsonResponse({'error': response.content.decode()}, status=response.status_code)


### PR DESCRIPTION
# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description
Impact: Mobile In-app purchases checkout/api
Fixes the error on checkout/ api used for mobile caused due to accessing request data in two separate DRF views.
This PR removes the check for already purchased products on checkout/ API since: 

- The check is already in place for basket/ and execute/ api.
- The check is causing fatal 500 error in the mobile purchase flow.

## Supporting information

Jira ticket link: https://2u-internal.atlassian.net/browse/LEARNER-9296
New relic error link: https://onenr.io/0Zw08Db90wv
