### PR TITLE
chore: update Django to 3.2.23 for Quince - Security Patch

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -103,7 +103,7 @@ defusedxml==0.7.1
     # via
     #   python3-openid
     #   social-auth-core
-django==3.2.20
+django==3.2.23
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -177,7 +177,7 @@ defusedxml==0.7.1
     #   social-auth-core
 diff-cover==7.6.0
     # via -r requirements/test.txt
-django==3.2.20
+django==3.2.23
     # via
     #   -r requirements/test.txt
     #   crispy-bootstrap3

--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -29,7 +29,7 @@ cryptography==41.0.1
     # via
     #   -c requirements/base.txt
     #   pyjwt
-django==3.2.20
+django==3.2.23
     # via
     #   -c requirements/base.txt
     #   -c requirements/common_constraints.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -105,7 +105,7 @@ defusedxml==0.7.1
     # via
     #   python3-openid
     #   social-auth-core
-django==3.2.20
+django==3.2.23
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in


### PR DESCRIPTION
### Description
This PR updates Django to version 3.2.23 in the Quince release branch. The update includes the latest security patch, as part of the BTR working group's ongoing efforts to ensure the security of Open edX's supported named releases.

For more information, see: [https://github.com/openedx/wg-build-test-release/issues/324](https://github.com/openedx/wg-build-test-release/issues/324)