### PR TITLE
feat: Add enterprise_customer_name in the event metadata for offer usage braze emails.

### DIFF
--- a/ecommerce/enterprise/management/commands/send_api_triggered_offer_emails.py
+++ b/ecommerce/enterprise/management/commands/send_api_triggered_offer_emails.py
@@ -225,6 +225,7 @@ class Command(BaseCommand):
             'current_usage_str': current_usage if is_enrollment_limit_offer else money_template.format(current_usage),
             'remaining_balance': remaining_balance,
             'remaining_balance_str': remaining_balance_str,
+            'enterprise_customer_name': offer.condition.enterprise_customer_name,
         }
 
     @staticmethod

--- a/ecommerce/enterprise/tests/test_send_enterprise_offer_limit_emails.py
+++ b/ecommerce/enterprise/tests/test_send_enterprise_offer_limit_emails.py
@@ -148,6 +148,7 @@ class SendEnterpriseOfferLimitEmailsTests(TestCase, SiteMixin, EnterpriseService
                         'offer_type': 'Booking', 'offer_name': offer_with_low_balance.name,
                         'current_usage': 7500.0, 'current_usage_str': '$7,500.00',
                         'remaining_balance': 2500.0, 'remaining_balance_str': '$2,500.00',
+                        'enterprise_customer_name': offer_with_low_balance.condition.enterprise_customer_name,
                     },
                     campaign_id=settings.CAMPAIGN_IDS_BY_EMAIL_TYPE[OfferUsageEmailTypes.LOW_BALANCE]
                 ),
@@ -160,6 +161,8 @@ class SendEnterpriseOfferLimitEmailsTests(TestCase, SiteMixin, EnterpriseService
                         'offer_type': 'Booking', 'offer_name': offer_with_low_balance_email_sent_before.name,
                         'current_usage': 7500.0, 'current_usage_str': '$7,500.00',
                         'remaining_balance': 2500.0, 'remaining_balance_str': '$2,500.00',
+                        'enterprise_customer_name':
+                            offer_with_low_balance_email_sent_before.condition.enterprise_customer_name,
                     },
                     campaign_id=settings.CAMPAIGN_IDS_BY_EMAIL_TYPE[OfferUsageEmailTypes.DIGEST]
                 ),
@@ -173,6 +176,8 @@ class SendEnterpriseOfferLimitEmailsTests(TestCase, SiteMixin, EnterpriseService
                         'offer_name': replenished_offer_with_low_balance_email_sent_before.name,
                         'current_usage': 15000.0, 'current_usage_str': '$15,000.00',
                         'remaining_balance': 5000.0, 'remaining_balance_str': '$5,000.00',
+                        'enterprise_customer_name':
+                            replenished_offer_with_low_balance_email_sent_before.condition.enterprise_customer_name,
                     },
                     campaign_id=settings.CAMPAIGN_IDS_BY_EMAIL_TYPE[OfferUsageEmailTypes.LOW_BALANCE]
                 ),
@@ -254,6 +259,7 @@ class SendEnterpriseOfferLimitEmailsTests(TestCase, SiteMixin, EnterpriseService
                         'offer_type': 'Booking', 'offer_name': offer_with_no_balance.name,
                         'current_usage': 9900.0, 'current_usage_str': '$9,900.00',
                         'remaining_balance': 100.0, 'remaining_balance_str': '$100.00',
+                        'enterprise_customer_name': offer_with_no_balance.condition.enterprise_customer_name,
                     },
                     campaign_id=settings.CAMPAIGN_IDS_BY_EMAIL_TYPE[OfferUsageEmailTypes.OUT_OF_BALANCE]
                 ),
@@ -266,6 +272,8 @@ class SendEnterpriseOfferLimitEmailsTests(TestCase, SiteMixin, EnterpriseService
                         'offer_type': 'Booking', 'offer_name': replenished_offer_with_no_balance_email_sent_before.name,
                         'current_usage': 19900.0, 'current_usage_str': '$19,900.00',
                         'remaining_balance': 100.0, 'remaining_balance_str': '$100.00',
+                        'enterprise_customer_name':
+                            replenished_offer_with_no_balance_email_sent_before.condition.enterprise_customer_name,
                     },
                     campaign_id=settings.CAMPAIGN_IDS_BY_EMAIL_TYPE[OfferUsageEmailTypes.OUT_OF_BALANCE]
                 ),
