### PR TITLE
refactor: Add courses metadata from basket to Stripe Payment Intent

### DIFF
--- a/ecommerce/extensions/payment/processors/stripe.py
+++ b/ecommerce/extensions/payment/processors/stripe.py
@@ -93,15 +93,23 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
         courses = []
         for line in basket.lines.all():
             try:
-                course_id = line.product.course.id if line.product.course else None
-                course_name = line.product.course.name if line.product.course else line.product.title
+                course_id = line.product.course.id
             except Exception:  # pylint: disable=broad-except
                 logger.exception(
-                    'Failed to retrieve course data from basket [%s] for payment intent metadata for order [%s]',
+                    'Failed to retrieve course_id data from basket [%s] for payment intent metadata for order [%s]',
                     basket.id,
                     basket.order_number
                 )
-                continue
+                course_id = None
+            try:
+                course_name = line.product.course.name if line.product.course else line.product.title
+            except Exception:  # pylint: disable=broad-except
+                logger.exception(
+                    'Failed to retrieve course_name data from basket [%s] for payment intent metadata for order [%s]',
+                    basket.id,
+                    basket.order_number
+                )
+                course_name = None
             course = {
                 'course_id': course_id,
                 'course_name': course_name,

--- a/ecommerce/extensions/payment/processors/stripe.py
+++ b/ecommerce/extensions/payment/processors/stripe.py
@@ -103,13 +103,13 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
                 course_id = None
             try:
                 course_name = line.product.course.name if line.product.course else line.product.title
-            except Exception:  # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except  # pragma: no cover
                 logger.exception(
                     'Failed to retrieve course_name data from basket [%s] for payment intent metadata for order [%s]',
                     basket.id,
                     basket.order_number
-                )
-                course_name = None
+                )  # pragma: no cover
+                course_name = None  # pragma: no cover
             course = {
                 'course_id': course_id,
                 'course_name': course_name,


### PR DESCRIPTION
[REV-3816](https://2u-internal.atlassian.net/browse/REV-3816).

Take 2 on adding courses metadata to Stripe's Payment Intent on the `/capture-context` call. There was an issue with the previous version (https://github.com/openedx/ecommerce/pull/4100) since not all baskets are alike, for entitlements, a Product (from the basket line) does not have a Course associated to it, even if the Product title is named `"Course XYZ"`. Also, a Line in a basket cannot be null, it must have a Product.