### PR TITLE
Added fallback approach for android purchase validation

### DIFF
--- a/ecommerce/extensions/iap/api/v1/google_validator.py
+++ b/ecommerce/extensions/iap/api/v1/google_validator.py
@@ -6,28 +6,39 @@ logger = logging.getLogger(__name__)
 
 
 class GooglePlayValidator:
-    def validate(self, receipt, configuration):
+    def validate(self, receipt, configuration, basket=None):
         """
         Accepts receipt, validates that the purchase has already been completed in
         Google for the mentioned productId.
         """
         purchase_token = receipt['purchaseToken']
-        product_sku = receipt['productId']
+        # Mobile assumes one course purchase at a time
+        stockrecord_price = int(basket.total_excl_tax)
+        product_sku = 'mobile.android.usd{}'.format(stockrecord_price)
         verifier = GooglePlayVerifier(
             configuration.get('google_bundle_id'),
             configuration.get('google_service_account_key_file'),
         )
         try:
-            response = verifier.verify_with_result(purchase_token, product_sku, is_subscription=False)
-            result = {
-                'raw_response': response.raw_response,
-                'is_canceled': response.is_canceled,
-                'is_expired': response.is_expired
-            }
-        except errors.GoogleError as exc:
-            logger.error('Purchase validation failed %s', exc)
-            result = {
-                'error': exc.raw_response,
-                'message': exc.message
-            }
+            result = self.verify_result(verifier, purchase_token, product_sku)
+        except errors.GoogleError:
+            try:
+                # Fallback to the old approach and verify token with partner_sku
+                # This fallback is for temporary reason untill all android users move on to new version
+                result = self.verify_result(verifier, purchase_token, receipt['productId'])
+            except errors.GoogleError as exc:
+                logger.error('Purchase validation failed %s', exc)
+                result = {
+                    'error': exc.raw_response,
+                    'message': exc.message
+                }
+        return result
+
+    def verify_result(self, verifier, purchase_token, product_sku):
+        response = verifier.verify_with_result(purchase_token, product_sku, is_subscription=False)
+        result = {
+            'raw_response': response.raw_response,
+            'is_canceled': response.is_canceled,
+            'is_expired': response.is_expired
+        }
         return result

--- a/ecommerce/extensions/iap/api/v1/google_validator.py
+++ b/ecommerce/extensions/iap/api/v1/google_validator.py
@@ -2,6 +2,8 @@ import logging
 
 from inapppy import GooglePlayVerifier, errors
 
+from ecommerce.extensions.iap.utils import get_consumable_android_sku
+
 logger = logging.getLogger(__name__)
 
 
@@ -12,9 +14,8 @@ class GooglePlayValidator:
         Google for the mentioned productId.
         """
         purchase_token = receipt['purchaseToken']
-        # Mobile assumes one course purchase at a time
-        stockrecord_price = int(basket.total_excl_tax)
-        product_sku = 'mobile.android.usd{}'.format(stockrecord_price)
+        # Mobile assumes one course is purchased at a time
+        product_sku = get_consumable_android_sku(basket.total_excl_tax)
         verifier = GooglePlayVerifier(
             configuration.get('google_bundle_id'),
             configuration.get('google_service_account_key_file'),
@@ -24,7 +25,7 @@ class GooglePlayValidator:
         except errors.GoogleError:
             try:
                 # Fallback to the old approach and verify token with partner_sku
-                # This fallback is for temporary reason untill all android users move on to new version
+                # This fallback is temporary until all android products are switched to consumable products.
                 result = self.verify_result(verifier, purchase_token, receipt['productId'])
             except errors.GoogleError as exc:
                 logger.error('Purchase validation failed %s', exc)

--- a/ecommerce/extensions/iap/api/v1/google_validator.py
+++ b/ecommerce/extensions/iap/api/v1/google_validator.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 class GooglePlayValidator:
-    def validate(self, receipt, configuration, basket=None):
+    def validate(self, receipt, configuration, basket):
         """
         Accepts receipt, validates that the purchase has already been completed in
         Google for the mentioned productId.
