### PR TITLE
fix: pytest-selenium, pytest-variables, pyjwkest dependency issues

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ analytics-python==1.4.post1
     # via -r requirements/base.in
 app-store-notifications-v2-validator==0.0.7
     # via -r requirements/base.in
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
 asn1crypto==1.5.1
     # via cybersource-rest-client-python
@@ -39,13 +39,13 @@ billiard==3.6.4.0
     # via celery
 bleach==6.0.0
     # via -r requirements/base.in
-boto3==1.26.133
+boto3==1.26.155
     # via -r requirements/base.in
-botocore==1.29.133
+botocore==1.29.155
     # via
     #   boto3
     #   s3transfer
-cachetools==5.3.0
+cachetools==5.3.1
     # via google-auth
 celery==4.4.7
     # via
@@ -72,20 +72,16 @@ click==8.1.3
 configparser==5.3.0
     # via cybersource-rest-client-python
 coreapi==2.3.3
-    # via
-    #   -r requirements/base.in
-    #   drf-yasg
+    # via -r requirements/base.in
 coreschema==0.0.4
-    # via
-    #   coreapi
-    #   drf-yasg
-coverage==7.2.5
+    # via coreapi
+coverage==7.2.7
     # via cybersource-rest-client-python
 crispy-bootstrap3==2022.1
     # via -r requirements/base.in
 crypto==1.4.1
     # via cybersource-rest-client-python
-cryptography==40.0.2
+cryptography==41.0.1
     # via
     #   app-store-notifications-v2-validator
     #   cybersource-rest-client-python
@@ -95,7 +91,7 @@ cryptography==40.0.2
     #   social-auth-core
 cssselect==1.2.0
     # via premailer
-cssutils==2.6.0
+cssutils==2.7.1
     # via premailer
 cybersource-rest-client-python==0.0.21
     # via
@@ -148,7 +144,7 @@ django-compressor==4.3.1
     #   django-libsass
 django-config-models==2.3.0
     # via -r requirements/base.in
-django-cors-headers==3.14.0
+django-cors-headers==4.1.0
     # via -r requirements/base.in
 django-crispy-forms==2.0
     # via
@@ -158,7 +154,7 @@ django-crum==0.7.9
     # via
     #   edx-django-utils
     #   edx-rbac
-django-extensions==3.2.1
+django-extensions==3.2.3
     # via -r requirements/base.in
 django-extra-views==0.13.0
     # via django-oscar
@@ -180,7 +176,7 @@ django-simple-history==3.0.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
-django-solo==2.0.0
+django-solo==2.1.0
     # via -r requirements/base.in
 django-tables2==2.4.1
     # via django-oscar
@@ -213,7 +209,7 @@ drf-extensions==0.7.1
     # via -r requirements/base.in
 drf-jwt==1.19.2
     # via edx-drf-extensions
-drf-yasg==1.21.5
+drf-yasg==1.21.6
     # via -r requirements/base.in
 edx-auth-backends==4.1.0
     # via -r requirements/base.in
@@ -223,18 +219,18 @@ edx-django-release-util==1.2.0
     # via -r requirements/base.in
 edx-django-sites-extensions==4.0.0
     # via -r requirements/base.in
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/base.in
     #   django-config-models
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   getsmarter-api-clients
-edx-drf-extensions==8.7.0
+edx-drf-extensions==8.8.0
     # via
     #   -r requirements/base.in
     #   edx-rbac
-edx-ecommerce-worker==3.3.3
+edx-ecommerce-worker==3.3.4
     # via -r requirements/base.in
 edx-opaque-keys==2.3.0
     # via
@@ -242,7 +238,7 @@ edx-opaque-keys==2.3.0
     #   edx-drf-extensions
 edx-rbac==1.7.0
     # via -r requirements/base.in
-edx-rest-api-client==5.5.0
+edx-rest-api-client==5.5.2
     # via
     #   -r requirements/base.in
     #   edx-ecommerce-worker
@@ -254,9 +250,9 @@ extras==1.0.0
     #   python-subunit
 factory-boy==2.12.0
     # via django-oscar
-faker==18.7.0
+faker==18.10.1
     # via factory-boy
-fixtures==4.0.1
+fixtures==4.1.0
     # via
     #   cybersource-rest-client-python
     #   testtools
@@ -266,24 +262,22 @@ frozenlist==1.3.3
     #   aiosignal
 funcsigs==1.0.2
     # via cybersource-rest-client-python
-future==0.18.3
-    # via pyjwkest
-getsmarter-api-clients==0.5.4
+getsmarter-api-clients==0.6.0
     # via -r requirements/base.in
-google-api-core==2.11.0
+google-api-core==2.11.1
     # via google-api-python-client
 google-api-python-client==2.31.0
     # via
     #   -r requirements/base.in
     #   inapppy
-google-auth==2.18.0
+google-auth==2.20.0
     # via
     #   google-api-core
     #   google-api-python-client
     #   google-auth-httplib2
 google-auth-httplib2==0.1.0
     # via google-api-python-client
-googleapis-common-protos==1.59.0
+googleapis-common-protos==1.59.1
     # via google-api-core
 httplib2==0.20.2
     # via
@@ -339,7 +333,7 @@ lxml==4.9.2
     #   zeep
 markdown==2.6.9
     # via -r requirements/base.in
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 monotonic==1.6
     # via analytics-python
@@ -370,7 +364,7 @@ oauthlib==3.2.2
     #   social-auth-core
 packaging==23.1
     # via drf-yasg
-paramiko==3.1.0
+paramiko==3.2.0
     # via cybersource-rest-client-python
 path-py==7.2
     # via -r requirements/base.in
@@ -382,17 +376,17 @@ pbr==5.11.1
     #   fixtures
     #   stevedore
     #   testtools
-phonenumbers==8.13.11
+phonenumbers==8.13.14
     # via django-oscar
 pillow==9.5.0
     # via django-oscar
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==3.5.1
+platformdirs==3.6.0
     # via zeep
 premailer==2.9.2
     # via -r requirements/base.in
-protobuf==4.23.0
+protobuf==4.23.3
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -419,16 +413,12 @@ pycparser==2.21
     #   app-store-notifications-v2-validator
     #   cffi
     #   cybersource-rest-client-python
-pycryptodome==3.17
+pycryptodome==3.18.0
     # via cybersource-rest-client-python
