### PR TITLE
feat: Add Dynamic Payment Methods BNPL

### DIFF
--- a/ecommerce/extensions/basket/constants.py
+++ b/ecommerce/extensions/basket/constants.py
@@ -2,6 +2,8 @@ TEMPORARY_BASKET_CACHE_KEY = "ecommerce.is_calculate_temporary_basket"
 EMAIL_OPT_IN_ATTRIBUTE = "email_opt_in"
 PURCHASER_BEHALF_ATTRIBUTE = "purchased_for_organization"
 PAYMENT_INTENT_ID_ATTRIBUTE = "payment_intent_id"
+PAYMENT_INTENT_STATUS_ATTRIBUTE = "payment_intent_status"
+DYNAMIC_PAYMENT_METHODS_ENABLED = "dynamic_payment_methods_enabled"
 
 # .. toggle_name: enable_stripe_payment_processor
 # .. toggle_type: waffle_flag

--- a/ecommerce/extensions/basket/constants.py
+++ b/ecommerce/extensions/basket/constants.py
@@ -2,7 +2,6 @@ TEMPORARY_BASKET_CACHE_KEY = "ecommerce.is_calculate_temporary_basket"
 EMAIL_OPT_IN_ATTRIBUTE = "email_opt_in"
 PURCHASER_BEHALF_ATTRIBUTE = "purchased_for_organization"
 PAYMENT_INTENT_ID_ATTRIBUTE = "payment_intent_id"
-PAYMENT_INTENT_STATUS_ATTRIBUTE = "payment_intent_status"
 DYNAMIC_PAYMENT_METHODS_ENABLED = "dynamic_payment_methods_enabled"
 
 # .. toggle_name: enable_stripe_payment_processor

--- a/ecommerce/extensions/basket/utils.py
+++ b/ecommerce/extensions/basket/utils.py
@@ -23,7 +23,6 @@ from ecommerce.extensions.basket.constants import (
     EMAIL_OPT_IN_ATTRIBUTE,
     ENABLE_STRIPE_PAYMENT_PROCESSOR,
     PAYMENT_INTENT_ID_ATTRIBUTE,
-    PAYMENT_INTENT_STATUS_ATTRIBUTE,
     PURCHASER_BEHALF_ATTRIBUTE,
     REDIRECT_WITH_WAFFLE_TESTING_QUERYSTRING
 )
@@ -394,20 +393,6 @@ def basket_add_organization_attribute(basket, request_data):
             attribute_type=purchaser_attribute,
             value_text=purchaser
         )
-
-
-@newrelic.agent.function_trace()
-def basket_add_payment_intent_status(basket, payment_intent_status):
-    payment_intent_status_attribute, __ = BasketAttributeType.objects.get_or_create(
-        name=PAYMENT_INTENT_STATUS_ATTRIBUTE)
-    # Do a get_or_create and update value_text after (instead of update_or_create)
-    # to prevent a particularly slow full table scan that uses a LIKE
-    basket_attribute, __ = BasketAttribute.objects.get_or_create(
-        attribute_type=payment_intent_status_attribute,
-        basket=basket,
-    )
-    basket_attribute.value_text = payment_intent_status
-    basket_attribute.save()
 
 
 @newrelic.agent.function_trace()

--- a/ecommerce/extensions/basket/views.py
+++ b/ecommerce/extensions/basket/views.py
@@ -50,8 +50,7 @@ from ecommerce.extensions.basket import message_utils
 from ecommerce.extensions.basket.constants import (
     DYNAMIC_PAYMENT_METHODS_ENABLED,
     ENABLE_STRIPE_PAYMENT_PROCESSOR,
-    PAYMENT_INTENT_ID_ATTRIBUTE,
-    PAYMENT_INTENT_STATUS_ATTRIBUTE
+    PAYMENT_INTENT_ID_ATTRIBUTE
 )
 from ecommerce.extensions.basket.exceptions import BadRequestException, RedirectException, VoucherException
 from ecommerce.extensions.basket.utils import (
@@ -683,7 +682,6 @@ class PaymentApiLogicMixin(BasketLogicMixin):
         self._add_coupons(response, context)
         self._add_enable_stripe_payment_processor(response)
         self._add_payment_intent_id(response, self.request.basket)
-        self._add_payment_intent_status(response, self.request.basket)
         self._add_is_dynamic_payment_methods(response, self.request.basket)
         return response
 
@@ -757,17 +755,6 @@ class PaymentApiLogicMixin(BasketLogicMixin):
             response['payment_intent_id'] = payment_intent_attr.value_text.strip()
         except (BasketAttribute.DoesNotExist, BasketAttributeType.DoesNotExist):
             response['payment_intent_id'] = None
-
-    def _add_payment_intent_status(self, response, basket):
-        try:
-            payment_intent_status_attribute = BasketAttributeType.objects.get(name=PAYMENT_INTENT_STATUS_ATTRIBUTE)
-            payment_intent_attr = BasketAttribute.objects.get(
-                basket=basket,
-                attribute_type=payment_intent_status_attribute
-            )
-            response['payment_intent_status'] = payment_intent_attr.value_text.strip()
-        except (BasketAttribute.DoesNotExist, BasketAttributeType.DoesNotExist):
-            response['payment_intent_status'] = None
 
     def _add_is_dynamic_payment_methods(self, response, basket):
         try:

--- a/ecommerce/extensions/checkout/mixins.py
+++ b/ecommerce/extensions/checkout/mixins.py
@@ -127,7 +127,6 @@ class EdxOrderPlacementMixin(OrderPlacementMixin, metaclass=abc.ABCMeta):
                     processor_response.transaction_id,
                     processor_response.status,
                 )
