### PR TITLE
fix: cached monitoring

### DIFF
--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -223,6 +223,7 @@ MIDDLEWARE = (
     'corsheaders.middleware.CorsMiddleware',
     'edx_django_utils.monitoring.DeploymentMonitoringMiddleware',
     'edx_django_utils.cache.middleware.RequestCacheMiddleware',
+    'edx_django_utils.monitoring.CachedCustomMonitoringMiddleware',
     'edx_django_utils.monitoring.CookieMonitoringMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',


### PR DESCRIPTION
Monitoring features such as use of the increment
method, to increment a custom attribute, requires
the CachedCustomMonitoringMiddleware. This has been added so the earlier calls to increment will function.

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?
Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.