-pycryptodomex==3.17
-    # via
-    #   cybersource-rest-client-python
-    #   pyjwkest
+pycryptodomex==3.18.0
+    # via cybersource-rest-client-python
 pygments==2.15.1
     # via -r requirements/base.in
-pyjwkest==1.4.2
-    # via edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   app-store-notifications-v2-validator
@@ -445,13 +435,13 @@ pynacl==1.5.0
     #   cybersource-rest-client-python
     #   edx-django-utils
     #   paramiko
-pyopenssl==23.1.1
+pyopenssl==23.2.0
     # via
     #   app-store-notifications-v2-validator
     #   cybersource-rest-client-python
     #   ndg-httpsclient
     #   paypalrestsdk
-pyparsing==3.0.9
+pyparsing==3.1.0
     # via httplib2
 pypi==2.1
     # via cybersource-rest-client-python
@@ -490,13 +480,14 @@ pytz==2023.3
 pyyaml==6.0
     # via
     #   cybersource-rest-client-python
+    #   drf-yasg
     #   edx-django-release-util
     #   naked
 rcssmin==1.1.1
     # via django-compressor
 redis==4.5.5
     # via edx-ecommerce-worker
-requests==2.30.0
+requests==2.31.0
     # via
     #   -r requirements/base.in
     #   analytics-python
@@ -508,7 +499,6 @@ requests==2.30.0
     #   inapppy
     #   naked
     #   paypalrestsdk
-    #   pyjwkest
     #   requests-file
     #   requests-oauthlib
     #   requests-toolbelt
@@ -532,10 +522,6 @@ rsa==4.9
     #   google-auth
     #   inapppy
     #   oauth2client
-ruamel-yaml==0.17.26
-    # via drf-yasg
-ruamel-yaml-clib==0.2.7
-    # via ruamel-yaml
 rules==3.3
     # via -r requirements/base.in
 s3transfer==0.6.1
@@ -567,7 +553,6 @@ six==1.16.0
     #   oauth2client
     #   paypalrestsdk
     #   purl
-    #   pyjwkest
     #   python-dateutil
     #   requests-file
 slumber==0.7.1
@@ -584,7 +569,7 @@ sorl-thumbnail==12.9.0
     # via -r requirements/base.in
 sqlparse==0.4.4
     # via django
-stevedore==5.0.0
+stevedore==5.1.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
@@ -598,6 +583,8 @@ traceback2==1.4.0
     # via cybersource-rest-client-python
 typing==3.7.4.3
     # via cybersource-rest-client-python
+typing-extensions==4.6.3
+    # via asgiref
 unicodecsv==0.14.1
     # via
     #   -r requirements/base.in
@@ -607,7 +594,7 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-yasg
     #   google-api-python-client
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   -c requirements/constraints.txt
     #   botocore

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -33,9 +33,15 @@ idna==2.7
 # TODO : Pinning this until we are sure there aren't any breaking changes, then we'll upgrade.
 celery<5.0.0
 
-# bok-choy 1.1.1 requires <4 (can remove once we have a version without that requirement)
+# bok-choy 2.0.1 still requires selenium<4
+# (bok-choy is now deprecated; updates unlikely)
+# - pytest-selenium v3 has inconsistent pytest dependency requirements
+#   (see pytest-selenium/issues/294)
+# - pytest-variables v3 uses pytest.stash instead of _variables. This
+#   conflicts with how pytest-selenium uses variables prior to v3.
 selenium<4.0.0
-pytest-selenium<4.0.0
+pytest-selenium<3.0.0
+pytest-variables<3.0.0
 
 # pylint>2.12.2 requires a lot of quality fixes. Can be resolved later on.
 pylint==2.12.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -28,7 +28,7 @@ analytics-python==1.4.post1
     # via -r requirements/test.txt
 app-store-notifications-v2-validator==0.0.7
     # via -r requirements/test.txt
-asgiref==3.6.0
+asgiref==3.7.2
     # via
     #   -r requirements/test.txt
     #   django
@@ -50,7 +50,6 @@ attrs==23.1.0
     #   -r requirements/test.txt
     #   aiohttp
     #   jsonschema
-    #   pytest
     #   zeep
 babel==2.12.1
     # via
@@ -82,14 +81,14 @@ bleach==6.0.0
     # via -r requirements/test.txt
 bok-choy==2.0.2
     # via -r requirements/test.txt
-boto3==1.26.133
+boto3==1.26.155
     # via -r requirements/test.txt
-botocore==1.29.133
+botocore==1.29.155
     # via
     #   -r requirements/test.txt
     #   boto3
     #   s3transfer
-cachetools==5.3.0
+cachetools==5.3.1
     # via
     #   -r requirements/test.txt
     #   google-auth
@@ -130,15 +129,12 @@ configparser==5.3.0
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
 coreapi==2.3.3
-    # via
-    #   -r requirements/test.txt
-    #   drf-yasg
+    # via -r requirements/test.txt
 coreschema==0.0.4
     # via
     #   -r requirements/test.txt
     #   coreapi
-    #   drf-yasg
-coverage[toml]==7.2.5
+coverage[toml]==7.2.7
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -149,7 +145,7 @@ crypto==1.4.1
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-cryptography==40.0.2
+cryptography==41.0.1
     # via
     #   -r requirements/test.txt
     #   app-store-notifications-v2-validator
@@ -162,7 +158,7 @@ cssselect==1.2.0
     # via
     #   -r requirements/test.txt
     #   premailer
-cssutils==2.6.0
+cssutils==2.7.1
     # via
     #   -r requirements/test.txt
     #   premailer
@@ -179,7 +175,7 @@ defusedxml==0.7.1
     #   -r requirements/test.txt
     #   python3-openid
     #   social-auth-core
-diff-cover==7.5.0
+diff-cover==7.6.0
     # via -r requirements/test.txt
 django==3.2.19
     # via
@@ -225,7 +221,7 @@ django-compressor==4.3.1
     #   django-libsass
 django-config-models==2.3.0
     # via -r requirements/test.txt
-django-cors-headers==3.14.0
+django-cors-headers==4.1.0
     # via -r requirements/test.txt
 django-crispy-forms==2.0
     # via
@@ -236,9 +232,9 @@ django-crum==0.7.9
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-rbac
-django-debug-toolbar==4.0.0
+django-debug-toolbar==4.1.0
     # via -r requirements/dev.in
-django-extensions==3.2.1
+django-extensions==3.2.3
     # via -r requirements/test.txt
 django-extra-views==0.13.0
     # via
