### PR TITLE
fix: fix codecov error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,9 @@ jobs:
           architecture: x64
       - name: Report coverage
         if: matrix.testname == 'test-python'
-        run: |
-          pip install codecov
-          codecov
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
 
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Codecov PyPI package was removed on 12 April and the recommended step is to migrate to codecov Github Action instead.