### PR TITLE
fix: update celery and libsass versions

### DIFF
--- a/.github/workflows/migrations-mysql8.yml
+++ b/.github/workflows/migrations-mysql8.yml
@@ -52,7 +52,7 @@ jobs:
         pip uninstall -y mysqlclient
         pip install --no-binary mysqlclient mysqlclient
         pip uninstall -y xmlsec
-        pip install --no-binary xmlsec xmlsec
+        pip install --no-binary xmlsec==1.3.13 xmlsec==1.3.13
 
     - name: Initiate Services
       run: |

--- a/.github/workflows/migrations-mysql8.yml
+++ b/.github/workflows/migrations-mysql8.yml
@@ -52,6 +52,9 @@ jobs:
         pip uninstall -y mysqlclient
         pip install --no-binary mysqlclient mysqlclient
         pip uninstall -y xmlsec
+        # pinning xmlsec to a stable release (version: 1.3.13) as the
+        # new release (version: 1.3.14) fails to compile according to
+        # https://github.com/xmlsec/python-xmlsec/issues/314
         pip install --no-binary xmlsec==1.3.13 xmlsec==1.3.13
 
     - name: Initiate Services

--- a/ecommerce/extensions/api/v2/urls.py
+++ b/ecommerce/extensions/api/v2/urls.py
@@ -160,12 +160,19 @@ router.register(
     order_views.ManualCourseEnrollmentOrderViewSet,
     basename='manual-course-enrollment-order'
 )
-router.register(r'partners', partner_views.PartnerViewSet) \
-    .register(r'catalogs', catalog_views.CatalogViewSet,
-              basename='partner-catalogs', parents_query_lookups=['partner_id'])
-router.register(r'partners', partner_views.PartnerViewSet) \
-    .register(r'products', product_views.ProductViewSet,
-              basename='partner-product', parents_query_lookups=['stockrecords__partner_id'])
+partner_router = router.register(r'partners', partner_views.PartnerViewSet, basename='partner')
+partner_router.register(
+    r'catalogs',
+    catalog_views.CatalogViewSet,
+    basename='partner-catalogs',
+    parents_query_lookups=['partner_id'],
+)
+partner_router.register(
+    r'products',
+    product_views.ProductViewSet,
+    basename='partner-product',
+    parents_query_lookups=['stockrecords__partner_id'],
+)
 router.register(r'products', product_views.ProductViewSet, basename='product')
 router.register(r'vouchers', voucher_views.VoucherViewSet, basename='vouchers')
 router.register(r'stockrecords', stockrecords_views.StockRecordViewSet, basename='stockrecords')

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -40,7 +40,8 @@ httplib2==0.20.2
 inapppy==2.5.2
 jsonfield
 jsonfield2
-libsass==0.9.2
+libsass
+lxml[html_clean]
 markdown==3.4.3
 mysqlclient<1.5
 newrelic

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -48,9 +48,9 @@ billiard==4.2.0
     # via celery
 bleach==6.1.0
     # via -r requirements/base.in
-boto3==1.34.87
+boto3==1.34.96
     # via -r requirements/base.in
-botocore==1.34.87
+botocore==1.34.96
     # via
     #   boto3
     #   s3transfer
@@ -93,7 +93,7 @@ coreapi==2.3.3
     # via -r requirements/base.in
 coreschema==0.0.4
     # via coreapi
-coverage==7.4.4
+coverage==7.5.0
     # via cybersource-rest-client-python
 crispy-bootstrap3==2024.1
     # via -r requirements/base.in
@@ -179,7 +179,7 @@ django-extra-views==0.14.0
     # via django-oscar
 django-filter==23.5
     # via -r requirements/base.in
-django-haystack==3.2.1
+django-haystack==3.3b2
     # via django-oscar
 django-libsass==0.9
     # via -r requirements/base.in
@@ -224,6 +224,8 @@ djangorestframework-csv==3.0.2
     # via -r requirements/base.in
 djangorestframework-datatables==0.7.1
     # via -r requirements/base.in
+dnspython==2.6.1
+    # via pymongo
 drf-extensions==0.7.1
     # via -r requirements/base.in
 drf-jwt==1.19.2
@@ -232,13 +234,13 @@ drf-yasg==1.21.7
     # via -r requirements/base.in
 edx-auth-backends==4.3.0
     # via -r requirements/base.in
-edx-braze-client==0.2.3
+edx-braze-client==0.2.5
     # via edx-ecommerce-worker
 edx-django-release-util==1.4.0
     # via -r requirements/base.in
 edx-django-sites-extensions==4.2.0
     # via -r requirements/base.in
-edx-django-utils==5.12.0
+edx-django-utils==5.13.0
     # via
     #   -r requirements/base.in
     #   django-config-models
@@ -251,11 +253,11 @@ edx-drf-extensions==10.3.0
     #   edx-rbac
 edx-ecommerce-worker==3.3.4
     # via -r requirements/base.in
-edx-opaque-keys==2.5.1
+edx-opaque-keys==2.9.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
-edx-rbac==1.8.0
+edx-rbac==1.9.0
     # via -r requirements/base.in
 edx-rest-api-client==5.7.0
     # via
@@ -267,7 +269,7 @@ extras==1.0.0
     # via cybersource-rest-client-python
 factory-boy==3.2.1
     # via django-oscar
-faker==24.11.0
+faker==25.0.0
     # via factory-boy
 fixtures==4.1.0
     # via cybersource-rest-client-python
@@ -279,7 +281,7 @@ funcsigs==1.0.2
     # via cybersource-rest-client-python
 getsmarter-api-clients==0.6.1
     # via -r requirements/base.in
-google-api-core==2.18.0
+google-api-core==2.19.0
     # via google-api-python-client
 google-api-python-client==2.31.0
     # via
@@ -334,7 +336,7 @@ jsonfield==3.1.0
     # via -r requirements/base.in
 jsonfield2==4.0.0.post0
     # via -r requirements/base.in
-jsonschema==4.21.1
+jsonschema==4.22.0
     # via cybersource-rest-client-python
 jsonschema-specifications==2023.12.1
     # via jsonschema
@@ -392,7 +394,9 @@ oauthlib==3.2.2
 openedx-atlas==0.6.0
     # via -r requirements/base.in
 packaging==24.0
-    # via drf-yasg
+    # via
+    #   django-haystack
+    #   drf-yasg
 paramiko==3.4.0
     # via cybersource-rest-client-python
 path-py==7.2
@@ -410,7 +414,7 @@ pillow==10.3.0
     # via django-oscar
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via zeep
 premailer==2.9.2
     # via -r requirements/base.in
@@ -461,7 +465,7 @@ pyjwt[crypto]==2.8.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pymongo==3.13.0
+pymongo==4.4.0
     # via edx-opaque-keys
 pynacl==1.5.0
     # via
@@ -514,9 +518,9 @@ pyyaml==6.0.1
     #   naked
 rcssmin==1.1.1
     # via django-compressor
-redis==5.0.3
+redis==5.0.4
     # via edx-ecommerce-worker
-referencing==0.34.0
+referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -592,7 +596,7 @@ social-auth-app-django==5.2.0
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   edx-auth-backends
-social-auth-core==4.5.3
+social-auth-core==4.5.4
     # via
     #   edx-auth-backends
     #   social-auth-app-django
@@ -604,7 +608,7 @@ stevedore==5.2.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-stripe==9.3.0
+stripe==9.4.0
     # via -r requirements/base.in
 testtools==2.7.1
     # via
@@ -618,7 +622,6 @@ typing-extensions==4.11.0
     # via
     #   asgiref
     #   edx-opaque-keys
-    #   faker
     #   kombu
     #   stripe
 tzdata==2024.1
@@ -651,7 +654,7 @@ wheel==0.43.0
     # via cybersource-rest-client-python
 x509==0.1
     # via cybersource-rest-client-python
-xss-utils==0.5.0
+xss-utils==0.6.0
     # via -r requirements/base.in
 yarl==1.9.4
     # via aiohttp

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,17 +4,17 @@
 #
 #    make upgrade
 #
-aiohttp==3.9.1
+aiohttp==3.9.5
     # via inapppy
 aiosignal==1.3.1
     # via aiohttp
-amqp==2.6.1
+amqp==5.2.0
     # via kombu
 analytics-python==1.4.post1
     # via -r requirements/base.in
 app-store-notifications-v2-validator==0.0.7
     # via -r requirements/base.in
-asgiref==3.7.2
+asgiref==3.8.1
     # via
     #   django
     #   django-cors-headers
@@ -34,27 +34,32 @@ babel==2.14.0
     # via django-oscar
 backoff==1.10.0
     # via analytics-python
+backports-zoneinfo[tzdata]==0.2.1
+    # via
+    #   celery
+    #   djangorestframework
+    #   kombu
 bcrypt==4.1.2
     # via
     #   cybersource-rest-client-python
     #   paramiko
-billiard==3.6.4.0
+billiard==4.2.0
     # via celery
 bleach==6.1.0
     # via -r requirements/base.in
-boto3==1.34.17
+boto3==1.34.87
     # via -r requirements/base.in
-botocore==1.34.17
+botocore==1.34.87
     # via
     #   boto3
     #   s3transfer
-cachetools==5.3.2
+cachetools==5.3.3
     # via google-auth
-celery==4.4.7
+celery==5.4.0
     # via
     #   -c requirements/constraints.txt
     #   edx-ecommerce-worker
-certifi==2023.11.17
+certifi==2024.2.2
     # via
     #   cybersource-rest-client-python
     #   requests
@@ -69,20 +74,31 @@ chardet==5.2.0
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
-    # via edx-django-utils
-configparser==6.0.0
+    # via
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
+    #   edx-django-utils
+click-didyoumean==0.3.1
+    # via celery
+click-plugins==1.1.1
+    # via celery
+click-repl==0.3.0
+    # via celery
+configparser==7.0.0
     # via cybersource-rest-client-python
 coreapi==2.3.3
     # via -r requirements/base.in
 coreschema==0.0.4
     # via coreapi
-coverage==7.4.0
+coverage==7.4.4
     # via cybersource-rest-client-python
-crispy-bootstrap3==2022.1
+crispy-bootstrap3==2024.1
     # via -r requirements/base.in
 crypto==1.4.1
     # via cybersource-rest-client-python
-cryptography==41.0.7
+cryptography==42.0.5
     # via
     #   app-store-notifications-v2-validator
     #   cybersource-rest-client-python
@@ -92,19 +108,19 @@ cryptography==41.0.7
     #   social-auth-core
 cssselect==1.2.0
     # via premailer
-cssutils==2.9.0
+cssutils==2.10.2
     # via premailer
 cybersource-rest-client-python==0.0.21
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-datetime==5.4
+datetime==5.5
     # via cybersource-rest-client-python
 defusedxml==0.8.0rc2
     # via
     #   python3-openid
     #   social-auth-core
-django==3.2.23
+django==3.2.25
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
@@ -144,7 +160,7 @@ django-compressor==4.4
     # via
     #   -r requirements/base.in
     #   django-libsass
-django-config-models==2.5.1
+django-config-models==2.7.0
     # via -r requirements/base.in
 django-cors-headers==4.3.1
     # via -r requirements/base.in
@@ -158,7 +174,7 @@ django-crum==0.7.9
     #   edx-rbac
 django-extensions==3.2.3
     # via -r requirements/base.in
-django-extra-views==0.13.0
+django-extra-views==0.14.0
     # via django-oscar
 django-filter==23.5
     # via -r requirements/base.in
@@ -166,25 +182,25 @@ django-haystack==3.2.1
     # via django-oscar
 django-libsass==0.9
     # via -r requirements/base.in
-django-model-utils==4.3.1
+django-model-utils==4.5.0
     # via edx-rbac
 django-oscar==3.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-django-phonenumber-field==5.0.0
+django-phonenumber-field==6.4.0
     # via django-oscar
 django-simple-history==3.0.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
-django-solo==2.1.0
+django-solo==2.2.0
     # via -r requirements/base.in
 django-tables2==2.3.4
     # via django-oscar
 django-threadlocals==0.10
     # via -r requirements/base.in
-django-treebeard==4.4
+django-treebeard==4.7.1
     # via django-oscar
 django-waffle==4.1.0
     # via
@@ -193,7 +209,7 @@ django-waffle==4.1.0
     #   edx-drf-extensions
 django-widget-tweaks==1.5.0
     # via django-oscar
-djangorestframework==3.14.0
+djangorestframework==3.15.1
     # via
     #   -r requirements/base.in
     #   django-config-models
@@ -205,7 +221,7 @@ djangorestframework==3.14.0
     #   edx-drf-extensions
 djangorestframework-csv==3.0.2
     # via -r requirements/base.in
-djangorestframework-datatables==0.7.0
+djangorestframework-datatables==0.7.1
     # via -r requirements/base.in
 drf-extensions==0.7.1
     # via -r requirements/base.in
@@ -213,22 +229,22 @@ drf-jwt==1.19.2
     # via edx-drf-extensions
 drf-yasg==1.21.7
     # via -r requirements/base.in
-edx-auth-backends==4.2.0
+edx-auth-backends==4.3.0
     # via -r requirements/base.in
-edx-braze-client==0.1.8
+edx-braze-client==0.2.3
     # via edx-ecommerce-worker
-edx-django-release-util==1.3.0
+edx-django-release-util==1.4.0
     # via -r requirements/base.in
-edx-django-sites-extensions==4.0.2
+edx-django-sites-extensions==4.2.0
     # via -r requirements/base.in
