### PR TITLE
feat: update_voucher_names now can be run synchronously and can batch…

### DIFF
--- a/ecommerce/extensions/voucher/management/commands/tests/test_update_voucher_names.py
+++ b/ecommerce/extensions/voucher/management/commands/tests/test_update_voucher_names.py
@@ -23,7 +23,7 @@ class ManagementCommandTests(TestCase):
 
         self.LOGGER_NAME = 'ecommerce.extensions.voucher.management.commands.update_voucher_names'
 
-    @mock.patch('ecommerce.extensions.voucher.tasks.update_voucher_names.delay')
+    @mock.patch('ecommerce.extensions.voucher.tasks.update_voucher_names_task.delay')
     def test_update_voucher_names_command(self, mock_delay):
         """
         Verify a celery task is spun off when the management command is run.
@@ -45,7 +45,7 @@ class ManagementCommandTests(TestCase):
         for voucher in vouchers:
             assert voucher.name == f'{voucher.id} - {self.voucher_name}'
 
-    @mock.patch('ecommerce.extensions.voucher.tasks.update_voucher_names.delay')
+    @mock.patch('ecommerce.extensions.voucher.tasks.update_voucher_names_task.delay')
     def test_update_voucher_names_synchronous(self, mock_delay):
         """
         Verify task is NOT called in management command, but rather, function is
@@ -124,7 +124,7 @@ class ManagementCommandTests(TestCase):
             for voucher in vouchers:
                 assert voucher.name == f'{voucher.id} - {self.voucher_name}'
 
-    @mock.patch('ecommerce.extensions.voucher.tasks.update_voucher_names.delay')
+    @mock.patch('ecommerce.extensions.voucher.tasks.update_voucher_names_task.delay')
     def test_update_voucher_names_command_failure(self, mock_delay):
         """
         Verify a when celery task fails to spin off, we log an error and continue.

--- a/ecommerce/extensions/voucher/management/commands/tests/test_update_voucher_names.py
+++ b/ecommerce/extensions/voucher/management/commands/tests/test_update_voucher_names.py
@@ -61,6 +61,29 @@ class ManagementCommandTests(TestCase):
 
         mock_delay.assert_not_called()
 
+    def test_update_voucher_names_offset(self):
+        """
+        Verify task processes correct # of records when offset is specified.
+        """
+        first_voucher = Voucher.objects.first()
+        last_voucher = Voucher.objects.last()
+        expected_first_voucher_name = first_voucher.name
+        expected_last_voucher_name = f'{last_voucher.id} - {last_voucher.name}'
+
+        # we expect vouchers 2 and 3 to be updated,
+        # but not voucher 1
+        call_command(
+            'update_voucher_names',
+            batch_size=1,
+            batch_offset=1,
+            run_async=False
+        )
+        first_voucher.refresh_from_db()
+        assert first_voucher.name == expected_first_voucher_name
+
+        last_voucher.refresh_from_db()
+        assert last_voucher.name == expected_last_voucher_name
+
     def test_update_voucher_names_long_name(self):
         """
         Verify task will truncate long voucher names to 128 chars

--- a/ecommerce/extensions/voucher/management/commands/update_voucher_names.py
+++ b/ecommerce/extensions/voucher/management/commands/update_voucher_names.py
@@ -5,7 +5,7 @@ from time import sleep
 from django.core.management.base import BaseCommand
 
 from ecommerce.extensions.voucher.models import Voucher
-from ecommerce.extensions.voucher.tasks import update_voucher_names
+from ecommerce.extensions.voucher.tasks import update_voucher_names, update_voucher_names_task
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ class Command(BaseCommand):
             try:
                 # Call the Celery task asynchronously for each batch
                 if run_async:
-                    update_voucher_names.delay(vouchers)
+                    update_voucher_names_task.delay(vouchers)
                 else:
                     update_voucher_names(vouchers)
             except Exception as exc:  # pylint: disable=broad-except

--- a/ecommerce/extensions/voucher/management/commands/update_voucher_names.py
+++ b/ecommerce/extensions/voucher/management/commands/update_voucher_names.py
@@ -38,14 +38,23 @@ class Command(BaseCommand):
             help='How long to sleep between batches.',
             type=int
         )
+        parser.add_argument(
+            '--batch-offset',
+            action='store',
+            dest='batch_offset',
+            default=0,
+            help='0-indexed offset to start processing at.',
+            type=int
+        )
 
     def handle(self, *args, **options):
         batch_size = options['batch_size']
         run_async = options['run_async']
         batch_sleep = options['batch_sleep']
