### PR TITLE
feat: Updates opportunity line item regex and tests

### DIFF
--- a/ecommerce/enterprise/constants.py
+++ b/ecommerce/enterprise/constants.py
@@ -18,6 +18,6 @@ SENDER_ALIAS = 'edX Support Team'
 # potential edge case).
 ENTERPRISE_SALES_FORCE_ID_REGEX = r'^006[a-zA-Z0-9]{15}$|^none$'
 
-# Salesforce Opportunity Opportunity Line item must be 18 alphanumeric characters
+# Salesforce Opportunity Line item must be 18 alphanumeric characters
 # and begin with a number OR be "none" (to accommodate potential edge case).
-ENTERPRISE_SALESFORCE_OPPORTUNITY_LINE_ITEM_REGEX = r'^[0-9]{1}[a-zA-Z0-9]{17}$|^none$'
+ENTERPRISE_SALESFORCE_OPPORTUNITY_LINE_ITEM_REGEX = r'^00k[a-zA-Z0-9]{15}$|^none$'

--- a/ecommerce/enterprise/forms.py
+++ b/ecommerce/enterprise/forms.py
@@ -173,7 +173,7 @@ class EnterpriseOfferForm(forms.ModelForm):
         if not re.match(ENTERPRISE_SALESFORCE_OPPORTUNITY_LINE_ITEM_REGEX, salesforce_opportunity_line_item):
             self.add_error(
                 'salesforce_opportunity_line_item',
-                _('The Salesforce Opportunity Line Item must be 18 alphanumeric characters and begin with a number.')
+                _('The Salesforce Opportunity Line Item must be 18 alphanumeric characters and begin with \'00k\'.')
             )
         return self.cleaned_data.get('salesforce_opportunity_line_item')
 

--- a/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/ecommerce/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -127,7 +127,7 @@ class Command(BaseCommand):
             "end_datetime": str(now() + datetime.timedelta(days=10)),
             "benefit_value": 100,
             "sales_force_id": '006aaaaaaaaaaaaaaa',
-            "sales_force_opportunity_line_item": '01aaaaaaaaaaaaaaaa',
+            "sales_force_opportunity_line_item": '00kaaaaaaaaaaaaaaa',
         }
         url = urljoin(f"{ecommerce_api_url}/", "enterprise/coupons/")
         response = api_client.post(url, json=request_obj)

--- a/ecommerce/enterprise/tests/test_forms.py
+++ b/ecommerce/enterprise/tests/test_forms.py
@@ -46,7 +46,7 @@ class EnterpriseOfferFormTests(EnterpriseServiceMockMixin, TestCase):
             'contract_discount_value': self.contract_discount_value,
             'prepaid_invoice_amount': self.prepaid_invoice_amount,
             'sales_force_id': '006abcde0123456789',
-            'salesforce_opportunity_line_item': '000abcde9876543210',
+            'salesforce_opportunity_line_item': '00kabcde9876543210',
             'max_global_applications': 2,
             'max_discount': 300,
             'max_user_discount': 50,
@@ -496,18 +496,18 @@ class EnterpriseOfferFormTests(EnterpriseServiceMockMixin, TestCase):
 
     @ddt.data(
         # Valid Cases
-        ('006abcde0123456789', None),
-        ('006ABCDE0123456789', None),
+        ('00kabcde0123456789', None),
+        ('00kABCDE0123456789', None),
         ('none', None),
         # Invalid Cases
         ('006ABCDE012345678123143',
-         'The Salesforce Opportunity Line Item must be 18 alphanumeric characters and begin with a number.'),
+         'The Salesforce Opportunity Line Item must be 18 alphanumeric characters and begin with \'00k\'.'),
         ('006ABCDE01234',
-         'The Salesforce Opportunity Line Item must be 18 alphanumeric characters and begin with a number.'),
+         'The Salesforce Opportunity Line Item must be 18 alphanumeric characters and begin with \'00k\'.'),
         ('a07ABCDE0123456789',
-         'The Salesforce Opportunity Line Item must be 18 alphanumeric characters and begin with a number.'),
+         'The Salesforce Opportunity Line Item must be 18 alphanumeric characters and begin with \'00k\'.'),
         ('006ABCDE0 12345678',
-         'The Salesforce Opportunity Line Item must be 18 alphanumeric characters and begin with a number.'),
+         'The Salesforce Opportunity Line Item must be 18 alphanumeric characters and begin with \'00k\'.'),
     )
     @ddt.unpack
     def test_salesforce_opportunity_line_item(self, salesforce_opportunity_line_item, expected_error):