@@ -23,6 +23,8 @@ class GooglePlayValidator:
         try:
             result = self.verify_result(verifier, purchase_token, product_sku)
         except errors.GoogleError:
+            logger.error('Purchase validation failed, Now moving to fallback approach for non consumable skus')
+
             try:
                 # Fallback to the old approach and verify token with partner_sku
                 # This fallback is temporary until all android products are switched to consumable products.

--- a/ecommerce/extensions/iap/api/v1/ios_validator.py
+++ b/ecommerce/extensions/iap/api/v1/ios_validator.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 
 class IOSValidator:
-    def validate(self, receipt, configuration, basket=None):
+    def validate(self, receipt, configuration, basket=None):  # pylint: disable=unused-argument
         """
         Accepts receipt, validates that the purchase has already been completed in
         Apple for the mentioned productId.

--- a/ecommerce/extensions/iap/api/v1/ios_validator.py
+++ b/ecommerce/extensions/iap/api/v1/ios_validator.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 
 class IOSValidator:
-    def validate(self, receipt, configuration):
+    def validate(self, receipt, configuration, basket=None):
         """
         Accepts receipt, validates that the purchase has already been completed in
         Apple for the mentioned productId.

--- a/ecommerce/extensions/iap/api/v1/tests/test_google_validator.py
+++ b/ecommerce/extensions/iap/api/v1/tests/test_google_validator.py
@@ -74,6 +74,11 @@ class GoogleValidatorTests(TestCase):
                 (
                     logger_name,
                     'ERROR',
+                    "Purchase validation failed, Now moving to fallback approach for non consumable skus"
+                ),
+                (
+                    logger_name,
+                    'ERROR',
                     "Purchase validation failed {}".format(
                         'GoogleError None None'
                     ),
@@ -81,3 +86,21 @@ class GoogleValidatorTests(TestCase):
             )
             self.assertIn('error', response)
             self.assertIn('message', response)
+
+    @mock.patch('ecommerce.extensions.iap.api.v1.google_validator.GooglePlayVerifier')
+    def test_validate_failure_for_consumable_sku(self, mock_google_verifier):
+        logger_name = 'ecommerce.extensions.iap.api.v1.google_validator'
+        with mock.patch.object(GooglePlayVerifierProxy, 'verify_with_result',
+                               side_effect=[errors.GoogleError(), GooglePlayVerifierResponse()]), \
+                LogCapture(logger_name) as google_validator_log_capture:
+            mock_google_verifier.return_value = GooglePlayVerifierProxy()
+
+            response = self.validator.validate(self.INVALID_RECEIPT, self.CONFIGURATION, self.basket)
+            google_validator_log_capture.check_present(
+                (
+                    logger_name,
+                    'ERROR',
+                    "Purchase validation failed, Now moving to fallback approach for non consumable skus"
+                ),
+            )
+            self.assertEqual(response, self.VALIDATED_RESPONSE)

--- a/ecommerce/extensions/iap/api/v1/tests/test_google_validator.py
+++ b/ecommerce/extensions/iap/api/v1/tests/test_google_validator.py
@@ -1,5 +1,6 @@
 import mock
 from inapppy import errors
+from oscar.test.factories import BasketFactory
 from testfixtures import LogCapture
 
 from ecommerce.extensions.iap.api.v1.google_validator import GooglePlayValidator
@@ -55,11 +56,13 @@ class GoogleValidatorTests(TestCase):
 
     def setUp(self):
         self.validator = GooglePlayValidator()
+        self.basket = BasketFactory()
+
 
     @mock.patch('ecommerce.extensions.iap.api.v1.google_validator.GooglePlayVerifier')
     def test_validate_successful(self, mock_google_verifier):
         mock_google_verifier.return_value = GooglePlayVerifierProxy()
