### PR TITLE
refactor: Add course info to Stripe Payment Intent metadata

### DIFF
--- a/ecommerce/extensions/payment/tests/views/test_stripe.py
+++ b/ecommerce/extensions/payment/tests/views/test_stripe.py
@@ -169,6 +169,11 @@ class StripeCheckoutViewTests(PaymentEventsMixin, TestCase):
         """
         basket = self.create_basket(product_class=SEAT_PRODUCT_CLASS_NAME)
         idempotency_key = f'basket_pi_create_v1_{basket.order_number}'
+        product = basket.lines.first().product
+        course = {
+            'course_id': product.course_id,
+            'course_name': product.course.name
+        }
 
         # need to call capture-context endpoint before we call do GET to the stripe checkout view
         # so that the PaymentProcessorResponse is already created
@@ -177,6 +182,7 @@ class StripeCheckoutViewTests(PaymentEventsMixin, TestCase):
             self.client.get(self.capture_context_url)
             mock_create.assert_called_once()
             assert mock_create.call_args.kwargs['idempotency_key'] == idempotency_key
+            assert mock_create.call_args.kwargs['metadata']['courses'] == str([(course)])
 
         with mock.patch('stripe.PaymentIntent.retrieve') as mock_retrieve:
             mock_retrieve.return_value = retrieve_addr_resp


### PR DESCRIPTION
[REV-3816](https://2u-internal.atlassian.net/browse/REV-3816).

Payments in Stripe only have the edX order number as information on the payment. But this becomes a problem if the order is not created in ecommerce backend due to some error, because Support can't access this order and know which items were in the basket.

This PR modifies the metadata we send to Stripe when a Payment Intent is created to include course ID and course title. This was info we had with Cybersource orders.

This is how it will look like on the Stripe Dashboard. It's added as a list so that is accommodates bundle purchases as well, but essentially converted to a string since that's the format Stripe will accept for metadata.
<img width="1406" alt="Screenshot 2024-01-16 at 5 12 08 PM" src="https://github.com/openedx/ecommerce/assets/13632680/7c14f29d-e7f7-43c2-93cf-9d9f81fe5d4f">