@@ -343,6 +351,7 @@ class SendEnterpriseOfferLimitEmailsTests(TestCase, SiteMixin, EnterpriseService
                         'total_limit': 10000.0, 'offer_name': offer_1.name, 'current_usage': 5000.0,
                         'current_usage_str': '$5,000.00',
                         'remaining_balance': 5000.0, 'remaining_balance_str': '$5,000.00',
+                        'enterprise_customer_name': offer_1.condition.enterprise_customer_name,
                     },
                     campaign_id=settings.CAMPAIGN_IDS_BY_EMAIL_TYPE[OfferUsageEmailTypes.DIGEST]
                 ),
@@ -355,6 +364,7 @@ class SendEnterpriseOfferLimitEmailsTests(TestCase, SiteMixin, EnterpriseService
                         'offer_type': 'Booking', 'offer_name': offer_2.name, 'current_usage': 5000.0,
                         'current_usage_str': '$5,000.00',
                         'remaining_balance': 5000.0, 'remaining_balance_str': '$5,000.00',
+                        'enterprise_customer_name': offer_2.condition.enterprise_customer_name,
                     },
                     campaign_id=settings.CAMPAIGN_IDS_BY_EMAIL_TYPE[OfferUsageEmailTypes.DIGEST]
                 ),
@@ -367,6 +377,7 @@ class SendEnterpriseOfferLimitEmailsTests(TestCase, SiteMixin, EnterpriseService
                         'offer_type': 'Enrollment', 'offer_name': offer_with_daily_frequency.name, 'current_usage': 0,
                         'current_usage_str': 0,
                         'remaining_balance': 10, 'remaining_balance_str': '10',
+                        'enterprise_customer_name': offer_with_daily_frequency.condition.enterprise_customer_name,
                     },
                     campaign_id=settings.CAMPAIGN_IDS_BY_EMAIL_TYPE[OfferUsageEmailTypes.DIGEST]
                 ),
@@ -379,6 +390,7 @@ class SendEnterpriseOfferLimitEmailsTests(TestCase, SiteMixin, EnterpriseService
                         'offer_type': 'Enrollment', 'offer_name': offer_with_weekly_frequency.name, 'current_usage': 0,
                         'current_usage_str': 0,
                         'remaining_balance': 10, 'remaining_balance_str': '10',
+                        'enterprise_customer_name': offer_with_weekly_frequency.condition.enterprise_customer_name,
                     },
                     campaign_id=settings.CAMPAIGN_IDS_BY_EMAIL_TYPE[OfferUsageEmailTypes.DIGEST]
                 ),
@@ -391,6 +403,7 @@ class SendEnterpriseOfferLimitEmailsTests(TestCase, SiteMixin, EnterpriseService
                         'offer_name': offer_with_monthly_frequency.name,
                         'current_usage': 0, 'current_usage_str': 0,
                         'remaining_balance': 10, 'remaining_balance_str': '10',
+                        'enterprise_customer_name': offer_with_monthly_frequency.condition.enterprise_customer_name,
                     },
                     campaign_id=settings.CAMPAIGN_IDS_BY_EMAIL_TYPE[OfferUsageEmailTypes.DIGEST]
                 ),
@@ -434,6 +447,7 @@ class SendEnterpriseOfferLimitEmailsTests(TestCase, SiteMixin, EnterpriseService
                         'offer_type': 'Booking', 'offer_name': offer_1.name, 'current_usage': 5000.0,
                         'current_usage_str': '$5,000.00',
                         'remaining_balance': 5000.0, 'remaining_balance_str': '$5,000.00',
+                        'enterprise_customer_name': offer_1.condition.enterprise_customer_name,
                     },
                     campaign_id=settings.CAMPAIGN_IDS_BY_EMAIL_TYPE[OfferUsageEmailTypes.DIGEST]
                 ),


### PR DESCRIPTION
# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)


## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description
This PR adds `enterprise_customer_name` into the event metadata for offer usage braze emails. The customer name will be used inside the email body. 

Useful information to include:
- This change will not affect anything, it is a small change that adds a field in the event metadata sent to Braze.

## Supporting information
__Jira Ticket:__ [ENT-7064](https://2u-internal.atlassian.net/browse/ENT-7064)

## Testing instructions
1. This is  just an addition of a field inside event metadata, it will be tested once I update braze campaign and use these field inside the email body.

## Other information
After this PR is merged and deployed, I will update corresponding braze campaign linked on the attached Jira Ticket.