-edx-django-utils==5.9.0
+edx-django-utils==5.12.0
     # via
     #   -r requirements/base.in
     #   django-config-models
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   getsmarter-api-clients
-edx-drf-extensions==9.1.2
+edx-drf-extensions==10.3.0
     # via
     #   -r requirements/base.in
     #   edx-rbac
@@ -240,19 +256,17 @@ edx-opaque-keys==2.5.1
     #   edx-drf-extensions
 edx-rbac==1.8.0
     # via -r requirements/base.in
-edx-rest-api-client==5.6.1
+edx-rest-api-client==5.7.0
     # via
     #   -r requirements/base.in
     #   edx-ecommerce-worker
 enum34==1.1.10
     # via cybersource-rest-client-python
 extras==1.0.0
-    # via
-    #   cybersource-rest-client-python
-    #   python-subunit
-factory-boy==3.1.0
+    # via cybersource-rest-client-python
+factory-boy==3.2.1
     # via django-oscar
-faker==22.2.0
+faker==24.11.0
     # via factory-boy
 fixtures==4.1.0
     # via cybersource-rest-client-python
@@ -264,20 +278,20 @@ funcsigs==1.0.2
     # via cybersource-rest-client-python
 getsmarter-api-clients==0.6.1
     # via -r requirements/base.in
-google-api-core==2.15.0
+google-api-core==2.18.0
     # via google-api-python-client
 google-api-python-client==2.31.0
     # via
     #   -r requirements/base.in
     #   inapppy
-google-auth==2.26.2
+google-auth==2.29.0
     # via
     #   google-api-core
     #   google-api-python-client
     #   google-auth-httplib2
 google-auth-httplib2==0.2.0
     # via google-api-python-client
-googleapis-common-protos==1.62.0
+googleapis-common-protos==1.63.0
     # via google-api-core
 httplib2==0.20.2
     # via
@@ -291,7 +305,9 @@ idna==2.7
     #   cybersource-rest-client-python
     #   requests
     #   yarl
-importlib-resources==6.1.1
+importlib-metadata==7.1.0
+    # via markdown
+importlib-resources==6.4.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -317,14 +333,15 @@ jsonfield==3.1.0
     # via -r requirements/base.in
 jsonfield2==4.0.0.post0
     # via -r requirements/base.in
-jsonschema==4.20.0
+jsonschema==4.21.1
     # via cybersource-rest-client-python
 jsonschema-specifications==2023.12.1
     # via jsonschema
-kombu==4.6.11
+kombu==5.3.7
     # via celery
-libsass==0.9.2
+libsass==0.23.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-libsass
 linecache2==1.0.0
@@ -333,17 +350,21 @@ linecache2==1.0.0
     #   traceback2
 logger==1.4
     # via cybersource-rest-client-python
-lxml==5.1.0
+lxml[html-clean,html_clean]==5.2.1
     # via
+    #   -r requirements/base.in
+    #   lxml-html-clean
     #   premailer
     #   zeep
+lxml-html-clean==0.1.1
+    # via lxml
 markdown==3.4.3
     # via -r requirements/base.in
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via jinja2
 monotonic==1.6
     # via analytics-python
-multidict==6.0.4
+multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
@@ -355,7 +376,7 @@ naked==0.1.32
     #   cybersource-rest-client-python
 ndg-httpsclient==0.5.1
     # via -r requirements/base.in
-newrelic==9.5.0
+newrelic==9.9.0
     # via
     #   -r requirements/base.in
     #   edx-django-utils
@@ -370,7 +391,7 @@ oauthlib==3.2.2
     #   social-auth-core
 openedx-atlas==0.6.0
     # via -r requirements/base.in
-packaging==23.2
+packaging==24.0
     # via drf-yasg
 paramiko==3.4.0
     # via cybersource-rest-client-python
@@ -383,25 +404,30 @@ pbr==6.0.0
     #   cybersource-rest-client-python
     #   fixtures
     #   stevedore
-phonenumbers==8.13.27
+phonenumbers==8.13.35
     # via django-oscar
-pillow==10.2.0
+pillow==10.3.0
     # via django-oscar
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==4.1.0
+platformdirs==4.2.0
     # via zeep
 premailer==2.9.2
     # via -r requirements/base.in
-protobuf==4.25.2
+prompt-toolkit==3.0.43
+    # via click-repl
+proto-plus==1.23.0
+    # via google-api-core
+protobuf==4.25.3
     # via
     #   google-api-core
     #   googleapis-common-protos
-psutil==5.9.7
+    #   proto-plus
+psutil==5.9.8
     # via edx-django-utils
 purl==1.6
     # via django-oscar
-pyasn1==0.5.1
+pyasn1==0.6.0
     # via
     #   cybersource-rest-client-python
     #   ndg-httpsclient
@@ -409,13 +435,13 @@ pyasn1==0.5.1
     #   pyasn1-modules
     #   rsa
     #   x509
-pyasn1-modules==0.3.0
+pyasn1-modules==0.4.0
     # via
     #   google-auth
     #   oauth2client
 pycountry==17.1.8
     # via -r requirements/base.in
-pycparser==2.21
+pycparser==2.22
     # via
     #   app-store-notifications-v2-validator
     #   cffi
@@ -442,21 +468,22 @@ pynacl==1.5.0
     #   cybersource-rest-client-python
     #   edx-django-utils
     #   paramiko
-pyopenssl==23.3.0
+pyopenssl==24.1.0
     # via
     #   app-store-notifications-v2-validator
     #   cybersource-rest-client-python
     #   ndg-httpsclient
     #   paypalrestsdk
-pyparsing==3.1.1
+pyparsing==3.1.2
     # via httplib2
 pypi==2.1
     # via cybersource-rest-client-python
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.in
     #   analytics-python
     #   botocore
+    #   celery
     #   faker
 python-mimeparse==1.6.0
     # via cybersource-rest-client-python
@@ -468,15 +495,13 @@ python3-openid==3.2.0
     # via
     #   -r requirements/base.in
     #   social-auth-core
-pytz==2023.3.post1
+pytz==2024.1
     # via
     #   -r requirements/base.in
     #   babel
-    #   celery
     #   cybersource-rest-client-python
     #   datetime
     #   django
-    #   djangorestframework
     #   djangorestframework-datatables
     #   drf-yasg
     #   getsmarter-api-clients
@@ -489,9 +514,9 @@ pyyaml==6.0.1
     #   naked
 rcssmin==1.1.1
     # via django-compressor
-redis==5.0.1
+redis==5.0.3
     # via edx-ecommerce-worker
-referencing==0.32.1
+referencing==0.34.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -514,9 +539,9 @@ requests==2.31.0
     #   social-auth-core
     #   stripe
     #   zeep
-requests-file==1.5.1
+requests-file==2.0.0
     # via zeep
-requests-oauthlib==1.3.1
+requests-oauthlib==2.0.0
     # via
     #   getsmarter-api-clients
     #   social-auth-core
@@ -524,7 +549,7 @@ requests-toolbelt==1.0.0
     # via zeep
 rjsmin==1.2.1
     # via django-compressor
-rpds-py==0.16.2
+rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
@@ -536,7 +561,7 @@ rsa==4.9
     #   oauth2client
 rules==3.3
     # via -r requirements/base.in
-s3transfer==0.10.0
+s3transfer==0.10.1
     # via boto3
 semantic-version==2.10.0
     # via edx-drf-extensions
@@ -551,18 +576,15 @@ six==1.16.0
     #   analytics-python
     #   bleach
     #   cybersource-rest-client-python
-    #   django-extra-views
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-ecommerce-worker
     #   edx-rbac
     #   isodate
-    #   libsass
     #   oauth2client
     #   paypalrestsdk
     #   purl
     #   python-dateutil
-    #   requests-file
 slumber==0.7.1
     # via edx-rest-api-client
 social-auth-app-django==5.2.0
@@ -570,19 +592,19 @@ social-auth-app-django==5.2.0
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   edx-auth-backends
-social-auth-core==4.5.1
+social-auth-core==4.5.3
     # via
     #   edx-auth-backends
     #   social-auth-app-django
 sorl-thumbnail==12.10.0
     # via -r requirements/base.in
-sqlparse==0.4.4
+sqlparse==0.5.0
     # via django
-stevedore==5.1.0
+stevedore==5.2.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-stripe==7.11.0
+stripe==9.3.0
     # via -r requirements/base.in
 testtools==2.7.1
     # via
@@ -592,12 +614,17 @@ traceback2==1.4.0
     # via cybersource-rest-client-python
 typing==3.7.4.3
     # via cybersource-rest-client-python
-typing-extensions==4.9.0
+typing-extensions==4.11.0
     # via
     #   asgiref
     #   edx-opaque-keys
     #   faker
+    #   kombu
     #   stripe
+tzdata==2024.1
+    # via
+    #   backports-zoneinfo
+    #   celery
 unicodecsv==0.14.1
     # via -r requirements/base.in
 uritemplate==4.1.1
@@ -611,13 +638,16 @@ urllib3==1.26.18
     #   botocore
     #   cybersource-rest-client-python
     #   requests
-vine==1.3.0
+vine==5.1.0
     # via
     #   amqp
     #   celery
+    #   kombu
+wcwidth==0.2.13
+    # via prompt-toolkit
 webencodings==0.5.1
     # via bleach
-wheel==0.42.0
+wheel==0.43.0
     # via cybersource-rest-client-python
 x509==0.1
     # via cybersource-rest-client-python
@@ -627,9 +657,11 @@ yarl==1.9.4
     # via aiohttp
 zeep==4.2.1
     # via -r requirements/base.in
-zipp==3.17.0
-    # via importlib-resources
-zope-interface==6.1
+zipp==3.18.1
+    # via
+    #   importlib-metadata
+    #   importlib-resources
+zope-interface==6.3
     # via
     #   cybersource-rest-client-python
     #   datetime

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -34,8 +34,9 @@ babel==2.14.0
     # via django-oscar
 backoff==1.10.0
     # via analytics-python
-backports-zoneinfo[tzdata]==0.2.1
+backports-zoneinfo[tzdata]==0.2.1 ; python_version < "3.9"
     # via
+    #   -c requirements/constraints.txt
     #   celery
     #   djangorestframework
     #   kombu

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -341,7 +341,6 @@ kombu==5.3.7
     # via celery
 libsass==0.23.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-libsass
 linecache2==1.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -31,7 +31,8 @@ pluggy<1.0.0  # pluggy==1.0.0 requires tox>3.14.6
 idna==2.7
 
 # TODO : Pinning this until we are sure there aren't any breaking changes, then we'll upgrade.
-celery<5.0.0
+celery<6.0.0
+libsass==0.23.0
 
 # social-auth-app-django 5.3.0 currently introduces a hanging migration for large table sizes
 # Pinning for now to reduce entropy

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -51,3 +51,7 @@ pylint==2.12.2
 mccabe<0.7
 # pylint==2.12.2 requires wrapt<1.14
 wrapt<1.14
+
+# backports-zoneinfo comes by-default in newer versions of python
+# it gives error while building wheel with python>=3.9
+backports.zoneinfo ; python_version < "3.9"

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -32,7 +32,6 @@ idna==2.7
 
 # TODO : Pinning this until we are sure there aren't any breaking changes, then we'll upgrade.
 celery<6.0.0
-libsass==0.23.0
 
 # social-auth-app-django 5.3.0 currently introduces a hanging migration for large table sizes
 # Pinning for now to reduce entropy

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -4,7 +4,8 @@
 django-debug-toolbar
 
 # i18n
-transifex-client
+# newer version of transifex-client doesn't work with python3.12.2
+transifex-client==0.12.5
 
 # Visual Studio Code Debugger
 ptvsd

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -64,7 +64,7 @@ backoff==1.10.0
     # via
     #   -r requirements/test.txt
     #   analytics-python
-backports-zoneinfo[tzdata]==0.2.1
+backports-zoneinfo[tzdata]==0.2.1 ; python_version < "3.9"
     # via
     #   -r requirements/test.txt
     #   celery

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ accessible-pygments==0.0.4
     # via
     #   -r requirements/docs.txt
     #   pydata-sphinx-theme
-aiohttp==3.9.1
+aiohttp==3.9.5
     # via
     #   -r requirements/test.txt
     #   inapppy
@@ -20,7 +20,7 @@ alabaster==0.7.13
     # via
     #   -r requirements/docs.txt
     #   sphinx
-amqp==2.6.1
+amqp==5.2.0
     # via
     #   -r requirements/test.txt
     #   kombu
@@ -28,7 +28,7 @@ analytics-python==1.4.post1
     # via -r requirements/test.txt
 app-store-notifications-v2-validator==0.0.7
     # via -r requirements/test.txt
-asgiref==3.7.2
+asgiref==3.8.1
     # via
     #   -r requirements/test.txt
     #   django
@@ -64,39 +64,45 @@ backoff==1.10.0
     # via
     #   -r requirements/test.txt
     #   analytics-python
+backports-zoneinfo[tzdata]==0.2.1
+    # via
+    #   -r requirements/test.txt
+    #   celery
+    #   djangorestframework
+    #   kombu
 bcrypt==4.1.2
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
     #   paramiko
-beautifulsoup4==4.12.2
+beautifulsoup4==4.12.3
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   pydata-sphinx-theme
     #   webtest
-billiard==3.6.4.0
+billiard==4.2.0
     # via
     #   -r requirements/test.txt
     #   celery
 bleach==6.1.0
     # via -r requirements/test.txt
-boto3==1.34.17
+boto3==1.34.87
     # via -r requirements/test.txt
-botocore==1.34.17
+botocore==1.34.87
     # via
     #   -r requirements/test.txt
     #   boto3
     #   s3transfer
