### PR TITLE
feat: Added data_share_consent field to order fullfillment notes

### DIFF
--- a/ecommerce/enterprise/tests/mixins.py
+++ b/ecommerce/enterprise/tests/mixins.py
@@ -464,6 +464,15 @@ class EnterpriseServiceMockMixin:
             ec_uuid
         )
 
+    def mock_consent_post(self, username, course_id, ec_uuid):
+        self.mock_consent_response(
+            username,
+            course_id,
+            ec_uuid,
+            method=responses.POST,
+            granted=True
+        )
+
     def mock_consent_missing(self, username, course_id, ec_uuid):
         self.mock_consent_response(
             username,

--- a/ecommerce/enterprise/tests/test_utils.py
+++ b/ecommerce/enterprise/tests/test_utils.py
@@ -18,6 +18,7 @@ from ecommerce.enterprise.api import get_enterprise_id_for_user
 from ecommerce.enterprise.tests.mixins import EnterpriseServiceMockMixin
 from ecommerce.enterprise.utils import (
     CUSTOMER_CATALOGS_DEFAULT_RESPONSE,
+    create_enterprise_customer_user_consent,
     enterprise_customer_user_needs_consent,
     find_active_enterprise_customer_user,
     get_enterprise_catalog,
@@ -143,6 +144,23 @@ class EnterpriseUtilsTests(EnterpriseServiceMockMixin, TestCase):
         self.assertEqual(enterprise_customer_user_needs_consent(**kw), True)
         self.mock_consent_not_required(**opts)
         self.assertEqual(enterprise_customer_user_needs_consent(**kw), False)
+
+    @responses.activate
+    def test_ecu_create_consent(self):
+        opts = {
+            'ec_uuid': 'fake-uuid',
+            'course_id': 'course-v1:real+course+id',
+            'username': 'johnsmith',
+        }
+        kw = {
+            'enterprise_customer_uuid': 'fake-uuid',
+            'course_id': 'course-v1:real+course+id',
+            'username': 'johnsmith',
+            'site': self.site
+        }
+        self.mock_access_token_response()
+        self.mock_consent_post(**opts)
+        self.assertEqual(create_enterprise_customer_user_consent(**kw), True)
 
     def test_get_enterprise_customer_uuid(self):
         """

--- a/ecommerce/enterprise/utils.py
+++ b/ecommerce/enterprise/utils.py
@@ -355,6 +355,34 @@ def enterprise_customer_user_needs_consent(site, enterprise_customer_uuid, cours
     return response.json()['consent_required']
 
 
+def create_enterprise_customer_user_consent(site, enterprise_customer_uuid, course_id, username):
+    """
+    Create a new consent for a particular username/EC UUID/course ID combination if one doesn't already exist.
+
+    Args:
+        site (Site): The site which is handling the consent-sensitive request
+        enterprise_customer_uuid (str): The UUID of the relevant EnterpriseCustomer
+        course_id (str): The ID of the relevant course for enrollment
+        username (str): The username of the user attempting to enroll into the course
+
+    Returns:
+        bool: consent recorded for the user specified by the username argument
+        for the EnterpriseCustomer specified by the enterprise_customer_uuid
+        argument and the course specified by the course_id argument.
+    """
+    data = {
+        "username": username,
+        "enterprise_customer_uuid": enterprise_customer_uuid,
+        "course_id": course_id
+    }
+    api_client = site.siteconfiguration.oauth_api_client
+    consent_url = urljoin(f"{site.siteconfiguration.consent_api_url}/", "data_sharing_consent")
+
+    response = api_client.post(consent_url, json=data)
+    response.raise_for_status()
+    return response.json()['consent_provided']
+
+
 def get_enterprise_customer_uuid_from_voucher(voucher):
     """
     Given a Voucher, find the associated Enterprise Customer UUID, if it exists.

--- a/ecommerce/extensions/executive_education_2u/mixins.py
+++ b/ecommerce/extensions/executive_education_2u/mixins.py
@@ -17,6 +17,7 @@ class ExecutiveEducation2UOrderPlacementMixin(EdxOrderPlacementMixin):
         address,
         user_details,
         terms_accepted_at,
+        data_share_consent,
         request=None,
     ):  # pylint: disable=arguments-differ
         """
@@ -49,6 +50,7 @@ class ExecutiveEducation2UOrderPlacementMixin(EdxOrderPlacementMixin):
             'address': address,
             'user_details': user_details,
             'terms_accepted_at': terms_accepted_at,
+            'data_share_consent': data_share_consent,
         })
 
         # Place an order. If order placement succeeds, the order is committed

--- a/ecommerce/extensions/executive_education_2u/serializers.py
+++ b/ecommerce/extensions/executive_education_2u/serializers.py
@@ -26,3 +26,4 @@ class CheckoutActionSerializer(serializers.Serializer):  # pylint: disable=abstr
     address = AddressSerializer(required=False)
     user_details = UserDetailsSerializer()
     terms_accepted_at = serializers.CharField()
+    data_share_consent = serializers.BooleanField(required=False)

--- a/ecommerce/extensions/executive_education_2u/tests/test_mixins.py
+++ b/ecommerce/extensions/executive_education_2u/tests/test_mixins.py
@@ -44,6 +44,7 @@ class EdxOrderPlacementMixinTests(
             'mobile_phone': '1234567890'
         }
         self.mock_terms_accepted_at = '2022-08-05T15:28:46.493Z',
+        self.mock_data_share_consent = True
 
         # Ensure that the basket attribute type exists for these tests
         self.basket_attribute_type, _ = BasketAttributeType.objects.get_or_create(
@@ -57,12 +58,14 @@ class EdxOrderPlacementMixinTests(
             'address': self.mock_address,
             'user_details': self.mock_user_details,
             'terms_accepted_at': self.mock_terms_accepted_at,
+            'data_share_consent': self.mock_data_share_consent,
         })
         order = ExecutiveEducation2UOrderPlacementMixin().place_free_order(
             basket,
             self.mock_address,
             self.mock_user_details,
             self.mock_terms_accepted_at,
+            self.mock_data_share_consent,
         )
 
         self.assertEqual(basket.status, Basket.SUBMITTED)
@@ -77,4 +80,5 @@ class EdxOrderPlacementMixinTests(
                 self.mock_address,
                 self.mock_user_details,
                 self.mock_terms_accepted_at,
+                self.mock_data_share_consent,
             )

--- a/ecommerce/extensions/executive_education_2u/tests/test_views.py
+++ b/ecommerce/extensions/executive_education_2u/tests/test_views.py
@@ -348,6 +348,7 @@ class ExecutiveEducation2UAPIViewSetTests(TestCase, JwtMixin):
                 'mobile_phone': '1234567890'
             },
             'terms_accepted_at': '2022-08-05T15:28:46.493Z',
+            'data_share_consent': True,
         }
 
     def _create_basket(self, product, has_offer=False):

--- a/ecommerce/extensions/executive_education_2u/views.py
+++ b/ecommerce/extensions/executive_education_2u/views.py
@@ -355,6 +355,7 @@ class ExecutiveEducation2UViewSet(viewsets.ViewSet, ExecutiveEducation2UOrderPla
                 address=request.data.get('address', {}),
                 user_details={**request.data['user_details'], 'email': request.user.email},
                 terms_accepted_at=request.data['terms_accepted_at'],
+                data_share_consent=request.data.get('data_share_consent', None),
                 request=request
             )
 

--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -29,10 +29,11 @@ from ecommerce.core.constants import (
 )
 from ecommerce.core.url_utils import get_lms_enrollment_api_url, get_lms_entitlement_api_url
 from ecommerce.courses.models import Course
-from ecommerce.courses.utils import mode_for_product
+from ecommerce.courses.utils import get_course_info_from_catalog, mode_for_product
 from ecommerce.enterprise.conditions import BasketAttributeType
 from ecommerce.enterprise.mixins import EnterpriseDiscountMixin
 from ecommerce.enterprise.utils import (
+    create_enterprise_customer_user_consent,
     get_enterprise_customer_uuid_from_voucher,
     get_or_create_enterprise_customer_user
 )
@@ -949,8 +950,9 @@ class ExecutiveEducation2UFulfillmentModule(BaseFulfillmentModule):
         # This will be the offer that was applied. We will let an error be thrown if this doesn't exist.
         discount = order.discounts.first()
         enterprise_customer_uuid = str(discount.offer.condition.enterprise_customer_uuid)
+        data_share_consent = fulfillment_details.get('data_share_consent', None)
 
-        return {
+        payload = {
             'payment_reference': order.number,
             'enterprise_customer_uuid': enterprise_customer_uuid,
             'currency': currency,
@@ -966,8 +968,30 @@ class ExecutiveEducation2UFulfillmentModule(BaseFulfillmentModule):
             ],
             **fulfillment_details.get('address', {}),
             **fulfillment_details.get('user_details', {}),
-            'terms_accepted_at': fulfillment_details.get('terms_accepted_at', '')
+            'terms_accepted_at': fulfillment_details.get('terms_accepted_at', ''),
         }
+        if data_share_consent:
+            payload['data_share_consent'] = data_share_consent
+
+        return payload
+
+    def _create_enterprise_customer_user_consent(
+        self,
+        order,
+        line,
+        fulfillment_details
+    ):
+        data_share_consent = fulfillment_details.get('data_share_consent', None)
+        course_info = get_course_info_from_catalog(order.site, line.product)
+        if data_share_consent and course_info:
+            discount = order.discounts.first()
+            enterprise_customer_uuid = str(discount.offer.condition.enterprise_customer_uuid)
+            create_enterprise_customer_user_consent(
+                site=order.site,
+                enterprise_customer_uuid=enterprise_customer_uuid,
+                course_id=course_info['key'],
+                username=order.user.username
+            )
 
     def _get_fulfillment_details(self, order):
         fulfillment_details_note = order.notes.filter(note_type='Fulfillment Details').first()
@@ -1020,6 +1044,11 @@ class ExecutiveEducation2UFulfillmentModule(BaseFulfillmentModule):
             )
 
             try:
+                self._create_enterprise_customer_user_consent(
+                    order=order,
+                    line=line,
+                    fulfillment_details=fulfillment_details
+                )
                 self.get_smarter_client.create_enterprise_allocation(**allocation_payload)
             except Exception as ex:  # pylint: disable=broad-except
                 reason = ''

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -258,7 +258,7 @@ funcsigs==1.0.2
     # via cybersource-rest-client-python
 future==0.18.2
     # via pyjwkest
-getsmarter-api-clients==0.4.0
+getsmarter-api-clients==0.5.0
     # via -r requirements/base.in
 google-api-core==1.30.0
     # via google-api-python-client

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -373,7 +373,7 @@ future==0.18.2
     # via
     #   -r requirements/test.txt
     #   pyjwkest
-getsmarter-api-clients==0.4.0
+getsmarter-api-clients==0.5.0
     # via -r requirements/test.txt
 gitdb==4.0.9
     # via gitpython

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -268,7 +268,7 @@ future==0.18.2
     # via
     #   django-ses
     #   pyjwkest
-getsmarter-api-clients==0.4.0
+getsmarter-api-clients==0.5.0
     # via -r requirements/base.in
     # via
     #   django-ses

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -379,7 +379,7 @@ future==0.18.2
     # via
     #   -r requirements/base.txt
     #   pyjwkest
-getsmarter-api-clients==0.4.0
+getsmarter-api-clients==0.5.0
     # via -r requirements/base.txt
 google-api-core==1.30.0
     # via


### PR DESCRIPTION
## Description

This PR adds a data sharing consent flag to the order fulfillment notes. The flag will record the learner's acceptance of the data sharing consent while registering for third party hosted course content. The PR also uses the LMS consent apis to record the data sharing consent by the learner.


## Supporting information

Jira: [ENT-6794](https://2u-internal.atlassian.net/browse/ENT-6794)