@@ -264,7 +260,7 @@ django-phonenumber-field==5.0.0
     #   django-oscar
 django-simple-history==3.0.0
     # via -r requirements/test.txt
-django-solo==2.0.0
+django-solo==2.1.0
     # via -r requirements/test.txt
 django-tables2==2.4.1
     # via
@@ -312,7 +308,7 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-drf-yasg==1.21.5
+drf-yasg==1.21.6
     # via -r requirements/test.txt
 edx-auth-backends==4.1.0
     # via -r requirements/test.txt
@@ -324,18 +320,18 @@ edx-django-release-util==1.2.0
     # via -r requirements/test.txt
 edx-django-sites-extensions==4.0.0
     # via -r requirements/test.txt
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/test.txt
     #   django-config-models
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   getsmarter-api-clients
-edx-drf-extensions==8.7.0
+edx-drf-extensions==8.8.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-edx-ecommerce-worker==3.3.3
+edx-ecommerce-worker==3.3.4
     # via -r requirements/test.txt
 edx-i18n-tools==0.9.2
     # via -r requirements/test.txt
@@ -345,7 +341,7 @@ edx-opaque-keys==2.3.0
     #   edx-drf-extensions
 edx-rbac==1.7.0
     # via -r requirements/test.txt
-edx-rest-api-client==5.5.0
+edx-rest-api-client==5.5.2
     # via
     #   -r requirements/test.txt
     #   edx-ecommerce-worker
@@ -353,6 +349,10 @@ enum34==1.1.10
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
+exceptiongroup==1.1.1
+    # via
+    #   -r requirements/test.txt
+    #   pytest
 extras==1.0.0
     # via
     #   -r requirements/test.txt
@@ -362,15 +362,15 @@ factory-boy==2.12.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
-faker==18.7.0
+faker==18.10.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.12.0
+filelock==3.12.2
     # via
     #   -r requirements/test.txt
     #   tox
-fixtures==4.0.1
+fixtures==4.1.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -390,13 +390,13 @@ future==0.18.3
     # via
     #   -r requirements/test.txt
     #   pyjwkest
-getsmarter-api-clients==0.5.4
+getsmarter-api-clients==0.6.0
     # via -r requirements/test.txt
 gitdb==4.0.10
     # via gitpython
 gitpython==3.1.31
     # via transifex-client
-google-api-core==2.11.0
+google-api-core==2.11.1
     # via
     #   -r requirements/test.txt
     #   google-api-python-client
@@ -404,7 +404,7 @@ google-api-python-client==2.31.0
     # via
     #   -r requirements/test.txt
     #   inapppy
-google-auth==2.18.0
+google-auth==2.20.0
     # via
     #   -r requirements/test.txt
     #   google-api-core
@@ -414,7 +414,7 @@ google-auth-httplib2==0.1.0
     # via
     #   -r requirements/test.txt
     #   google-api-python-client
-googleapis-common-protos==1.59.0
+googleapis-common-protos==1.59.1
     # via
     #   -r requirements/test.txt
     #   google-api-core
@@ -435,7 +435,7 @@ imagesize==1.4.1
     # via
     #   -r requirements/docs.txt
     #   sphinx
-importlib-metadata==6.6.0
+importlib-metadata==6.7.0
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -523,7 +523,7 @@ lxml==4.9.2
     #   zeep
 markdown==2.6.9
     # via -r requirements/test.txt
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -579,7 +579,7 @@ packaging==23.1
     #   pytest
     #   sphinx
     #   tox
-paramiko==3.1.0
+paramiko==3.2.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -598,7 +598,7 @@ pbr==5.11.1
     #   fixtures
     #   stevedore
     #   testtools
-phonenumbers==8.13.11
+phonenumbers==8.13.14
     # via
     #   -r requirements/test.txt
     #   django-oscar
@@ -610,7 +610,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/test.txt
     #   jsonschema
-platformdirs==3.5.1
+platformdirs==3.6.0
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -627,7 +627,7 @@ polib==1.2.0
     #   edx-i18n-tools
 premailer==2.9.2
     # via -r requirements/test.txt
-protobuf==4.23.0
+protobuf==4.23.3
     # via
     #   -r requirements/test.txt
     #   google-api-core
@@ -645,7 +645,6 @@ purl==1.6
 py==1.11.0
     # via
     #   -r requirements/test.txt
-    #   pytest
     #   pytest-html
     #   tox
 pyasn1==0.5.0
@@ -672,11 +671,11 @@ pycparser==2.21
     #   app-store-notifications-v2-validator
     #   cffi
     #   cybersource-rest-client-python
-pycryptodome==3.17
+pycryptodome==3.18.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-pycryptodomex==3.17
+pycryptodomex==3.18.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -694,9 +693,7 @@ pygments==2.15.1
     #   pydata-sphinx-theme
     #   sphinx
 pyjwkest==1.4.2
-    # via
-    #   -r requirements/test.txt
-    #   edx-drf-extensions
+    # via -r requirements/test.txt
 pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/test.txt
@@ -719,14 +716,14 @@ pynacl==1.5.0
     #   cybersource-rest-client-python
     #   edx-django-utils
     #   paramiko
-pyopenssl==23.1.1
+pyopenssl==23.2.0
     # via
     #   -r requirements/test.txt
     #   app-store-notifications-v2-validator
     #   cybersource-rest-client-python
     #   ndg-httpsclient
     #   paypalrestsdk
-pyparsing==3.0.9
+pyparsing==3.1.0
     # via
     #   -r requirements/test.txt
     #   httplib2
@@ -738,7 +735,7 @@ pyrsistent==0.19.3
     # via
     #   -r requirements/test.txt
     #   jsonschema
-pytest==6.2.5
+pytest==7.3.2
     # via
     #   -r requirements/test.txt
     #   pytest-base-url
@@ -750,11 +747,11 @@ pytest==6.2.5
     #   pytest-selenium
     #   pytest-timeout
     #   pytest-variables
-pytest-base-url==1.4.2
+pytest-base-url==2.0.0
     # via
     #   -r requirements/test.txt
     #   pytest-selenium
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.txt
 pytest-django==4.5.2
     # via -r requirements/test.txt
@@ -762,17 +759,17 @@ pytest-html==3.2.0
     # via
     #   -r requirements/test.txt
     #   pytest-selenium
-pytest-metadata==2.0.4
+pytest-metadata==3.0.0
     # via
     #   -r requirements/test.txt
     #   pytest-html
 pytest-randomly==3.12.0
     # via -r requirements/test.txt