-cachetools==5.3.2
+cachetools==5.3.3
     # via
     #   -r requirements/test.txt
     #   google-auth
-celery==4.4.7
+celery==5.4.0
     # via
     #   -r requirements/test.txt
     #   edx-ecommerce-worker
-certifi==2023.11.17
+certifi==2024.2.2
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -122,8 +128,24 @@ charset-normalizer==3.3.2
 click==8.1.7
     # via
     #   -r requirements/test.txt
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
     #   edx-django-utils
-configparser==6.0.0
+click-didyoumean==0.3.1
+    # via
+    #   -r requirements/test.txt
+    #   celery
+click-plugins==1.1.1
+    # via
+    #   -r requirements/test.txt
+    #   celery
+click-repl==0.3.0
+    # via
+    #   -r requirements/test.txt
+    #   celery
+configparser==7.0.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -133,19 +155,18 @@ coreschema==0.0.4
     # via
     #   -r requirements/test.txt
     #   coreapi
-coverage[toml]==7.4.0
+coverage[toml]==7.4.4
     # via
     #   -r requirements/test.txt
-    #   coverage
     #   cybersource-rest-client-python
     #   pytest-cov
-crispy-bootstrap3==2022.1
+crispy-bootstrap3==2024.1
     # via -r requirements/test.txt
 crypto==1.4.1
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-cryptography==41.0.7
+cryptography==42.0.5
     # via
     #   -r requirements/test.txt
     #   app-store-notifications-v2-validator
@@ -158,26 +179,26 @@ cssselect==1.2.0
     # via
     #   -r requirements/test.txt
     #   premailer
-cssutils==2.9.0
+cssutils==2.10.2
     # via
     #   -r requirements/test.txt
     #   premailer
 cybersource-rest-client-python==0.0.21
     # via -r requirements/test.txt
-datetime==5.4
+datetime==5.5
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-ddt==1.7.1
+ddt==1.7.2
     # via -r requirements/test.txt
 defusedxml==0.8.0rc2
     # via
     #   -r requirements/test.txt
     #   python3-openid
     #   social-auth-core
-diff-cover==8.0.2
+diff-cover==7.7.0
     # via -r requirements/test.txt
-django==3.2.23
+django==3.2.25
     # via
     #   -r requirements/test.txt
     #   crispy-bootstrap3
@@ -220,7 +241,7 @@ django-compressor==4.4
     # via
     #   -r requirements/test.txt
     #   django-libsass
-django-config-models==2.5.1
+django-config-models==2.7.0
     # via -r requirements/test.txt
 django-cors-headers==4.3.1
     # via -r requirements/test.txt
@@ -233,11 +254,11 @@ django-crum==0.7.9
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-rbac
-django-debug-toolbar==4.2.0
+django-debug-toolbar==4.3.0
     # via -r requirements/dev.in
 django-extensions==3.2.3
     # via -r requirements/test.txt
-django-extra-views==0.13.0
+django-extra-views==0.14.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
@@ -249,19 +270,19 @@ django-haystack==3.2.1
     #   django-oscar
 django-libsass==0.9
     # via -r requirements/test.txt
-django-model-utils==4.3.1
+django-model-utils==4.5.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
 django-oscar==3.2
     # via -r requirements/test.txt
-django-phonenumber-field==5.0.0
+django-phonenumber-field==6.4.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
 django-simple-history==3.0.0
     # via -r requirements/test.txt
-django-solo==2.1.0
+django-solo==2.2.0
     # via -r requirements/test.txt
 django-tables2==2.3.4
     # via
@@ -269,7 +290,7 @@ django-tables2==2.3.4
     #   django-oscar
 django-threadlocals==0.10
     # via -r requirements/test.txt
-django-treebeard==4.4
+django-treebeard==4.7.1
     # via
     #   -r requirements/test.txt
     #   django-oscar
@@ -284,7 +305,7 @@ django-widget-tweaks==1.5.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
-djangorestframework==3.14.0
+djangorestframework==3.15.1
     # via
     #   -r requirements/test.txt
     #   django-config-models
@@ -296,7 +317,7 @@ djangorestframework==3.14.0
     #   edx-drf-extensions
 djangorestframework-csv==3.0.2
     # via -r requirements/test.txt
-djangorestframework-datatables==0.7.0
+djangorestframework-datatables==0.7.1
     # via -r requirements/test.txt
 docutils==0.19
     # via
@@ -311,30 +332,30 @@ drf-jwt==1.19.2
     #   edx-drf-extensions
 drf-yasg==1.21.7
     # via -r requirements/test.txt
-edx-auth-backends==4.2.0
+edx-auth-backends==4.3.0
     # via -r requirements/test.txt
-edx-braze-client==0.1.8
+edx-braze-client==0.2.3
     # via
     #   -r requirements/test.txt
     #   edx-ecommerce-worker
-edx-django-release-util==1.3.0
+edx-django-release-util==1.4.0
     # via -r requirements/test.txt
-edx-django-sites-extensions==4.0.2
+edx-django-sites-extensions==4.2.0
     # via -r requirements/test.txt
-edx-django-utils==5.9.0
+edx-django-utils==5.12.0
     # via
     #   -r requirements/test.txt
     #   django-config-models
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   getsmarter-api-clients
-edx-drf-extensions==9.1.2
+edx-drf-extensions==10.3.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
 edx-ecommerce-worker==3.3.4
     # via -r requirements/test.txt
-edx-i18n-tools==1.3.0
+edx-i18n-tools==1.5.0
     # via -r requirements/test.txt
 edx-opaque-keys==2.5.1
     # via
@@ -342,7 +363,7 @@ edx-opaque-keys==2.5.1
     #   edx-drf-extensions
 edx-rbac==1.8.0
     # via -r requirements/test.txt
-edx-rest-api-client==5.6.1
+edx-rest-api-client==5.7.0
     # via
     #   -r requirements/test.txt
     #   edx-ecommerce-worker
@@ -350,7 +371,7 @@ enum34==1.1.10
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -358,16 +379,15 @@ extras==1.0.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-    #   python-subunit
-factory-boy==3.1.0
+factory-boy==3.2.1
     # via
     #   -r requirements/test.txt
     #   django-oscar
-faker==22.2.0
+faker==24.11.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.13.1
+filelock==3.13.4
     # via
     #   -r requirements/test.txt
     #   tox
@@ -386,7 +406,7 @@ funcsigs==1.0.2
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-future==0.18.3
+future==1.0.0
     # via
     #   -r requirements/test.txt
     #   pyjwkest
@@ -394,9 +414,9 @@ getsmarter-api-clients==0.6.1
     # via -r requirements/test.txt
 gitdb==4.0.11
     # via gitpython
-gitpython==3.1.41
+gitpython==3.1.43
     # via transifex-client
-google-api-core==2.15.0
+google-api-core==2.18.0
     # via
     #   -r requirements/test.txt
     #   google-api-python-client
@@ -404,7 +424,7 @@ google-api-python-client==2.31.0
     # via
     #   -r requirements/test.txt
     #   inapppy
-google-auth==2.26.2
+google-auth==2.29.0
     # via
     #   -r requirements/test.txt
     #   google-api-core
@@ -414,7 +434,7 @@ google-auth-httplib2==0.2.0
     # via
     #   -r requirements/test.txt
     #   google-api-python-client
-googleapis-common-protos==1.62.0
+googleapis-common-protos==1.63.0
     # via
     #   -r requirements/test.txt
     #   google-api-core
@@ -435,13 +455,14 @@ imagesize==1.4.1
     # via
     #   -r requirements/docs.txt
     #   sphinx
-importlib-metadata==7.0.1
+importlib-metadata==7.1.0
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
+    #   markdown
     #   pytest-randomly
     #   sphinx
-importlib-resources==6.1.1
+importlib-resources==6.4.0
     # via
     #   -r requirements/test.txt
     #   jsonschema
@@ -493,7 +514,7 @@ jsonfield==3.1.0
     # via -r requirements/test.txt
 jsonfield2==4.0.0.post0
     # via -r requirements/test.txt
-jsonschema==4.20.0
+jsonschema==4.21.1
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -501,7 +522,7 @@ jsonschema-specifications==2023.12.1
     # via
     #   -r requirements/test.txt
     #   jsonschema
-kombu==4.6.11
+kombu==5.3.7
     # via
     #   -r requirements/test.txt
     #   celery
@@ -509,7 +530,7 @@ lazy-object-proxy==1.10.0
     # via
     #   -r requirements/test.txt
     #   astroid
-libsass==0.9.2
+libsass==0.23.0
     # via
     #   -r requirements/test.txt
     #   django-libsass
@@ -522,15 +543,18 @@ logger==1.4
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-lxml==5.1.0
+lxml[html-clean]==5.2.1
     # via
     #   -r requirements/test.txt
     #   edx-i18n-tools
+    #   lxml-html-clean
     #   premailer
     #   zeep
+lxml-html-clean==0.1.1
+    # via -r requirements/test.txt
 markdown==3.4.3
     # via -r requirements/test.txt
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -545,7 +569,7 @@ monotonic==1.6
     # via
     #   -r requirements/test.txt
     #   analytics-python
-multidict==6.0.4
+multidict==6.0.5
     # via
     #   -r requirements/test.txt
     #   aiohttp
@@ -559,7 +583,7 @@ naked==0.1.32
     #   cybersource-rest-client-python
 ndg-httpsclient==0.5.1
     # via -r requirements/test.txt
-newrelic==9.5.0
+newrelic==9.9.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -579,7 +603,7 @@ oauthlib==3.2.2
     #   social-auth-core
 openedx-atlas==0.6.0
     # via -r requirements/test.txt
-packaging==23.2
+packaging==24.0
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -592,7 +616,7 @@ paramiko==3.4.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-path==16.9.0
+path==16.14.0
     # via
     #   -r requirements/test.txt
     #   edx-i18n-tools
@@ -606,11 +630,11 @@ pbr==6.0.0
     #   cybersource-rest-client-python
     #   fixtures
     #   stevedore
-phonenumbers==8.13.27
+phonenumbers==8.13.35
     # via
     #   -r requirements/test.txt
     #   django-oscar
-pillow==10.2.0
+pillow==10.3.0
     # via
     #   -r requirements/test.txt
     #   django-oscar
@@ -618,7 +642,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/test.txt
     #   jsonschema
-platformdirs==4.1.0
+platformdirs==4.2.0
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -635,12 +659,21 @@ polib==1.2.0
     #   edx-i18n-tools
 premailer==2.9.2
     # via -r requirements/test.txt
-protobuf==4.25.2
+prompt-toolkit==3.0.43
+    # via
+    #   -r requirements/test.txt
+    #   click-repl
+proto-plus==1.23.0
+    # via
+    #   -r requirements/test.txt
+    #   google-api-core
+protobuf==4.25.3
     # via
     #   -r requirements/test.txt
     #   google-api-core
     #   googleapis-common-protos
-psutil==5.9.7
+    #   proto-plus
+psutil==5.9.8
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -654,7 +687,7 @@ py==1.11.0
     # via
     #   -r requirements/test.txt
     #   tox
-pyasn1==0.5.1
+pyasn1==0.6.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -663,7 +696,7 @@ pyasn1==0.5.1
     #   pyasn1-modules
     #   rsa
     #   x509
-pyasn1-modules==0.3.0
+pyasn1-modules==0.4.0
     # via
     #   -r requirements/test.txt
     #   google-auth
@@ -672,7 +705,7 @@ pycodestyle==2.11.1
     # via -r requirements/test.txt
 pycountry==17.1.8
     # via -r requirements/test.txt
-pycparser==2.21
+pycparser==2.22
     # via
     #   -r requirements/test.txt
     #   app-store-notifications-v2-validator
@@ -710,7 +743,6 @@ pyjwt[crypto]==2.8.0
     #   edx-auth-backends
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwt
     #   social-auth-core
 pylint==2.12.2
     # via -r requirements/test.txt
@@ -724,14 +756,14 @@ pynacl==1.5.0
     #   cybersource-rest-client-python
     #   edx-django-utils
     #   paramiko
-pyopenssl==23.3.0
+pyopenssl==24.1.0
     # via
     #   -r requirements/test.txt
     #   app-store-notifications-v2-validator
     #   cybersource-rest-client-python
     #   ndg-httpsclient
     #   paypalrestsdk
-pyparsing==3.1.1
+pyparsing==3.1.2
     # via
     #   -r requirements/test.txt
     #   httplib2
@@ -751,19 +783,19 @@ pytest==7.4.4
     #   pytest-selenium
     #   pytest-timeout
     #   pytest-variables
-pytest-base-url==2.0.0
+pytest-base-url==2.1.0
     # via
     #   -r requirements/test.txt
     #   pytest-selenium
-pytest-cov==4.1.0
+pytest-cov==5.0.0
     # via -r requirements/test.txt
-pytest-django==4.7.0
+pytest-django==4.8.0
     # via -r requirements/test.txt
 pytest-html==4.1.1
     # via
     #   -r requirements/test.txt
     #   pytest-selenium
-pytest-metadata==3.0.0
+pytest-metadata==3.1.1
     # via
     #   -r requirements/test.txt
     #   pytest-html
@@ -771,20 +803,21 @@ pytest-randomly==3.15.0
     # via -r requirements/test.txt
 pytest-selenium==2.0.1
     # via -r requirements/test.txt
-pytest-timeout==2.2.0
+pytest-timeout==2.3.1
     # via -r requirements/test.txt
 pytest-variables==2.0.0
     # via
     #   -r requirements/test.txt
     #   pytest-selenium
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -r requirements/test.txt
     #   analytics-python
     #   botocore
+    #   celery
     #   faker
     #   freezegun
