### PR TITLE
chore: bump openedx-atlas==0.6.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -368,7 +368,7 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-atlas==0.5.0
+openedx-atlas==0.6.0
     # via -r requirements/base.in
 packaging==23.2
     # via drf-yasg

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -577,7 +577,7 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-atlas==0.5.0
+openedx-atlas==0.6.0
     # via -r requirements/test.txt
 packaging==23.2
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -378,7 +378,7 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-atlas==0.5.0
+openedx-atlas==0.6.0
     # via -r requirements/base.in
 packaging==23.2
     # via drf-yasg

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -558,7 +558,7 @@ oauthlib==3.2.2
     #   getsmarter-api-clients
     #   requests-oauthlib
     #   social-auth-core
-openedx-atlas==0.5.0
+openedx-atlas==0.6.0
     # via -r requirements/base.txt
 packaging==23.2
     # via


### PR DESCRIPTION
This is blocking:

 - https://github.com/overhangio/tutor-ecommerce/pull/49

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).