-pytest-selenium==3.0.0
+pytest-selenium==2.0.1
     # via -r requirements/test.txt
 pytest-timeout==2.1.0
     # via -r requirements/test.txt
-pytest-variables==1.9.0
+pytest-variables==2.0.0
     # via
     #   -r requirements/test.txt
     #   pytest-selenium
@@ -826,6 +823,7 @@ pyyaml==6.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
+    #   drf-yasg
     #   edx-django-release-util
     #   edx-i18n-tools
     #   naked
@@ -838,7 +836,7 @@ redis==4.5.5
     # via
     #   -r requirements/test.txt
     #   edx-ecommerce-worker
-requests==2.30.0
+requests==2.31.0
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -890,14 +888,6 @@ rsa==4.9
     #   google-auth
     #   inapppy
     #   oauth2client
-ruamel-yaml==0.17.26
-    # via
-    #   -r requirements/test.txt
-    #   drf-yasg
-ruamel-yaml-clib==0.2.7
-    # via
-    #   -r requirements/test.txt
-    #   ruamel-yaml
 rules==3.3
     # via -r requirements/test.txt
 s3transfer==0.6.1
@@ -1009,7 +999,7 @@ sqlparse==0.4.4
     #   -r requirements/test.txt
     #   django
     #   django-debug-toolbar
-stevedore==5.0.0
+stevedore==5.1.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -1033,12 +1023,12 @@ toml==0.10.2
     # via
     #   -r requirements/test.txt
     #   pylint
-    #   pytest
     #   tox
 tomli==2.0.1
     # via
     #   -r requirements/test.txt
     #   coverage
+    #   pytest
 tox==3.14.6
     # via
     #   -r requirements/test.txt
@@ -1051,7 +1041,7 @@ traceback2==1.4.0
     #   cybersource-rest-client-python
 transifex-client==0.14.4
     # via -r requirements/dev.in
-types-pyyaml==6.0.12.9
+types-pyyaml==6.0.12.10
     # via
     #   -r requirements/test.txt
     #   responses
@@ -1059,10 +1049,11 @@ typing==3.7.4.3
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
+    #   asgiref
     #   astroid
     #   pydata-sphinx-theme
     #   pylint
@@ -1076,7 +1067,7 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-yasg
     #   google-api-python-client
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -28,11 +28,11 @@ idna==2.7
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.6.0
+importlib-metadata==6.7.0
     # via sphinx
 jinja2==3.1.2
     # via sphinx
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 packaging==23.1
     # via
@@ -47,7 +47,7 @@ pygments==2.15.1
     #   sphinx
 pytz==2023.3
     # via babel
-requests==2.30.0
+requests==2.31.0
     # via sphinx
 snowballstemmer==2.2.0
     # via sphinx
@@ -73,9 +73,9 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via pydata-sphinx-theme
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   -c requirements/constraints.txt
     #   requests

--- a/requirements/e2e.in
+++ b/requirements/e2e.in
@@ -3,6 +3,7 @@
 
 # Packages required to run e2e tests
 edx-rest-api-client
+pyjwkest
 pytest
 pytest-randomly
 pytest-selenium

--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -4,14 +4,10 @@
 #
 #    make upgrade
 #
-asgiref==3.6.0
+asgiref==3.7.2
     # via
     #   -c requirements/base.txt
     #   django
-attrs==23.1.0
-    # via
-    #   -c requirements/base.txt
-    #   pytest
 certifi==2023.5.7
     # via
     #   -c requirements/base.txt
@@ -29,7 +25,7 @@ click==8.1.3
     # via
     #   -c requirements/base.txt
     #   edx-django-utils
-cryptography==40.0.2
+cryptography==41.0.1
     # via
     #   -c requirements/base.txt
     #   pyjwt
@@ -47,20 +43,24 @@ django-waffle==3.0.0
     # via
     #   -c requirements/base.txt
     #   edx-django-utils
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -c requirements/base.txt
     #   edx-rest-api-client
-edx-rest-api-client==5.5.0
+edx-rest-api-client==5.5.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/e2e.in
+exceptiongroup==1.1.1
+    # via pytest
+future==0.18.3
+    # via pyjwkest
 idna==2.7
     # via
     #   -c requirements/base.txt
     #   -c requirements/constraints.txt
     #   requests
-importlib-metadata==6.6.0
+importlib-metadata==6.7.0
     # via pytest-randomly
 iniconfig==2.0.0
     # via pytest
@@ -85,13 +85,17 @@ psutil==5.9.5
     #   -c requirements/base.txt
     #   edx-django-utils
 py==1.11.0
-    # via
-    #   pytest
-    #   pytest-html
+    # via pytest-html
 pycparser==2.21
     # via
     #   -c requirements/base.txt
     #   cffi
+pycryptodomex==3.18.0
+    # via
+    #   -c requirements/base.txt
+    #   pyjwkest
+pyjwkest==1.4.2
+    # via -r requirements/e2e.in
 pyjwt[crypto]==2.7.0
     # via
     #   -c requirements/base.txt
@@ -100,7 +104,7 @@ pynacl==1.5.0
     # via
     #   -c requirements/base.txt
     #   edx-django-utils
-pytest==6.2.5
+pytest==7.3.2
     # via
     #   -r requirements/e2e.in
     #   pytest-base-url
@@ -110,32 +114,35 @@ pytest==6.2.5
     #   pytest-selenium
     #   pytest-timeout
     #   pytest-variables
-pytest-base-url==1.4.2
+pytest-base-url==2.0.0
     # via pytest-selenium
 pytest-html==3.2.0
     # via pytest-selenium
-pytest-metadata==2.0.4
+pytest-metadata==3.0.0
     # via pytest-html
 pytest-randomly==3.12.0
     # via -r requirements/e2e.in
-pytest-selenium==3.0.0
+pytest-selenium==2.0.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/e2e.in
 pytest-timeout==2.1.0
     # via -r requirements/e2e.in
-pytest-variables==1.9.0
-    # via pytest-selenium
+pytest-variables==2.0.0
+    # via
+    #   -c requirements/constraints.txt
+    #   pytest-selenium
 python-dotenv==1.0.0
     # via -r requirements/e2e.in
 pytz==2023.3
     # via
     #   -c requirements/base.txt
     #   django
-requests==2.30.0
+requests==2.31.0
     # via
     #   -c requirements/base.txt
     #   edx-rest-api-client
