### PR TITLE
fix: Enable TrackingMiddleware for Mobile IAP basket api call

### DIFF
--- a/ecommerce/extensions/iap/api/v1/views.py
+++ b/ecommerce/extensions/iap/api/v1/views.py
@@ -11,6 +11,7 @@ from django.utils.decorators import method_decorator
 from django.utils.html import escape
 from django.utils.translation import ugettext as _
 from edx_django_utils import monitoring as monitoring_utils
+from edx_rest_framework_extensions.permissions import LoginRedirectIfUnauthenticated
 from googleapiclient.discovery import build
 from oauth2client.service_account import ServiceAccountCredentials
 from oscar.apps.basket.views import *  # pylint: disable=wildcard-import, unused-wildcard-import
@@ -87,7 +88,7 @@ class MobileBasketAddItemsView(BasketLogicMixin, APIView):
     """
     View that adds single or multiple products to a mobile user's basket.
     """
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (LoginRedirectIfUnauthenticated,)
 
     def get(self, request):
         # Send time when this view is called - https://openedx.atlassian.net/browse/REV-984


### PR DESCRIPTION
# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Enable `TrackingMiddleware` for Mobile IAP basket api call.
The `TrackingMiddleware` checks if the request.user object is authenticated. In case of Mobile api call, the user is JWT authenticated user, and request.user has the right object only if it is set by `edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware`. The pre-requisite of edx_rest_framework_extensions to process a view is that the view is using the permission class `LoginRedirectIfUnauthenticated` which is basically an abstraction over the previously used `isAuthenticated` class.

Hence the permission class has been changed, and no change in tests is needed.

## Supporting information

Jira Ticket: https://2u-internal.atlassian.net/browse/LEARNER-9368
Related Documentation:
- https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0009-jwt-in-session-cookie.rst
- https://github.com/openedx/ecommerce/blob/master/docs/decisions/0004-unique-identifier-for-users.rst


## Testing instructions

Authenticate a user via JWT using POSTMAN and create a basket using the API `{{ecommerce_domain}}/api/iap/v1/basket/add/?sku={{sku}}`.

