### PR TITLE
feat: Fix capture_context error on Payment MFE

### DIFF
--- a/ecommerce/extensions/payment/processors/stripe.py
+++ b/ecommerce/extensions/payment/processors/stripe.py
@@ -111,39 +111,47 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
                 basket.id,
                 basket.order_number,
             )
-            return None
-        try:
-            stripe_response = stripe.PaymentIntent.create(
-                **self._build_payment_intent_parameters(basket),
-                # This means this payment intent can only be confirmed with secret key (as in, from ecommerce)
-                secret_key_confirmation='required',
-                # don't create a new intent for the same basket
-                idempotency_key=self.generate_basket_pi_idempotency_key(basket),
-            )
-            # id is the payment_intent_id from Stripe
-            transaction_id = stripe_response['id']
+             
+            # Create a default stripe_response object with the necessary fields to combat 400 errors
+            stripe_response = {
+                'id': '',
+                'client_secret': '',
+            }
+        else:
+            try:
+                logger.info("*** GETTING STRIPE RESPONSE ***")
+                stripe_response = stripe.PaymentIntent.create(
+                    **self._build_payment_intent_parameters(basket),
+                    # This means this payment intent can only be confirmed with secret key (as in, from ecommerce)
+                    secret_key_confirmation='required',
+                    # don't create a new intent for the same basket
+                    idempotency_key=self.generate_basket_pi_idempotency_key(basket),
+                )
+                logger.info("*** STRIPE RESPONSE %s ***", stripe_response)
+                # id is the payment_intent_id from Stripe
+                transaction_id = stripe_response['id']
 
