### PR TITLE
fix: Enable enrollment code purchase with mobile seats

### DIFF
--- a/ecommerce/extensions/fulfillment/modules.py
+++ b/ecommerce/extensions/fulfillment/modules.py
@@ -14,6 +14,7 @@ from urllib.parse import urlencode, urljoin
 import requests
 import waffle
 from django.conf import settings
+from django.db.models import Q
 from django.urls import reverse
 from getsmarter_api_clients.geag import GetSmarterEnterpriseApiClient
 from oscar.core.loading import get_model
@@ -553,6 +554,7 @@ class EnrollmentCodeFulfillmentModule(BaseFulfillmentModule):
                 attributes__name='course_key',
                 attribute_values__value_text=line.product.attr.course_key
             ).get(
+                ~Q(stockrecords__partner_sku__icontains="mobile"),
                 attributes__name='certificate_type',
                 attribute_values__value_text=line.product.attr.seat_type
             )


### PR DESCRIPTION
# ⛔️ MAIN BRANCH WARNING! 2U EMPLOYEES must make branches against the 2u/main BRANCH

- [ ] I have checked the branch to which I would like to merge.

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.


## Description
Enable purchasing enrollment codes in presence of multiple enrollment codes for mobile.

Related Jira links:
https://2u-internal.atlassian.net/browse/REV-3857
https://2u-internal.atlassian.net/browse/LEARNER-9837

