### PR TITLE
fix: Fix send email error and add tests

### DIFF
--- a/ecommerce/extensions/communication/tests/test_utils.py
+++ b/ecommerce/extensions/communication/tests/test_utils.py
@@ -1,0 +1,60 @@
+import mock
+
+from django.conf import settings
+
+from ecommerce.extensions.communication.utils import Dispatcher
+from ecommerce.tests.testcases import TestCase
+
+
+class TestDispatcher(TestCase):
+
+    def setUp(self):
+        super(TestDispatcher, self).setUp()
+        self.user = self.create_user(is_staff=False, email="user@example.com")
+
+    @mock.patch('ecommerce.extensions.communication.utils.EmailMessage')
+    def test_send_email_messages_no_html(self, mock_email_message):
+        dispatcher = Dispatcher()
+        messages = {
+            'subject': 'Test Subject',
+            'body': 'Test Body',
+        }
+        dispatcher.send_email_messages('recipient@example.com', messages)
+        mock_email_message.assert_called_once_with(
+            'Test Subject',
+            'Test Body',
+            from_email=settings.OSCAR_FROM_EMAIL,
+            to=['recipient@example.com']
+        )
+
+    @mock.patch('ecommerce.extensions.communication.utils.EmailMessage')
+    def test_send_email_messages_plain(self, mock_email_message):
+        dispatcher = Dispatcher()
+        messages = {
+            'subject': 'Test Subject',
+            'body': 'Test Body',
+            'html': None
+        }
+        dispatcher.send_email_messages('recipient@example.com', messages)
+        mock_email_message.assert_called_once_with(
+            'Test Subject',
+            'Test Body',
+            from_email=settings.OSCAR_FROM_EMAIL,
+            to=['recipient@example.com']
+        )
+
+    @mock.patch('ecommerce.extensions.communication.utils.EmailMultiAlternatives')
+    def test_send_email_messages_html(self, mock_email_multi_alternatives):
+        dispatcher = Dispatcher()
+        messages = {
+            'subject': 'Test Subject',
+            'body': 'Test Body',
+            'html': '<html><body>Test HTML Body</body></html>'
+        }
+        dispatcher.send_email_messages('recipient@example.com', messages)
+        mock_email_multi_alternatives.assert_called_once_with(
+            'Test Subject',
+            'Test Body',
+            from_email=settings.OSCAR_FROM_EMAIL,
+            to=['recipient@example.com']
+        )

--- a/ecommerce/extensions/communication/tests/test_utils.py
+++ b/ecommerce/extensions/communication/tests/test_utils.py
@@ -45,6 +45,8 @@ class TestDispatcher(TestCase):
     @mock.patch('ecommerce.extensions.communication.utils.EmailMultiAlternatives')
     def test_send_email_messages_html(self, mock_email_multi_alternatives):
         dispatcher = Dispatcher()
+        mock_email_instance = mock_email_multi_alternatives.return_value
+
         messages = {
             'subject': 'Test Subject',
             'body': 'Test Body',
@@ -56,4 +58,8 @@ class TestDispatcher(TestCase):
             'Test Body',
             from_email=settings.OSCAR_FROM_EMAIL,
             to=['recipient@example.com']
+        )
+        mock_email_instance.attach_alternative.assert_called_once_with(
+            '<html><body>Test HTML Body</body></html>',
+            "text/html"
         )

--- a/ecommerce/extensions/communication/tests/test_utils.py
+++ b/ecommerce/extensions/communication/tests/test_utils.py
@@ -1,5 +1,4 @@
 import mock
-
 from django.conf import settings
 
 from ecommerce.extensions.communication.utils import Dispatcher

--- a/ecommerce/extensions/communication/utils.py
+++ b/ecommerce/extensions/communication/utils.py
@@ -70,7 +70,7 @@ class Dispatcher(Dispatcher):
             from_email = site.siteconfiguration.get_from_email()
 
         # Determine whether we are sending a HTML version too
-        if messages['html']:
+        if messages.get('html'):
             email = EmailMultiAlternatives(messages['subject'],
                                            messages['body'],
                                            from_email=from_email,


### PR DESCRIPTION
# ⛔️ MAIN BRANCH WARNING! 2U EMPLOYEES must make branches against the 2u/main BRANCH

- [ ] I have checked the branch to which I would like to merge.

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Email communication code breaks in absence of optional attributes of the object `messages`. This change replaces direct dictionary fetch `[]` with a `.get()` and adds unit tests for the method involved.

Related tickets:
1. https://2u-internal.atlassian.net/servicedesk/customer/portal/9/CR-6507
2. https://2u-internal.atlassian.net/browse/AU-1693
3. https://2u-internal.atlassian.net/browse/LEARNER-9838

Related Bug trace(s):

![Screenshot 2024-02-13 at 8 06 01 PM (1)](https://github.com/openedx/ecommerce/assets/17109504/cf83fe8a-28d0-4df3-a94f-61e8ffebb918)