+    #   pyjwkest
     #   pytest-base-url
     #   pytest-selenium
     #   slumber
@@ -147,6 +154,7 @@ selenium==3.141.0
 six==1.16.0
     # via
     #   -c requirements/base.txt
+    #   pyjwkest
     #   tenacity
 slumber==0.7.1
     # via
@@ -156,15 +164,19 @@ sqlparse==0.4.4
     # via
     #   -c requirements/base.txt
     #   django
-stevedore==5.0.0
+stevedore==5.1.0
     # via
     #   -c requirements/base.txt
     #   edx-django-utils
 tenacity==6.3.1
     # via pytest-selenium
-toml==0.10.2
+tomli==2.0.1
     # via pytest
-urllib3==1.26.15
+typing-extensions==4.6.3
+    # via
+    #   -c requirements/base.txt
+    #   asgiref
+urllib3==1.26.16
     # via
     #   -c requirements/base.txt
     #   -c requirements/constraints.txt

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.40.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.1.2
     # via -r requirements/pip.in
-setuptools==67.7.2
+setuptools==68.0.0
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -14,7 +14,7 @@ analytics-python==1.4.post1
     # via -r requirements/base.in
 app-store-notifications-v2-validator==0.0.7
     # via -r requirements/base.in
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
 asn1crypto==1.5.1
     # via cybersource-rest-client-python
@@ -39,15 +39,15 @@ billiard==3.6.4.0
     # via celery
 bleach==6.0.0
     # via -r requirements/base.in
-boto3==1.26.133
+boto3==1.26.155
     # via
     #   -r requirements/base.in
     #   django-ses
-botocore==1.29.133
+botocore==1.29.155
     # via
     #   boto3
     #   s3transfer
-cachetools==5.3.0
+cachetools==5.3.1
     # via google-auth
 celery==4.4.7
     # via
@@ -74,20 +74,16 @@ click==8.1.3
 configparser==5.3.0
     # via cybersource-rest-client-python
 coreapi==2.3.3
-    # via
-    #   -r requirements/base.in
-    #   drf-yasg
+    # via -r requirements/base.in
 coreschema==0.0.4
-    # via
-    #   coreapi
-    #   drf-yasg
-coverage==7.2.5
+    # via coreapi
+coverage==7.2.7
     # via cybersource-rest-client-python
 crispy-bootstrap3==2022.1
     # via -r requirements/base.in
 crypto==1.4.1
     # via cybersource-rest-client-python
-cryptography==40.0.2
+cryptography==41.0.1
     # via
     #   app-store-notifications-v2-validator
     #   cybersource-rest-client-python
@@ -97,7 +93,7 @@ cryptography==40.0.2
     #   social-auth-core
 cssselect==1.2.0
     # via premailer
-cssutils==2.6.0
+cssutils==2.7.1
     # via premailer
 cybersource-rest-client-python==0.0.21
     # via
@@ -151,7 +147,7 @@ django-compressor==4.3.1
     #   django-libsass
 django-config-models==2.3.0
     # via -r requirements/base.in
-django-cors-headers==3.14.0
+django-cors-headers==4.1.0
     # via -r requirements/base.in
 django-crispy-forms==2.0
     # via
@@ -161,7 +157,7 @@ django-crum==0.7.9
     # via
     #   edx-django-utils
     #   edx-rbac
-django-extensions==3.2.1
+django-extensions==3.2.3
     # via -r requirements/base.in
 django-extra-views==0.13.0
     # via django-oscar
@@ -179,13 +175,13 @@ django-oscar==2.2
     #   -r requirements/base.in
 django-phonenumber-field==5.0.0
     # via django-oscar
-django-ses==3.4.1
+django-ses==3.5.0
     # via -r requirements/production.in
 django-simple-history==3.0.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
-django-solo==2.0.0
+django-solo==2.1.0
     # via -r requirements/base.in
 django-tables2==2.4.1
     # via django-oscar
@@ -218,7 +214,7 @@ drf-extensions==0.7.1
     # via -r requirements/base.in
 drf-jwt==1.19.2
     # via edx-drf-extensions
-drf-yasg==1.21.5
+drf-yasg==1.21.6
     # via -r requirements/base.in
 edx-auth-backends==4.1.0
     # via -r requirements/base.in
@@ -228,18 +224,18 @@ edx-django-release-util==1.2.0
     # via -r requirements/base.in
 edx-django-sites-extensions==4.0.0
     # via -r requirements/base.in
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/base.in
     #   django-config-models
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   getsmarter-api-clients
-edx-drf-extensions==8.7.0
+edx-drf-extensions==8.8.0
     # via
     #   -r requirements/base.in
     #   edx-rbac
-edx-ecommerce-worker==3.3.3
+edx-ecommerce-worker==3.3.4
     # via -r requirements/base.in
 edx-opaque-keys==2.3.0
     # via
@@ -247,7 +243,7 @@ edx-opaque-keys==2.3.0
     #   edx-drf-extensions
 edx-rbac==1.7.0
     # via -r requirements/base.in
-edx-rest-api-client==5.5.0
+edx-rest-api-client==5.5.2
     # via
     #   -r requirements/base.in
     #   edx-ecommerce-worker
@@ -259,9 +255,9 @@ extras==1.0.0
     #   python-subunit
 factory-boy==2.12.0
     # via django-oscar
-faker==18.7.0
+faker==18.10.1
     # via factory-boy
-fixtures==4.0.1
+fixtures==4.1.0
     # via
     #   cybersource-rest-client-python
     #   testtools
@@ -271,24 +267,22 @@ frozenlist==1.3.3
     #   aiosignal
 funcsigs==1.0.2
     # via cybersource-rest-client-python
-future==0.18.3
-    # via pyjwkest
-getsmarter-api-clients==0.5.4
+getsmarter-api-clients==0.6.0
     # via -r requirements/base.in
-google-api-core==2.11.0
+google-api-core==2.11.1
     # via google-api-python-client
 google-api-python-client==2.31.0
     # via
     #   -r requirements/base.in
     #   inapppy
-google-auth==2.18.0
+google-auth==2.20.0
     # via
     #   google-api-core
     #   google-api-python-client
     #   google-auth-httplib2
 google-auth-httplib2==0.1.0
     # via google-api-python-client
-googleapis-common-protos==1.59.0
+googleapis-common-protos==1.59.1
     # via google-api-core
 gunicorn==19.7.1
     # via -r requirements/production.in
