### PR TITLE
fix: Course to have multiple seats with certificate_type attribute

### DIFF
--- a/ecommerce/courses/models.py
+++ b/ecommerce/courses/models.py
@@ -345,10 +345,10 @@ class Course(models.Model):
         enrollment_code = self.get_enrollment_code()
         if enrollment_code:
             if is_active:
-                seat = self.seat_products.get(
+                seat = self.seat_products.filter(
                     attributes__name='certificate_type',
                     attribute_values__value_text=enrollment_code.attr.seat_type
-                )
+                ).order_by('-expires').first()
                 enrollment_code.expires = seat.expires if seat.expires else now() + timedelta(days=365)
             else:
                 enrollment_code.expires = now() - timedelta(days=365)

--- a/ecommerce/courses/tests/test_models.py
+++ b/ecommerce/courses/tests/test_models.py
@@ -371,3 +371,17 @@ class CourseTests(DiscoveryTestMixin, TestCase):
         ec_expires = now() - timedelta(days=365)
         self.assertEqual(course.get_enrollment_code().expires, ec_expires)
         self.assertIsNone(course.enrollment_code_product)
+
+    def test_toggle_enrollment_code_with_multiple_seats(self):
+        """Verify enrollment code expiration date is set when course has multiple seats"""
+        seat_one_expires = now() + timedelta(days=365)
+        seat_two_expires = now() + timedelta(days=366)
+        course, _, enrollment_code = self.create_course_seat_and_enrollment_code(expires=seat_one_expires)
+        seat_two = course.create_or_update_seat(
+            "verified", False, 10, expires=seat_two_expires, create_enrollment_code=False
+        )
+        course.toggle_enrollment_code_status(True)
+        ec_expires = seat_two.expires
+
+        self.assertEqual(course.get_enrollment_code().expires, ec_expires)
+        self.assertEqual(course.enrollment_code_product, enrollment_code)

--- a/ecommerce/courses/tests/test_models.py
+++ b/ecommerce/courses/tests/test_models.py
@@ -42,8 +42,10 @@ class CourseTests(DiscoveryTestMixin, TestCase):
 
         # Create the seat products
         seats = [course.create_or_update_seat('honor', False, 0),
-                 course.create_or_update_seat('verified', True, 50, create_enrollment_code=True)]
-        self.assertEqual(course.products.count(), 4)
+                 course.create_or_update_seat('verified', True, 50, create_enrollment_code=True),
+                 course.create_or_update_seat('verified', True, 60),
+                 course.create_or_update_seat('verified', True, 70)]
+        self.assertEqual(course.products.count(), 6)
 
         # The property should return only the child seats.
         self.assertEqual(set(course.seat_products), set(seats))
@@ -376,12 +378,13 @@ class CourseTests(DiscoveryTestMixin, TestCase):
         """Verify enrollment code expiration date is set when course has multiple seats"""
         seat_one_expires = now() + timedelta(days=365)
         seat_two_expires = now() + timedelta(days=366)
+        seat_three_expires = now() + timedelta(days=367)
         course, _, enrollment_code = self.create_course_seat_and_enrollment_code(expires=seat_one_expires)
-        seat_two = course.create_or_update_seat(
-            "verified", False, 10, expires=seat_two_expires, create_enrollment_code=False
-        )
+        course.create_or_update_seat("honor", False, 0)
+        course.create_or_update_seat("verified", True, 10, expires=seat_two_expires)
+        course.create_or_update_seat("verified", True, 10, expires=seat_three_expires)
         course.toggle_enrollment_code_status(True)
-        ec_expires = seat_two.expires
+        ec_expires = seat_three_expires
 
         self.assertEqual(course.get_enrollment_code().expires, ec_expires)
         self.assertEqual(course.enrollment_code_product, enrollment_code)

--- a/ecommerce/extensions/catalogue/tests/test_utils.py
+++ b/ecommerce/extensions/catalogue/tests/test_utils.py
@@ -58,7 +58,8 @@ class UtilsTests(DiscoveryTestMixin, TestCase):
         certificate_type = 'audit'
         product = course.create_or_update_seat(certificate_type, False, 0)
 
-        _hash = '{} {} {} {} {}'.format(certificate_type, course_id, 'False', '', self.partner.id).encode('utf-8')
+        _hash = '{} {} {} {} {} {}'.format(certificate_type, course_id, 'False', '', product.id,
+                                           self.partner.id).encode('utf-8')
         _hash = md5(_hash.lower()).hexdigest()[-7:]
         # verify that generated sku has partner 'short_code' as prefix
         expected = _hash.upper()

--- a/ecommerce/extensions/catalogue/utils.py
+++ b/ecommerce/extensions/catalogue/utils.py
@@ -204,6 +204,7 @@ def generate_sku(product, partner):
             str(product.attr.course_key),
             str(product.attr.id_verification_required),
             getattr(product.attr, 'credit_provider', ''),
+            str(product.id),
             str(partner.id)
         )).encode('utf-8')
     elif product.is_course_entitlement_product:


### PR DESCRIPTION
# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

This PR fixes the error that arises when submitting a course run for review on publisher for a course that has more than one Seat type Products with the attribute certificate_type i.e. verified mode seats.

This PR also modifies the attributes used by the hash to generate SKU for a seat. Added attribute: product.id in case of a 'Seat' type product. The reason is product SKU's need to have an independent attribute used in generation ofSKU so we will have different SKU values of two seats with verified certificate belonging to the same course.

Mobile In-app payments makes use of 2 Seat variants created on Ecommerce with different SKU's and prices to enable live payment experience for mobile. A bug in the backend is fixed that expected a single Seat type Product with attribute certificate_type, which was the case before mobile release.

## Supporting information

Main Jira ticket: https://2u-internal.atlassian.net/browse/LEARNER-9335

## Testing instructions

1. Create a course run on Publisher
2. Create its respective course on Ecommerce via <ecommerce_url/courses/new>
3. Browse to the Seat for this course in the Ecommerce Catalogue, and Add a new variant in the Product with type 'Seat'
4. Add a test SKU to this variant with the attribute `certificate` set to `verified`
5. Save seat variant on ecommerce.
6. Attempt to send the course run on Publisher for review.
7. Error is reproduced.

