### PR TITLE
Changes for compataible with pyjwt 2

### DIFF
--- a/ecommerce/extensions/payment/processors/cybersource.py
+++ b/ecommerce/extensions/payment/processors/cybersource.py
@@ -222,7 +222,7 @@ class CybersourceREST(ApplePayMixin, BaseClientSidePaymentProcessor):
             (capture_context, decoded_capture_context)
             for (capture_context, decoded_capture_context)
             in (
-                (capture_context, jwt.decode(capture_context['key_id'], verify=False))
+                (capture_context, jwt.decode(capture_context['key_id'], options={"verify_signature": False}))
                 for capture_context
                 in session.get('capture_contexts', [])
             )


### PR DESCRIPTION
the jwt.decode function has changed since pyJwt 2, that

`jwt.decode(capture_context['key_id'], verify=False)` has changed to
`jwt.decode(capture_context['key_id'], options={"verify_signature": False})`

so this commit fixes the error while calling while pyjwt >=2 is installed