-            basket_add_payment_intent_id_attribute(basket, transaction_id)
-        # for when basket was already created, but with different amount
-        except stripe.error.IdempotencyError:
-            # if this PI has been created before, we should be able to retrieve
-            # it from Stripe using the payment_intent_id BasketAttribute.
-            # Note that we update the PI's price in handle_processor_response
-            # before hitting the confirm endpoint, so we don't need to do that here
-            payment_intent_id_attribute = BasketAttributeType.objects.get(name=PAYMENT_INTENT_ID_ATTRIBUTE)
-            payment_intent_attr = BasketAttribute.objects.get(
-                basket=basket,
-                attribute_type=payment_intent_id_attribute
-            )
-            transaction_id = payment_intent_attr.value_text.strip()
-            logger.info(
-                'Idempotency Error: Retrieving existing Payment Intent for basket [%d]'
-                ' with transaction ID [%s] and order number [%s].',
-                basket.id,
-                transaction_id,
-                basket.order_number,
-            )
-            stripe_response = stripe.PaymentIntent.retrieve(id=transaction_id)
+                basket_add_payment_intent_id_attribute(basket, transaction_id)
+            # for when basket was already created, but with different amount
+            except stripe.error.IdempotencyError:
+                # if this PI has been created before, we should be able to retrieve
+                # it from Stripe using the payment_intent_id BasketAttribute.
+                # Note that we update the PI's price in handle_processor_response
+                # before hitting the confirm endpoint, so we don't need to do that here
+                payment_intent_id_attribute = BasketAttributeType.objects.get(name=PAYMENT_INTENT_ID_ATTRIBUTE)
+                payment_intent_attr = BasketAttribute.objects.get(
+                    basket=basket,
+                    attribute_type=payment_intent_id_attribute
+                )
+                transaction_id = payment_intent_attr.value_text.strip()
+                logger.info(
+                    'Idempotency Error: Retrieving existing Payment Intent for basket [%d]'
+                    ' with transaction ID [%s] and order number [%s].',
+                    basket.id,
+                    transaction_id,
+                    basket.order_number,
+                )
+                stripe_response = stripe.PaymentIntent.retrieve(id=transaction_id)
 
         new_capture_context = {
             'key_id': stripe_response['client_secret'],

--- a/ecommerce/extensions/payment/processors/stripe.py
+++ b/ecommerce/extensions/payment/processors/stripe.py
@@ -110,8 +110,7 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
                 'Stripe capture-context called with empty basket [%d] and order number [%s].',
                 basket.id,
                 basket.order_number,
-            )
-             
+            )             
             # Create a default stripe_response object with the necessary fields to combat 400 errors
             stripe_response = {
                 'id': '',

--- a/ecommerce/extensions/payment/processors/stripe.py
+++ b/ecommerce/extensions/payment/processors/stripe.py
@@ -110,7 +110,7 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
                 'Stripe capture-context called with empty basket [%d] and order number [%s].',
                 basket.id,
                 basket.order_number,
-            )             
+            )
             # Create a default stripe_response object with the necessary fields to combat 400 errors
             stripe_response = {
                 'id': '',

--- a/ecommerce/extensions/payment/tests/views/test_stripe.py
+++ b/ecommerce/extensions/payment/tests/views/test_stripe.py
@@ -265,15 +265,6 @@ class StripeCheckoutViewTests(PaymentEventsMixin, TestCase):
                 assert mock_retrieve.call_args.kwargs['id'] == 'pi_3LsftNIadiFyUl1x2TWxaADZ'
 
     def test_capture_context_empty_basket(self):
-        # basket = create_basket(owner=self.user, site=self.site)
-        # basket.flush()
-
-        # with mock.patch('stripe.PaymentIntent.create') as mock_create:
-        #     self.assertTrue(basket.is_empty)
-        #     response = self.client.get(self.capture_context_url)
-        #     mock_create.assert_not_called()
-        #     self.assertDictEqual(response.json(), {})
-        #     self.assertEqual(response.status_code, 400)
         basket = create_basket(owner=self.user, site=self.site)
         basket.flush()
 
@@ -287,7 +278,12 @@ class StripeCheckoutViewTests(PaymentEventsMixin, TestCase):
             response = self.client.get(self.capture_context_url)
 
             mock_create.assert_not_called()
-            self.assertDictEqual(response.json(), mock_create.return_value)
+            self.assertDictEqual(response.json(), {
+                'capture_context': {
+                    'key_id': mock_create.return_value['client_secret'],
+                    'order_id': basket.order_number,
+                }
+            })
             self.assertEqual(response.status_code, 200)
 
     def test_payment_error_no_basket(self):

--- a/ecommerce/extensions/payment/tests/views/test_stripe.py
+++ b/ecommerce/extensions/payment/tests/views/test_stripe.py
@@ -265,15 +265,30 @@ class StripeCheckoutViewTests(PaymentEventsMixin, TestCase):
                 assert mock_retrieve.call_args.kwargs['id'] == 'pi_3LsftNIadiFyUl1x2TWxaADZ'
 
     def test_capture_context_empty_basket(self):
+        # basket = create_basket(owner=self.user, site=self.site)
+        # basket.flush()
+
+        # with mock.patch('stripe.PaymentIntent.create') as mock_create:
+        #     self.assertTrue(basket.is_empty)
+        #     response = self.client.get(self.capture_context_url)
+        #     mock_create.assert_not_called()
+        #     self.assertDictEqual(response.json(), {})
+        #     self.assertEqual(response.status_code, 400)
         basket = create_basket(owner=self.user, site=self.site)
         basket.flush()
 
         with mock.patch('stripe.PaymentIntent.create') as mock_create:
+            mock_create.return_value = {
+                'id': '',
+                'client_secret': '',
+            }
+
             self.assertTrue(basket.is_empty)
             response = self.client.get(self.capture_context_url)
+
             mock_create.assert_not_called()
-            self.assertDictEqual(response.json(), {})
-            self.assertEqual(response.status_code, 400)
+            self.assertDictEqual(response.json(), mock_create.return_value)
+            self.assertEqual(response.status_code, 200)
 
     def test_payment_error_no_basket(self):
         """


### PR DESCRIPTION
REV-3545 Payment MFE: Empty basket page shows "Unexpected error"

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 

## Description
The capture_context endpoint throws a 400 error because it does not generate a stripe_response when is get_capture_context called. This is due to an if condition that checks if the cart is empty (has no line items) and returns ‘None' before a stripe_response and the capture_context can be created and returned. To bypass this issue I have removed the return from the if condition and added a default stripe_response that can be called upon the same way a populated cart would.

## Testing instructions
- [ ] Ensure there is no capture_context 400 error in devtools console.
- [ ] Ensure payment process is not broken on populated carts (make a test purchase)

