### PR TITLE
fix: Update SDN CSL URL used for fallback

### DIFF
--- a/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
+++ b/ecommerce/core/management/commands/populate_sdn_fallback_data_and_metadata.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         # download the csv locally, to check size and pass along to import
         threshold = options['threshold']
-        url = 'http://api.trade.gov/static/consolidated_screening_list/consolidated.csv'
+        url = 'https://data.trade.gov/downloadable_consolidated_screening_list/v1/consolidated.csv'
         timeout = settings.SDN_CHECK_REQUEST_TIMEOUT
 
         with requests.Session() as s:

--- a/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
+++ b/ecommerce/core/management/commands/tests/test_download_sdn_fallback.py
@@ -90,7 +90,7 @@ class TestDownloadSndFallbackCommand(TestCase):
 
 class TestDownloadSndFallbackCommandExceptions(TestCase):
     LOGGER_NAME = 'ecommerce.core.management.commands.populate_sdn_fallback_data_and_metadata'
-    URL = 'http://api.trade.gov/static/consolidated_screening_list/consolidated.csv'
+    URL = 'https://data.trade.gov/downloadable_consolidated_screening_list/v1/consolidated.csv'
     ERROR_MESSAGE = 'some foo error'
 
     @responses.activate


### PR DESCRIPTION
[REV-3062](https://2u-internal.atlassian.net/browse/REV-3062).

The government updated the URL where we get the SDN Consolidated Screening list, the old URL points to the new one but at some point that won't be the case anymore.

For sanctions service, we have the URL under settings in edx-internal but ecommerce does not, it's hard coded, keeping the same pattern since eventually this will be deprecated.