+        batch_offset = options['batch_offset']
 
         total_vouchers = Voucher.objects.count()
-        processed_vouchers = 0
+        processed_vouchers = batch_offset
 
         logger.info("Total number of vouchers: %d", total_vouchers)
 

--- a/ecommerce/extensions/voucher/management/commands/update_voucher_names.py
+++ b/ecommerce/extensions/voucher/management/commands/update_voucher_names.py
@@ -1,5 +1,6 @@
 # ecommerce/extensions/vouchers/management/commands/update_voucher_names.py
 import logging
+from time import sleep
 
 from django.core.management.base import BaseCommand
 
@@ -10,13 +11,38 @@ logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = 'Update voucher names asynchronously'
+    help = 'Update voucher names to be unique'
 
     def add_arguments(self, parser):
-        parser.add_argument('--batch-size', type=int, default=1000, help='Number of vouchers to process in each batch')
+        parser.add_argument(
+            '--batch-size',
+            action='store',
+            dest='batch_size',
+            type=int,
+            default=1000,
+            help='Number of vouchers to process in each batch'
+        )
+        parser.add_argument(
+            '--run-async',
+            action='store',
+            dest='run_async',
+            type=bool,
+            default=False,
+            help='Bool if this task run on celery (default to False)'
+        )
+        parser.add_argument(
+            '--batch-sleep',
+            action='store',
+            dest='batch_sleep',
+            default=0,
+            help='How long to sleep between batches.',
+            type=int
+        )
 
     def handle(self, *args, **options):
         batch_size = options['batch_size']
+        run_async = options['run_async']
+        batch_sleep = options['batch_sleep']
 
         total_vouchers = Voucher.objects.count()
         processed_vouchers = 0
@@ -27,9 +53,14 @@ class Command(BaseCommand):
             vouchers = Voucher.objects.all()[processed_vouchers:processed_vouchers + batch_size]
             try:
                 # Call the Celery task asynchronously for each batch
-                update_voucher_names.delay(vouchers)
+                if run_async:
+                    update_voucher_names.delay(vouchers)
+                else:
+                    update_voucher_names(vouchers)
             except Exception as exc:  # pylint: disable=broad-except
                 logger.exception("Error updating voucher names: %s", exc)
 
             processed_vouchers += len(vouchers)
             logger.info("Processed %d out of %d vouchers", processed_vouchers, total_vouchers)
+
+            sleep(batch_sleep)

--- a/ecommerce/extensions/voucher/management/commands/update_voucher_names.py
+++ b/ecommerce/extensions/voucher/management/commands/update_voucher_names.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
             dest='run_async',
             type=bool,
             default=False,
-            help='Bool if this task run on celery (default to False)'
+            help='Bool if this task is run on celery (default to False)'
         )
         parser.add_argument(
             '--batch-sleep',

--- a/ecommerce/extensions/voucher/tasks.py
+++ b/ecommerce/extensions/voucher/tasks.py
@@ -6,7 +6,16 @@ logger = logging.getLogger(__name__)
 
 
 @shared_task(bind=True, ignore_result=True)
-def update_voucher_names(self, vouchers):  # pylint: disable=unused-argument
+def update_voucher_names_task(self, vouchers):  # pylint: disable=unused-argument
+    """
+    Wrapper to allow update_voucher_names be run as a celery task.
+    """
+    update_voucher_names(vouchers)
+
+def update_voucher_names(vouchers):
+    """
+    Update voucher names to be unique, and no more than 128 chars long.
+    """
     for voucher in vouchers:
         if f"{voucher.id} -" not in voucher.name:
             updated_name = f"{voucher.id} - {voucher.name}"

--- a/ecommerce/extensions/voucher/tasks.py
+++ b/ecommerce/extensions/voucher/tasks.py
@@ -12,6 +12,7 @@ def update_voucher_names_task(self, vouchers):  # pylint: disable=unused-argumen
     """
     update_voucher_names(vouchers)
 
+
 def update_voucher_names(vouchers):
     """
     Update voucher names to be unique, and no more than 128 chars long.


### PR DESCRIPTION
… sleep

# ⛔️ MAIN BRANCH WARNING! 2U EMPLOYEES must make branches against the 2u/main BRANCH

- [ ] I have checked the branch to which I would like to merge.

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?
Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