@@ -346,7 +340,7 @@ lxml==4.9.2
     #   zeep
 markdown==2.6.9
     # via -r requirements/base.in
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 monotonic==1.6
     # via analytics-python
@@ -380,7 +374,7 @@ oauthlib==3.2.2
     #   social-auth-core
 packaging==23.1
     # via drf-yasg
-paramiko==3.1.0
+paramiko==3.2.0
     # via cybersource-rest-client-python
 path-py==7.2
     # via -r requirements/base.in
@@ -392,17 +386,17 @@ pbr==5.11.1
     #   fixtures
     #   stevedore
     #   testtools
-phonenumbers==8.13.11
+phonenumbers==8.13.14
     # via django-oscar
 pillow==9.5.0
     # via django-oscar
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==3.5.1
+platformdirs==3.6.0
     # via zeep
 premailer==2.9.2
     # via -r requirements/base.in
-protobuf==4.23.0
+protobuf==4.23.3
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -429,16 +423,12 @@ pycparser==2.21
     #   app-store-notifications-v2-validator
     #   cffi
     #   cybersource-rest-client-python
-pycryptodome==3.17
+pycryptodome==3.18.0
     # via cybersource-rest-client-python
-pycryptodomex==3.17
-    # via
-    #   cybersource-rest-client-python
-    #   pyjwkest
+pycryptodomex==3.18.0
+    # via cybersource-rest-client-python
 pygments==2.15.1
     # via -r requirements/base.in
-pyjwkest==1.4.2
-    # via edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   app-store-notifications-v2-validator
@@ -455,13 +445,13 @@ pynacl==1.5.0
     #   cybersource-rest-client-python
     #   edx-django-utils
     #   paramiko
-pyopenssl==23.1.1
+pyopenssl==23.2.0
     # via
     #   app-store-notifications-v2-validator
     #   cybersource-rest-client-python
     #   ndg-httpsclient
     #   paypalrestsdk
-pyparsing==3.0.9
+pyparsing==3.1.0
     # via httplib2
 pypi==2.1
     # via cybersource-rest-client-python
@@ -504,6 +494,7 @@ pyyaml==6.0
     # via
     #   -r requirements/production.in
     #   cybersource-rest-client-python
+    #   drf-yasg
     #   edx-django-release-util
     #   naked
 rcssmin==1.1.1
@@ -512,7 +503,7 @@ redis==4.5.5
     # via
     #   -r requirements/production.in
     #   edx-ecommerce-worker
-requests==2.30.0
+requests==2.31.0
     # via
     #   -r requirements/base.in
     #   analytics-python
@@ -524,7 +515,6 @@ requests==2.30.0
     #   inapppy
     #   naked
     #   paypalrestsdk
-    #   pyjwkest
     #   requests-file
     #   requests-oauthlib
     #   requests-toolbelt
@@ -548,10 +538,6 @@ rsa==4.9
     #   google-auth
     #   inapppy
     #   oauth2client
-ruamel-yaml==0.17.26
-    # via drf-yasg
-ruamel-yaml-clib==0.2.7
-    # via ruamel-yaml
 rules==3.3
     # via -r requirements/base.in
 s3transfer==0.6.1
@@ -583,7 +569,6 @@ six==1.16.0
     #   oauth2client
     #   paypalrestsdk
     #   purl
-    #   pyjwkest
     #   python-dateutil
     #   python-memcached
     #   requests-file
@@ -601,7 +586,7 @@ sorl-thumbnail==12.9.0
     # via -r requirements/base.in
 sqlparse==0.4.4
     # via django
-stevedore==5.0.0
+stevedore==5.1.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
@@ -615,6 +600,8 @@ traceback2==1.4.0
     # via cybersource-rest-client-python
 typing==3.7.4.3
     # via cybersource-rest-client-python
+typing-extensions==4.6.3
+    # via asgiref
 unicodecsv==0.14.1
     # via
     #   -r requirements/base.in
@@ -624,7 +611,7 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-yasg
     #   google-api-python-client
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   -c requirements/constraints.txt
     #   botocore

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -20,7 +20,7 @@ analytics-python==1.4.post1
     # via -r requirements/base.txt
 app-store-notifications-v2-validator==0.0.7
     # via -r requirements/base.txt
-asgiref==3.6.0
+asgiref==3.7.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -39,10 +39,8 @@ async-timeout==4.0.2
 attrs==23.1.0
     # via
     #   -r requirements/base.txt
-    #   -r requirements/e2e.txt
     #   aiohttp
     #   jsonschema
-    #   pytest
     #   zeep
 babel==2.12.1
     # via
@@ -67,14 +65,14 @@ bleach==6.0.0
     # via -r requirements/base.txt
 bok-choy==2.0.2
     # via -r requirements/test.in
-boto3==1.26.133
+boto3==1.26.155
     # via -r requirements/base.txt
-botocore==1.29.133
+botocore==1.29.155
     # via
     #   -r requirements/base.txt
     #   boto3
     #   s3transfer
-cachetools==5.3.0
+cachetools==5.3.1
     # via
     #   -r requirements/base.txt
     #   google-auth
@@ -118,15 +116,12 @@ configparser==5.3.0
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
 coreapi==2.3.3
-    # via
-    #   -r requirements/base.txt
-    #   drf-yasg
+    # via -r requirements/base.txt
 coreschema==0.0.4
     # via
     #   -r requirements/base.txt
     #   coreapi
-    #   drf-yasg
-coverage[toml]==7.2.5
+coverage[toml]==7.2.7
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
@@ -138,7 +133,7 @@ crypto==1.4.1
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-cryptography==40.0.2
+cryptography==41.0.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -152,7 +147,7 @@ cssselect==1.2.0
     # via
     #   -r requirements/base.txt
     #   premailer
-cssutils==2.6.0
+cssutils==2.7.1
     # via
     #   -r requirements/base.txt
     #   premailer
@@ -171,7 +166,7 @@ defusedxml==0.7.1
     #   -r requirements/base.txt
     #   python3-openid
     #   social-auth-core
-diff-cover==7.5.0
+diff-cover==7.6.0
     # via -r requirements/test.in
     # via
     #   -c requirements/common_constraints.txt
@@ -217,7 +212,7 @@ django-compressor==4.3.1
     #   django-libsass
 django-config-models==2.3.0
     # via -r requirements/base.txt
