### PR TITLE
fix: Clip courses metadata value to less than 500 characters for Stripe

### DIFF
--- a/ecommerce/extensions/payment/processors/stripe.py
+++ b/ecommerce/extensions/payment/processors/stripe.py
@@ -115,7 +115,10 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
                 'course_name': course_name,
             }
             courses.append(course)
-        return str(courses) if courses else None
+
+        # Stripe metadata field value must be a string under 500 characters.
+        courses_string = str(courses)
+        return courses_string[:499] if courses else None
 
     def _build_payment_intent_parameters(self, basket):
         order_number = basket.order_number

--- a/ecommerce/extensions/payment/tests/views/test_stripe.py
+++ b/ecommerce/extensions/payment/tests/views/test_stripe.py
@@ -346,6 +346,27 @@ class StripeCheckoutViewTests(PaymentEventsMixin, TestCase):
                 assert courses_metadata_list[index]['course_id'] is None
                 assert courses_metadata_list[index]['course_name'] == line.product.title
 
+    def test_capture_context_large_characters_basket(self):
+        """
+        Verify we don't send Stripe metadata value that is longer than 500 characters.
+        """
+        # Create basket with a course that will result in courses list > 500 characters
+        very_long_course_name = 'a' * 500
+        course = CourseFactory(id='edX/DemoX/Demo_Course', name=very_long_course_name, partner=self.partner)
+        product = course.create_or_update_seat('verified', False, 50)
+        basket = self.create_basket()
+        basket.add_product(product)
+
+        with mock.patch('stripe.PaymentIntent.create') as mock_create:
+            mock_create.return_value = {
+                'id': 'pi_3LsftNIadiFyUl1x2TWxaADZ',
+                'client_secret': 'pi_3LsftNIadiFyUl1x2TWxaADZ_secret_VxRx7Y1skyp0jKtq7Gdu80Xnh',
+            }
+            self.client.get(self.capture_context_url)
+            mock_create.assert_called_once()
+            # The metadata must be less than 500 characters
+            assert len(mock_create.call_args.kwargs['metadata']['courses']) < 500
+
     def test_payment_error_no_basket(self):
         """
         Verify view redirects to error page if no basket exists for payment_intent_id.

--- a/ecommerce/extensions/payment/tests/views/test_stripe.py
+++ b/ecommerce/extensions/payment/tests/views/test_stripe.py
@@ -352,7 +352,7 @@ class StripeCheckoutViewTests(PaymentEventsMixin, TestCase):
         """
         # Create basket with courses that will result in courses list > 500 characters
         basket = self.create_basket()
-        very_long_course_name = 'a' * 250
+        very_long_course_name = 'a' * 200
         course_1 = CourseFactory(id='edX/DemoX/Demo_Course_1', name=very_long_course_name, partner=self.partner)
         product = course_1.create_or_update_seat('verified', False, 50)
         basket.add_product(product)

--- a/ecommerce/extensions/payment/tests/views/test_stripe.py
+++ b/ecommerce/extensions/payment/tests/views/test_stripe.py
@@ -350,11 +350,14 @@ class StripeCheckoutViewTests(PaymentEventsMixin, TestCase):
         """
         Verify we don't send Stripe metadata value that is longer than 500 characters.
         """
-        # Create basket with a course that will result in courses list > 500 characters
-        very_long_course_name = 'a' * 500
-        course = CourseFactory(id='edX/DemoX/Demo_Course', name=very_long_course_name, partner=self.partner)
-        product = course.create_or_update_seat('verified', False, 50)
+        # Create basket with courses that will result in courses list > 500 characters
         basket = self.create_basket()
+        very_long_course_name = 'a' * 250
+        course_1 = CourseFactory(id='edX/DemoX/Demo_Course_1', name=very_long_course_name, partner=self.partner)
+        product = course_1.create_or_update_seat('verified', False, 50)
+        basket.add_product(product)
+        course_2 = CourseFactory(id='edX/DemoX/Demo_Course_2', name=very_long_course_name, partner=self.partner)
+        product = course_2.create_or_update_seat('verified', False, 100)
         basket.add_product(product)
 
         with mock.patch('stripe.PaymentIntent.create') as mock_create:


### PR DESCRIPTION
[REV-3816](https://2u-internal.atlassian.net/browse/REV-3816).

We found that some programs have a large number of courses, which results in metadata value that is longer than 500 that Stripe does not accept for a metadata value `invalid_request_error - metadata` https://stripe.com/docs/api/metadata

Support decided that it's better to have clipped metadata (at 499 characters) than no metadata at all.