-python-dotenv==1.0.0
+python-dotenv==1.0.1
     # via -r requirements/test.txt
 python-memcached==1.59
     # via -r requirements/test.txt
@@ -806,21 +839,19 @@ python3-openid==3.2.0
     # via
     #   -r requirements/test.txt
     #   social-auth-core
-pytz==2023.3.post1
+pytz==2024.1
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   babel
-    #   celery
     #   cybersource-rest-client-python
     #   datetime
     #   django
-    #   djangorestframework
     #   djangorestframework-datatables
     #   drf-yasg
     #   getsmarter-api-clients
     #   zeep
-pywatchman==1.4.1
+pywatchman==2.0.0
     # via -r requirements/dev.in
 pyyaml==6.0.1
     # via
@@ -835,11 +866,11 @@ rcssmin==1.1.1
     # via
     #   -r requirements/test.txt
     #   django-compressor
-redis==5.0.1
+redis==5.0.3
     # via
     #   -r requirements/test.txt
     #   edx-ecommerce-worker
-referencing==0.32.1
+referencing==0.34.0
     # via
     #   -r requirements/test.txt
     #   jsonschema
@@ -870,11 +901,11 @@ requests==2.31.0
     #   stripe
     #   transifex-client
     #   zeep
-requests-file==1.5.1
+requests-file==2.0.0
     # via
     #   -r requirements/test.txt
     #   zeep
-requests-oauthlib==1.3.1
+requests-oauthlib==2.0.0
     # via
     #   -r requirements/test.txt
     #   getsmarter-api-clients
@@ -883,13 +914,13 @@ requests-toolbelt==1.0.0
     # via
     #   -r requirements/test.txt
     #   zeep
-responses==0.24.1
+responses==0.25.0
     # via -r requirements/test.txt
 rjsmin==1.2.1
     # via
     #   -r requirements/test.txt
     #   django-compressor
-rpds-py==0.16.2
+rpds-py==0.18.0
     # via
     #   -r requirements/test.txt
     #   jsonschema
@@ -903,7 +934,7 @@ rsa==4.9
     #   oauth2client
 rules==3.3
     # via -r requirements/test.txt
-s3transfer==0.10.0
+s3transfer==0.10.1
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -928,20 +959,17 @@ six==1.16.0
     #   analytics-python
     #   bleach
     #   cybersource-rest-client-python
-    #   django-extra-views
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-ecommerce-worker
     #   edx-rbac
     #   isodate
-    #   libsass
     #   oauth2client
     #   paypalrestsdk
     #   purl
     #   pyjwkest
     #   python-dateutil
     #   python-memcached
-    #   requests-file
     #   tenacity
     #   tox
     #   transifex-client
@@ -959,7 +987,7 @@ social-auth-app-django==5.2.0
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.5.1
+social-auth-core==4.5.3
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
@@ -1002,23 +1030,23 @@ sphinxcontrib-serializinghtml==1.1.5
     # via
     #   -r requirements/docs.txt
     #   sphinx
-sqlparse==0.4.4
+sqlparse==0.5.0
     # via
     #   -r requirements/test.txt
     #   django
     #   django-debug-toolbar
-stevedore==5.1.0
+stevedore==5.2.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-opaque-keys
-stripe==7.11.0
+stripe==9.3.0
     # via -r requirements/test.txt
 tenacity==6.3.1
     # via
     #   -r requirements/test.txt
     #   pytest-selenium
-testfixtures==7.2.2
+testfixtures==8.1.0
     # via -r requirements/test.txt
 testtools==2.7.1
     # via
@@ -1053,7 +1081,7 @@ typing==3.7.4.3
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-typing-extensions==4.9.0
+typing-extensions==4.11.0
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -1061,9 +1089,15 @@ typing-extensions==4.9.0
     #   astroid
     #   edx-opaque-keys
     #   faker
+    #   kombu
     #   pydata-sphinx-theme
     #   pylint
     #   stripe
+tzdata==2024.1
+    # via
+    #   -r requirements/test.txt
+    #   backports-zoneinfo
+    #   celery
 unicodecsv==0.14.1
     # via -r requirements/test.txt
 uritemplate==4.1.1
@@ -1082,19 +1116,24 @@ urllib3==1.26.18
     #   responses
     #   selenium
     #   transifex-client
-vine==1.3.0
+vine==5.1.0
     # via
     #   -r requirements/test.txt
     #   amqp
     #   celery
+    #   kombu
 virtualenv==16.7.9
     # via
     #   -r requirements/test.txt
     #   tox
-waitress==2.1.2
+waitress==3.0.0
     # via
     #   -r requirements/test.txt
     #   webtest
+wcwidth==0.2.13
+    # via
+    #   -r requirements/test.txt
+    #   prompt-toolkit
 webencodings==0.5.1
     # via
     #   -r requirements/test.txt
@@ -1107,7 +1146,7 @@ webtest==3.0.0
     # via
     #   -r requirements/test.txt
     #   django-webtest
-wheel==0.42.0
+wheel==0.43.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -1127,13 +1166,13 @@ yarl==1.9.4
     #   aiohttp
 zeep==4.2.1
     # via -r requirements/test.txt
-zipp==3.17.0
+zipp==3.18.1
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   importlib-metadata
     #   importlib-resources
-zope-interface==6.1
+zope-interface==6.3
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -87,9 +87,9 @@ billiard==4.2.0
     #   celery
 bleach==6.1.0
     # via -r requirements/test.txt
-boto3==1.34.87
+boto3==1.34.96
     # via -r requirements/test.txt
-botocore==1.34.87
+botocore==1.34.96
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -155,7 +155,7 @@ coreschema==0.0.4
     # via
     #   -r requirements/test.txt
     #   coreapi
-coverage[toml]==7.4.4
+coverage[toml]==7.5.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -264,7 +264,7 @@ django-extra-views==0.14.0
     #   django-oscar
 django-filter==23.5
     # via -r requirements/test.txt
-django-haystack==3.2.1
+django-haystack==3.3b2
     # via
     #   -r requirements/test.txt
     #   django-oscar
@@ -319,6 +319,10 @@ djangorestframework-csv==3.0.2
     # via -r requirements/test.txt
 djangorestframework-datatables==0.7.1
     # via -r requirements/test.txt
+dnspython==2.6.1
+    # via
+    #   -r requirements/test.txt
+    #   pymongo
 docutils==0.19
     # via
     #   -r requirements/docs.txt
@@ -334,7 +338,7 @@ drf-yasg==1.21.7
     # via -r requirements/test.txt
 edx-auth-backends==4.3.0
     # via -r requirements/test.txt
-edx-braze-client==0.2.3
+edx-braze-client==0.2.5
     # via
     #   -r requirements/test.txt
     #   edx-ecommerce-worker
@@ -342,7 +346,7 @@ edx-django-release-util==1.4.0
     # via -r requirements/test.txt
 edx-django-sites-extensions==4.2.0
     # via -r requirements/test.txt
-edx-django-utils==5.12.0
+edx-django-utils==5.13.0
     # via
     #   -r requirements/test.txt
     #   django-config-models
@@ -355,13 +359,13 @@ edx-drf-extensions==10.3.0
     #   edx-rbac
 edx-ecommerce-worker==3.3.4
     # via -r requirements/test.txt
-edx-i18n-tools==1.5.0
+edx-i18n-tools==1.6.0
     # via -r requirements/test.txt
-edx-opaque-keys==2.5.1
+edx-opaque-keys==2.9.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-edx-rbac==1.8.0
+edx-rbac==1.9.0
     # via -r requirements/test.txt
 edx-rest-api-client==5.7.0
     # via
@@ -383,11 +387,11 @@ factory-boy==3.2.1
     # via
     #   -r requirements/test.txt
     #   django-oscar
-faker==24.11.0
+faker==25.0.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.13.4
+filelock==3.14.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -395,7 +399,7 @@ fixtures==4.1.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-freezegun==1.4.0
+freezegun==1.5.0
     # via -r requirements/test.txt
 frozenlist==1.4.1
     # via
@@ -412,11 +416,7 @@ future==1.0.0
     #   pyjwkest
 getsmarter-api-clients==0.6.1
     # via -r requirements/test.txt
-gitdb==4.0.11
-    # via gitpython
-gitpython==3.1.43
-    # via transifex-client
-google-api-core==2.18.0
+google-api-core==2.19.0
     # via
     #   -r requirements/test.txt
     #   google-api-python-client
@@ -514,7 +514,7 @@ jsonfield==3.1.0
     # via -r requirements/test.txt
 jsonfield2==4.0.0.post0
     # via -r requirements/test.txt
-jsonschema==4.21.1
+jsonschema==4.22.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
@@ -607,6 +607,7 @@ packaging==24.0
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
+    #   django-haystack
     #   drf-yasg
     #   pydata-sphinx-theme
     #   pytest
@@ -642,7 +643,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/test.txt
     #   jsonschema
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -746,7 +747,7 @@ pyjwt[crypto]==2.8.0
     #   social-auth-core
 pylint==2.12.2
     # via -r requirements/test.txt
-pymongo==3.13.0
+pymongo==4.4.0
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -825,8 +826,6 @@ python-mimeparse==1.6.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-python-slugify==4.0.1
-    # via transifex-client
 python-subunit==1.4.4
     # via
     #   -r requirements/test.txt
@@ -866,11 +865,11 @@ rcssmin==1.1.1
     # via
     #   -r requirements/test.txt
     #   django-compressor
-redis==5.0.3
+redis==5.0.4
     # via
     #   -r requirements/test.txt
     #   edx-ecommerce-worker
-referencing==0.34.0
+referencing==0.35.1
     # via
     #   -r requirements/test.txt
     #   jsonschema
@@ -899,7 +898,6 @@ requests==2.31.0
     #   social-auth-core
     #   sphinx
     #   stripe
-    #   transifex-client
     #   zeep
 requests-file==2.0.0
     # via
@@ -977,8 +975,6 @@ slumber==0.7.1
     # via
     #   -r requirements/test.txt
     #   edx-rest-api-client
-smmap==5.0.1
-    # via gitdb
 snowballstemmer==2.2.0
     # via
     #   -r requirements/docs.txt
@@ -987,7 +983,7 @@ social-auth-app-django==5.2.0
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.5.3
+social-auth-core==4.5.4
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
@@ -1040,21 +1036,19 @@ stevedore==5.2.0
     #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-opaque-keys
-stripe==9.3.0
+stripe==9.4.0
     # via -r requirements/test.txt
 tenacity==6.3.1
     # via
     #   -r requirements/test.txt
     #   pytest-selenium
-testfixtures==8.1.0
+testfixtures==8.2.0
     # via -r requirements/test.txt
 testtools==2.7.1
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
     #   python-subunit
-text-unidecode==1.3
-    # via python-slugify
 toml==0.10.2
     # via
     #   -r requirements/test.txt
@@ -1075,7 +1069,7 @@ traceback2==1.4.0
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-transifex-client==0.14.4
+transifex-client==0.12.5
     # via -r requirements/dev.in
 typing==3.7.4.3
     # via
@@ -1088,7 +1082,6 @@ typing-extensions==4.11.0
     #   asgiref
     #   astroid
     #   edx-opaque-keys
-    #   faker
     #   kombu
     #   pydata-sphinx-theme
     #   pylint
@@ -1158,7 +1151,7 @@ x509==0.1
     # via
     #   -r requirements/test.txt
     #   cybersource-rest-client-python
-xss-utils==0.5.0
+xss-utils==0.6.0
     # via -r requirements/test.txt
 yarl==1.9.4
     # via

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -12,9 +12,9 @@ babel==2.14.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
-beautifulsoup4==4.12.2
+beautifulsoup4==4.12.3
     # via pydata-sphinx-theme
-certifi==2023.11.17
+certifi==2024.2.2
     # via requests
 charset-normalizer==3.3.2
     # via requests
@@ -28,13 +28,13 @@ idna==2.7
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==7.0.1
+importlib-metadata==7.1.0
     # via sphinx
 jinja2==3.1.3
     # via sphinx
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via jinja2
-packaging==23.2
+packaging==24.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
@@ -45,7 +45,7 @@ pygments==2.17.2
     #   accessible-pygments
     #   pydata-sphinx-theme
     #   sphinx
-pytz==2023.3.post1
+pytz==2024.1
     # via babel
 requests==2.31.0
     # via sphinx
@@ -72,11 +72,11 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-typing-extensions==4.9.0
+typing-extensions==4.11.0
     # via pydata-sphinx-theme
 urllib3==1.26.18
     # via
     #   -c requirements/constraints.txt
     #   requests
-zipp==3.17.0
+zipp==3.18.1
     # via importlib-metadata

--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -39,7 +39,7 @@ django-waffle==4.1.0
     # via
     #   -c requirements/base.txt
     #   edx-django-utils
-edx-django-utils==5.12.0
+edx-django-utils==5.13.0
     # via
     #   -c requirements/base.txt
     #   edx-rest-api-client

--- a/requirements/e2e.txt
+++ b/requirements/e2e.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-asgiref==3.7.2
+asgiref==3.8.1
     # via
     #   -c requirements/base.txt
     #   django
-certifi==2023.11.17
+certifi==2024.2.2
     # via
     #   -c requirements/base.txt
     #   requests
@@ -24,7 +24,7 @@ click==8.1.7
     # via
     #   -c requirements/base.txt
     #   edx-django-utils
-django==3.2.23
+django==3.2.25
     # via
     #   -c requirements/base.txt
     #   -c requirements/common_constraints.txt
@@ -39,40 +39,42 @@ django-waffle==4.1.0
     # via
     #   -c requirements/base.txt
     #   edx-django-utils
