### PR TITLE
feat: add coupon sf opp line item attribute

### DIFF
--- a/ecommerce/extensions/catalogue/migrations/0055_sf_opp_line_item_ent_attr.py
+++ b/ecommerce/extensions/catalogue/migrations/0055_sf_opp_line_item_ent_attr.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+
+from django.db import migrations
+from oscar.core.loading import get_model
+
+from ecommerce.core.constants import COUPON_PRODUCT_CLASS_NAME
+
+ProductAttribute = get_model("catalogue", "ProductAttribute")
+ProductClass = get_model("catalogue", "ProductClass")
+
+SF_LINE_ITEM_ATTRIBUTE_CODE = 'salesforce_opportunity_line_item'
+
+
+def create_sf_opp_line_item_attribute(apps, schema_editor):
+    """Create enterprise coupon salesforce_opportunity_line_item product attribute."""
+    ProductAttribute.skip_history_when_saving = True
+    coupon = ProductClass.objects.get(name=COUPON_PRODUCT_CLASS_NAME)
+    pa = ProductAttribute(
+        product_class=coupon,
+        name='Salesforce Opportunity Line Item',
+        code=SF_LINE_ITEM_ATTRIBUTE_CODE,
+        type='text',
+        required=True,
+    )
+    pa.save()
+
+
+def remove_sf_opp_line_item_attribute(apps, schema_editor):
+    """Remove enterprise coupon salesforce_opportunity_line_item product attribute."""
+    coupon = ProductClass.objects.get(name=COUPON_PRODUCT_CLASS_NAME)
+    ProductAttribute.skip_history_when_saving = True
+    ProductAttribute.objects.get(product_class=coupon, code=SF_LINE_ITEM_ATTRIBUTE_CODE).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('catalogue', '0054_add_variant_id_product_attr')
+    ]
+    operations = [
+        migrations.RunPython(
+            create_sf_opp_line_item_attribute,
+            remove_sf_opp_line_item_attribute,
+        ),
+    ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,6 @@
 ignore=E501,E722,W504
 max_line_length=119
 exclude=settings,migrations,ecommerce/static,bower_components,ecommerce/wsgi.py
+
+[flake8]
+max-line-length=119


### PR DESCRIPTION
We added a form field for `salesforce_opportunity_line_item` in https://github.com/openedx/ecommerce/pull/3984/files, but we never added a product attribute to persist values of this new field.  This PR adds that product attribute for the Coupon product

## Required Testing
* Run migrations
* Go to http://localhost:18130/enterprise/coupons/
* Edit a coupon and add a value for the field above.
* Save changes, reload, edit again, and notice the value has been persisted.
* Go to http://localhost:18130/admin/catalogue/productattribute/?code=salesforce_opportunity_line_item and notice the new product attribute exists
* Go to http://localhost:18130/admin/catalogue/productattributevalue/ and notice a value was persisted from your edit above (the value table is joined to the attribute table, so I can't give you an easy link to follow in here).
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

https://2u-internal.atlassian.net/browse/ENT-7306
