### PR TITLE
docs: Update the security e-mail address.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 This repository is deprecated and in maintainence-only operation while we work on a replacement, please see `this announcement <https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839>`__ for more information.
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to `security@edx.org <mailto:security@edx.org>`__
+Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to `security@openedx.org <mailto:security@edx.org>`__
 
 edX E-Commerce Service  |CI|_ |Codecov|_
 ============================================
@@ -37,7 +37,7 @@ Please also read `How To Contribute <https://github.com/openedx/.github/blob/mas
 Reporting Security Issues
 -------------------------
 
-Please do not report security issues in public. Please email security@edx.org.
+Please do not report security issues in public. Please email security@openedx.org.
 
 Get Help
 --------


### PR DESCRIPTION
This repository is now managed by the Axim Collaborative and security issues
with it should be reported to security@openedx.org instead of security@edx.org

This work is being done as a part of https://github.com/openedx/wg-security/issues/16
