### PR TITLE
docs: Update RTD config.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,8 +10,13 @@ sphinx:
   configuration: docs/conf.py
   fail_on_warning: true
 
+# Set the version of python needed to build these docs.
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.8"
+
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: "3.8"
   install:
     - requirements: requirements/docs.txt


### PR DESCRIPTION
The 'build.os' setting is now required.
