### PR TITLE
feat: upgrade edx-drf-extensions and newrelic

### DIFF
--- a/ecommerce/tests/mixins.py
+++ b/ecommerce/tests/mixins.py
@@ -137,6 +137,7 @@ class JwtMixin:
         # create a mock user, and not the actual user, because we want to confirm that
         #   the user is created during JWT authentication
         user = Mock()
+        user.id = 1
         user.username = username
         user.email = email
         user.is_staff = is_staff

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -226,7 +226,7 @@ edx-django-utils==5.5.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   getsmarter-api-clients
-edx-drf-extensions==8.8.0
+edx-drf-extensions==8.12.0
     # via
     #   -r requirements/base.in
     #   edx-rbac
@@ -452,7 +452,6 @@ python-dateutil==2.8.2
     #   -r requirements/base.in
     #   analytics-python
     #   botocore
-    #   edx-drf-extensions
     #   faker
 python-mimeparse==1.6.0
     # via cybersource-rest-client-python
@@ -543,7 +542,6 @@ six==1.16.0
     #   djangorestframework-csv
     #   edx-auth-backends
     #   edx-django-release-util
-    #   edx-drf-extensions
     #   edx-ecommerce-worker
     #   edx-rbac
     #   google-auth

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -349,7 +349,7 @@ naked==0.1.32
     #   cybersource-rest-client-python
 ndg-httpsclient==0.5.1
     # via -r requirements/base.in
-newrelic==8.8.0
+newrelic==9.1.0
     # via
     #   -r requirements/base.in
     #   edx-django-utils

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -552,7 +552,7 @@ naked==0.1.32
     #   cybersource-rest-client-python
 ndg-httpsclient==0.5.1
     # via -r requirements/test.txt
-newrelic==8.8.0
+newrelic==9.1.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -327,7 +327,7 @@ edx-django-utils==5.5.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   getsmarter-api-clients
-edx-drf-extensions==8.8.0
+edx-drf-extensions==8.12.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
@@ -778,7 +778,6 @@ python-dateutil==2.8.2
     #   -r requirements/test.txt
     #   analytics-python
     #   botocore
-    #   edx-drf-extensions
     #   faker
     #   freezegun
 python-dotenv==1.0.0
@@ -920,7 +919,6 @@ six==1.16.0
     #   djangorestframework-csv
     #   edx-auth-backends
     #   edx-django-release-util
-    #   edx-drf-extensions
     #   edx-ecommerce-worker
     #   edx-rbac
     #   google-auth

--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -64,7 +64,7 @@ importlib-metadata==6.7.0
     # via pytest-randomly
 iniconfig==2.0.0
     # via pytest
-newrelic==8.8.0
+newrelic==9.1.0
     # via
     #   -c requirements/base.txt
     #   edx-django-utils

--- a/requirements/production.in
+++ b/requirements/production.in
@@ -4,7 +4,7 @@
 
 django-ses
 gunicorn==19.7.1
-newrelic<5
+newrelic
 python-memcached==1.59
 PyYAML
 nodeenv==1.1.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -231,7 +231,7 @@ edx-django-utils==5.5.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   getsmarter-api-clients
-edx-drf-extensions==8.8.0
+edx-drf-extensions==8.12.0
     # via
     #   -r requirements/base.in
     #   edx-rbac
@@ -462,7 +462,6 @@ python-dateutil==2.8.2
     #   -r requirements/base.in
     #   analytics-python
     #   botocore
-    #   edx-drf-extensions
     #   faker
 python-memcached==1.59
     # via -r requirements/production.in
@@ -559,7 +558,6 @@ six==1.16.0
     #   djangorestframework-csv
     #   edx-auth-backends
     #   edx-django-release-util
-    #   edx-drf-extensions
     #   edx-ecommerce-worker
     #   edx-rbac
     #   google-auth

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -356,7 +356,7 @@ naked==0.1.32
     #   cybersource-rest-client-python
 ndg-httpsclient==0.5.1
     # via -r requirements/base.in
-newrelic==4.20.1.121
+newrelic==9.1.0
     # via
     #   -r requirements/base.in
     #   -r requirements/production.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -530,7 +530,7 @@ naked==0.1.32
     #   cybersource-rest-client-python
 ndg-httpsclient==0.5.1
     # via -r requirements/base.txt
-newrelic==8.8.0
+newrelic==9.1.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -318,7 +318,7 @@ edx-django-utils==5.5.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   getsmarter-api-clients
-edx-drf-extensions==8.8.0
+edx-drf-extensions==8.12.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
@@ -757,7 +757,6 @@ python-dateutil==2.8.2
     #   -r requirements/base.txt
     #   analytics-python
     #   botocore
-    #   edx-drf-extensions
     #   faker
     #   freezegun
 python-dotenv==1.0.0
@@ -897,7 +896,6 @@ six==1.16.0
     #   djangorestframework-csv
     #   edx-auth-backends
     #   edx-django-release-util
-    #   edx-drf-extensions
     #   edx-ecommerce-worker
     #   edx-rbac
     #   google-auth


### PR DESCRIPTION
## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

* Upgrade edx-drf-extensions to 8.12.0.
  * Upgrade performed using a temporary constraint and pip-compile without the --upgrade to keep from upgrading unrelated requirements.
  * This is to enable forgiving JWTs as part of https://github.com/edx/edx-arch-experiments/issues/429
  * Note: This upgrade will not really cause a change until a separate toggle is enabled as a follow-up.
* Upgrade newrelic by removing constraint from production.in
  *  Upgrade performed using a temporary constraint and pip-compile without the --upgrade to keep from upgrading unrelated requirements.