### PR TITLE
test: Add tests for Mobile IAP

### DIFF
--- a/ecommerce/extensions/iap/api/v1/views.py
+++ b/ecommerce/extensions/iap/api/v1/views.py
@@ -214,16 +214,14 @@ class MobileCoursePurchaseExecutionView(EdxOrderPlacementMixin, APIView):
             return JsonResponse({'error': ERROR_DURING_PAYMENT_HANDLING}, status=400)
 
         try:
-            with transaction.atomic():
-                order = self.create_order(request, basket)
+            order = self.create_order(request, basket)
         except Exception:  # pylint: disable=broad-except
             # Any errors here will be logged in the create_order method. If we wanted any
             # IAP specific logging for this error, we would do that here.
             return JsonResponse({'error': ERROR_DURING_ORDER_CREATION}, status=400)
 
         try:
-            with transaction.atomic():
-                self.handle_post_order(order)
+            self.handle_post_order(order)
         except Exception:  # pylint: disable=broad-except
             self.log_order_placement_exception(basket.order_number, basket.id)
             return JsonResponse({'error': ERROR_DURING_POST_ORDER_OP}, status=200)

--- a/ecommerce/extensions/iap/api/v1/views.py
+++ b/ecommerce/extensions/iap/api/v1/views.py
@@ -214,14 +214,16 @@ class MobileCoursePurchaseExecutionView(EdxOrderPlacementMixin, APIView):
             return JsonResponse({'error': ERROR_DURING_PAYMENT_HANDLING}, status=400)
 
         try:
-            order = self.create_order(request, basket)
+            with transaction.atomic():
+                order = self.create_order(request, basket)
         except Exception:  # pylint: disable=broad-except
             # Any errors here will be logged in the create_order method. If we wanted any
             # IAP specific logging for this error, we would do that here.
             return JsonResponse({'error': ERROR_DURING_ORDER_CREATION}, status=400)
 
         try:
-            self.handle_post_order(order)
+            with transaction.atomic():
+                self.handle_post_order(order)
         except Exception:  # pylint: disable=broad-except
             self.log_order_placement_exception(basket.order_number, basket.id)
             return JsonResponse({'error': ERROR_DURING_POST_ORDER_OP}, status=200)

--- a/ecommerce/extensions/iap/tests/processors/test_android_iap.py
+++ b/ecommerce/extensions/iap/tests/processors/test_android_iap.py
@@ -2,6 +2,7 @@
 """Unit tests of Android IAP payment processor implementation."""
 
 
+import uuid
 from urllib.parse import urljoin
 
 import ddt
@@ -80,6 +81,19 @@ class AndroidIAPTests(PaymentProcessorTestCaseMixin, TestCase):
         }
         actual = self.processor.get_transaction_parameters(self.basket)
         self.assertEqual(actual, expected)
+
+    def test_is_payment_redundant(self):
+        """
+        Test that True is returned only if no PaymentProcessorResponse entry is found with
+        the given transaction_id.
+        """
+        transaction_id = str(uuid.uuid4())
+        result = self.processor.is_payment_redundant(transaction_id=transaction_id)
+        self.assertFalse(result)
+
+        PaymentProcessorResponse.objects.create(transaction_id=transaction_id, processor_name=self.processor_name)
+        result = self.processor.is_payment_redundant(transaction_id=transaction_id)
+        self.assertTrue(result)
 
     @mock.patch.object(GooglePlayValidator, 'validate')
     def test_handle_processor_response_error(self, mock_google_validator):


### PR DESCRIPTION
# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Add tests for 1is_payment_redundant` method in for android and ios iap processors.

## Supporting information

Jira issue: https://2u-internal.atlassian.net/browse/LEARNER-9317



