### PR TITLE
feat: Added course and expires field in product form on ecommerce dashboard

### DIFF
--- a/ecommerce/extensions/dashboard/catalogue/__init__.py
+++ b/ecommerce/extensions/dashboard/catalogue/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'ecommerce.extensions.dashboard.catalogue.apps.CatalogueDashboardConfig'

--- a/ecommerce/extensions/dashboard/catalogue/apps.py
+++ b/ecommerce/extensions/dashboard/catalogue/apps.py
@@ -1,0 +1,5 @@
+from oscar.apps.dashboard.catalogue import apps
+
+
+class CatalogueDashboardConfig(apps.CatalogueDashboardConfig):
+    name = 'ecommerce.extensions.dashboard.catalogue'

--- a/ecommerce/extensions/dashboard/catalogue/forms.py
+++ b/ecommerce/extensions/dashboard/catalogue/forms.py
@@ -1,0 +1,9 @@
+from oscar.apps.dashboard.catalogue.forms import ProductForm as BaseProductForm
+
+
+class ProductForm(BaseProductForm):
+    class Meta(BaseProductForm.Meta):
+        fields = [
+            'title', 'course', 'expires', 'upc', 'description',
+            'is_public', 'is_discountable', 'structure'
+        ]

--- a/ecommerce/settings/_oscar.py
+++ b/ecommerce/settings/_oscar.py
@@ -42,7 +42,6 @@ OSCAR_APPS = [
     # To prevent issues with Oscar’s dynamic model loading, overrides of dashboard applications should
     # follow overrides of core applications
     'oscar.apps.dashboard.reports',
-    'oscar.apps.dashboard.catalogue',
     'oscar.apps.dashboard.partners',
     'oscar.apps.dashboard.pages',
     'oscar.apps.dashboard.ranges',
@@ -52,6 +51,7 @@ OSCAR_APPS = [
     'oscar.apps.dashboard.shipping',
 
     'ecommerce.extensions.dashboard',
+    'ecommerce.extensions.dashboard.catalogue',
     'ecommerce.extensions.dashboard.offers',
     'ecommerce.extensions.dashboard.refunds',
     'ecommerce.extensions.dashboard.orders',


### PR DESCRIPTION
## Description

Forked catalogue app from oscar and added course and expire field in ProductForm. This change will enable to add Android sku from a same dashboard page.

Jira Link: https://2u-internal.atlassian.net/browse/LEARNER-9323

## Other information

Product dashboard now:
<img width="738" alt="Screen Shot 2023-04-06 at 3 43 55 PM" src="https://user-images.githubusercontent.com/5320368/230354627-d84e4577-25f4-4fcf-a780-a9440cfc3016.png">

