### PR TITLE
refactor: add logging to mobile IAP

### DIFF
--- a/ecommerce/extensions/iap/api/v1/constants.py
+++ b/ecommerce/extensions/iap/api/v1/constants.py
@@ -14,9 +14,24 @@ ERROR_TRANSACTION_NOT_FOUND_FOR_REFUND = "Could not find any transaction to refu
 ERROR_DURING_POST_ORDER_OP = "An error occurred during post order operations."
 ERROR_WHILE_OBTAINING_BASKET_FOR_USER = "An unexpected exception occurred while obtaining basket for user [{}]."
 GOOGLE_PUBLISHER_API_SCOPE = "https://www.googleapis.com/auth/androidpublisher"
-LOGGER_BASKET_NOT_FOUND = "Basket [%s] not found."
-LOGGER_PAYMENT_APPROVED = "Payment [%s] approved by payer [%s]"
-LOGGER_PAYMENT_FAILED_FOR_BASKET = "Attempts to handle payment for basket [%d] failed."
+LOGGER_BASKET_ALREADY_PURCHASED = "Basket creation failed for user [%s] with SKUS [%s]. Products already purchased"
+LOGGER_BASKET_CREATED = "Basket created for user [%s] with SKUS [%s]"
+LOGGER_BASKET_CREATION_FAILED = "Basket creation failed for user [%s]. Error: [%s]"
+LOGGER_BASKET_NOT_FOUND = "Basket [%s] not found for user [%s]."
+LOGGER_EXECUTE_ALREADY_PURCHASED = "Execute payment failed for user [%s] and basket [%s]. " \
+                                   "Products already purchased."
+LOGGER_EXECUTE_ERROR_WHILE_OBTAINING_BASKET = "Execute payment failed for user [%s] and basket [%s]. " \
+                                              "Fetching basket failed with error [%s]."
+LOGGER_EXECUTE_ORDER_CREATION_FAILED = "Execute payment failed for user [%s] and basket [%s]. " \
+                                       "Order Creation failed with error [%s]."
+LOGGER_EXECUTE_PAYMENT_ERROR = "Execute payment failed for user [%s] and basket [%s]. " \
+                               "Payment error [%s]."
+LOGGER_EXECUTE_REDUNDANT_PAYMENT = "Execute payment failed for user [%s] and basket [%s]. " \
+                                   "Redundant payment."
+LOGGER_EXECUTE_STARTED = "Beginning Payment execution for user [%s], basket [%s], processor [%s]"
+LOGGER_EXECUTE_SUCCESSFUL = "Payment execution successful for user [%s], basket [%s], processor [%s]"
+LOGGER_PAYMENT_FAILED_FOR_BASKET = "Attempts to handle payment for basket [%s] failed with error [%s]."
+LOGGER_REFUND_SUCCESSFUL = "Refund successful. OrderId: [%s] Processor: [%s] "
 LOGGER_STARTING_PAYMENT_FLOW = "Starting payment flow for user [%s] for products [%s]."
 NO_PRODUCT_AVAILABLE = "No product is available to buy."
 PRODUCTS_DO_NOT_EXIST = "Products with SKU(s) [{skus}] do not exist."