-edx-django-utils==5.9.0
+edx-django-utils==5.12.0
     # via
     #   -c requirements/base.txt
     #   edx-rest-api-client
-edx-rest-api-client==5.6.1
+edx-rest-api-client==5.7.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/e2e.in
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via pytest
-future==0.18.3
+future==1.0.0
     # via pyjwkest
 idna==2.7
     # via
     #   -c requirements/base.txt
     #   -c requirements/constraints.txt
     #   requests
-importlib-metadata==7.0.1
-    # via pytest-randomly
+importlib-metadata==7.1.0
+    # via
+    #   -c requirements/base.txt
+    #   pytest-randomly
 iniconfig==2.0.0
     # via pytest
 jinja2==3.1.3
     # via
     #   -c requirements/base.txt
     #   pytest-html
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   -c requirements/base.txt
     #   jinja2
-newrelic==9.5.0
+newrelic==9.9.0
     # via
     #   -c requirements/base.txt
     #   edx-django-utils
-packaging==23.2
+packaging==24.0
     # via
     #   -c requirements/base.txt
     #   pytest
@@ -84,11 +86,11 @@ pluggy==0.13.1
     # via
     #   -c requirements/constraints.txt
     #   pytest
-psutil==5.9.7
+psutil==5.9.8
     # via
     #   -c requirements/base.txt
     #   edx-django-utils
-pycparser==2.21
+pycparser==2.22
     # via
     #   -c requirements/base.txt
     #   cffi
@@ -116,11 +118,11 @@ pytest==7.4.4
     #   pytest-selenium
     #   pytest-timeout
     #   pytest-variables
-pytest-base-url==2.0.0
+pytest-base-url==2.1.0
     # via pytest-selenium
 pytest-html==4.1.1
     # via pytest-selenium
-pytest-metadata==3.0.0
+pytest-metadata==3.1.1
     # via pytest-html
 pytest-randomly==3.15.0
     # via -r requirements/e2e.in
@@ -128,15 +130,15 @@ pytest-selenium==2.0.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/e2e.in
-pytest-timeout==2.2.0
+pytest-timeout==2.3.1
     # via -r requirements/e2e.in
 pytest-variables==2.0.0
     # via
     #   -c requirements/constraints.txt
     #   pytest-selenium
-python-dotenv==1.0.0
+python-dotenv==1.0.1
     # via -r requirements/e2e.in
-pytz==2023.3.post1
+pytz==2024.1
     # via
     #   -c requirements/base.txt
     #   django
@@ -162,11 +164,11 @@ slumber==0.7.1
     # via
     #   -c requirements/base.txt
     #   edx-rest-api-client
-sqlparse==0.4.4
+sqlparse==0.5.0
     # via
     #   -c requirements/base.txt
     #   django
-stevedore==5.1.0
+stevedore==5.2.0
     # via
     #   -c requirements/base.txt
     #   edx-django-utils
@@ -174,7 +176,7 @@ tenacity==6.3.1
     # via pytest-selenium
 tomli==2.0.1
     # via pytest
-typing-extensions==4.9.0
+typing-extensions==4.11.0
     # via
     #   -c requirements/base.txt
     #   asgiref
@@ -184,7 +186,7 @@ urllib3==1.26.18
     #   -c requirements/constraints.txt
     #   requests
     #   selenium
-zipp==3.17.0
+zipp==3.18.1
     # via
     #   -c requirements/base.txt
     #   importlib-metadata

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.42.0
+wheel==0.43.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3.2
+pip==24.0
     # via -r requirements/pip.in
-setuptools==69.0.3
+setuptools==69.5.1
     # via -r requirements/pip.in

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -14,7 +14,7 @@ packaging==24.0
     # via build
 pip-tools==7.4.1
     # via -r requirements/pip_tools.in
-pyproject-hooks==1.0.0
+pyproject-hooks==1.1.0
     # via
     #   build
     #   pip-tools
@@ -22,7 +22,6 @@ tomli==2.0.1
     # via
     #   build
     #   pip-tools
-    #   pyproject-hooks
 wheel==0.43.0
     # via pip-tools
 zipp==3.18.1

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,26 +4,28 @@
 #
 #    make upgrade
 #
-build==1.0.3
+build==1.2.1
     # via pip-tools
 click==8.1.7
     # via pip-tools
-importlib-metadata==7.0.1
+importlib-metadata==7.1.0
     # via build
-packaging==23.2
+packaging==24.0
     # via build
-pip-tools==7.3.0
+pip-tools==7.4.1
     # via -r requirements/pip_tools.in
 pyproject-hooks==1.0.0
-    # via build
+    # via
+    #   build
+    #   pip-tools
 tomli==2.0.1
     # via
     #   build
     #   pip-tools
     #   pyproject-hooks
-wheel==0.42.0
+wheel==0.43.0
     # via pip-tools
-zipp==3.17.0
+zipp==3.18.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -348,7 +348,6 @@ kombu==5.3.7
     # via celery
 libsass==0.23.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-libsass
 linecache2==1.0.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -48,11 +48,11 @@ billiard==4.2.0
     # via celery
 bleach==6.1.0
     # via -r requirements/base.in
-boto3==1.34.87
+boto3==1.34.96
     # via
     #   -r requirements/base.in
     #   django-ses
-botocore==1.34.87
+botocore==1.34.96
     # via
     #   boto3
     #   s3transfer
@@ -95,7 +95,7 @@ coreapi==2.3.3
     # via -r requirements/base.in
 coreschema==0.0.4
     # via coreapi
-coverage==7.4.4
+coverage==7.5.0
     # via cybersource-rest-client-python
 crispy-bootstrap3==2024.1
     # via -r requirements/base.in
@@ -182,7 +182,7 @@ django-extra-views==0.14.0
     # via django-oscar
 django-filter==23.5
     # via -r requirements/base.in
-django-haystack==3.2.1
+django-haystack==3.3b2
     # via django-oscar
 django-libsass==0.9
     # via -r requirements/base.in
@@ -194,7 +194,7 @@ django-oscar==3.2
     #   -r requirements/base.in
 django-phonenumber-field==6.4.0
     # via django-oscar
-django-ses==3.6.0
+django-ses==4.0.0
     # via -r requirements/production.in
 django-simple-history==3.0.0
     # via
@@ -229,6 +229,8 @@ djangorestframework-csv==3.0.2
     # via -r requirements/base.in
 djangorestframework-datatables==0.7.1
     # via -r requirements/base.in
+dnspython==2.6.1
+    # via pymongo
 drf-extensions==0.7.1
     # via -r requirements/base.in
 drf-jwt==1.19.2
@@ -237,13 +239,13 @@ drf-yasg==1.21.7
     # via -r requirements/base.in
 edx-auth-backends==4.3.0
     # via -r requirements/base.in
-edx-braze-client==0.2.3
+edx-braze-client==0.2.5
     # via edx-ecommerce-worker
 edx-django-release-util==1.4.0
     # via -r requirements/base.in
 edx-django-sites-extensions==4.2.0
     # via -r requirements/base.in
-edx-django-utils==5.12.0
+edx-django-utils==5.13.0
     # via
     #   -r requirements/base.in
     #   django-config-models
@@ -256,11 +258,11 @@ edx-drf-extensions==10.3.0
     #   edx-rbac
 edx-ecommerce-worker==3.3.4
     # via -r requirements/base.in
-edx-opaque-keys==2.5.1
+edx-opaque-keys==2.9.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
-edx-rbac==1.8.0
+edx-rbac==1.9.0
     # via -r requirements/base.in
 edx-rest-api-client==5.7.0
     # via
@@ -272,7 +274,7 @@ extras==1.0.0
     # via cybersource-rest-client-python
 factory-boy==3.2.1
     # via django-oscar
-faker==24.11.0
+faker==25.0.0
     # via factory-boy
 fixtures==4.1.0
     # via cybersource-rest-client-python
@@ -284,7 +286,7 @@ funcsigs==1.0.2
     # via cybersource-rest-client-python
 getsmarter-api-clients==0.6.1
     # via -r requirements/base.in
-google-api-core==2.18.0
+google-api-core==2.19.0
     # via google-api-python-client
 google-api-python-client==2.31.0
     # via
@@ -341,7 +343,7 @@ jsonfield==3.1.0
     # via -r requirements/base.in
 jsonfield2==4.0.0.post0
     # via -r requirements/base.in
-jsonschema==4.21.1
+jsonschema==4.22.0
     # via cybersource-rest-client-python
 jsonschema-specifications==2023.12.1
     # via jsonschema
@@ -402,7 +404,9 @@ oauthlib==3.2.2
 openedx-atlas==0.6.0
     # via -r requirements/base.in
 packaging==24.0
-    # via drf-yasg
+    # via
+    #   django-haystack
+    #   drf-yasg
 paramiko==3.4.0
     # via cybersource-rest-client-python
 path-py==7.2
@@ -420,7 +424,7 @@ pillow==10.3.0
     # via django-oscar
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via zeep
 premailer==2.9.2
     # via -r requirements/base.in
@@ -471,7 +475,7 @@ pyjwt[crypto]==2.8.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pymongo==3.13.0
+pymongo==4.4.0
     # via edx-opaque-keys
 pynacl==1.5.0
     # via
@@ -528,11 +532,11 @@ pyyaml==6.0.1
     #   naked
 rcssmin==1.1.1
     # via django-compressor
-redis==5.0.3
+redis==5.0.4
     # via
     #   -r requirements/production.in
     #   edx-ecommerce-worker
-referencing==0.34.0
+referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -609,7 +613,7 @@ social-auth-app-django==5.2.0
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   edx-auth-backends
-social-auth-core==4.5.3
+social-auth-core==4.5.4
     # via
     #   edx-auth-backends
     #   social-auth-app-django
@@ -621,7 +625,7 @@ stevedore==5.2.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-stripe==9.3.0
+stripe==9.4.0
     # via -r requirements/base.in
 testtools==2.7.1
     # via
@@ -635,7 +639,6 @@ typing-extensions==4.11.0
     # via
     #   asgiref
     #   edx-opaque-keys
-    #   faker
     #   kombu
     #   stripe
 tzdata==2024.1
@@ -668,7 +671,7 @@ wheel==0.43.0
     # via cybersource-rest-client-python
 x509==0.1
     # via cybersource-rest-client-python
-xss-utils==0.5.0
+xss-utils==0.6.0
     # via -r requirements/base.in
 yarl==1.9.4
     # via aiohttp

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,17 +4,17 @@
 #
 #    make upgrade
 #
-aiohttp==3.9.1
+aiohttp==3.9.5
     # via inapppy
 aiosignal==1.3.1
     # via aiohttp
-amqp==2.6.1
+amqp==5.2.0
     # via kombu
 analytics-python==1.4.post1
     # via -r requirements/base.in
 app-store-notifications-v2-validator==0.0.7
     # via -r requirements/base.in
-asgiref==3.7.2
+asgiref==3.8.1
     # via
     #   django
     #   django-cors-headers
@@ -34,29 +34,34 @@ babel==2.14.0
     # via django-oscar
 backoff==1.10.0
     # via analytics-python
+backports-zoneinfo[tzdata]==0.2.1
+    # via
+    #   celery
+    #   djangorestframework
+    #   kombu
 bcrypt==4.1.2
     # via
     #   cybersource-rest-client-python
     #   paramiko
-billiard==3.6.4.0
+billiard==4.2.0
     # via celery
 bleach==6.1.0
     # via -r requirements/base.in
-boto3==1.34.17
+boto3==1.34.87
     # via
     #   -r requirements/base.in
     #   django-ses
-botocore==1.34.17
+botocore==1.34.87
     # via
     #   boto3
     #   s3transfer
-cachetools==5.3.2
+cachetools==5.3.3
     # via google-auth
-celery==4.4.7
+celery==5.4.0
     # via
     #   -c requirements/constraints.txt
     #   edx-ecommerce-worker
-certifi==2023.11.17
+certifi==2024.2.2
     # via
     #   cybersource-rest-client-python
     #   requests
@@ -71,20 +76,31 @@ chardet==5.2.0
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
-    # via edx-django-utils
-configparser==6.0.0
+    # via
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
+    #   edx-django-utils
+click-didyoumean==0.3.1
+    # via celery
+click-plugins==1.1.1
+    # via celery
+click-repl==0.3.0
+    # via celery
+configparser==7.0.0
     # via cybersource-rest-client-python
 coreapi==2.3.3
     # via -r requirements/base.in
 coreschema==0.0.4
     # via coreapi
-coverage==7.4.0
+coverage==7.4.4
     # via cybersource-rest-client-python
-crispy-bootstrap3==2022.1
+crispy-bootstrap3==2024.1
     # via -r requirements/base.in
 crypto==1.4.1
     # via cybersource-rest-client-python
-cryptography==41.0.7
+cryptography==42.0.5
     # via
     #   app-store-notifications-v2-validator
     #   cybersource-rest-client-python
@@ -94,19 +110,19 @@ cryptography==41.0.7
     #   social-auth-core
 cssselect==1.2.0
     # via premailer
-cssutils==2.9.0
+cssutils==2.10.2
     # via premailer
 cybersource-rest-client-python==0.0.21
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-datetime==5.4
+datetime==5.5
     # via cybersource-rest-client-python
 defusedxml==0.8.0rc2
     # via
     #   python3-openid
     #   social-auth-core
-django==3.2.23
+django==3.2.25
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
@@ -147,7 +163,7 @@ django-compressor==4.4
     # via
     #   -r requirements/base.in
     #   django-libsass
