### PR TITLE
feat: add additional fields to EnterpriseLearnerOfferApiSerializer

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -1135,7 +1135,6 @@ class CouponListSerializer(serializers.ModelSerializer):
         fields = ('category', 'client', 'code', 'id', 'title', 'date_created')
 
 
-
 class EnterpriseLearnerOfferApiSerializer(serializers.BaseSerializer):  # pylint: disable=abstract-method
     """
     Serializer for EnterpriseOffer learner endpoint.

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -1144,6 +1144,7 @@ def _serialize_remaining_balance_value(conditional_offer):
         remaining_balance = str(remaining_balance)
     return remaining_balance
 
+
 def _serialize_remaining_balance_for_user(conditional_offer, request):
     """
     Determines the remaining balance for the user.
@@ -1152,6 +1153,7 @@ def _serialize_remaining_balance_for_user(conditional_offer, request):
         return str(conditional_offer.max_user_discount - sum_user_discounts_for_offer(request.user, conditional_offer))
     return None
 
+
 def _serialize_remaining_applications_value(conditional_offer):
     """
     Calculate and return remaining number of applications on the offer.
@@ -1159,6 +1161,7 @@ def _serialize_remaining_applications_value(conditional_offer):
     if conditional_offer.max_global_applications is not None:
         return conditional_offer.max_global_applications - conditional_offer.num_applications
     return None
+
 
 def _serialize_remaining_applications_for_user(conditional_offer, request):
     """

--- a/ecommerce/extensions/api/v2/tests/test_serializers.py
+++ b/ecommerce/extensions/api/v2/tests/test_serializers.py
@@ -17,18 +17,19 @@ Voucher = get_model('voucher', 'Voucher')
 class EnterpriseLearnerOfferApiSerializerTests(TestCase):
 
     @ddt.data(
-        (100, '74.5'),
-        (None, None)
+        (100, 25.5, '74.5'),
+        (None, None, None)
     )
     @ddt.unpack
     @mock.patch('ecommerce.extensions.api.serializers.sum_user_discounts_for_offer')
     def test_serialize_remaining_balance_for_user(
         self,
         max_user_discount,
-        expected_remaining_balance,
+        existing_user_spend,
+        expected_remaining_balance_for_user,
         mock_sum_user_discounts_for_offer
     ):
-        mock_sum_user_discounts_for_offer.return_value = 25.5
+        mock_sum_user_discounts_for_offer.return_value = existing_user_spend
         enterprise_customer_uuid = str(uuid4())
         condition = extended_factories.EnterpriseCustomerConditionFactory(
             enterprise_customer_uuid=enterprise_customer_uuid
@@ -45,4 +46,90 @@ class EnterpriseLearnerOfferApiSerializerTests(TestCase):
             }
         )
         data = serializer.to_representation(enterprise_offer)
-        assert data['remaining_balance_for_user'] == expected_remaining_balance
+        assert data['remaining_balance_for_user'] == expected_remaining_balance_for_user
+
+    @ddt.data(
+        (5250, '5250'),
+        (None, None)
+    )
+    @ddt.unpack
+    @mock.patch('ecommerce.extensions.api.serializers.calculate_remaining_offer_balance')
+    def test_serialize_remaining_balance(
+        self,
+        max_discount,
+        expected_remaining_balance,
+        mock_calculate_remaining_offer_balance
+    ):
+        mock_calculate_remaining_offer_balance.return_value = max_discount
+        enterprise_customer_uuid = str(uuid4())
+        condition = extended_factories.EnterpriseCustomerConditionFactory(
+            enterprise_customer_uuid=enterprise_customer_uuid
+        )
+        enterprise_offer = extended_factories.EnterpriseOfferFactory.create(
+            partner=self.partner,
+            condition=condition,
+        )
+        serializer = EnterpriseLearnerOfferApiSerializer(
+            data=enterprise_offer,
+            context={
+                'request': mock.MagicMock(user=UserFactory())
+            }
+        )
+        data = serializer.to_representation(enterprise_offer)
+        assert data['remaining_balance'] == expected_remaining_balance
+
+    @ddt.data(
+        (1000, 1000),
+        (None, None)
+    )
+    @ddt.unpack
+    def test_serialize_remaining_applications_for_user(
+        self,
+        max_user_applications,
+        expected_remaining_applications_for_user,
+    ):
+        enterprise_customer_uuid = str(uuid4())
+        condition = extended_factories.EnterpriseCustomerConditionFactory(
+            enterprise_customer_uuid=enterprise_customer_uuid
+        )
+        enterprise_offer = extended_factories.EnterpriseOfferFactory.create(
+            partner=self.partner,
+            condition=condition,
+            max_user_applications=max_user_applications,
+        )
+        serializer = EnterpriseLearnerOfferApiSerializer(
+            data=enterprise_offer,
+            context={
+                'request': mock.MagicMock(user=UserFactory())
+            }
+        )
+        data = serializer.to_representation(enterprise_offer)
+        assert data['remaining_applications_for_user'] == expected_remaining_applications_for_user
+
+    @ddt.data(
+        (2, 2),
+        (None, None)
+    )
+    @ddt.unpack
+    def test_serialize_remaining_applications(
+        self,
+        max_global_applications,
+        expected_remaining_applications,
+    ):
+        enterprise_customer_uuid = str(uuid4())
+        condition = extended_factories.EnterpriseCustomerConditionFactory(
+            enterprise_customer_uuid=enterprise_customer_uuid
+        )
+        enterprise_offer = extended_factories.EnterpriseOfferFactory.create(
+            partner=self.partner,
+            condition=condition,
+            max_global_applications=max_global_applications,
+        )
+        serializer = EnterpriseLearnerOfferApiSerializer(
+            data=enterprise_offer,
+            context={
+                'request': mock.MagicMock(user=UserFactory())
+            }
+        )
+        data = serializer.to_representation(enterprise_offer)
+        assert data['remaining_applications'] == expected_remaining_applications


### PR DESCRIPTION
# Description

Adds the following fields to `EnterpriseLearnerOfferApiSerializer` in support of ENT-6960:
* `enterprise_customer_uuid`
* `max_user_applications`
* `remaining_applications`
* `remaining_applications_for_user`

Also adds the `remaining_applications` to `EnterpriseAdminOfferApiSerializer`.

Related PRs:
* https://github.com/openedx/frontend-app-learner-portal-enterprise/pull/732

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?
Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