-django-cors-headers==3.14.0
+django-cors-headers==4.1.0
     # via -r requirements/base.txt
 django-crispy-forms==2.0
     # via
@@ -229,7 +224,7 @@ django-crum==0.7.9
     #   -r requirements/e2e.txt
     #   edx-django-utils
     #   edx-rbac
-django-extensions==3.2.1
+django-extensions==3.2.3
     # via -r requirements/base.txt
 django-extra-views==0.13.0
     # via
@@ -259,7 +254,7 @@ django-simple-history==3.0.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
-django-solo==2.0.0
+django-solo==2.1.0
     # via -r requirements/base.txt
 django-tables2==2.4.1
     # via
@@ -303,7 +298,7 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-drf-yasg==1.21.5
+drf-yasg==1.21.6
     # via -r requirements/base.txt
 edx-auth-backends==4.1.0
     # via -r requirements/base.txt
@@ -315,7 +310,7 @@ edx-django-release-util==1.2.0
     # via -r requirements/base.txt
 edx-django-sites-extensions==4.0.0
     # via -r requirements/base.txt
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -323,11 +318,11 @@ edx-django-utils==5.4.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   getsmarter-api-clients
-edx-drf-extensions==8.7.0
+edx-drf-extensions==8.8.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-edx-ecommerce-worker==3.3.3
+edx-ecommerce-worker==3.3.4
     # via -r requirements/base.txt
 edx-i18n-tools==0.9.2
     # via -r requirements/test.in
@@ -337,7 +332,7 @@ edx-opaque-keys==2.3.0
     #   edx-drf-extensions
 edx-rbac==1.7.0
     # via -r requirements/base.txt
-edx-rest-api-client==5.5.0
+edx-rest-api-client==5.5.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -346,6 +341,10 @@ enum34==1.1.10
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
+exceptiongroup==1.1.1
+    # via
+    #   -r requirements/e2e.txt
+    #   pytest
 extras==1.0.0
     # via
     #   -r requirements/base.txt
@@ -356,15 +355,15 @@ factory-boy==2.12.0
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   django-oscar
-faker==18.7.0
+faker==18.10.1
     # via
     #   -r requirements/base.txt
     #   factory-boy
-filelock==3.12.0
+filelock==3.12.2
     # via
     #   -r requirements/tox.txt
     #   tox
-fixtures==4.0.1
+fixtures==4.1.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
@@ -382,11 +381,11 @@ funcsigs==1.0.2
     #   cybersource-rest-client-python
 future==0.18.3
     # via
-    #   -r requirements/base.txt
+    #   -r requirements/e2e.txt
     #   pyjwkest
-getsmarter-api-clients==0.5.4
+getsmarter-api-clients==0.6.0
     # via -r requirements/base.txt
-google-api-core==2.11.0
+google-api-core==2.11.1
     # via
     #   -r requirements/base.txt
     #   google-api-python-client
@@ -394,7 +393,7 @@ google-api-python-client==2.31.0
     # via
     #   -r requirements/base.txt
     #   inapppy
-google-auth==2.18.0
+google-auth==2.20.0
     # via
     #   -r requirements/base.txt
     #   google-api-core
@@ -404,7 +403,7 @@ google-auth-httplib2==0.1.0
     # via
     #   -r requirements/base.txt
     #   google-api-python-client
-googleapis-common-protos==1.59.0
+googleapis-common-protos==1.59.1
     # via
     #   -r requirements/base.txt
     #   google-api-core
@@ -422,7 +421,7 @@ idna==2.7
     #   cybersource-rest-client-python
     #   requests
     #   yarl
-importlib-metadata==6.6.0
+importlib-metadata==6.7.0
     # via
     #   -r requirements/e2e.txt
     #   pytest-randomly
@@ -503,7 +502,7 @@ lxml==4.9.2
     #   zeep
 markdown==2.6.9
     # via -r requirements/base.txt
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via
     #   -r requirements/base.txt
     #   jinja2
@@ -558,7 +557,7 @@ packaging==23.1
     #   drf-yasg
     #   pytest
     #   tox
-paramiko==3.1.0
+paramiko==3.2.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
@@ -576,7 +575,7 @@ pbr==5.11.1
     #   fixtures
     #   stevedore
     #   testtools
-phonenumbers==8.13.11
+phonenumbers==8.13.14
     # via
     #   -r requirements/base.txt
     #   django-oscar
@@ -588,7 +587,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/base.txt
     #   jsonschema
-platformdirs==3.5.1
+platformdirs==3.6.0
     # via
     #   -r requirements/base.txt
     #   pylint
@@ -605,7 +604,7 @@ polib==1.2.0
     # via edx-i18n-tools
 premailer==2.9.2
     # via -r requirements/base.txt
-protobuf==4.23.0
+protobuf==4.23.3
     # via
     #   -r requirements/base.txt
     #   google-api-core
@@ -623,7 +622,6 @@ py==1.11.0
     # via
     #   -r requirements/e2e.txt
     #   -r requirements/tox.txt
-    #   pytest
     #   pytest-html
     #   tox
 pyasn1==0.5.0
@@ -651,13 +649,14 @@ pycparser==2.21
     #   app-store-notifications-v2-validator
     #   cffi
     #   cybersource-rest-client-python
-pycryptodome==3.17
+pycryptodome==3.18.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-pycryptodomex==3.17
+pycryptodomex==3.18.0
     # via
     #   -r requirements/base.txt
+    #   -r requirements/e2e.txt
     #   cybersource-rest-client-python
     #   pyjwkest
 pygments==2.15.1
@@ -665,9 +664,7 @@ pygments==2.15.1
     #   -r requirements/base.txt
     #   diff-cover
 pyjwkest==1.4.2
-    # via
-    #   -r requirements/base.txt
-    #   edx-drf-extensions
+    # via -r requirements/e2e.txt
 pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/base.txt
@@ -694,14 +691,14 @@ pynacl==1.5.0
     #   cybersource-rest-client-python
     #   edx-django-utils
     #   paramiko
-pyopenssl==23.1.1
+pyopenssl==23.2.0
     # via
     #   -r requirements/base.txt
     #   app-store-notifications-v2-validator
     #   cybersource-rest-client-python
     #   ndg-httpsclient
     #   paypalrestsdk
-pyparsing==3.0.9
+pyparsing==3.1.0
     # via
     #   -r requirements/base.txt
     #   httplib2
@@ -713,7 +710,7 @@ pyrsistent==0.19.3
     # via
     #   -r requirements/base.txt
     #   jsonschema
