### PR TITLE
feat: add atlas pull support - FC-0012

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ FROM ubuntu:focal as app
 ENV DEBIAN_FRONTEND noninteractive
 # System requirements.
 RUN apt update && \
-  apt-get install -qy \ 
+  apt-get install -qy \
   curl \
+  gettext \
   git \
   language-pack-en \
   build-essential \

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,13 @@ compile_translations: requirements.tox
 fake_translations: extract_translations dummy_translations compile_translations
 
 pull_translations:
+ifeq ($(OPENEDX_ATLAS_PULL),)
 	cd ecommerce && tx pull -a -f -t --mode reviewed
+else
+	find ecommerce/conf/locale -mindepth 1 -maxdepth 1 -type d -exec rm -r {} \;
+	atlas pull $(OPENEDX_ATLAS_ARGS) translations/ecommerce/ecommerce/conf/locale:ecommerce/conf/locale
+	python manage.py compilemessages
+endif
 
 push_translations:
 	cd ecommerce && tx push -s

--- a/ecommerce/conf/locale/config.yaml
+++ b/ecommerce/conf/locale/config.yaml
@@ -92,5 +92,6 @@ ignore_dirs:
     - i18n
     - assets
     - node_modules
+    - tests
     - static/bower_components
     - static/build

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -45,6 +45,7 @@ markdown==2.6.9
 mysqlclient<1.5
 newrelic
 ndg-httpsclient
+openedx-atlas
 path.py==7.2
 paypalrestsdk
 premailer==2.9.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -362,6 +362,8 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
+openedx-atlas==0.5.0
+    # via -r requirements/base.in
 packaging==23.1
     # via drf-yasg
 paramiko==3.2.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -333,7 +333,7 @@ edx-drf-extensions==9.0.0
     #   edx-rbac
 edx-ecommerce-worker==3.3.4
     # via -r requirements/test.txt
-edx-i18n-tools==0.9.2
+edx-i18n-tools==1.3.0
     # via -r requirements/test.txt
 edx-opaque-keys==2.3.0
     # via
@@ -570,6 +570,8 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
+openedx-atlas==0.5.0
+    # via -r requirements/base.in
 packaging==23.1
     # via
     #   -r requirements/docs.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -372,6 +372,8 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
+openedx-atlas==0.5.0
+    # via -r requirements/base.in
 packaging==23.1
     # via drf-yasg
 paramiko==3.2.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -324,7 +324,7 @@ edx-drf-extensions==9.0.0
     #   edx-rbac
 edx-ecommerce-worker==3.3.4
     # via -r requirements/base.txt
-edx-i18n-tools==0.9.2
+edx-i18n-tools==1.3.0
     # via -r requirements/test.in
 edx-opaque-keys==2.3.0
     # via
@@ -549,6 +549,8 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
+openedx-atlas==0.5.0
+    # via -r requirements/base.in
 packaging==23.1
     # via
     #   -r requirements/base.txt

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,7 @@ setenv =
     tests: DJANGO_SETTINGS_MODULE = ecommerce.settings.test
     acceptance: DJANGO_SETTINGS_MODULE = ecommerce.settings.test
     check_keywords: DJANGO_SETTINGS_MODULE = ecommerce.settings.test
+    extract_translations: DJANGO_SETTINGS_MODULE=
     BOKCHOY_HEADLESS = true
     NODE_BIN = ./node_modules/.bin
     PATH=$PATH:$NODE_BIN
@@ -51,7 +52,7 @@ deps =
 allowlist_externals =
     /bin/bash
 changedir =
-    dummy_translations,compile_translations,detect_changed_translations,validate_translations: ecommerce
+    extract_translations,dummy_translations,compile_translations,detect_changed_translations,validate_translations: ecommerce
 commands =
     static: python manage.py collectstatic --noinput --verbosity 0
 	static: python manage.py compress --force
@@ -64,8 +65,7 @@ commands =
 
     pylint: pylint -j 0 --rcfile=pylintrc ecommerce e2e
 
-    extract_translations: python manage.py makemessages -l en -v1 -d django --ignore="docs/*" --ignore="src/*" --ignore="i18n/*" --ignore="assets/*" --ignore="node_modules/*" --ignore="ecommerce/static/bower_components/*" --ignore="ecommerce/static/build/*"
-    extract_translations: python manage.py makemessages -l en -v1 -d djangojs --ignore="docs/*" --ignore="src/*" --ignore="i18n/*" --ignore="assets/*" --ignore="node_modules/*" --ignore="ecommerce/static/bower_components/*" --ignore="ecommerce/static/build/*"
+    extract_translations: i18n_tool extract --no-segment
 
     dummy_translations: i18n_tool dummy
     compile_translations: python ../manage.py compilemessages


### PR DESCRIPTION
Add atlas pull support. (atlas pull) will be performed only if `OPENEDX_ATLAS_PULL` environment variable is set

- [x] Tested on devstack, docker build is working fine
- [x] Tested on devstack, `make extract_translation` is still running fine with latest `i18-tools==1.3.0`
- [x] Tested on devstack, `OPENEDX_ATLAS_PULL=yes make pull_translation` is working fine
- [x] Tested on devstack, `OPENEDX_ATLAS_PULL=yes make pull_translation` is deleting old translations and pulling the latest translations


References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern. But before that, please know the strategy we're following to avoid breaking changes

**For XBlocks:**
 - The standard translation path must be `conf/locale`. Therefore, we are creating a link from `conf/locale` to `translations` so Atlas can find the path without disrupting the current way of having translations locally within the XBlocks
 - [openedx-translations](https://github.com/openedx/openedx-translations) will have a related PR that adds the XBlock to the pipeline. This will not affect the current way of managing/updating translations
 - At the end of the project, a clear change log will be added and all translations will be handled by Atlas. Thus, the local translation will be removed from the repo within the version bump
 - A notification for the community will be published to ensure that everyone knows why translations directories are removed from all repos
 

