### PR TITLE
Fix: Support create-mobile-skus to run again if failed

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -861,11 +861,13 @@ class AtomicPublicationSerializer(serializers.Serializer):  # pylint: disable=ab
         partner_short_code = self.context['request'].site.siteconfiguration.partner.short_code
         configuration = settings.PAYMENT_PROCESSOR_CONFIG[partner_short_code.lower()][IOSIAP.NAME.lower()]
         headers = get_auth_headers(configuration)
-        try:
-            ios_product_id = mobile_seat.attr.app_store_id
-            apply_price_of_inapp_purchase(price, ios_product_id, headers)
-        except AttributeError:
+        ios_product_id = getattr(mobile_seat.attr, 'app_store_id', None)
+        if not ios_product_id:
             logger.error("app_store_id not associated with [%s]", mobile_seat.course)
+            return
+
+        apply_price_of_inapp_purchase(price, ios_product_id, headers)
+
 
     def get_partner(self):
         """Validate partner"""

--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -868,7 +868,6 @@ class AtomicPublicationSerializer(serializers.Serializer):  # pylint: disable=ab
 
         apply_price_of_inapp_purchase(price, ios_product_id, headers)
 
-
     def get_partner(self):
         """Validate partner"""
         if not self.partner:

--- a/ecommerce/extensions/iap/api/v1/utils.py
+++ b/ecommerce/extensions/iap/api/v1/utils.py
@@ -48,6 +48,7 @@ def create_ios_product(course, ios_product, configuration):
         logger.error(error_msg)
         return error_msg
 
+
 def get_or_create_inapp_purchase(ios_stock_record, course, configuration, headers):
     """
     Returns inapp_purchase_id from product attr
@@ -62,6 +63,7 @@ def get_or_create_inapp_purchase(ios_stock_record, course, configuration, header
         ios_stock_record.product.save()
 
     return in_app_purchase_id
+
 
 def request_connect_store(url, headers, data=None, method="post"):
     """ Request the given endpoint with multiple tries and backoff time """

--- a/ecommerce/extensions/iap/api/v1/utils.py
+++ b/ecommerce/extensions/iap/api/v1/utils.py
@@ -36,9 +36,7 @@ def create_ios_product(course, ios_product, configuration):
     """
     headers = get_auth_headers(configuration)
     try:
-        in_app_purchase_id = create_inapp_purchase(course, ios_product.partner_sku, configuration['apple_id'], headers)
-        ios_product.product.attr.app_store_id = in_app_purchase_id
-        ios_product.product.save()
+        in_app_purchase_id = get_or_create_inapp_purchase(ios_product, course, configuration, headers)
         localize_inapp_purchase(in_app_purchase_id, headers)
         apply_price_of_inapp_purchase(course['price'], in_app_purchase_id, headers)
         upload_screenshot_of_inapp_purchase(in_app_purchase_id, headers)
@@ -50,6 +48,20 @@ def create_ios_product(course, ios_product, configuration):
         logger.error(error_msg)
         return error_msg
 
+def get_or_create_inapp_purchase(ios_stock_record, course, configuration, headers):
+    """
+    Returns inapp_purchase_id from product attr
+    If not present there create a product on ios store and return its inapp_purchase_id
+    """
+
+    in_app_purchase_id = getattr(ios_stock_record.product.attr, 'app_store_id', '')
+    if not in_app_purchase_id:
+        in_app_purchase_id = create_inapp_purchase(course, ios_stock_record.partner_sku,
+                                                   configuration['apple_id'], headers)
+        ios_stock_record.product.attr.app_store_id = in_app_purchase_id
+        ios_stock_record.product.save()
+
+    return in_app_purchase_id
 
 def request_connect_store(url, headers, data=None, method="post"):
     """ Request the given endpoint with multiple tries and backoff time """

--- a/ecommerce/extensions/iap/api/v1/views.py
+++ b/ecommerce/extensions/iap/api/v1/views.py
@@ -404,7 +404,7 @@ class MobileSkusCreationView(APIView):
                 product_class__name=SEAT_PRODUCT_CLASS_NAME,
                 children__expires__gt=now(),
                 course=course_run,
-            )
+            ).distinct()
 
             if not parent_product.exists():
                 failed_course_runs.append(course_run_key)

--- a/ecommerce/extensions/iap/utils.py
+++ b/ecommerce/extensions/iap/utils.py
@@ -57,7 +57,9 @@ def create_mobile_seat(sku_prefix, existing_web_seat):
     if 'ios' in sku_prefix:
         # We need this attribute defined for ios products
         # Actual values will be assigned when we create product on appstore
-        new_mobile_seat.attr.app_store_id = ''
+        app_store_id = getattr(new_mobile_seat.attr, 'app_store_id', None)
+        if not app_store_id:
+            new_mobile_seat.attr.app_store_id = ''
 
     new_mobile_seat.attr.save()
 


### PR DESCRIPTION
# ⛔️ MAIN BRANCH WARNING! 2U EMPLOYEES must make branches against the 2u/main BRANCH

- [x] I have checked the branch to which I would like to merge.

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Support create-mobile-skus to run again if failed

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