-                # TODO: do we track this event if in progress?
                 return processor_response
             # We only record successful payments in the database.
             self.record_payment(basket, processor_response)

--- a/ecommerce/extensions/payment/processors/__init__.py
+++ b/ecommerce/extensions/payment/processors/__init__.py
@@ -14,6 +14,10 @@ PaymentProcessorResponse = get_model('payment', 'PaymentProcessorResponse')
 HandledProcessorResponse = namedtuple('HandledProcessorResponse',
                                       ['transaction_id', 'total', 'currency', 'card_number', 'card_type'])
 
+InProgressProcessorResponse = namedtuple('InProgressProcessorResponse',
+                                         ['basket_id', 'order_number', 'transaction_id', 'confirmation_client_secret',
+                                          'status', 'payment_method', 'total'])
+
 logger = logging.getLogger(__name__)
 
 

--- a/ecommerce/extensions/payment/processors/stripe.py
+++ b/ecommerce/extensions/payment/processors/stripe.py
@@ -4,6 +4,7 @@
 import logging
 
 import stripe
+from django.conf import settings
 from oscar.apps.payment.exceptions import GatewayError
 from oscar.core.loading import get_model
 
@@ -19,7 +20,8 @@ from ecommerce.extensions.payment.constants import STRIPE_CARD_TYPE_MAP
 from ecommerce.extensions.payment.processors import (
     ApplePayMixin,
     BaseClientSidePaymentProcessor,
-    HandledProcessorResponse
+    HandledProcessorResponse,
+    InProgressProcessorResponse
 )
 
 logger = logging.getLogger(__name__)
@@ -103,6 +105,30 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
             },
         }
 
