### PR TITLE
docs: Update RTD configuration for Quince.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,8 +10,13 @@ sphinx:
   configuration: docs/conf.py
   fail_on_warning: true
 
+# Set the version of python needed to build these docs.
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.8"
+
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: "3.8"
   install:
     - requirements: requirements/docs.txt


### PR DESCRIPTION
This is a backport from [master](https://github.com/openedx/ecommerce/pull/4042) 

## Description
This Pull Request updates our `.readthedocs.yml` file to align with the updated configuration requirements set by Read the Docs. As outlined in their announcement ([Read the Docs Blog: Use build.os instead of build.image on your configuration file](https://blog.readthedocs.com/use-build-os-config/)), the `build.os` configuration key is now a requirement for successful documentation builds.