### PR TITLE
fix: reorder JWT decoders

### DIFF
--- a/ecommerce/extensions/api/tests/test_handlers.py
+++ b/ecommerce/extensions/api/tests/test_handlers.py
@@ -49,9 +49,9 @@ class JWTDecodeHandlerTests(TestCase):
             'JWT_VERIFY_AUDIENCE': False,
         }
     )
-    @mock.patch('edx_django_utils.monitoring.set_custom_metric')
+    @mock.patch('edx_django_utils.monitoring.increment')
     @mock.patch('ecommerce.extensions.api.handlers._ecommerce_jwt_decode_handler_multiple_issuers')
-    def test_decode_success_edx_drf_extensions(self, mock_multiple_issuer_decoder, mock_set_custom_metric):
+    def test_decode_success_edx_drf_extensions(self, mock_multiple_issuer_decoder, mock_increment):
         """
         Should pass using the edx-drf-extensions jwt_decode_handler.
 
@@ -63,7 +63,7 @@ class JWTDecodeHandlerTests(TestCase):
         payload = generate_jwt_payload(self.user, issuer_name=first_issuer['ISSUER'])
         token = generate_jwt_token(payload, first_issuer['SECRET_KEY'])
         self.assertDictContainsSubset(payload, jwt_decode_handler(token))
-        mock_set_custom_metric.assert_called_with('ecom_jwt_decode_handler', 'edx-drf-extensions')
+        mock_increment.assert_called_with('ecom_jwt_decode_standard')
 
     @override_settings(
         JWT_AUTH={
@@ -87,9 +87,9 @@ class JWTDecodeHandlerTests(TestCase):
             'JWT_VERIFY_AUDIENCE': False,
         }
     )
-    @mock.patch('edx_django_utils.monitoring.set_custom_metric')
+    @mock.patch('edx_django_utils.monitoring.increment')
     @mock.patch('ecommerce.extensions.api.handlers.logger')
-    def test_decode_success_multiple_issuers(self, mock_logger, mock_set_custom_metric):
+    def test_decode_success_multiple_issuers(self, mock_logger, mock_increment):
         """
         Should pass using ``_ecommerce_jwt_decode_handler_multiple_issuers``.
 
@@ -101,7 +101,7 @@ class JWTDecodeHandlerTests(TestCase):
         payload = generate_jwt_payload(self.user, issuer_name=non_first_issuer['ISSUER'])
         token = generate_jwt_token(payload, non_first_issuer['SECRET_KEY'])
         self.assertDictContainsSubset(payload, jwt_decode_handler(token))
-        mock_set_custom_metric.assert_called_with('ecom_jwt_decode_handler', 'ecommerce-multiple-issuers')
+        mock_increment.assert_called_with('ecom_jwt_decode_custom')
         mock_logger.exception.assert_not_called()
         mock_logger.warning.assert_not_called()
         mock_logger.error.assert_not_called()
@@ -141,6 +141,6 @@ class JWTDecodeHandlerTests(TestCase):
 
         mock_logger.exception.assert_called_with('Custom config JWT decode failed!')
         mock_logger.info.assert_has_calls(calls=[
-            mock.call('Failed to use ecommerce multiple issuer jwt_decode_handler.', exc_info=True),
             mock.call('Failed to use edx-drf-extensions jwt_decode_handler.', exc_info=True),
+            mock.call('Failed to use ecommerce multiple issuer jwt_decode_handler.', exc_info=True),
         ])


### PR DESCRIPTION
Reordered the JWT decoders to first use the standard library version, and then use the custom ecommerce decoder which uses multiple issuers. In this way, we can see if any JWTs cannot be decoded by that standard library version, and when and if we are ready to retire the custom JWT decoding code.

See DEPR https://github.com/openedx/public-engineering/issues/83

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?
Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