+    def create_new_payment_intent_for_basket(self, basket, payment_intent_id):
+        """
+        Create a new Stripe payment intent to associate with the current basket.
+        This is used as a reset of the payment to allow payment retries when the intent gets into unexpected states.
+        """
+        # Cancel existing Payment Intent
+        stripe.PaymentIntent.cancel(payment_intent_id)
+
+        # Create a new Payment Intent and add to Basket
+        new_payment_intent = stripe.PaymentIntent.create(
+            **self._build_payment_intent_parameters(basket),
+            # This means this payment intent can only be confirmed with secret key (as in, from ecommerce)
+            secret_key_confirmation='required',
+            # don't create a new intent for the same basket
+            idempotency_key=self.generate_basket_pi_idempotency_key(basket),
+            # Enable dynamic payment methods, w/o payment method configuration ID due to Custom Actions Beta:
+            # 'allow_redirects' is default to 'always',
+            # 'enabled' is not default to True with CAB, only for Deferred Intents.
+            automatic_payment_methods={'enabled': True},
+        )
+        new_payment_intent_id = new_payment_intent['id']
+        basket_add_payment_intent_id_attribute(basket, new_payment_intent_id)
+        return new_payment_intent
+
     def generate_basket_pi_idempotency_key(self, basket):
         """
         Generate an idempotency key for creating a PaymentIntent for a Basket.
@@ -132,6 +158,10 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
                     secret_key_confirmation='required',
                     # don't create a new intent for the same basket
                     idempotency_key=self.generate_basket_pi_idempotency_key(basket),
+                    # Enable dynamic payment methods, w/o payment method configuration ID due to Custom Actions Beta
+                    # 'allow_redirects' is default to 'always'
+                    # 'enabled' is not default to True with CAB, only for Deferred Intents
+                    automatic_payment_methods={'enabled': True},
                 )
 
                 # id is the payment_intent_id from Stripe
@@ -179,6 +209,7 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
         # pretty sure we should simply return/error if basket is None, as not
         # sure what it would mean if there
         payment_intent_id = response['payment_intent_id']
+        dynamic_payment_methods_enabled = response['dynamic_payment_methods_enabled']
         # NOTE: In the future we may want to get/create a Customer. See https://stripe.com/docs/api#customers.
 
         # rewrite order amount so it's updated for coupon & quantity and unchanged by the user
@@ -186,17 +217,46 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
             payment_intent_id,
             **self._build_payment_intent_parameters(basket),
         )
+
+        # Need a return_url for dynamic payment methods that require action outside of the payment MFE
+        return_url = settings.PAYMENT_MICROFRONTEND_URL
+
         try:
             confirm_api_response = stripe.PaymentIntent.confirm(
                 payment_intent_id,
                 # stop on complicated payments MFE can't handle yet
                 error_on_requires_action=True,
                 expand=['payment_method'],
+                return_url=return_url,
             )
         except stripe.error.CardError as err:
             self.record_processor_response(err.json_body, transaction_id=payment_intent_id, basket=basket)
             logger.exception('Card Error for basket [%d]: %s}', basket.id, err)
             raise
+
+        # If the payment has another status other than 'succeeded', we want to return to the MFE something it can handle
+        if dynamic_payment_methods_enabled:
+            if confirm_api_response['status'] == 'requires_action':
+                # The Payment Intent in this status will result in 'payment_intent_unexpected_state', since it cannot
+                # be confirmed again unless in 'requires_confirmation' or 'requires_payment_intent' status.
+                # Need to create a new one so the MFE can let the learner retry payment
+                new_payment_intent = self.create_new_payment_intent_for_basket(confirm_api_response['id'], basket)
+                logger.info(
+                    'Dynamic Payment Method received requires additional action for edX order %s, '
+                    'created a new Payment Intent %s with status %s.',
+                    confirm_api_response['metadata']['order_number'],
+                    new_payment_intent['id'],
+                    new_payment_intent['status'],
+                )
+                return InProgressProcessorResponse(
+                    basket_id=basket.id,
+                    order_number=basket.order_number,
+                    status=new_payment_intent['status'],
+                    confirmation_client_secret=new_payment_intent['client_secret'],
+                    transaction_id=new_payment_intent['id'],
+                    payment_method=new_payment_intent['payment_method'],
+                    total=new_payment_intent['amount'],
+                )
 
         # proceed only if payment went through
         assert confirm_api_response['status'] == "succeeded"

--- a/ecommerce/extensions/payment/tests/processors/test_webhooks.py
+++ b/ecommerce/extensions/payment/tests/processors/test_webhooks.py
@@ -161,7 +161,7 @@ class StripeWebhooksProcessorTests(PaymentProcessorTestCaseMixin, TestCase):
             },
         }
         self.processor_class(self.site).handle_webhooks_payment(
-            self.request, succeeded_payment_intent, 'afterpay_clearpay'
+            self.request, succeeded_payment_intent, 'affirm'
         )
         properties = {
             'basket_id': self.basket.id,
@@ -169,6 +169,7 @@ class StripeWebhooksProcessorTests(PaymentProcessorTestCaseMixin, TestCase):
             'stripe_enabled': True,
             'total': self.basket.total_incl_tax,
             'success': True,
+            'payment_method': succeeded_payment_intent['charges']['data'][0]['payment_method_details']['type'],
         }
         mock_track.assert_called_once_with(
             self.basket.site, self.basket.owner, 'Payment Processor Response', properties

--- a/ecommerce/extensions/payment/tests/views/fixtures/test_stripe_test_payment_flow.json
+++ b/ecommerce/extensions/payment/tests/views/fixtures/test_stripe_test_payment_flow.json
@@ -418,7 +418,7 @@
       "source": null,
       "statement_descriptor": null,
       "statement_descriptor_suffix": null,
-      "status": "requires_payment_method",
+      "status": "requires_action",
       "transfer_data": null,
       "transfer_group": null
     },
@@ -478,7 +478,7 @@
       "transfer_group": null
     },
     "cancel_resp": {
-      "id": "pi_3LsftNIadiFyUl1x2TWxaADZ",
+      "id": "pi_3OqcQ5H4caH7G0X11y8NKNa4",
       "object": "payment_intent",
       "amount": 14900,
       "amount_capturable": 0,
@@ -502,9 +502,9 @@
         ],
         "has_more": false,
         "total_count": 0,
-        "url": "/v1/charges?payment_intent=pi_3LsftNIadiFyUl1x2TWxaADZ"
+        "url": "/v1/charges?payment_intent=pi_3OqcQ5H4caH7G0X11y8NKNa4"
       },
-      "client_secret": "pi_3LsftNIadiFyUl1x2TWxaADZ_secret_VxRx7Y1skyp0jKtq7Gdu80Xnh",
+      "client_secret": "pi_3OqcQ5H4caH7G0X11y8NKNa4_secret_kbBQP5DZGLccIESMInIq5GECO",
       "confirmation_method": "automatic",
       "created": 1709561818,
       "currency": "usd",

--- a/ecommerce/extensions/payment/tests/views/fixtures/test_stripe_test_payment_flow.json
+++ b/ecommerce/extensions/payment/tests/views/fixtures/test_stripe_test_payment_flow.json
@@ -153,6 +153,133 @@
       "transfer_data": null,
       "transfer_group": null
     },
+    "confirm_resp_in_progress": {
+      "id": "pi_3LsftNIadiFyUl1x2TWxaADZ",
+      "object": "payment_intent",
+      "amount": 14900,
+      "amount_capturable": 0,
+      "amount_details": {
+        "tip": {}
+      },
+      "amount_received": 0,
+      "application": null,
+      "application_fee_amount": null,
+      "automatic_payment_methods": {
+        "allow_redirects": "always",
+        "enabled": true
+      },
+      "canceled_at": null,
+      "cancellation_reason": null,
+      "capture_method": "automatic",
+      "charges": {
+        "object": "list",
+        "data": [],
+        "has_more": false,
+        "total_count": 0,
+        "url": "/v1/charges?payment_intent=pi_3LsftNIadiFyUl1x2TWxaADZ"
+      },
+      "client_secret": "pi_3LsftNIadiFyUl1x2TWxaADZ_secret_VxRx7Y1skyp0jKtq7Gdu80Xnh",
+      "confirmation_method": "automatic",
+      "created": 1665723185,
+      "currency": "usd",
+      "customer": null,
+      "description": "EDX-100011",
+      "invoice": null,
+      "last_payment_error": null,
+      "livemode": false,
+      "metadata": {
+        "order_number": "EDX-100011",
+        "courses": "[{'course_id': 'course-v1:edX+DemoX+Demo_Course', 'course_name': 'edX Demonstration Course'}]"
+      },
+      "next_action": {
+        "redirect_to_url": {
+          "return_url": "http://localhost:1998",
+          "url": "https://pm-redirects.stripe.com/authorize/acct_1Ls7QSH4caH7G0X1/pa_nonce_PfyM6Ous6q0DWlvWSStpSEBAONfxwOL"
+        },
+        "type": "redirect_to_url"
+      },
+      "on_behalf_of": null,
+      "payment_method": {
+        "id": "pm_1OqcPrH4caH7G0X1YGu1IGJf",
+        "object": "payment_method",
+        "billing_details": {
+          "address": {
+            "city": "Beverly Hills",
+            "country": "US",
+            "line1": "Amsterdam Ave",
+            "line2": "Apt 214",
+            "postal_code": "10024",
+            "state": "NY"
+          },
+          "email": "customer@email.us",
+          "name": "Test Person-us",
+          "phone": null
+        },
+        "created": 1709562175,
+        "customer": null,
+        "klarna": {
+        },
+        "livemode": false,
+        "metadata": {
+        },
+        "type": "klarna"
+      },
+      "payment_method_configuration_details": {
+        "id": "pmc_1LspDWH4caH7G0X1LXrN8QMJ",
+        "parent": null
+      },
+      "payment_method_options": {
+        "affirm": {
+        },
+        "afterpay_clearpay": {
+          "reference": null
+        },
+        "card": {
+          "installments": null,
+          "mandate_options": null,
+          "network": null,
+          "request_three_d_secure": "automatic"
+        },
+        "klarna": {
+          "preferred_locale": null
+        },
+        "link": {
+          "persistent_token": null
+        }
+      },
+      "payment_method_types": [
+        "card",
+        "afterpay_clearpay",
+        "klarna",
+        "link",
+        "affirm"
+      ],
+      "processing": null,
+      "receipt_email": null,
+      "review": null,
+      "secret_key_confirmation": "required",
+      "setup_future_usage": null,
+      "shipping": {
+        "address": {
+          "city": "Beverly Hills",
+          "country": "US",
+          "line1": "Amsterdam Ave",
+          "line2": "Apt 214",
+          "postal_code": "10024",
+          "state": "NY"
+        },
+        "carrier": null,
+        "name": "Test Person-us",
+        "phone": null,
+        "tracking_number": null
+      },
+      "source": null,
+      "statement_descriptor": null,
+      "statement_descriptor_suffix": null,
+      "status": "requires_action",
+      "transfer_data": null,
+      "transfer_group": null
+    },
     "create_resp": {
       "id": "pi_3LsftNIadiFyUl1x2TWxaADZ",
       "object": "payment_intent",
@@ -194,6 +321,93 @@
       },
       "payment_method_types": [
         "card"
+      ],
+      "processing": null,
+      "receipt_email": null,
+      "review": null,
+      "secret_key_confirmation": "required",
+      "setup_future_usage": null,
+      "shipping": null,
+      "source": null,
+      "statement_descriptor": null,
+      "statement_descriptor_suffix": null,
+      "status": "requires_payment_method",
+      "transfer_data": null,
+      "transfer_group": null
+    },
+    "create_resp_in_progress": {
+      "id": "pi_3OqcQ5H4caH7G0X11y8NKNa4",
+      "object": "payment_intent",
+      "amount": 14900,
+      "amount_capturable": 0,
+      "amount_details": {
+        "tip": {
+        }
+      },
+      "amount_received": 0,
+      "application": null,
+      "application_fee_amount": null,
+      "automatic_payment_methods": {
+        "allow_redirects": "always",
+        "enabled": true
+      },
+      "canceled_at": null,
+      "cancellation_reason": null,
+      "capture_method": "automatic",
+      "charges": {
+        "object": "list",
+        "data": [
+        ],
+        "has_more": false,
+        "total_count": 0,
+        "url": "/v1/charges?payment_intent=pi_3OqcQ5H4caH7G0X11y8NKNa4"
+      },
+      "client_secret": "pi_3OqcQ5H4caH7G0X11y8NKNa4_secret_kbBQP5DZGLccIESMInIq5GECO",
+      "confirmation_method": "automatic",
+      "created": 1709562189,
+      "currency": "usd",
+      "customer": null,
+      "description": "EDX-100011",
+      "invoice": null,
+      "last_payment_error": null,
+      "latest_charge": null,
+      "livemode": false,
+      "metadata": {
+        "order_number": "EDX-100011",
+        "courses": "[{'course_id': 'course-v1:edX+DemoX+Demo_Course', 'course_name': 'edX Demonstration Course'}]"
+      },
+      "next_action": null,
+      "on_behalf_of": null,
+      "payment_method": null,
+      "payment_method_configuration_details": {
+        "id": "pmc_1LspDWH4caH7G0X1LXrN8QMJ",
+        "parent": null
+      },
+      "payment_method_options": {
+        "affirm": {
+        },
+        "afterpay_clearpay": {
+          "reference": null
+        },
+        "card": {
+          "installments": null,
+          "mandate_options": null,
+          "network": null,
+          "request_three_d_secure": "automatic"
+        },
+        "klarna": {
+          "preferred_locale": null
+        },
+        "link": {
+          "persistent_token": null
+        }
+      },
+      "payment_method_types": [
+        "card",
+        "afterpay_clearpay",
+        "klarna",
+        "link",
+        "affirm"
       ],
       "processing": null,
       "receipt_email": null,
@@ -260,6 +474,106 @@
       "statement_descriptor": null,
       "statement_descriptor_suffix": null,
       "status": "requires_confirmation",
+      "transfer_data": null,
+      "transfer_group": null
+    },
+    "cancel_resp": {
+      "id": "pi_3LsftNIadiFyUl1x2TWxaADZ",
+      "object": "payment_intent",
+      "amount": 14900,
+      "amount_capturable": 0,
+      "amount_details": {
+        "tip": {
+        }
+      },
+      "amount_received": 0,
+      "application": null,
+      "application_fee_amount": null,
+      "automatic_payment_methods": {
+        "allow_redirects": "always",
+        "enabled": true
+      },
+      "canceled_at": 1709562188,
+      "cancellation_reason": null,
+      "capture_method": "automatic",
+      "charges": {
+        "object": "list",
+        "data": [
+        ],
+        "has_more": false,
+        "total_count": 0,
+        "url": "/v1/charges?payment_intent=pi_3LsftNIadiFyUl1x2TWxaADZ"
+      },
+      "client_secret": "pi_3LsftNIadiFyUl1x2TWxaADZ_secret_VxRx7Y1skyp0jKtq7Gdu80Xnh",
+      "confirmation_method": "automatic",
+      "created": 1709561818,
+      "currency": "usd",
+      "customer": null,
+      "description": "EDX-100011",
+      "invoice": null,
+      "last_payment_error": null,
+      "latest_charge": null,
+      "livemode": false,
+      "metadata": {
+        "order_number": "EDX-100011",
+        "courses": "[{'course_id': 'course-v1:edX+DemoX+Demo_Course', 'course_name': 'edX Demonstration Course'}]"
+      },
+      "next_action": null,
+      "on_behalf_of": null,
+      "payment_method": "pm_1OqcPrH4caH7G0X1YGu1IGJf",
+      "payment_method_configuration_details": {
+        "id": "pmc_1LspDWH4caH7G0X1LXrN8QMJ",
+        "parent": null
+      },
+      "payment_method_options": {
+        "affirm": {
+        },
+        "afterpay_clearpay": {
+          "reference": null
+        },
+        "card": {
+          "installments": null,
+          "mandate_options": null,
+          "network": null,
+          "request_three_d_secure": "automatic"
+        },
+        "klarna": {
+          "preferred_locale": null
+        },
+        "link": {
+          "persistent_token": null
+        }
+      },
+      "payment_method_types": [
+        "card",
+        "afterpay_clearpay",
+        "klarna",
+        "link",
+        "affirm"
+      ],
+      "processing": null,
+      "receipt_email": null,
+      "review": null,
+      "secret_key_confirmation": "required",
+      "setup_future_usage": null,
+      "shipping": {
+        "address": {
+          "city": "Beverly Hills",
+          "country": "US",
+          "line1": "Amsterdam Ave",
+          "line2": "Apt 214",
+          "postal_code": "10024",
+          "state": "NY"
+        },
+        "carrier": null,
+        "name": "Test Person-us",
+        "phone": null,
+        "tracking_number": null
+      },
+      "source": null,
+      "statement_descriptor": null,
+      "statement_descriptor_suffix": null,
+      "status": "canceled",
       "transfer_data": null,
       "transfer_group": null
     },

--- a/ecommerce/extensions/payment/tests/views/fixtures/test_stripe_test_payment_flow.json
+++ b/ecommerce/extensions/payment/tests/views/fixtures/test_stripe_test_payment_flow.json
@@ -335,93 +335,6 @@
       "transfer_data": null,
       "transfer_group": null
     },
-    "create_resp_in_progress": {
-      "id": "pi_3OqcQ5H4caH7G0X11y8NKNa4",
-      "object": "payment_intent",
-      "amount": 14900,
-      "amount_capturable": 0,
-      "amount_details": {
-        "tip": {
-        }
-      },
-      "amount_received": 0,
-      "application": null,
-      "application_fee_amount": null,
-      "automatic_payment_methods": {
-        "allow_redirects": "always",
-        "enabled": true
-      },
-      "canceled_at": null,
-      "cancellation_reason": null,
-      "capture_method": "automatic",
-      "charges": {
-        "object": "list",
-        "data": [
-        ],
-        "has_more": false,
-        "total_count": 0,
-        "url": "/v1/charges?payment_intent=pi_3OqcQ5H4caH7G0X11y8NKNa4"
-      },
-      "client_secret": "pi_3OqcQ5H4caH7G0X11y8NKNa4_secret_kbBQP5DZGLccIESMInIq5GECO",
-      "confirmation_method": "automatic",
-      "created": 1709562189,
-      "currency": "usd",
-      "customer": null,
-      "description": "EDX-100011",
-      "invoice": null,
-      "last_payment_error": null,
-      "latest_charge": null,
-      "livemode": false,
-      "metadata": {
-        "order_number": "EDX-100011",
-        "courses": "[{'course_id': 'course-v1:edX+DemoX+Demo_Course', 'course_name': 'edX Demonstration Course'}]"
-      },
-      "next_action": null,
-      "on_behalf_of": null,
-      "payment_method": null,
-      "payment_method_configuration_details": {
-        "id": "pmc_1LspDWH4caH7G0X1LXrN8QMJ",
-        "parent": null
-      },
-      "payment_method_options": {
-        "affirm": {
-        },
-        "afterpay_clearpay": {
-          "reference": null
-        },
-        "card": {
-          "installments": null,
-          "mandate_options": null,
-          "network": null,
-          "request_three_d_secure": "automatic"
-        },
-        "klarna": {
-          "preferred_locale": null
-        },
-        "link": {
-          "persistent_token": null
-        }
-      },
-      "payment_method_types": [
-        "card",
-        "afterpay_clearpay",
-        "klarna",
-        "link",
-        "affirm"
-      ],
-      "processing": null,
-      "receipt_email": null,
-      "review": null,
-      "secret_key_confirmation": "required",
-      "setup_future_usage": null,
-      "shipping": null,
-      "source": null,
-      "statement_descriptor": null,
-      "statement_descriptor_suffix": null,
-      "status": "requires_action",
-      "transfer_data": null,
-      "transfer_group": null
-    },
     "modify_resp": {
       "id": "pi_3LsftNIadiFyUl1x2TWxaADZ",
       "object": "payment_intent",
@@ -691,6 +604,93 @@
       "statement_descriptor": null,
       "statement_descriptor_suffix": null,
       "status": "requires_confirmation",
+      "transfer_data": null,
+      "transfer_group": null
+    },
+    "retrieve_resp_in_progress": {
+      "id": "pi_3OqcQ5H4caH7G0X11y8NKNa4",
+      "object": "payment_intent",
+      "amount": 14900,
+      "amount_capturable": 0,
+      "amount_details": {
+        "tip": {
+        }
+      },
+      "amount_received": 0,
+      "application": null,
+      "application_fee_amount": null,
+      "automatic_payment_methods": {
+        "allow_redirects": "always",
+        "enabled": true
+      },
+      "canceled_at": null,
+      "cancellation_reason": null,
+      "capture_method": "automatic",
+      "charges": {
+        "object": "list",
+        "data": [
+        ],
+        "has_more": false,
+        "total_count": 0,
+        "url": "/v1/charges?payment_intent=pi_3OqcQ5H4caH7G0X11y8NKNa4"
+      },
+      "client_secret": "pi_3OqcQ5H4caH7G0X11y8NKNa4_secret_kbBQP5DZGLccIESMInIq5GECO",
+      "confirmation_method": "automatic",
+      "created": 1709562189,
+      "currency": "usd",
+      "customer": null,
+      "description": "EDX-100011",
+      "invoice": null,
+      "last_payment_error": null,
+      "latest_charge": null,
+      "livemode": false,
+      "metadata": {
+        "order_number": "EDX-100011",
+        "courses": "[{'course_id': 'course-v1:edX+DemoX+Demo_Course', 'course_name': 'edX Demonstration Course'}]"
+      },
+      "next_action": null,
+      "on_behalf_of": null,
+      "payment_method": null,
+      "payment_method_configuration_details": {
+        "id": "pmc_1LspDWH4caH7G0X1LXrN8QMJ",
+        "parent": null
+      },
+      "payment_method_options": {
+        "affirm": {
+        },
+        "afterpay_clearpay": {
+          "reference": null
+        },
+        "card": {
+          "installments": null,
+          "mandate_options": null,
+          "network": null,
+          "request_three_d_secure": "automatic"
+        },
+        "klarna": {
+          "preferred_locale": null
+        },
+        "link": {
+          "persistent_token": null
+        }
+      },
+      "payment_method_types": [
+        "card",
+        "afterpay_clearpay",
+        "klarna",
+        "link",
+        "affirm"
+      ],
+      "processing": null,
+      "receipt_email": null,
+      "review": null,
+      "secret_key_confirmation": "required",
+      "setup_future_usage": null,
+      "shipping": null,
+      "source": null,
+      "statement_descriptor": null,
+      "statement_descriptor_suffix": null,
+      "status": "requires_action",
       "transfer_data": null,
       "transfer_group": null
     }

--- a/ecommerce/extensions/payment/views/stripe.py
+++ b/ecommerce/extensions/payment/views/stripe.py
@@ -228,13 +228,16 @@ class StripeCheckoutView(EdxOrderPlacementMixin, APIView):
         try:
             with transaction.atomic():
                 try:
-                    self.handle_payment(stripe_response, basket)
+                    in_progress_payment = self.handle_payment(stripe_response, basket)
                 except CardError as err:
                     return self.stripe_error_response(err)
         except:  # pylint: disable=bare-except
             logger.exception('Attempts to handle payment for basket [%d] failed.', basket.id)
             return self.error_page_response()
 
+        # We'll only have a return value if the payment is a dynamic payment methods in progress
+        if in_progress_payment:
+            return self.dynamic_payment_methods_response(in_progress_payment)
         try:
             billing_address = self.create_billing_address(
                 user=self.request.user,
@@ -293,3 +296,15 @@ class StripeCheckoutView(EdxOrderPlacementMixin, APIView):
             'error_code': error.code,
             'user_message': error.user_message,
         }, status=400)
+
+    def dynamic_payment_methods_response(self, in_progress_payment):
+        """Tell the frontend the Payment Intent status and it will decide what to do."""
+        if 'status' in in_progress_payment._fields:
+            response_data = {
+                'status': in_progress_payment.status,
+                'confirmation_client_secret': in_progress_payment.confirmation_client_secret,
+                'payment_method': in_progress_payment.payment_method,
+                'total': in_progress_payment.total,
+                'transaction_id': in_progress_payment.transaction_id,
+            }
+        return JsonResponse(response_data, status=201)

--- a/ecommerce/extensions/payment/views/stripe.py
+++ b/ecommerce/extensions/payment/views/stripe.py
@@ -237,6 +237,14 @@ class StripeCheckoutView(EdxOrderPlacementMixin, APIView):
 
         # We'll only have a return value if the payment is a dynamic payment methods in progress
         if in_progress_payment:
+            logger.info(
+                'Dynamic Payment Method received for edX order %s with basket %d, '
+                'returning Payment Intent %s with status %s to the payment MFE',
+                in_progress_payment.order_number,
+                in_progress_payment.basket_id,
+                in_progress_payment.transaction_id,
+                in_progress_payment.status,
+            )
             return self.dynamic_payment_methods_response(in_progress_payment)
         try:
             billing_address = self.create_billing_address(
@@ -298,13 +306,12 @@ class StripeCheckoutView(EdxOrderPlacementMixin, APIView):
         }, status=400)
 
     def dynamic_payment_methods_response(self, in_progress_payment):
-        """Tell the frontend the Payment Intent status and it will decide what to do."""
+        """Tell the frontend the Payment Intent ID and status and it will decide what to do."""
         if 'status' in in_progress_payment._fields:
             response_data = {
                 'status': in_progress_payment.status,
                 'confirmation_client_secret': in_progress_payment.confirmation_client_secret,
                 'payment_method': in_progress_payment.payment_method,
-                'total': in_progress_payment.total,
                 'transaction_id': in_progress_payment.transaction_id,
             }
         return JsonResponse(response_data, status=201)

--- a/ecommerce/extensions/payment/views/stripe.py
+++ b/ecommerce/extensions/payment/views/stripe.py
@@ -307,11 +307,10 @@ class StripeCheckoutView(EdxOrderPlacementMixin, APIView):
 
     def dynamic_payment_methods_response(self, in_progress_payment):
         """Tell the frontend the Payment Intent ID and status and it will decide what to do."""
-        if 'status' in in_progress_payment._fields:
-            response_data = {
-                'status': in_progress_payment.status,
-                'confirmation_client_secret': in_progress_payment.confirmation_client_secret,
-                'payment_method': in_progress_payment.payment_method,
-                'transaction_id': in_progress_payment.transaction_id,
-            }
+        response_data = {
+            'status': in_progress_payment.status,
+            'confirmation_client_secret': in_progress_payment.confirmation_client_secret,
+            'payment_method': in_progress_payment.payment_method,
+            'transaction_id': in_progress_payment.transaction_id,
+        }
         return JsonResponse(response_data, status=201)

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -865,7 +865,7 @@ API_ROOT = None
 ECOMMERCE_MICROFRONTEND_URL = os.environ.get('ECOMMERCE_MICROFRONTEND_URL')
 
 # Needed to link to the payment micro-frontend
-PAYMENT_MICROFRONTEND_URL = None
+PAYMENT_MICROFRONTEND_URL = os.environ.get('PAYMENT_MICROFRONTEND_URL')
 
 # For Enterprise purchases to send purchase information to HubSpot for marketing leads
 HUBSPOT_FORMS_API_URI = "SET-ME-PLEASE"

--- a/ecommerce/settings/devstack.py
+++ b/ecommerce/settings/devstack.py
@@ -63,6 +63,8 @@ CORS_ALLOW_HEADERS = corsheaders_default_headers + (
 )
 CORS_ALLOW_CREDENTIALS = True
 
+PAYMENT_MICROFRONTEND_URL = 'http://localhost:1998'
+
 ECOMMERCE_MICROFRONTEND_URL = 'http://localhost:1996'
 
 ENTERPRISE_CATALOG_API_URL = urljoin(f"{ENTERPRISE_CATALOG_SERVICE_URL}/", 'api/v1/')


### PR DESCRIPTION
[REV-3821](https://2u-internal.atlassian.net/browse/REV-3821).

Legacy uses Custom Actions Beta (CAB), which do not have `automatic_payment_methods` enabled by default in Stripe.
In preparation for the DPM experiment, we need to refactor our code in ecommerce and payment MFE to be able to handle a different payment flow.

**A note on server/client side confirmation with DPM and redirect to receipt:**
The docs for dynamic payment methods use client-side Payment Intent confirmation, and even though with CAB we can confirm the Payment Intent server-side, the "next action" is still handled from the client. 
This means that on "Place Order" in the payment MFE, we make a `POST` request to ecommerce to confirm the Payment Intent (among other things), but this is not finalized until we're back in the MFE after a re-direct from the BNPL environment. 
This means that it would skip order and billing address creation and order fulfillment in ecommerce, and the redirect to the receipt page would have to happen from the MFE to an order that doesn't exist yet --> we will use webhooks to make this happen async, included in [this](https://github.com/openedx/ecommerce/pull/4151) PR.