--- a/ecommerce/extensions/iap/api/v1/urls.py
+++ b/ecommerce/extensions/iap/api/v1/urls.py
@@ -9,7 +9,7 @@ from ecommerce.extensions.iap.api.v1.views import (
 
 urlpatterns = [
     url(r'^basket/add/$', MobileBasketAddItemsView.as_view(), name='mobile-basket-add'),
-    url(r'^execute/$', MobileCoursePurchaseExecutionView.as_view(), name='iap-execute'),
     url(r'^checkout/$', MobileCheckoutView.as_view(), name='iap-checkout'),
+    url(r'^execute/$', MobileCoursePurchaseExecutionView.as_view(), name='iap-execute'),
     url(r'^android/refund/$', AndroidRefund.as_view(), name='android-refund')
 ]

--- a/ecommerce/extensions/iap/api/v1/views.py
+++ b/ecommerce/extensions/iap/api/v1/views.py
@@ -44,9 +44,19 @@ from ecommerce.extensions.iap.api.v1.constants import (
     ERROR_TRANSACTION_NOT_FOUND_FOR_REFUND,
     ERROR_WHILE_OBTAINING_BASKET_FOR_USER,
     GOOGLE_PUBLISHER_API_SCOPE,
+    LOGGER_BASKET_ALREADY_PURCHASED,
+    LOGGER_BASKET_CREATED,
+    LOGGER_BASKET_CREATION_FAILED,
     LOGGER_BASKET_NOT_FOUND,
-    LOGGER_PAYMENT_APPROVED,
+    LOGGER_EXECUTE_ALREADY_PURCHASED,
+    LOGGER_EXECUTE_ERROR_WHILE_OBTAINING_BASKET,
+    LOGGER_EXECUTE_ORDER_CREATION_FAILED,
+    LOGGER_EXECUTE_PAYMENT_ERROR,
+    LOGGER_EXECUTE_REDUNDANT_PAYMENT,
+    LOGGER_EXECUTE_STARTED,
+    LOGGER_EXECUTE_SUCCESSFUL,
     LOGGER_PAYMENT_FAILED_FOR_BASKET,
+    LOGGER_REFUND_SUCCESSFUL,
     LOGGER_STARTING_PAYMENT_FLOW,
     NO_PRODUCT_AVAILABLE,
     PRODUCT_IS_NOT_AVAILABLE,
@@ -95,15 +105,19 @@ class MobileBasketAddItemsView(BasketLogicMixin, APIView):
             try:
                 basket = prepare_basket(request, available_products)
             except AlreadyPlacedOrderException:
+                logger.exception(LOGGER_BASKET_ALREADY_PURCHASED, request.user.username, skus)
                 return JsonResponse({'error': _(ERROR_ALREADY_PURCHASED)}, status=406)
 
             set_email_preference_on_basket(request, basket)
 
+            logger.info(LOGGER_BASKET_CREATED, request.user.username, skus)
+
             return JsonResponse({'success': _(COURSE_ADDED_TO_BASKET), 'basket_id': basket.id},
                                 status=200)
 
-        except BadRequestException as e:
-            return JsonResponse({'error': str(e)}, status=400)
+        except BadRequestException as exc:
+            logger.exception(LOGGER_BASKET_CREATION_FAILED, request.user.username, str(exc))
+            return JsonResponse({'error': str(exc)}, status=400)
 
     def _get_skus(self, request):
         skus = [escape(sku) for sku in request.GET.getlist('sku')]
@@ -134,6 +148,19 @@ class MobileBasketAddItemsView(BasketLogicMixin, APIView):
             raise BadRequestException(_(NO_PRODUCT_AVAILABLE))
 
         return available_products
+
+
+class MobileCheckoutView(APIView):
+    permission_classes = (IsAuthenticated,)
+
+    def post(self, request):
+        # TODO: Add check for products_in_basket_already_purchased
+        # TODO: Add logging for api/user_info after reading from request obj
+        response = CheckoutView.as_view()(request._request)  # pylint: disable=W0212
+        if response.status_code != 200:
+            return JsonResponse({'error': response.content.decode()}, status=response.status_code)
+
+        return response
 
 
 class MobileCoursePurchaseExecutionView(EdxOrderPlacementMixin, APIView):
@@ -187,37 +214,38 @@ class MobileCoursePurchaseExecutionView(EdxOrderPlacementMixin, APIView):
         basket_id = receipt.get('basket_id')
         if not basket_id:
             return JsonResponse({'error': ERROR_BASKET_ID_NOT_PROVIDED}, status=400)
-        logger.info(LOGGER_PAYMENT_APPROVED, receipt.get('transactionId'), request.user.id)
+        logger.info(LOGGER_EXECUTE_STARTED, request.user.username, basket_id, self.payment_processor.NAME)
 
         try:
             basket = self._get_basket(request, basket_id)
         except ObjectDoesNotExist:
-            logger.exception(LOGGER_BASKET_NOT_FOUND, basket_id)
+            logger.exception(LOGGER_BASKET_NOT_FOUND, basket_id, request.user.username)
             return JsonResponse({'error': ERROR_BASKET_NOT_FOUND.format(basket_id)}, status=400)
         except AlreadyPlacedOrderException:
+            logger.exception(LOGGER_EXECUTE_ALREADY_PURCHASED, request.user.username, basket_id)
             return JsonResponse({'error': _(ERROR_ALREADY_PURCHASED)}, status=406)
-        except:  # pylint: disable=bare-except
-            error_message = ERROR_WHILE_OBTAINING_BASKET_FOR_USER.format(request.user.email)
-            logger.exception(error_message)
-            return JsonResponse({'error': error_message}, status=400)
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.exception(LOGGER_EXECUTE_ERROR_WHILE_OBTAINING_BASKET, request.user.username, basket_id, str(exc))
+            return JsonResponse({'error': ERROR_WHILE_OBTAINING_BASKET_FOR_USER.format(request.user.email)}, status=400)
 
         try:
             with transaction.atomic():
                 try:
                     self.handle_payment(receipt, basket)
                 except RedundantPaymentNotificationError:
+                    logger.exception(LOGGER_EXECUTE_REDUNDANT_PAYMENT, request.user.username, basket_id)
                     return JsonResponse({'error': COURSE_ALREADY_PAID_ON_DEVICE}, status=409)
-                except PaymentError:
+                except PaymentError as exception:
+                    logger.exception(LOGGER_EXECUTE_PAYMENT_ERROR, request.user.username, basket_id, str(exception))
                     return JsonResponse({'error': ERROR_DURING_PAYMENT_HANDLING}, status=400)
-        except:  # pylint: disable=bare-except
-            logger.exception(LOGGER_PAYMENT_FAILED_FOR_BASKET, basket.id)
+        except Exception as exception:  # pylint: disable=broad-except
+            logger.exception(LOGGER_PAYMENT_FAILED_FOR_BASKET, basket_id, str(exception))
             return JsonResponse({'error': ERROR_DURING_PAYMENT_HANDLING}, status=400)
 
         try:
             order = self.create_order(request, basket)
-        except Exception:  # pylint: disable=broad-except
-            # Any errors here will be logged in the create_order method. If we wanted any
-            # IAP specific logging for this error, we would do that here.
+        except Exception as exception:  # pylint: disable=broad-except
+            logger.exception(LOGGER_EXECUTE_ORDER_CREATION_FAILED, request.user.username, basket_id, str(exception))
             return JsonResponse({'error': ERROR_DURING_ORDER_CREATION}, status=400)
 
         try:
@@ -226,19 +254,8 @@ class MobileCoursePurchaseExecutionView(EdxOrderPlacementMixin, APIView):
             self.log_order_placement_exception(basket.order_number, basket.id)
             return JsonResponse({'error': ERROR_DURING_POST_ORDER_OP}, status=200)
 
+        logger.info(LOGGER_EXECUTE_SUCCESSFUL, request.user.username, basket_id, self.payment_processor.NAME)
         return JsonResponse({'order_data': MobileOrderSerializer(order, context={'request': request}).data}, status=200)
-
-
-class MobileCheckoutView(APIView):
-    permission_classes = (IsAuthenticated,)
-
-    def post(self, request):
-        # TODO: Add check for products_in_basket_already_purchased
-        response = CheckoutView.as_view()(request._request)  # pylint: disable=W0212
-        if response.status_code != 200:
-            return JsonResponse({'error': response.content.decode()}, status=response.status_code)
-
-        return response
 
 
 class BaseRefund(APIView):
@@ -274,6 +291,8 @@ class BaseRefund(APIView):
                 PaymentProcessorResponse.objects.create(processor_name=self.processor_name,
                                                         transaction_id=transaction_id,
                                                         response=processor_response, basket=basket)
+                logger.info(LOGGER_REFUND_SUCCESSFUL, transaction_id, self.processor_name)
+
         except RefundCompletionException:
             logger.exception(ERROR_REFUND_NOT_COMPLETED, user.username, course_key, self.processor_name)
 


### PR DESCRIPTION
# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Add Logging to the Mobile In-app purchase flow so user journey is visibly trackable in the Splunk logs with relevant info.
Logs in the IAP checkout/ api will be added as part of a later scheduled ticket.

## Supporting information

Jira ticket: https://2u-internal.atlassian.net/browse/LEARNER-9345

## Testing instructions

Test normal mobile IAP flow via basket/ checkout/ and execute/ API.

