### PR TITLE
feat: adds salesforce_opportunity_line_item field to ConditionalOffer model

### DIFF
--- a/ecommerce/extensions/offer/models.py
+++ b/ecommerce/extensions/offer/models.py
@@ -214,6 +214,7 @@ class ConditionalOffer(AbstractConditionalOffer):
     UPDATABLE_OFFER_FIELDS = ['email_domains', 'max_uses']
     email_domains = models.CharField(max_length=255, blank=True, null=True)
     sales_force_id = models.CharField(max_length=30, blank=True, null=True)
+    salesforce_opportunity_line_item = models.CharField(max_length=30, blank=True, null=True)
     max_user_discount = models.DecimalField(
         verbose_name='Max user discount',
         max_digits=12,

--- a/ecommerce/settings/devstack.py
+++ b/ecommerce/settings/devstack.py
@@ -51,12 +51,12 @@ JWT_AUTH.update({
 })
 
 CORS_ORIGIN_WHITELIST = (
-    'http://localhost:1991',
+    'http://localhost:1991', # Enterprise Admin Portal MFE
     'http://localhost:1996',
     'http://localhost:1997', # Account MFE
     'http://localhost:1998',
     'http://localhost:2000', # Learning MFE
-    'http://localhost:8734',
+    'http://localhost:8734', # Enterprise Learner Portal MFE
 )
 CORS_ALLOW_HEADERS = corsheaders_default_headers + (
     'use-jwt-cookie',


### PR DESCRIPTION
## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 

## Description
https://2u-internal.atlassian.net/browse/ENT-7013

As an enterprise data analyst, I want all current products to utilize “Opportunity Product” as a financial key, so that the new universal order form + learner credit + rev rec + old products will work in harmony

Change salesforce_opprotunity_id to Opportunity

## Supporting information
https://2u-internal.atlassian.net/browse/ENT-7013