--- a/ecommerce/enterprise/tests/test_views.py
+++ b/ecommerce/enterprise/tests/test_views.py
@@ -109,7 +109,7 @@ class EnterpriseOfferUpdateViewTests(EnterpriseServiceMockMixin, ViewTestMixin, 
             'contract_discount_value': 200,
             'prepaid_invoice_amount': 2000,
             'sales_force_id': '006abcde0123456789',
-            'salesforce_opportunity_line_item': '000abcde9876543210',
+            'salesforce_opportunity_line_item': '00kabcde9876543210',
             'usage_email_frequency': ConditionalOffer.DAILY
         }
         response = self.client.post(self.path, data, follow=False)
@@ -131,7 +131,7 @@ class EnterpriseOfferCreateViewTests(EnterpriseServiceMockMixin, ViewTestMixin, 
         expected_discount_type = 'Absolute'
         expected_prepaid_invoice_amount = 12345
         sales_force_id = '006abcde0123456789'
-        salesforce_opportunity_line_item = '000abcde9876543210'
+        salesforce_opportunity_line_item = '00kabcde9876543210'
         data = {
             'enterprise_customer_uuid': expected_ec_uuid,
             'enterprise_customer_catalog_uuid': expected_ec_catalog_uuid,

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -1697,7 +1697,7 @@ class CouponSerializer(CouponMixin, ProductPaymentInfoMixin, serializers.ModelSe
                 re.match(ENTERPRISE_SALESFORCE_OPPORTUNITY_LINE_ITEM_REGEX, salesforce_opportunity_line_item):
             raise ValidationError({
                 'salesforce_opportunity_line_item':
-                'Salesforce Opportunity Line Item must be 18 alphanumeric characters and begin with a number.'
+                'Salesforce Opportunity Line Item must be 18 alphanumeric characters and begin with \'00k\'.'
             })
 
 

--- a/ecommerce/extensions/api/v2/tests/views/test_coupons.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_coupons.py
@@ -248,7 +248,7 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
             'title': 'Tešt čoupon',
             'voucher_type': Voucher.SINGLE_USE,
             'sales_force_id': '006ABCDE0123456789',
-            'salesforce_opportunity_line_item': '000ABCDE9876543210',
+            'salesforce_opportunity_line_item': '00kABCDE9876543210',
         }
         self.response = self.get_response('POST', COUPONS_LINK, self.data)
         self.coupon = Product.objects.get(title=self.data['title'])
@@ -697,7 +697,7 @@ class CouponViewSetFunctionalTest(CouponMixin, DiscoveryTestMixin, DiscoveryMock
         self.assertEqual(new_coupon.attr.note, note)
 
     @ddt.data(
-        '006abcde0123456789', 'otherSalesForce', ''
+        '00kabcde0123456789', 'otherSalesForce', ''
     )
     def test_update_sales_force_id(self, sales_force_id):
         """

--- a/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_enterprise.py
@@ -323,7 +323,7 @@ class EnterpriseCouponViewSetRbacTests(
             'contract_discount_value': '12.35',
             'notify_learners': True,
             'sales_force_id': '006ABCDE0123456789',
-            'salesforce_opportunity_line_item': '000ABCDE9876543210',
+            'salesforce_opportunity_line_item': '00kABCDE9876543210',
         }
 
         self.course = CourseFactory(id='course-v1:test-org+course+run', partner=self.partner)
@@ -458,21 +458,21 @@ class EnterpriseCouponViewSetRbacTests(
             self.assertEqual(coupon.attr.salesforce_opportunity_line_item, salesforce_opportunity_line_item)
 
     @ddt.data(
-        ('006abcde0123456789', 200, None),
-        ('006ABCDE0123456789', 200, None),
+        ('00kabcde0123456789', 200, None),
+        ('00kABCDE0123456789', 200, None),
         ('none', 200, None),
         (None, 400, 'This field is required.'),
         (
             '006ABCDE012345678123143',
             400,
-            'Salesforce Opportunity Line Item must be 18 alphanumeric characters and begin with a number.'
+            'Salesforce Opportunity Line Item must be 18 alphanumeric characters and begin with \'00k\'.'
         ),
         ('006ABCDE01234', 400,
-         'Salesforce Opportunity Line Item must be 18 alphanumeric characters and begin with a number.'),
-        ('a07ABCDE0123456789', 400,
-         'Salesforce Opportunity Line Item must be 18 alphanumeric characters and begin with a number.'),
+         'Salesforce Opportunity Line Item must be 18 alphanumeric characters and begin with \'00k\'.'),
+        ('a0KABCDE0123456789', 400,
+         'Salesforce Opportunity Line Item must be 18 alphanumeric characters and begin with \'00k\'.'),
         ('006ABCDE0 12345678', 400,
-         'Salesforce Opportunity Line Item must be 18 alphanumeric characters and begin with a number.'),
+         'Salesforce Opportunity Line Item must be 18 alphanumeric characters and begin with \'00k\'.'),
     )
     @ddt.unpack
     def test_salesforce_opportunity_line_item(self, salesforce_opportunity_line_item, expected_status_code, error_mesg):

--- a/ecommerce/extensions/api/v2/views/orders.py
+++ b/ecommerce/extensions/api/v2/views/orders.py
@@ -125,7 +125,7 @@ class ManualCourseEnrollmentOrderViewSet(EdxOrderPlacementMixin, EnterpriseDisco
             >>>             "discount_percentage": 75.0,
             >>>             "date_placed": '2020-02-11T09:38:47.634561+00:00',  # optional param, only for old records.
             >>>             "sales_force_id": '252F0060L00000ppWfu',
-            >>>             "salesforce_opportunity_line_item": 'abcF0060L00000ppWfu',
+            >>>             "salesforce_opportunity_line_item": '00kF0060L00000ppWfu',
             >>>             "mode": 'verified',
             >>>             "enterprise_customer_name": "an-enterprise-customer",
             >>>             "enterprise_customer_uuid": "394a5ce5-6ff4-4b2b-bea1-a273c6920ae1",
@@ -153,7 +153,7 @@ class ManualCourseEnrollmentOrderViewSet(EdxOrderPlacementMixin, EnterpriseDisco
             >>>             "discount_percentage": 75.0,
             >>>             "date_placed": '2020-02-11T09:38:47.634561+00:00',
             >>>             "sales_force_id": '252F0060L00000ppWfu',
-            >>>             "salesforce_opportunity_line_item": 'abcF0060L00000ppWfu',
+            >>>             "salesforce_opportunity_line_item": '00kF0060L00000ppWfu',
             >>>             "mode": 'verified',
             >>>             "enterprise_customer_name": "an-enterprise-customer",
             >>>             "enterprise_customer_uuid": "394a5ce5-6ff4-4b2b-bea1-a273c6920ae1",

--- a/ecommerce/static/js/test/mock_data/coupons.js
+++ b/ecommerce/static/js/test/mock_data/coupons.js
@@ -263,7 +263,7 @@ define([], function() {
             contract_discount_value: 30,
             prepaid_invoice_amount: 10000,
             sales_force_id: '006ABCDE0123456789',
-            salesforce_opportunity_line_item: '000ABCDE9876543210',
+            salesforce_opportunity_line_item: '00kABCDE9876543210',
             invoice_type: 'Not-Applicable'
         },
         couponAPIResponseData = {

--- a/ecommerce/static/js/test/specs/views/enterprise_coupon_create_edit_view_spec.js
+++ b/ecommerce/static/js/test/specs/views/enterprise_coupon_create_edit_view_spec.js
@@ -44,7 +44,7 @@ define([
 
             it('should submit enterprise coupon form with valid fields', function() {
                 view.$('[name=sales_force_id]').val('006ABCDE0123456789').trigger('change');
-                view.$('[name=salesforce_opportunity_line_item]').val('000ABCDE9876543210').trigger('change');
+                view.$('[name=salesforce_opportunity_line_item]').val('00kABCDE9876543210').trigger('change');
                 view.$('[name=contract_discount_value]').val(30).trigger('change');
                 view.$('[name=prepaid_invoice_amount]').val(10000).trigger('change');
                 view.$('[name=title]').val('Test Enrollment').trigger('change');

--- a/ecommerce/static/js/utils/validation_patterns.js
+++ b/ecommerce/static/js/utils/validation_patterns.js
@@ -35,12 +35,12 @@ define([
         });
 
         _.extend(Backbone.Validation.patterns, {
-            salesforce_opportunity_line_item: /^[0-9]{1}[a-zA-Z0-9]{17}$|^none$/
+            salesforce_opportunity_line_item: /^00k[a-zA-Z0-9]{15}$|^none$/
         });
 
         _.extend(Backbone.Validation.messages, {
             salesforce_opportunity_line_item: gettext(
-                'Salesforce Opportunity Line Item must be 18 alphanumeric characters and begin with a number'
+                'Salesforce Opportunity Line Item must be 18 alphanumeric characters and begin with \'00k\''
                 )
         });
     }


### PR DESCRIPTION
Updates regex for `salesforce_opportunity_line_item` and corresponding tests

The criteria for an Salesforce opportunity line item must be a 18 character alphanumeric string that begins with '00k'.
Only the lower case 'k' will be accepted.

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?
Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
