### PR TITLE
feat: unenroll refunded android users daily

### DIFF
--- a/ecommerce/core/management/commands/tests/test_unenroll_refunded_android_users.py
+++ b/ecommerce/core/management/commands/tests/test_unenroll_refunded_android_users.py
@@ -1,0 +1,52 @@
+"""
+Tests for Django management command to un-enroll refunded android users.
+"""
+from django.core.management import call_command
+from mock import patch
+from testfixtures import LogCapture
+
+from ecommerce.tests.testcases import TestCase
+
+
+class TestUnenrollRefundedAndroidUsersCommand(TestCase):
+
+    LOGGER_NAME = 'ecommerce.core.management.commands.unenroll_refunded_android_users'
+
+    @patch('requests.get')
+    def test_handle_pass(self, mock_response):
+        """ Test using mock response from setup, using threshold it will clear"""
+
+        mock_response.return_value.status_code = 200
+
+        with LogCapture(self.LOGGER_NAME) as log:
+            call_command('unenroll_refunded_android_users')
+
+            log.check(
+                (
+                    self.LOGGER_NAME,
+                    'INFO',
+                    'Sending request to un-enroll refunded android users'
+                )
+            )
+
+    @patch('requests.get')
+    def test_handle_fail(self, mock_response):
+        """ Test using mock response from setup, using threshold it will clear"""
+
+        mock_response.return_value.status_code = 400
+
+        with LogCapture(self.LOGGER_NAME) as log:
+            call_command('unenroll_refunded_android_users')
+
+            log.check(
+                (
+                    self.LOGGER_NAME,
+                    'INFO',
+                    'Sending request to un-enroll refunded android users'
+                ),
+                (
+                    self.LOGGER_NAME,
+                    'ERROR',
+                    'Failed to refund android users with status code 400'
+                )
+            )

--- a/ecommerce/core/management/commands/unenroll_refunded_android_users.py
+++ b/ecommerce/core/management/commands/unenroll_refunded_android_users.py
@@ -5,8 +5,8 @@ Command is run by Jenkins job daily.
 """
 import logging
 
-from django.core.management.base import BaseCommand
 import requests
+from django.core.management.base import BaseCommand
 from rest_framework import status
 
 from ecommerce.core.models import SiteConfiguration

--- a/ecommerce/core/management/commands/unenroll_refunded_android_users.py
+++ b/ecommerce/core/management/commands/unenroll_refunded_android_users.py
@@ -1,0 +1,27 @@
+"""
+Django management command to un-enroll refunded android users.
+
+Command is run by Jenkins job daily.
+"""
+import logging
+
+from django.core.management.base import BaseCommand
+import requests
+from rest_framework import status
+
+from ecommerce.core.models import SiteConfiguration
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = 'Management command to un-enroll refunded android users.'
+
+    def handle(self, *args, **options):
+        site = SiteConfiguration.objects.first()
+        refund_api_url = '{}/api/iap/v1/android/refund/'.format(site.build_ecommerce_url())
+        logger.info("Sending request to un-enroll refunded android users")
+        response = requests.get(refund_api_url)
+
+        if response.status_code != status.HTTP_200_OK:
+            logger.error("Failed to refund android users with status code %s", response.status_code)


### PR DESCRIPTION
## Description
Django management command to un-enroll refunded android users.
This command will be run by Jenkins job daily.

After this PR is merged, I'll put cronjob [here](https://github.com/edx/edx-internal/blob/8b4b403b126731c93ba0247985e27b5a1f6bbe08/ansible/vars/prod-edx.yml#L1002).
