### PR TITLE
refactor: Add logging to mobile IAP checkout/ API

### DIFF
--- a/ecommerce/extensions/iap/api/v1/constants.py
+++ b/ecommerce/extensions/iap/api/v1/constants.py
@@ -19,6 +19,7 @@ LOGGER_BASKET_ALREADY_PURCHASED = "Basket creation failed for user [%s] with SKU
 LOGGER_BASKET_CREATED = "Basket created for user [%s] with SKUS [%s]"
 LOGGER_BASKET_CREATION_FAILED = "Basket creation failed for user [%s]. Error: [%s]"
 LOGGER_BASKET_NOT_FOUND = "Basket [%s] not found for user [%s]."
+LOGGER_CHECKOUT_ERROR = "Checkout failed with the error [%s] and status code [%s]."
 LOGGER_EXECUTE_ALREADY_PURCHASED = "Execute payment failed for user [%s] and basket [%s]. " \
                                    "Products already purchased."
 LOGGER_EXECUTE_GATEWAY_ERROR = "Execute payment validation failed for user [%s] and basket [%s]. Error: [%s]"

--- a/ecommerce/extensions/iap/api/v1/ios_validator.py
+++ b/ecommerce/extensions/iap/api/v1/ios_validator.py
@@ -12,10 +12,9 @@ class IOSValidator:
         Apple for the mentioned productId.
         """
         bundle_id = configuration.get('ios_bundle_id')
-        # If True, automatically query sandbox endpoint if validation fails on production endpoint
-        # TODO: Add auto_retry_wrong_env_request to environment variables
-        auto_retry_wrong_env_request = True
-        validator = AppStoreValidator(bundle_id, auto_retry_wrong_env_request=auto_retry_wrong_env_request)
+        # auto_retry_wrong_env_request = True automatically queries sandbox endpoint if
+        # validation fails on production endpoint
+        validator = AppStoreValidator(bundle_id, auto_retry_wrong_env_request=True)
 
         try:
             validation_result = validator.validate(

--- a/ecommerce/extensions/iap/api/v1/views.py
+++ b/ecommerce/extensions/iap/api/v1/views.py
@@ -51,6 +51,7 @@ from ecommerce.extensions.iap.api.v1.constants import (
     LOGGER_BASKET_CREATED,
     LOGGER_BASKET_CREATION_FAILED,
     LOGGER_BASKET_NOT_FOUND,
+    LOGGER_CHECKOUT_ERROR,
     LOGGER_EXECUTE_ALREADY_PURCHASED,
     LOGGER_EXECUTE_GATEWAY_ERROR,
     LOGGER_EXECUTE_ORDER_CREATION_FAILED,
@@ -158,10 +159,9 @@ class MobileCheckoutView(APIView):
     permission_classes = (IsAuthenticated,)
 
     def post(self, request):
-        # TODO: Add check for products_in_basket_already_purchased
-        # TODO: Add logging for api/user_info after reading from request obj
         response = CheckoutView.as_view()(request._request)  # pylint: disable=W0212
         if response.status_code != 200:
+            logger.exception(LOGGER_CHECKOUT_ERROR, response.content.decode(), response.status_code)
             return JsonResponse({'error': response.content.decode()}, status=response.status_code)
 
         return response


### PR DESCRIPTION
# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

### TODO: Add auto_retry_wrong_env_request to environment variables
auto_retry_wrong_env_request = True retries the payment validation on Apple sandbox servers in case the receipt belongs to a different environment on Apple.
#### Quoting [Apple docs](https://developer.apple.com/documentation/appstorereceipts/verifyreceipt):
`As a best practice, always call the production URL https://buy.itunes.apple.com/verifyReceipt first and proceed to verify with the sandbox URL if you receive a 21007 [status](https://developer.apple.com/documentation/appstorereceipts/status) code. Following this approach ensures that you don’t have to switch between URLs while your app is in testing, in review by App Review, or live in the App Store.`

More on [receipt validation status](https://developer.apple.com/documentation/appstorereceipts/status).

Hence the variable is not added to environment variables and set to `True` instead.

### TODO: Add check for products_in_basket_already_purchased and TODO: Add logging for api/user_info after reading from request obj

In the checkout/ API case, the request is received in `iap.api.v1.views. MobileCheckoutView` as Rest Framework request object, while the second view called i.e. `extensions.api.v2.views.CheckoutView` expects a Django HttpRequest. Which is forwarded by accessing the protected attribute `request._request`.
Reading the data stream from the POST payload causing the error `You cannot access body after reading from request's data stream` in the second view while accessing the payload resulting in a 500.

#### Link to error: https://onenr.io/0Zw08Db90wv

Hence logging has been added for exception without accessing payload.

## Other information

Jira link: https://2u-internal.atlassian.net/browse/LEARNER-9347