-        response = self.validator.validate(self.VALID_RECEIPT, self.CONFIGURATION)
+        response = self.validator.validate(self.VALID_RECEIPT, self.CONFIGURATION, self.basket)
         self.assertEqual(response, self.VALIDATED_RESPONSE)
 
     @mock.patch('ecommerce.extensions.iap.api.v1.google_validator.GooglePlayVerifier')
@@ -67,7 +70,7 @@ class GoogleValidatorTests(TestCase):
         mock_google_verifier.return_value = GooglePlayVerifierProxy()
         logger_name = 'ecommerce.extensions.iap.api.v1.google_validator'
         with LogCapture(logger_name) as google_validator_log_capture:
-            response = self.validator.validate(self.INVALID_RECEIPT, self.CONFIGURATION)
+            response = self.validator.validate(self.INVALID_RECEIPT, self.CONFIGURATION, self.basket)
             google_validator_log_capture.check_present(
                 (
                     logger_name,

--- a/ecommerce/extensions/iap/api/v1/tests/test_google_validator.py
+++ b/ecommerce/extensions/iap/api/v1/tests/test_google_validator.py
@@ -58,7 +58,6 @@ class GoogleValidatorTests(TestCase):
         self.validator = GooglePlayValidator()
         self.basket = BasketFactory()
 
-
     @mock.patch('ecommerce.extensions.iap.api.v1.google_validator.GooglePlayVerifier')
     def test_validate_successful(self, mock_google_verifier):
         mock_google_verifier.return_value = GooglePlayVerifierProxy()

--- a/ecommerce/extensions/iap/processors/base_iap.py
+++ b/ecommerce/extensions/iap/processors/base_iap.py
@@ -83,7 +83,7 @@ class BaseIAP(BasePaymentProcessor):
             available_attempts = available_attempts + self.retry_attempts
 
         for attempt_count in range(1, available_attempts + 1):
-            validation_response = self.validator.validate(response, self.configuration)
+            validation_response = self.validator.validate(response, self.configuration, basket)
             validation_error = validation_response.get('error')
             if not validation_error:
                 break

--- a/ecommerce/extensions/iap/tests/test_utils.py
+++ b/ecommerce/extensions/iap/tests/test_utils.py
@@ -1,0 +1,14 @@
+from ecommerce.extensions.iap.utils import get_consumable_android_sku
+from ecommerce.tests.testcases import TestCase
+
+
+class ConsumableAndroidSkuTests(TestCase):
+    expected_sku = 'mobile.android.usd49'
+
+    def test_decimal_price(self):
+        sku = get_consumable_android_sku(49.50)
+        self.assertEqual(sku, self.expected_sku)
+
+    def test_integer_price(self):
+        sku = get_consumable_android_sku(49)
+        self.assertEqual(sku, self.expected_sku)

--- a/ecommerce/extensions/iap/utils.py
+++ b/ecommerce/extensions/iap/utils.py
@@ -79,3 +79,6 @@ def create_mobile_seat(sku_prefix, existing_web_seat):
     mobile_stock_record.save()
 
     return mobile_stock_record
+
+def get_consumable_android_sku(price):
+    return 'mobile.android.usd{}'.format(int(price))

--- a/ecommerce/extensions/iap/utils.py
+++ b/ecommerce/extensions/iap/utils.py
@@ -80,5 +80,6 @@ def create_mobile_seat(sku_prefix, existing_web_seat):
 
     return mobile_stock_record
 
+
 def get_consumable_android_sku(price):
     return 'mobile.android.usd{}'.format(int(price))


### PR DESCRIPTION
# ⛔️ MAIN BRANCH WARNING! 2U EMPLOYEES must make branches against the 2u/main BRANCH

- [x] I have checked the branch to which I would like to merge.

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Added fallback approach for android purchase validation

-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description
Added fallback approach for android purchase validation, This fallback is for temporary reason untill all android users move on to new version.

https://2u-internal.atlassian.net/browse/LEARNER-9860
Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