-django-config-models==2.5.1
+django-config-models==2.7.0
     # via -r requirements/base.in
 django-cors-headers==4.3.1
     # via -r requirements/base.in
@@ -161,7 +177,7 @@ django-crum==0.7.9
     #   edx-rbac
 django-extensions==3.2.3
     # via -r requirements/base.in
-django-extra-views==0.13.0
+django-extra-views==0.14.0
     # via django-oscar
 django-filter==23.5
     # via -r requirements/base.in
@@ -169,27 +185,27 @@ django-haystack==3.2.1
     # via django-oscar
 django-libsass==0.9
     # via -r requirements/base.in
-django-model-utils==4.3.1
+django-model-utils==4.5.0
     # via edx-rbac
 django-oscar==3.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-django-phonenumber-field==5.0.0
+django-phonenumber-field==6.4.0
     # via django-oscar
-django-ses==3.5.2
+django-ses==3.6.0
     # via -r requirements/production.in
 django-simple-history==3.0.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
-django-solo==2.1.0
+django-solo==2.2.0
     # via -r requirements/base.in
 django-tables2==2.3.4
     # via django-oscar
 django-threadlocals==0.10
     # via -r requirements/base.in
-django-treebeard==4.4
+django-treebeard==4.7.1
     # via django-oscar
 django-waffle==4.1.0
     # via
@@ -198,7 +214,7 @@ django-waffle==4.1.0
     #   edx-drf-extensions
 django-widget-tweaks==1.5.0
     # via django-oscar
-djangorestframework==3.14.0
+djangorestframework==3.15.1
     # via
     #   -r requirements/base.in
     #   django-config-models
@@ -210,7 +226,7 @@ djangorestframework==3.14.0
     #   edx-drf-extensions
 djangorestframework-csv==3.0.2
     # via -r requirements/base.in
-djangorestframework-datatables==0.7.0
+djangorestframework-datatables==0.7.1
     # via -r requirements/base.in
 drf-extensions==0.7.1
     # via -r requirements/base.in
@@ -218,22 +234,22 @@ drf-jwt==1.19.2
     # via edx-drf-extensions
 drf-yasg==1.21.7
     # via -r requirements/base.in
-edx-auth-backends==4.2.0
+edx-auth-backends==4.3.0
     # via -r requirements/base.in
-edx-braze-client==0.1.8
+edx-braze-client==0.2.3
     # via edx-ecommerce-worker
-edx-django-release-util==1.3.0
+edx-django-release-util==1.4.0
     # via -r requirements/base.in
-edx-django-sites-extensions==4.0.2
+edx-django-sites-extensions==4.2.0
     # via -r requirements/base.in
-edx-django-utils==5.9.0
+edx-django-utils==5.12.0
     # via
     #   -r requirements/base.in
     #   django-config-models
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   getsmarter-api-clients
-edx-drf-extensions==9.1.2
+edx-drf-extensions==10.3.0
     # via
     #   -r requirements/base.in
     #   edx-rbac
@@ -245,19 +261,17 @@ edx-opaque-keys==2.5.1
     #   edx-drf-extensions
 edx-rbac==1.8.0
     # via -r requirements/base.in
-edx-rest-api-client==5.6.1
+edx-rest-api-client==5.7.0
     # via
     #   -r requirements/base.in
     #   edx-ecommerce-worker
 enum34==1.1.10
     # via cybersource-rest-client-python
 extras==1.0.0
-    # via
-    #   cybersource-rest-client-python
-    #   python-subunit
-factory-boy==3.1.0
+    # via cybersource-rest-client-python
+factory-boy==3.2.1
     # via django-oscar
-faker==22.2.0
+faker==24.11.0
     # via factory-boy
 fixtures==4.1.0
     # via cybersource-rest-client-python
@@ -269,20 +283,20 @@ funcsigs==1.0.2
     # via cybersource-rest-client-python
 getsmarter-api-clients==0.6.1
     # via -r requirements/base.in
-google-api-core==2.15.0
+google-api-core==2.18.0
     # via google-api-python-client
 google-api-python-client==2.31.0
     # via
     #   -r requirements/base.in
     #   inapppy
-google-auth==2.26.2
+google-auth==2.29.0
     # via
     #   google-api-core
     #   google-api-python-client
     #   google-auth-httplib2
 google-auth-httplib2==0.2.0
     # via google-api-python-client
-googleapis-common-protos==1.62.0
+googleapis-common-protos==1.63.0
     # via google-api-core
 gunicorn==19.7.1
     # via -r requirements/production.in
@@ -298,7 +312,9 @@ idna==2.7
     #   cybersource-rest-client-python
     #   requests
     #   yarl
-importlib-resources==6.1.1
+importlib-metadata==7.1.0
+    # via markdown
+importlib-resources==6.4.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -324,14 +340,15 @@ jsonfield==3.1.0
     # via -r requirements/base.in
 jsonfield2==4.0.0.post0
     # via -r requirements/base.in
-jsonschema==4.20.0
+jsonschema==4.21.1
     # via cybersource-rest-client-python
 jsonschema-specifications==2023.12.1
     # via jsonschema
-kombu==4.6.11
+kombu==5.3.7
     # via celery
-libsass==0.9.2
+libsass==0.23.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-libsass
 linecache2==1.0.0
@@ -340,17 +357,21 @@ linecache2==1.0.0
     #   traceback2
 logger==1.4
     # via cybersource-rest-client-python
-lxml==5.1.0
+lxml[html-clean,html_clean]==5.2.1
     # via
+    #   -r requirements/base.in
+    #   lxml-html-clean
     #   premailer
     #   zeep
+lxml-html-clean==0.1.1
+    # via lxml
 markdown==3.4.3
     # via -r requirements/base.in
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via jinja2
 monotonic==1.6
     # via analytics-python
-multidict==6.0.4
+multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
@@ -362,7 +383,7 @@ naked==0.1.32
     #   cybersource-rest-client-python
 ndg-httpsclient==0.5.1
     # via -r requirements/base.in
-newrelic==9.5.0
+newrelic==9.9.0
     # via
     #   -r requirements/base.in
     #   -r requirements/production.in
@@ -380,7 +401,7 @@ oauthlib==3.2.2
     #   social-auth-core
 openedx-atlas==0.6.0
     # via -r requirements/base.in
-packaging==23.2
+packaging==24.0
     # via drf-yasg
 paramiko==3.4.0
     # via cybersource-rest-client-python
@@ -393,25 +414,30 @@ pbr==6.0.0
     #   cybersource-rest-client-python
     #   fixtures
     #   stevedore
-phonenumbers==8.13.27
+phonenumbers==8.13.35
     # via django-oscar
-pillow==10.2.0
+pillow==10.3.0
     # via django-oscar
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==4.1.0
+platformdirs==4.2.0
     # via zeep
 premailer==2.9.2
     # via -r requirements/base.in
-protobuf==4.25.2
+prompt-toolkit==3.0.43
+    # via click-repl
+proto-plus==1.23.0
+    # via google-api-core
+protobuf==4.25.3
     # via
     #   google-api-core
     #   googleapis-common-protos
-psutil==5.9.7
+    #   proto-plus
+psutil==5.9.8
     # via edx-django-utils
 purl==1.6
     # via django-oscar
-pyasn1==0.5.1
+pyasn1==0.6.0
     # via
     #   cybersource-rest-client-python
     #   ndg-httpsclient
@@ -419,13 +445,13 @@ pyasn1==0.5.1
     #   pyasn1-modules
     #   rsa
     #   x509
-pyasn1-modules==0.3.0
+pyasn1-modules==0.4.0
     # via
     #   google-auth
     #   oauth2client
 pycountry==17.1.8
     # via -r requirements/base.in
-pycparser==2.21
+pycparser==2.22
     # via
     #   app-store-notifications-v2-validator
     #   cffi
@@ -452,21 +478,22 @@ pynacl==1.5.0
     #   cybersource-rest-client-python
     #   edx-django-utils
     #   paramiko
-pyopenssl==23.3.0
+pyopenssl==24.1.0
     # via
     #   app-store-notifications-v2-validator
     #   cybersource-rest-client-python
     #   ndg-httpsclient
     #   paypalrestsdk
-pyparsing==3.1.1
+pyparsing==3.1.2
     # via httplib2
 pypi==2.1
     # via cybersource-rest-client-python
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.in
     #   analytics-python
     #   botocore
+    #   celery
     #   faker
 python-memcached==1.59
     # via -r requirements/production.in
@@ -480,16 +507,14 @@ python3-openid==3.2.0
     # via
     #   -r requirements/base.in
     #   social-auth-core
-pytz==2023.3.post1
+pytz==2024.1
     # via
     #   -r requirements/base.in
     #   babel
-    #   celery
     #   cybersource-rest-client-python
     #   datetime
     #   django
     #   django-ses
-    #   djangorestframework
     #   djangorestframework-datatables
     #   drf-yasg
     #   getsmarter-api-clients
@@ -503,11 +528,11 @@ pyyaml==6.0.1
     #   naked
 rcssmin==1.1.1
     # via django-compressor
-redis==5.0.1
+redis==5.0.3
     # via
     #   -r requirements/production.in
     #   edx-ecommerce-worker
-referencing==0.32.1
+referencing==0.34.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -530,9 +555,9 @@ requests==2.31.0
     #   social-auth-core
     #   stripe
     #   zeep
-requests-file==1.5.1
+requests-file==2.0.0
     # via zeep
-requests-oauthlib==1.3.1
+requests-oauthlib==2.0.0
     # via
     #   getsmarter-api-clients
     #   social-auth-core
@@ -540,7 +565,7 @@ requests-toolbelt==1.0.0
     # via zeep
 rjsmin==1.2.1
     # via django-compressor
-rpds-py==0.16.2
+rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
@@ -552,7 +577,7 @@ rsa==4.9
     #   oauth2client
 rules==3.3
     # via -r requirements/base.in
-s3transfer==0.10.0
+s3transfer==0.10.1
     # via boto3
 semantic-version==2.10.0
     # via edx-drf-extensions
@@ -567,19 +592,16 @@ six==1.16.0
     #   analytics-python
     #   bleach
     #   cybersource-rest-client-python
-    #   django-extra-views
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-ecommerce-worker
     #   edx-rbac
     #   isodate
-    #   libsass
     #   oauth2client
     #   paypalrestsdk
     #   purl
     #   python-dateutil
     #   python-memcached
-    #   requests-file
 slumber==0.7.1
     # via edx-rest-api-client
 social-auth-app-django==5.2.0
@@ -587,19 +609,19 @@ social-auth-app-django==5.2.0
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   edx-auth-backends
-social-auth-core==4.5.1
+social-auth-core==4.5.3
     # via
     #   edx-auth-backends
     #   social-auth-app-django
 sorl-thumbnail==12.10.0
     # via -r requirements/base.in
-sqlparse==0.4.4
+sqlparse==0.5.0
     # via django
-stevedore==5.1.0
+stevedore==5.2.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-stripe==7.11.0
+stripe==9.3.0
     # via -r requirements/base.in
 testtools==2.7.1
     # via
@@ -609,12 +631,17 @@ traceback2==1.4.0
     # via cybersource-rest-client-python
 typing==3.7.4.3
     # via cybersource-rest-client-python
-typing-extensions==4.9.0
+typing-extensions==4.11.0
     # via
     #   asgiref
     #   edx-opaque-keys
     #   faker
+    #   kombu
     #   stripe
+tzdata==2024.1
+    # via
+    #   backports-zoneinfo
+    #   celery
 unicodecsv==0.14.1
     # via -r requirements/base.in
 uritemplate==4.1.1
@@ -628,13 +655,16 @@ urllib3==1.26.18
     #   botocore
     #   cybersource-rest-client-python
     #   requests
-vine==1.3.0
+vine==5.1.0
     # via
     #   amqp
     #   celery
+    #   kombu
+wcwidth==0.2.13
+    # via prompt-toolkit
 webencodings==0.5.1
     # via bleach
-wheel==0.42.0
+wheel==0.43.0
     # via cybersource-rest-client-python
 x509==0.1
     # via cybersource-rest-client-python
@@ -644,9 +674,11 @@ yarl==1.9.4
     # via aiohttp
 zeep==4.2.1
     # via -r requirements/base.in
-zipp==3.17.0
-    # via importlib-resources
-zope-interface==6.1
+zipp==3.18.1
+    # via
+    #   importlib-metadata
+    #   importlib-resources
+zope-interface==6.3
     # via
     #   cybersource-rest-client-python
     #   datetime

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -34,8 +34,9 @@ babel==2.14.0
     # via django-oscar
 backoff==1.10.0
     # via analytics-python
-backports-zoneinfo[tzdata]==0.2.1
+backports-zoneinfo[tzdata]==0.2.1 ; python_version < "3.9"
     # via
+    #   -c requirements/constraints.txt
     #   celery
     #   djangorestframework
     #   kombu

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-aiohttp==3.9.1
+aiohttp==3.9.5
     # via
     #   -r requirements/base.txt
     #   inapppy
@@ -12,7 +12,7 @@ aiosignal==1.3.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
-amqp==2.6.1
+amqp==5.2.0
     # via
     #   -r requirements/base.txt
     #   kombu
@@ -20,7 +20,7 @@ analytics-python==1.4.post1
     # via -r requirements/base.txt
 app-store-notifications-v2-validator==0.0.7
     # via -r requirements/base.txt
-asgiref==3.7.2
+asgiref==3.8.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -52,36 +52,42 @@ backoff==1.10.0
     # via
     #   -r requirements/base.txt
     #   analytics-python
+backports-zoneinfo[tzdata]==0.2.1
+    # via
+    #   -r requirements/base.txt
+    #   celery
+    #   djangorestframework
+    #   kombu
 bcrypt==4.1.2
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
     #   paramiko