-pytest==6.2.5
+pytest==7.3.2
     # via
     #   -r requirements/e2e.txt
     #   -r requirements/test.in
@@ -726,11 +723,11 @@ pytest==6.2.5
     #   pytest-selenium
     #   pytest-timeout
     #   pytest-variables
-pytest-base-url==1.4.2
+pytest-base-url==2.0.0
     # via
     #   -r requirements/e2e.txt
     #   pytest-selenium
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.in
 pytest-django==4.5.2
     # via -r requirements/test.in
@@ -738,20 +735,21 @@ pytest-html==3.2.0
     # via
     #   -r requirements/e2e.txt
     #   pytest-selenium
-pytest-metadata==2.0.4
+pytest-metadata==3.0.0
     # via
     #   -r requirements/e2e.txt
     #   pytest-html
 pytest-randomly==3.12.0
     # via -r requirements/e2e.txt
-pytest-selenium==3.0.0
+pytest-selenium==2.0.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/e2e.txt
 pytest-timeout==2.1.0
     # via -r requirements/e2e.txt
-pytest-variables==1.9.0
+pytest-variables==2.0.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/e2e.txt
     #   pytest-selenium
 python-dateutil==2.8.2
@@ -800,6 +798,7 @@ pyyaml==6.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
+    #   drf-yasg
     #   edx-django-release-util
     #   edx-i18n-tools
     #   naked
@@ -812,7 +811,7 @@ redis==4.5.5
     # via
     #   -r requirements/base.txt
     #   edx-ecommerce-worker
-requests==2.30.0
+requests==2.31.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -862,14 +861,6 @@ rsa==4.9
     #   google-auth
     #   inapppy
     #   oauth2client
-ruamel-yaml==0.17.26
-    # via
-    #   -r requirements/base.txt
-    #   drf-yasg
-ruamel-yaml-clib==0.2.7
-    # via
-    #   -r requirements/base.txt
-    #   ruamel-yaml
 rules==3.3
     # via -r requirements/base.txt
 s3transfer==0.6.1
@@ -945,7 +936,7 @@ sqlparse==0.4.4
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
     #   django
-stevedore==5.0.0
+stevedore==5.1.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -966,13 +957,14 @@ testtools==2.6.0
     #   python-subunit
 toml==0.10.2
     # via
-    #   -r requirements/e2e.txt
     #   -r requirements/tox.txt
     #   pylint
-    #   pytest
     #   tox
 tomli==2.0.1
-    # via coverage
+    # via
+    #   -r requirements/e2e.txt
+    #   coverage
+    #   pytest
 tox==3.14.6
     # via
     #   -c requirements/common_constraints.txt
@@ -985,14 +977,17 @@ traceback2==1.4.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-types-pyyaml==6.0.12.9
+types-pyyaml==6.0.12.10
     # via responses
 typing==3.7.4.3
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via
+    #   -r requirements/base.txt
+    #   -r requirements/e2e.txt
+    #   asgiref
     #   astroid
     #   pylint
 unicodecsv==0.14.1
@@ -1005,7 +1000,7 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-yasg
     #   google-api-python-client
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-filelock==3.12.0
+filelock==3.12.2
     # via tox
 packaging==23.1
     # via tox


### PR DESCRIPTION
## Description

### make upgrade

Original reason for PR: Bump edx-ecommerce-worker to 3.3.4.

### pin `pytest-selenium` to v2

There is a dependency conflict [[potential upstream issue](https://github.com/pytest-dev/pytest-selenium/issues/294)] for pytest in pytest-selenium v3, which requires both:

- [pytest v6](https://github.com/pytest-dev/pytest-selenium/blob/8e0a5d549049a1db353ead98bf0b46f8ef04e014/pyproject.toml#L46)
- pytest-metadata (via pytest-html), whose latest 3.0.0 [requires pytest v7](https://github.com/pytest-dev/pytest-metadata/blob/4f70f2ae74dc880772d445b1ee2cbe8d50bedcbd/pyproject.toml#L43)

Pin pytest-selenium to v2 for now.

<details>
<summary>Details of `make upgrade` error resolved by pin</summary>

    There are incompatible versions in the resolved dependencies:
      pytest (from -r requirements/e2e.in (line 6))
      pytest<7.0.0,>=6.0.0 (from pytest-selenium==3.0.0->-r requirements/e2e.in (line 8))
      pytest>=2.4.2 (from pytest-variables==1.9.0->pytest-selenium==3.0.0->-r requirements/e2e.in (line 8))
      pytest>=7.0.0 (from pytest-metadata==3.0.0->pytest-html==3.2.0->pytest-selenium==3.0.0->-r requirements/e2e.in (line 8))
      pytest>=5.0.0 (from pytest-timeout==2.1.0->-r requirements/e2e.in (line 9))
      pytest>=2.7.3 (from pytest-base-url==1.4.2->pytest-selenium==3.0.0->-r requirements/e2e.in (line 8))
      pytest (from pytest-randomly==3.12.0->-r requirements/e2e.in (line 7))
      pytest!=6.0.0,>=5.0 (from pytest-html==3.2.0->pytest-selenium==3.0.0->-r requirements/e2e.in (line 8))

</details>

### pin `pytest-variables` to v2

pytest-variables v3 deprecates _variables, which is used by other pytest v2 libraries: see [[changelog](https://github.com/pytest-dev/pytest-variables/blob/13f4b2e4620c682ae0856e03b11106ad3b6e6894/CHANGES.rst)]

Pin pytest-variables to v2 for now.

This resolves `make acceptance` error:

    AttributeError: 'Config' object has no attribute '_variables'

### add pyjwkest to e2e.in 

On `make acceptance`, we now have a `ModuleNotFoundError` for jwkest.

Why: Library pyjwkest has been deprecated by edx-drf-extensions: https://github.com/openedx/edx-drf-extensions/pull/345

But there was a hidden dependency of ecommerce acceptance tests on jwkest.

Add pyjwkest (the providing package) explicitly into requirements/e2e.in.

This is not optimal because our goal is to deprecate pyjwkest, but we would need to modify ecommerce's tests first to be pyjwkest-free before removing the library from ecommerce's dependencies.

## Additional Information

* Jira: [REV-3587](https://2u-internal.atlassian.net/browse/REV-3587) ecomworker broken on stage
* Originating PR: https://github.com/openedx/ecommerce-worker/pull/202