-beautifulsoup4==4.12.2
+beautifulsoup4==4.12.3
     # via webtest
-billiard==3.6.4.0
+billiard==4.2.0
     # via
     #   -r requirements/base.txt
     #   celery
 bleach==6.1.0
     # via -r requirements/base.txt
-boto3==1.34.17
+boto3==1.34.87
     # via -r requirements/base.txt
-botocore==1.34.17
+botocore==1.34.87
     # via
     #   -r requirements/base.txt
     #   boto3
     #   s3transfer
-cachetools==5.3.2
+cachetools==5.3.3
     # via
     #   -r requirements/base.txt
     #   google-auth
-celery==4.4.7
+celery==5.4.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-ecommerce-worker
-certifi==2023.11.17
+certifi==2024.2.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -109,8 +115,24 @@ click==8.1.7
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
     #   edx-django-utils
-configparser==6.0.0
+click-didyoumean==0.3.1
+    # via
+    #   -r requirements/base.txt
+    #   celery
+click-plugins==1.1.1
+    # via
+    #   -r requirements/base.txt
+    #   celery
+click-repl==0.3.0
+    # via
+    #   -r requirements/base.txt
+    #   celery
+configparser==7.0.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
@@ -120,19 +142,19 @@ coreschema==0.0.4
     # via
     #   -r requirements/base.txt
     #   coreapi
-coverage[toml]==7.4.0
+coverage[toml]==7.4.4
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   cybersource-rest-client-python
     #   pytest-cov
-crispy-bootstrap3==2022.1
+crispy-bootstrap3==2024.1
     # via -r requirements/base.txt
 crypto==1.4.1
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-cryptography==41.0.7
+cryptography==42.0.5
     # via
     #   -r requirements/base.txt
     #   app-store-notifications-v2-validator
@@ -145,7 +167,7 @@ cssselect==1.2.0
     # via
     #   -r requirements/base.txt
     #   premailer
-cssutils==2.9.0
+cssutils==2.10.2
     # via
     #   -r requirements/base.txt
     #   premailer
@@ -153,18 +175,18 @@ cybersource-rest-client-python==0.0.21
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-datetime==5.4
+datetime==5.5
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-ddt==1.7.1
+ddt==1.7.2
     # via -r requirements/test.in
 defusedxml==0.8.0rc2
     # via
     #   -r requirements/base.txt
     #   python3-openid
     #   social-auth-core
-diff-cover==8.0.2
+diff-cover==7.7.0
     # via -r requirements/test.in
     # via
     #   -c requirements/common_constraints.txt
@@ -209,7 +231,7 @@ django-compressor==4.4
     # via
     #   -r requirements/base.txt
     #   django-libsass
-django-config-models==2.5.1
+django-config-models==2.7.0
     # via -r requirements/base.txt
 django-cors-headers==4.3.1
     # via -r requirements/base.txt
@@ -225,7 +247,7 @@ django-crum==0.7.9
     #   edx-rbac
 django-extensions==3.2.3
     # via -r requirements/base.txt
-django-extra-views==0.13.0
+django-extra-views==0.14.0
     # via
     #   -r requirements/base.txt
     #   django-oscar
@@ -237,7 +259,7 @@ django-haystack==3.2.1
     #   django-oscar
 django-libsass==0.9
     # via -r requirements/base.txt
-django-model-utils==4.3.1
+django-model-utils==4.5.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
@@ -245,7 +267,7 @@ django-oscar==3.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-django-phonenumber-field==5.0.0
+django-phonenumber-field==6.4.0
     # via
     #   -r requirements/base.txt
     #   django-oscar
@@ -253,7 +275,7 @@ django-simple-history==3.0.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
-django-solo==2.1.0
+django-solo==2.2.0
     # via -r requirements/base.txt
 django-tables2==2.3.4
     # via
@@ -261,7 +283,7 @@ django-tables2==2.3.4
     #   django-oscar
 django-threadlocals==0.10
     # via -r requirements/base.txt
-django-treebeard==4.4
+django-treebeard==4.7.1
     # via
     #   -r requirements/base.txt
     #   django-oscar
@@ -277,7 +299,7 @@ django-widget-tweaks==1.5.0
     # via
     #   -r requirements/base.txt
     #   django-oscar
-djangorestframework==3.14.0
+djangorestframework==3.15.1
     # via
     #   -r requirements/base.txt
     #   django-config-models
@@ -289,7 +311,7 @@ djangorestframework==3.14.0
     #   edx-drf-extensions
 djangorestframework-csv==3.0.2
     # via -r requirements/base.txt
-djangorestframework-datatables==0.7.0
+djangorestframework-datatables==0.7.1
     # via -r requirements/base.txt
 drf-extensions==0.7.1
     # via -r requirements/base.txt
@@ -299,17 +321,17 @@ drf-jwt==1.19.2
     #   edx-drf-extensions
 drf-yasg==1.21.7
     # via -r requirements/base.txt
-edx-auth-backends==4.2.0
+edx-auth-backends==4.3.0
     # via -r requirements/base.txt
-edx-braze-client==0.1.8
+edx-braze-client==0.2.3
     # via
     #   -r requirements/base.txt
     #   edx-ecommerce-worker
-edx-django-release-util==1.3.0
+edx-django-release-util==1.4.0
     # via -r requirements/base.txt
-edx-django-sites-extensions==4.0.2
+edx-django-sites-extensions==4.2.0
     # via -r requirements/base.txt
-edx-django-utils==5.9.0
+edx-django-utils==5.12.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -317,13 +339,13 @@ edx-django-utils==5.9.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   getsmarter-api-clients
-edx-drf-extensions==9.1.2
+edx-drf-extensions==10.3.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
 edx-ecommerce-worker==3.3.4
     # via -r requirements/base.txt
-edx-i18n-tools==1.3.0
+edx-i18n-tools==1.5.0
     # via -r requirements/test.in
 edx-opaque-keys==2.5.1
     # via
@@ -331,7 +353,7 @@ edx-opaque-keys==2.5.1
     #   edx-drf-extensions
 edx-rbac==1.8.0
     # via -r requirements/base.txt
-edx-rest-api-client==5.6.1
+edx-rest-api-client==5.7.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -340,7 +362,7 @@ enum34==1.1.10
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   -r requirements/e2e.txt
     #   pytest
@@ -348,17 +370,16 @@ extras==1.0.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-    #   python-subunit
-factory-boy==3.1.0
+factory-boy==3.2.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   django-oscar
-faker==22.2.0
+faker==24.11.0
     # via
     #   -r requirements/base.txt
     #   factory-boy
-filelock==3.13.1
+filelock==3.13.4
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -377,13 +398,13 @@ funcsigs==1.0.2
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-future==0.18.3
+future==1.0.0
     # via
     #   -r requirements/e2e.txt
     #   pyjwkest
 getsmarter-api-clients==0.6.1
     # via -r requirements/base.txt
-google-api-core==2.15.0
+google-api-core==2.18.0
     # via
     #   -r requirements/base.txt
     #   google-api-python-client
@@ -391,7 +412,7 @@ google-api-python-client==2.31.0
     # via
     #   -r requirements/base.txt
     #   inapppy
-google-auth==2.26.2
+google-auth==2.29.0
     # via
     #   -r requirements/base.txt
     #   google-api-core
@@ -401,7 +422,7 @@ google-auth-httplib2==0.2.0
     # via
     #   -r requirements/base.txt
     #   google-api-python-client
-googleapis-common-protos==1.62.0
+googleapis-common-protos==1.63.0
     # via
     #   -r requirements/base.txt
     #   google-api-core
@@ -419,11 +440,13 @@ idna==2.7
     #   cybersource-rest-client-python
     #   requests
     #   yarl
-importlib-metadata==7.0.1
+importlib-metadata==7.1.0
     # via
+    #   -r requirements/base.txt
     #   -r requirements/e2e.txt
+    #   markdown
     #   pytest-randomly
-importlib-resources==6.1.1
+importlib-resources==6.4.0
     # via
     #   -r requirements/base.txt
     #   jsonschema
@@ -474,7 +497,7 @@ jsonfield==3.1.0
     # via -r requirements/base.txt
 jsonfield2==4.0.0.post0
     # via -r requirements/base.txt
-jsonschema==4.20.0
+jsonschema==4.21.1
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
@@ -482,14 +505,15 @@ jsonschema-specifications==2023.12.1
     # via
     #   -r requirements/base.txt
     #   jsonschema
-kombu==4.6.11
+kombu==5.3.7
     # via
     #   -r requirements/base.txt
     #   celery
 lazy-object-proxy==1.10.0
     # via astroid
-libsass==0.9.2
+libsass==0.23.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django-libsass
 linecache2==1.0.0
@@ -501,16 +525,21 @@ logger==1.4
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-lxml==5.1.0
+lxml[html-clean]==5.2.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   edx-i18n-tools
+    #   lxml-html-clean
     #   premailer
     #   zeep
+lxml-html-clean==0.1.1
+    # via
+    #   -r requirements/base.txt
+    #   lxml
 markdown==3.4.3
     # via -r requirements/base.txt
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -525,7 +554,7 @@ monotonic==1.6
     # via
     #   -r requirements/base.txt
     #   analytics-python
-multidict==6.0.4
+multidict==6.0.5
     # via
     #   -r requirements/base.txt
     #   aiohttp
@@ -539,7 +568,7 @@ naked==0.1.32
     #   cybersource-rest-client-python
 ndg-httpsclient==0.5.1
     # via -r requirements/base.txt
-newrelic==9.5.0
+newrelic==9.9.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -560,7 +589,7 @@ oauthlib==3.2.2
     #   social-auth-core
 openedx-atlas==0.6.0
     # via -r requirements/base.txt
-packaging==23.2
+packaging==24.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -572,7 +601,7 @@ paramiko==3.4.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-path==16.9.0
+path==16.14.0
     # via edx-i18n-tools
 path-py==7.2
     # via -r requirements/base.txt
@@ -585,11 +614,11 @@ pbr==6.0.0
     #   cybersource-rest-client-python
     #   fixtures
     #   stevedore
-phonenumbers==8.13.27
+phonenumbers==8.13.35
     # via
     #   -r requirements/base.txt
     #   django-oscar
-pillow==10.2.0
+pillow==10.3.0
     # via
     #   -r requirements/base.txt
     #   django-oscar
@@ -597,7 +626,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/base.txt
     #   jsonschema
-platformdirs==4.1.0
+platformdirs==4.2.0
     # via
     #   -r requirements/base.txt
     #   pylint
@@ -614,12 +643,21 @@ polib==1.2.0
     # via edx-i18n-tools
 premailer==2.9.2
     # via -r requirements/base.txt
-protobuf==4.25.2
+prompt-toolkit==3.0.43
+    # via
+    #   -r requirements/base.txt
+    #   click-repl
+proto-plus==1.23.0
+    # via
+    #   -r requirements/base.txt
+    #   google-api-core
+protobuf==4.25.3
     # via
     #   -r requirements/base.txt
     #   google-api-core
     #   googleapis-common-protos
-psutil==5.9.7
+    #   proto-plus
+psutil==5.9.8
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -632,7 +670,7 @@ py==1.11.0
     # via
     #   -r requirements/tox.txt
     #   tox
-pyasn1==0.5.1
+pyasn1==0.6.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
@@ -641,7 +679,7 @@ pyasn1==0.5.1
     #   pyasn1-modules
     #   rsa
     #   x509
-pyasn1-modules==0.3.0
+pyasn1-modules==0.4.0
     # via
     #   -r requirements/base.txt
     #   google-auth
@@ -650,7 +688,7 @@ pycodestyle==2.11.1
     # via -r requirements/test.in
 pycountry==17.1.8
     # via -r requirements/base.txt
-pycparser==2.21
+pycparser==2.22
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -683,7 +721,6 @@ pyjwt[crypto]==2.8.0
     #   edx-auth-backends
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwt
     #   social-auth-core
 pylint==2.12.2
     # via
@@ -700,14 +737,14 @@ pynacl==1.5.0
     #   cybersource-rest-client-python
     #   edx-django-utils
     #   paramiko
-pyopenssl==23.3.0
+pyopenssl==24.1.0
     # via
     #   -r requirements/base.txt
     #   app-store-notifications-v2-validator
     #   cybersource-rest-client-python
     #   ndg-httpsclient
     #   paypalrestsdk
-pyparsing==3.1.1
+pyparsing==3.1.2
     # via
     #   -r requirements/base.txt
     #   httplib2
@@ -728,19 +765,19 @@ pytest==7.4.4
     #   pytest-selenium
     #   pytest-timeout
     #   pytest-variables
-pytest-base-url==2.0.0
+pytest-base-url==2.1.0
     # via
     #   -r requirements/e2e.txt
     #   pytest-selenium
-pytest-cov==4.1.0
+pytest-cov==5.0.0
     # via -r requirements/test.in
-pytest-django==4.7.0
+pytest-django==4.8.0
     # via -r requirements/test.in
 pytest-html==4.1.1
     # via
     #   -r requirements/e2e.txt
     #   pytest-selenium
-pytest-metadata==3.0.0
+pytest-metadata==3.1.1
     # via
     #   -r requirements/e2e.txt
     #   pytest-html
@@ -750,21 +787,22 @@ pytest-selenium==2.0.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/e2e.txt
-pytest-timeout==2.2.0
+pytest-timeout==2.3.1
     # via -r requirements/e2e.txt
 pytest-variables==2.0.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/e2e.txt
     #   pytest-selenium
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.txt
     #   analytics-python
     #   botocore
+    #   celery
     #   faker
     #   freezegun
-python-dotenv==1.0.0
+python-dotenv==1.0.1
     # via -r requirements/e2e.txt
 python-memcached==1.59
     # via -r requirements/test.in
@@ -784,16 +822,14 @@ python3-openid==3.2.0
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-pytz==2023.3.post1
+pytz==2024.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
     #   babel
-    #   celery
     #   cybersource-rest-client-python
     #   datetime
     #   django
-    #   djangorestframework
     #   djangorestframework-datatables
     #   drf-yasg
     #   getsmarter-api-clients
@@ -811,11 +847,11 @@ rcssmin==1.1.1
     # via
     #   -r requirements/base.txt
     #   django-compressor
-redis==5.0.1
+redis==5.0.3
     # via
     #   -r requirements/base.txt
     #   edx-ecommerce-worker
-referencing==0.32.1
+referencing==0.34.0
     # via
     #   -r requirements/base.txt
     #   jsonschema
@@ -844,11 +880,11 @@ requests==2.31.0
     #   social-auth-core
     #   stripe
     #   zeep
-requests-file==1.5.1
+requests-file==2.0.0
     # via
     #   -r requirements/base.txt
     #   zeep
-requests-oauthlib==1.3.1
+requests-oauthlib==2.0.0
     # via
     #   -r requirements/base.txt
     #   getsmarter-api-clients
@@ -857,13 +893,13 @@ requests-toolbelt==1.0.0
     # via
     #   -r requirements/base.txt
     #   zeep
-responses==0.24.1
+responses==0.25.0
     # via -r requirements/test.in
 rjsmin==1.2.1
     # via
     #   -r requirements/base.txt
     #   django-compressor
-rpds-py==0.16.2
+rpds-py==0.18.0
     # via
     #   -r requirements/base.txt
     #   jsonschema
@@ -877,7 +913,7 @@ rsa==4.9
     #   oauth2client
 rules==3.3
     # via -r requirements/base.txt
-s3transfer==0.10.0
+s3transfer==0.10.1
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -906,20 +942,17 @@ six==1.16.0
     #   analytics-python
     #   bleach
     #   cybersource-rest-client-python
-    #   django-extra-views
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-ecommerce-worker
     #   edx-rbac
     #   isodate
-    #   libsass
     #   oauth2client
     #   paypalrestsdk
     #   purl
     #   pyjwkest
     #   python-dateutil
     #   python-memcached
-    #   requests-file
     #   tenacity
     #   tox
 slumber==0.7.1
@@ -932,7 +965,7 @@ social-auth-app-django==5.2.0
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.5.1
+social-auth-core==4.5.3
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
@@ -941,24 +974,24 @@ sorl-thumbnail==12.10.0
     # via -r requirements/base.txt
 soupsieve==2.5
     # via beautifulsoup4
-sqlparse==0.4.4
+sqlparse==0.5.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
     #   django
-stevedore==5.1.0
+stevedore==5.2.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
     #   edx-django-utils
     #   edx-opaque-keys
-stripe==7.11.0
+stripe==9.3.0
     # via -r requirements/base.txt
 tenacity==6.3.1
     # via
     #   -r requirements/e2e.txt
     #   pytest-selenium
-testfixtures==7.2.2
+testfixtures==8.1.0
     # via -r requirements/test.in
 testtools==2.7.1
     # via
@@ -990,7 +1023,7 @@ typing==3.7.4.3
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-typing-extensions==4.9.0
+typing-extensions==4.11.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -998,8 +1031,14 @@ typing-extensions==4.9.0
     #   astroid
     #   edx-opaque-keys
     #   faker
+    #   kombu
     #   pylint
     #   stripe
+tzdata==2024.1
+    # via
+    #   -r requirements/base.txt
+    #   backports-zoneinfo
+    #   celery
 unicodecsv==0.14.1
     # via -r requirements/base.txt
 uritemplate==4.1.1
@@ -1018,18 +1057,23 @@ urllib3==1.26.18
     #   requests
     #   responses
     #   selenium
-vine==1.3.0
+vine==5.1.0
     # via
     #   -r requirements/base.txt
     #   amqp
     #   celery
+    #   kombu
 virtualenv==16.7.9
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/tox.txt
     #   tox
-waitress==2.1.2
+waitress==3.0.0
     # via webtest
+wcwidth==0.2.13
+    # via
+    #   -r requirements/base.txt
+    #   prompt-toolkit
 webencodings==0.5.1
     # via
     #   -r requirements/base.txt
@@ -1038,7 +1082,7 @@ webob==1.8.7
     # via webtest
 webtest==3.0.0
     # via django-webtest
-wheel==0.42.0
+wheel==0.43.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
@@ -1058,13 +1102,13 @@ yarl==1.9.4
     #   aiohttp
 zeep==4.2.1
     # via -r requirements/base.txt
-zipp==3.17.0
+zipp==3.18.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
     #   importlib-metadata
     #   importlib-resources
-zope-interface==6.1
+zope-interface==6.3
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -52,8 +52,9 @@ backoff==1.10.0
     # via
     #   -r requirements/base.txt
     #   analytics-python
-backports-zoneinfo[tzdata]==0.2.1
+backports-zoneinfo[tzdata]==0.2.1 ; python_version < "3.9"
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   celery
     #   djangorestframework

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -513,7 +513,6 @@ lazy-object-proxy==1.10.0
     # via astroid
 libsass==0.23.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django-libsass
 linecache2==1.0.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -72,9 +72,9 @@ billiard==4.2.0
     #   celery
 bleach==6.1.0
     # via -r requirements/base.txt
-boto3==1.34.87
+boto3==1.34.96
     # via -r requirements/base.txt
-botocore==1.34.87
+botocore==1.34.96
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -143,7 +143,7 @@ coreschema==0.0.4
     # via
     #   -r requirements/base.txt
     #   coreapi
-coverage[toml]==7.4.4
+coverage[toml]==7.5.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
@@ -254,7 +254,7 @@ django-extra-views==0.14.0
     #   django-oscar
 django-filter==23.5
     # via -r requirements/base.txt
-django-haystack==3.2.1
+django-haystack==3.3b2
     # via
     #   -r requirements/base.txt
     #   django-oscar
@@ -314,6 +314,10 @@ djangorestframework-csv==3.0.2
     # via -r requirements/base.txt
 djangorestframework-datatables==0.7.1
     # via -r requirements/base.txt
+dnspython==2.6.1
+    # via
+    #   -r requirements/base.txt
+    #   pymongo
 drf-extensions==0.7.1
     # via -r requirements/base.txt
 drf-jwt==1.19.2
@@ -324,7 +328,7 @@ drf-yasg==1.21.7
     # via -r requirements/base.txt
 edx-auth-backends==4.3.0
     # via -r requirements/base.txt
-edx-braze-client==0.2.3
+edx-braze-client==0.2.5
     # via
     #   -r requirements/base.txt
     #   edx-ecommerce-worker
@@ -332,7 +336,7 @@ edx-django-release-util==1.4.0
     # via -r requirements/base.txt
 edx-django-sites-extensions==4.2.0
     # via -r requirements/base.txt
-edx-django-utils==5.12.0
+edx-django-utils==5.13.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
@@ -346,13 +350,13 @@ edx-drf-extensions==10.3.0
     #   edx-rbac
 edx-ecommerce-worker==3.3.4
     # via -r requirements/base.txt
-edx-i18n-tools==1.5.0
+edx-i18n-tools==1.6.0
     # via -r requirements/test.in
-edx-opaque-keys==2.5.1
+edx-opaque-keys==2.9.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-edx-rbac==1.8.0
+edx-rbac==1.9.0
     # via -r requirements/base.txt
 edx-rest-api-client==5.7.0
     # via
@@ -376,11 +380,11 @@ factory-boy==3.2.1
     #   -r requirements/base.txt
     #   -r requirements/test.in
     #   django-oscar
-faker==24.11.0
+faker==25.0.0
     # via
     #   -r requirements/base.txt
     #   factory-boy
-filelock==3.13.4
+filelock==3.14.0
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -388,7 +392,7 @@ fixtures==4.1.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-freezegun==1.4.0
+freezegun==1.5.0
     # via -r requirements/test.in
 frozenlist==1.4.1
     # via
@@ -405,7 +409,7 @@ future==1.0.0
     #   pyjwkest
 getsmarter-api-clients==0.6.1
     # via -r requirements/base.txt
-google-api-core==2.18.0
+google-api-core==2.19.0
     # via
     #   -r requirements/base.txt
     #   google-api-python-client
@@ -498,7 +502,7 @@ jsonfield==3.1.0
     # via -r requirements/base.txt
 jsonfield2==4.0.0.post0
     # via -r requirements/base.txt
-jsonschema==4.21.1
+jsonschema==4.22.0
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
@@ -594,6 +598,7 @@ packaging==24.0
     #   -r requirements/base.txt
     #   -r requirements/e2e.txt
     #   -r requirements/tox.txt
+    #   django-haystack
     #   drf-yasg
     #   pytest
     #   tox
@@ -626,7 +631,7 @@ pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements/base.txt
     #   jsonschema
-platformdirs==4.2.0
+platformdirs==4.2.1
     # via
     #   -r requirements/base.txt
     #   pylint
@@ -726,7 +731,7 @@ pylint==2.12.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.in
-pymongo==3.13.0
+pymongo==4.4.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -847,11 +852,11 @@ rcssmin==1.1.1
     # via
     #   -r requirements/base.txt
     #   django-compressor
-redis==5.0.3
+redis==5.0.4
     # via
     #   -r requirements/base.txt
     #   edx-ecommerce-worker
-referencing==0.34.0
+referencing==0.35.1
     # via
     #   -r requirements/base.txt
     #   jsonschema
@@ -965,7 +970,7 @@ social-auth-app-django==5.2.0
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.5.3
+social-auth-core==4.5.4
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
@@ -985,13 +990,13 @@ stevedore==5.2.0
     #   -r requirements/e2e.txt
     #   edx-django-utils
     #   edx-opaque-keys
-stripe==9.3.0
+stripe==9.4.0
     # via -r requirements/base.txt
 tenacity==6.3.1
     # via
     #   -r requirements/e2e.txt
     #   pytest-selenium
-testfixtures==8.1.0
+testfixtures==8.2.0
     # via -r requirements/test.in
 testtools==2.7.1
     # via
@@ -1030,7 +1035,6 @@ typing-extensions==4.11.0
     #   asgiref
     #   astroid
     #   edx-opaque-keys
-    #   faker
     #   kombu
     #   pylint
     #   stripe
@@ -1094,7 +1098,7 @@ x509==0.1
     # via
     #   -r requirements/base.txt
     #   cybersource-rest-client-python
-xss-utils==0.5.0
+xss-utils==0.6.0
     # via -r requirements/base.txt
 yarl==1.9.4
     # via

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,9 +4,9 @@
 #
 #    make upgrade
 #
-filelock==3.13.1
+filelock==3.13.4
     # via tox
-packaging==23.2
+packaging==24.0
     # via tox
 pluggy==0.13.1
     # via

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-filelock==3.13.4
+filelock==3.14.0
     # via tox
 packaging==24.0
     # via tox


### PR DESCRIPTION
celery version needs to updated due to below error
```
1.512   File "/openedx/ecommerce/ecommerce/extensions/offer/utils.py", line 15, in <module>
1.513     from ecommerce_worker.email.v1.api import send_offer_assignment_email, send_offer_update_email
1.513   File "/openedx/venv/lib/python3.12/site-packages/ecommerce_worker/email/v1/api.py", line 7, in <module>
1.513     from .tasks import (
1.513   File "/openedx/venv/lib/python3.12/site-packages/ecommerce_worker/email/v1/tasks.py", line 6, in <module>
1.514     from celery import shared_task
1.514   File "/openedx/venv/lib/python3.12/site-packages/celery/__init__.py", line 19, in <module>
1.514     from . import local  # noqa
1.514     ^^^^^^^^^^^^^^^^^^^
1.514   File "/openedx/venv/lib/python3.12/site-packages/celery/local.py", line 17, in <module>
1.515     from .five import PY3, bytes_if_py2, items, string, string_t
1.515   File "/openedx/venv/lib/python3.12/site-packages/celery/five.py", line 7, in <module>
1.515     import vine.five
1.515   File "/openedx/venv/lib/python3.12/site-packages/vine/__init__.py", line 8, in <module>
1.515     from .abstract import Thenable
1.515   File "/openedx/venv/lib/python3.12/site-packages/vine/abstract.py", line 6, in <module>
1.516     from .five import with_metaclass, Callable
1.516   File "/openedx/venv/lib/python3.12/site-packages/vine/five.py", line 364, in <module>
1.516     from inspect import formatargspec, getargspec as _getargspec  # noqa
1.516     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1.517 ImportError: cannot import name 'formatargspec' from 'inspect' (/opt/pyenv/versions/3.12.2/lib/python3.12/inspect.py). Did you mean: 'formatargvalues'?
```
libsass version needs to updated due to below error
```
1.603   File "/openedx/ecommerce/ecommerce/theming/management/commands/update_assets.py", line 7, in <module>
1.604     import sass
1.604   File "/openedx/venv/lib/python3.12/site-packages/sass.py", line 609, in <module>
1.604     class SassMap(collections.Mapping):
1.604                   ^^^^^^^^^^^^^^^^^^^
1.604 AttributeError: module 'collections' has no attribute 'Mapping'
```
This PR needs to be merged to close this tutor-ecommerce [issue](https://github.com/overhangio/tutor-ecommerce/issues/68). These changes work with python 3.8.0 to 3.12.2.