### PR TITLE
feat: Handle Stripe webhooks payment received for DPM order fulfillment

### DIFF
--- a/ecommerce/extensions/api/v2/tests/views/test_webhooks.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_webhooks.py
@@ -37,13 +37,13 @@ class StripeWebhooksViewTests(TestCase):
         self.mock_header = {
             'HTTP_STRIPE_SIGNATURE': 't=1674755157,v1=a5e6655d0f41076ca300150ed98b125ab0203f8672ced6f7cc9c8856517727e8',
         }
-        self.mock_stripe_event = mock.Mock()
 
-    def _build_request_data(self, **kwargs):
+    def _build_event_data(self, **kwargs):
         event_type = kwargs.get('event_type', None)
         amount = kwargs.get('amount', None)
         payment_intent_id = kwargs.get('payment_intent_id', None)
         is_dynamic_payment_methods = kwargs.get('is_dynamic_payment_methods', None)
+
         payment_method_details = {
             'card': {
                 'brand': 'visa',
@@ -55,42 +55,53 @@ class StripeWebhooksViewTests(TestCase):
             },
             'type': 'card'
         }
+
         payment_method_details_dpm = {
             'affirm': {
                 'order_id': 'JCkYW6Afa0hELU0p1Urf',
             },
             'type': 'affirm'
         }
+
+        charge_data = {
+            "id": "ch_3P4QCyH4caH7G0X10RkSR7Px",
+            "object": "charge",
+            "amount": amount,
+            "payment_intent": payment_intent_id,
+            "payment_method": "pm_1P4QCvH4caH7G0X1xMAs7Gld",
+            "payment_method_details": (
+                payment_method_details_dpm if is_dynamic_payment_methods
+                else payment_method_details
+            ),
+        }
+
         return {
-            'id': 'evt_123dummy',
-            'object': 'event',
-            'api_version': '2022-08-01',
-            'created': 1673630016,
-            'data': {
-                'object': {
-                    'object': 'payment_intent',
-                    'id': payment_intent_id,
-                    'amount': amount,
-                    'amount_received': amount,
-                    'confirmation_method': 'automatic',
-                    'currency': 'usd',
-                    'description': 'EDX-10001',
-                    'metadata': {
-                        'order_number': 'EDX-10001'
+            "id": "evt_3P4Q10H4caH7G0X10U4oCAXb",
+            "object": "event",
+            "api_version": "2022-08-01",
+            "created": 1712851098,
+            "data": {
+                "object": {
+                    "id": payment_intent_id,
+                    "object": "payment_intent",
+                    "amount": amount,
+                    "charges": {
+                        "object": "list",
+                        "data": [
+                            charge_data if event_type == 'payment_intent.succeeded' else None
+                        ],
                     },
-                    'payment_method': 'pm_123dummy',
-                    'payment_method_details': payment_method_details_dpm if is_dynamic_payment_methods
-                    else payment_method_details,
-                    'secret_key_confirmation': 'required',
-                    'status': 'succeeded',
-                },
+                    "created": 1712851098,
+                    "currency": "usd",
+                    "description": "EDX-100001",
+                    "metadata": {
+                        "order_number": "EDX-100001"
+                    },
+                    "payment_method": "pm_123dummy",
+                    "status": "requires_payment_method",
+                }
             },
-            'pending_webhooks': 3,
-            'request': {
-                'id': 'req_123dummy',
-                'idempotency_key': '123dummy'
-            },
-            'type': event_type,
+            "type": event_type
         }
 
     @ddt.data('get', 'put', 'patch', 'head')
@@ -124,7 +135,7 @@ class StripeWebhooksViewTests(TestCase):
                     'error on signature verification', self.mock_header['HTTP_STRIPE_SIGNATURE']
                 )
                 response = self.client.post(
-                    self.url, self._build_request_data(), content_type=JSON_CONTENT_TYPE, **self.mock_header
+                    self.url, self._build_event_data(), content_type=JSON_CONTENT_TYPE, **self.mock_header
                 )
                 self.assertEqual(response.status_code, 400)
                 self.assertTrue(mock_logger.called)
@@ -151,8 +162,7 @@ class StripeWebhooksViewTests(TestCase):
         Verify the expected logs for the known handled event types are logged
         with the correct event type and other attributes.
         """
-        payment_method_details_type = 'affirm' if is_dynamic_payment_methods else 'card'
-        post_data = self._build_request_data(
+        event_data = self._build_event_data(
             event_type=event_type,
             amount=amount,
             payment_intent_id=payment_intent_id,
@@ -175,13 +185,9 @@ class StripeWebhooksViewTests(TestCase):
             ),
         ]
         with self.settings(**self.mock_settings):
-            self.mock_stripe_event.type = event_type
-            self.mock_stripe_event.data.object.amount = amount
-            self.mock_stripe_event.data.object.id = payment_intent_id
-            self.mock_stripe_event.data.object.payment_method_details.type = payment_method_details_type
-            mock_construct_event.return_value = self.mock_stripe_event
+            mock_construct_event.return_value = event_data
             with LogCapture(log_name) as log_capture:
-                response = self.client.post(self.url, post_data, content_type=JSON_CONTENT_TYPE, **self.mock_header)
+                response = self.client.post(self.url, event_data, content_type=JSON_CONTENT_TYPE, **self.mock_header)
                 self.assertEqual(response.status_code, 200)
                 if is_dynamic_payment_methods:
                     mock_webhooks_processor.assert_called()
@@ -196,18 +202,17 @@ class StripeWebhooksViewTests(TestCase):
         Verify the expected logs for the unhandled event types are logged with the correct event type.
         """
         event_type = 'account_updated'
-        post_data = self._build_request_data(event_type=event_type)
+        event_data = self._build_event_data(event_type=event_type)
         expected_logs = [
             (
                 log_name,
                 'WARNING',
-                '[Stripe webhooks] unhandled event with type [{}].'.format(post_data['type']),
+                '[Stripe webhooks] unhandled event with type [{}].'.format(event_data['type']),
             ),
         ]
         with self.settings(**self.mock_settings):
-            self.mock_stripe_event.type = event_type
-            mock_construct_event.return_value = self.mock_stripe_event
+            mock_construct_event.return_value = event_data
             with LogCapture(log_name) as log_capture:
-                response = self.client.post(self.url, post_data, content_type=JSON_CONTENT_TYPE, **self.mock_header)
+                response = self.client.post(self.url, event_data, content_type=JSON_CONTENT_TYPE, **self.mock_header)
                 self.assertEqual(response.status_code, 200)
                 log_capture.check_present(*expected_logs)

--- a/ecommerce/extensions/api/v2/tests/views/test_webhooks.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_webhooks.py
@@ -140,7 +140,7 @@ class StripeWebhooksViewTests(TestCase):
                 self.assertEqual(response.status_code, 400)
                 self.assertTrue(mock_logger.called)
 
-    @mock.patch('ecommerce.extensions.payment.processors.webhooks.StripeWebhooksPayment.handle_webhooks_payment')
+    @mock.patch('ecommerce.extensions.payment.processors.webhooks.StripeWebhooksProcessor.handle_webhooks_payment')
     @mock.patch('stripe.Webhook.construct_event')
     @ddt.data(
         ('payment_intent.succeeded', 299, 'pi_123dummy', False),

--- a/ecommerce/extensions/api/v2/tests/views/test_webhooks.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_webhooks.py
@@ -43,6 +43,24 @@ class StripeWebhooksViewTests(TestCase):
         event_type = kwargs.get('event_type', None)
         amount = kwargs.get('amount', None)
         payment_intent_id = kwargs.get('payment_intent_id', None)
+        is_dynamic_payment_methods = kwargs.get('is_dynamic_payment_methods', None)
+        payment_method_details = {
+            'card': {
+                'brand': 'visa',
+                'country': 'US',
+                'exp_month': 4,
+                'exp_year': 2025,
+                'funding': 'credit',
+                'last4': '4242',
+            },
+            'type': 'card'
+        }
+        payment_method_details_dpm = {
+            'affirm': {
+                'order_id': 'JCkYW6Afa0hELU0p1Urf',
+            },
+            'type': 'affirm'
+        }
         return {
             'id': 'evt_123dummy',
             'object': 'event',
@@ -61,6 +79,8 @@ class StripeWebhooksViewTests(TestCase):
                         'order_number': 'EDX-10001'
                     },
                     'payment_method': 'pm_123dummy',
+                    'payment_method_details': payment_method_details_dpm if is_dynamic_payment_methods
+                    else payment_method_details,
                     'secret_key_confirmation': 'required',
                     'status': 'succeeded',
                 },
@@ -109,19 +129,35 @@ class StripeWebhooksViewTests(TestCase):
                 self.assertEqual(response.status_code, 400)
                 self.assertTrue(mock_logger.called)
 
+    @mock.patch('ecommerce.extensions.payment.processors.webhooks.StripeWebhooksPayment.handle_webhooks_payment')
     @mock.patch('stripe.Webhook.construct_event')
     @ddt.data(
-        ('payment_intent.succeeded', 299, 'pi_123dummy'),
-        ('payment_intent.requires_action', 399, 'pi_456dummy'),
-        ('payment_intent.payment_failed', 499, 'pi_789dummy'),
+        ('payment_intent.succeeded', 299, 'pi_123dummy', False),
+        ('payment_intent.requires_action', 399, 'pi_456dummy', False),
+        ('payment_intent.payment_failed', 499, 'pi_789dummy', False),
+        ('payment_intent.succeeded', 199, 'pi_123dpm', True),
     )
     @ddt.unpack
-    def test_handled_webhook_event(self, event_type, amount, payment_intent_id, mock_construct_event):
+    def test_handled_webhook_event(
+        self,
+        event_type,
+        amount,
+        payment_intent_id,
+        is_dynamic_payment_methods,
+        mock_construct_event,
+        mock_webhooks_processor
+    ):
         """
         Verify the expected logs for the known handled event types are logged
         with the correct event type and other attributes.
         """
-        post_data = self._build_request_data(event_type=event_type, amount=amount, payment_intent_id=payment_intent_id)
+        payment_method_details_type = 'affirm' if is_dynamic_payment_methods else 'card'
+        post_data = self._build_request_data(
+            event_type=event_type,
+            amount=amount,
+            payment_intent_id=payment_intent_id,
+            is_dynamic_payment_methods=is_dynamic_payment_methods
+        )
         expected_logs = [
             (
                 log_name,
@@ -130,15 +166,29 @@ class StripeWebhooksViewTests(TestCase):
                 .format(event_type, amount, payment_intent_id),
             ),
         ]
+        expected_logs_dpm = [
+            (
+                log_name,
+                'INFO',
+                '[Stripe webhooks] Dynamic Payment Methods event {} with amount {} and payment intent ID [{}].'
+                .format(event_type, amount, payment_intent_id),
+            ),
+        ]
         with self.settings(**self.mock_settings):
             self.mock_stripe_event.type = event_type
             self.mock_stripe_event.data.object.amount = amount
             self.mock_stripe_event.data.object.id = payment_intent_id
+            self.mock_stripe_event.data.object.payment_method_details.type = payment_method_details_type
             mock_construct_event.return_value = self.mock_stripe_event
             with LogCapture(log_name) as log_capture:
                 response = self.client.post(self.url, post_data, content_type=JSON_CONTENT_TYPE, **self.mock_header)
                 self.assertEqual(response.status_code, 200)
-                log_capture.check_present(*expected_logs)
+                if is_dynamic_payment_methods:
+                    mock_webhooks_processor.assert_called()
+                    log_capture.check_present(*expected_logs_dpm)
+                else:
+                    mock_webhooks_processor.assert_not_called()
+                    log_capture.check_present(*expected_logs)
 
     @mock.patch('stripe.Webhook.construct_event')
     def test_unhandled_webhook_event(self, mock_construct_event):

--- a/ecommerce/extensions/api/v2/views/webhooks.py
+++ b/ecommerce/extensions/api/v2/views/webhooks.py
@@ -12,7 +12,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from stripe.error import SignatureVerificationError
 
-from ecommerce.extensions.payment.processors.webhooks import StripeWebhooksPayment
+from ecommerce.extensions.payment.processors.webhooks import StripeWebhooksProcessor
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +69,7 @@ class StripeWebhooksView(APIView):
                     payment_intent['amount'],
                     payment_intent['id'],
                 )
-                webhooks_payment = StripeWebhooksPayment(site=None)
+                webhooks_payment = StripeWebhooksProcessor(site=None)
                 webhooks_payment.handle_webhooks_payment(request, payment_intent, payment_method_type)
             else:
                 logger.info(

--- a/ecommerce/extensions/checkout/mixins.py
+++ b/ecommerce/extensions/checkout/mixins.py
@@ -124,11 +124,12 @@ class EdxOrderPlacementMixin(OrderPlacementMixin, metaclass=abc.ABCMeta):
 
     def emit_checkout_step_events(self, basket, handled_processor_response, payment_processor):
         """ Emit events necessary to track the user in the checkout funnel. """
-
+        payment_method_type = (handled_processor_response.card_type if handled_processor_response.card_type
+                               else handled_processor_response.card_number)
         properties = {
             'checkout_id': basket.order_number,
             'step': 1,
-            'payment_method': '{} | {}'.format(handled_processor_response.card_type, payment_processor.NAME)
+            'payment_method': '{} | {}'.format(payment_method_type, payment_processor.NAME)
         }
         track_segment_event(basket.site, basket.owner, 'Checkout Step Completed', properties)
 

--- a/ecommerce/extensions/checkout/tests/test_views.py
+++ b/ecommerce/extensions/checkout/tests/test_views.py
@@ -325,6 +325,16 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         payment_method = ReceiptResponseView().get_payment_method(order)
         self.assertEqual(payment_method, '{} {}'.format(source.card_type, source.label))
 
+    def test_get_payment_method_stripe_dynamic_payment_methods_purchase(self):
+        """
+        Dynamic Payment Method type (source label) should be displayed as the Payment method
+        when Stripe DPM was used to purchase a product.
+        """
+        order = self.create_order()
+        source = factories.SourceFactory(order=order, card_type=None, label='Stripe affirm')
+        payment_method = ReceiptResponseView().get_payment_method(order)
+        self.assertEqual(payment_method, source.label)
+
     @patch('ecommerce.extensions.checkout.views.fetch_enterprise_learner_data')
     @responses.activate
     def test_get_receipt_for_existing_order(self, mock_learner_data):

--- a/ecommerce/extensions/checkout/tests/test_views.py
+++ b/ecommerce/extensions/checkout/tests/test_views.py
@@ -332,7 +332,7 @@ class ReceiptResponseViewTests(DiscoveryMockMixin, LmsApiMockMixin, RefundTestMi
         when Stripe DPM was used to purchase a product.
         """
         order = self.create_order()
-        source = factories.SourceFactory(order=order, card_type=None, label='Stripe affirm')
+        source = factories.SourceFactory(order=order, card_type=None, label='affirm')
         payment_method = ReceiptResponseView().get_payment_method(order)
         self.assertEqual(payment_method, source.label)
 

--- a/ecommerce/extensions/checkout/views.py
+++ b/ecommerce/extensions/checkout/views.py
@@ -243,7 +243,7 @@ class ReceiptResponseView(ThankYouView):
                     type=source.get_card_type_display(),
                     number=source.label
                 )
-            return source.source_type.name
+            return source.label if source.label else source.source_type.name
         return None
 
     def order_contains_credit_seat(self, order):

--- a/ecommerce/extensions/payment/processors/webhooks.py
+++ b/ecommerce/extensions/payment/processors/webhooks.py
@@ -19,7 +19,7 @@ Basket = get_model('basket', 'Basket')
 OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
 
 
-class StripeWebhooksPayment(EdxOrderPlacementMixin, BasePaymentProcessor):
+class StripeWebhooksProcessor(EdxOrderPlacementMixin, BasePaymentProcessor):
     """
     Handle a payment success received through Stripe webhooks.
     """
@@ -33,7 +33,7 @@ class StripeWebhooksPayment(EdxOrderPlacementMixin, BasePaymentProcessor):
         Raises:
             KeyError: If no settings configured for this payment processor.
         """
-        super(StripeWebhooksPayment, self).__init__(site)
+        super(StripeWebhooksProcessor, self).__init__(site)
         self.site = site
 
     @property

--- a/ecommerce/extensions/payment/processors/webhooks.py
+++ b/ecommerce/extensions/payment/processors/webhooks.py
@@ -141,6 +141,13 @@ class StripeWebhooksProcessor(EdxOrderPlacementMixin, BasePaymentProcessor):
             try:
                 order = self.create_order(request, basket, billing_address)
                 self.handle_post_order(order)
+                logger.info(
+                    '[Dynamic Payment Methods] Successfully completed processing Stripe payment intent [%s] '
+                    'for basket [%d] and order number [%s].',
+                    payment_intent_id,
+                    basket.id,
+                    basket.order_number,
+                )
             except Exception:  # pylint: disable=broad-except
                 logger.exception(
                     '[Dynamic Payment Methods] Error processing order for transaction [%s], '

--- a/ecommerce/extensions/payment/processors/webhooks.py
+++ b/ecommerce/extensions/payment/processors/webhooks.py
@@ -110,12 +110,11 @@ class StripeWebhooksProcessor(EdxOrderPlacementMixin, BasePaymentProcessor):
             else:
                 # Card number is required for Source object, it cannot be null (payment_source.label)
                 # Dynamic payment methods payment intents do not contain card information, adding DPM type instead.
-                label = 'stripe {}'.format(payment_method_type)
                 handled_processor_response = HandledProcessorResponse(
                     transaction_id=payment_intent_id,
                     total=total,
                     currency=currency,
-                    card_number=label,
+                    card_number=payment_method_type,
                     card_type=None
                 )
                 self.record_payment(basket, handled_processor_response)

--- a/ecommerce/extensions/payment/processors/webhooks.py
+++ b/ecommerce/extensions/payment/processors/webhooks.py
@@ -1,0 +1,141 @@
+""" Webhooks handling for payment processing. """
+
+
+import logging
+
+import stripe
+from oscar.apps.partner import strategy
+from oscar.core.loading import get_class, get_model
+
+from ecommerce.extensions.analytics.utils import track_segment_event
+from ecommerce.extensions.basket.utils import get_billing_address_from_payment_intent_data
+from ecommerce.extensions.checkout.mixins import EdxOrderPlacementMixin
+from ecommerce.extensions.payment.processors import BasePaymentProcessor, HandledProcessorResponse
+from ecommerce.extensions.payment.processors.stripe import Stripe
+
+logger = logging.getLogger(__name__)
+
+Basket = get_model('basket', 'Basket')
+OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
+
+
+class StripeWebhooksPayment(EdxOrderPlacementMixin, BasePaymentProcessor):
+    """
+    Handle a payment success received through Stripe webhooks.
+    """
+
+    NAME = 'stripe'
+
+    @property
+    def payment_processor(self):
+        return Stripe(self.site)
+
+    def get_transaction_parameters(self, basket, request=None, use_client_side_checkout=False, **kwargs):
+        raise NotImplementedError
+
+    def handle_processor_response(self, response, basket=None):
+        raise NotImplementedError
+
+    def issue_credit(self, order_number, basket, reference_number, amount, currency):
+        raise NotImplementedError
+
+    def _get_address_from_token(self, payment_intent_id):
+        """
+        Retrieves the billing address associated with a PaymentIntent.
+
+        Returns:
+            BillingAddress
+        """
+        retrieve_kwargs = {
+            'expand': ['payment_method'],
+        }
+
+        payment_intent = stripe.PaymentIntent.retrieve(
+            payment_intent_id,
+            **retrieve_kwargs,
+        )
+
+        return get_billing_address_from_payment_intent_data(payment_intent)
+
+    def handle_webhooks_payment(self, request, payment_intent, payment_method_type):
+        """
+        Upon receipt of the payment_intent.succeeded event from Stripe, create an order, create a billing address,
+        fulfill order, and save payment processor data.
+        """
+        # Get basket associated to the Payment Intent
+        payment_intent_id = payment_intent['id']
+        order_number = payment_intent['description']
+        basket_id = OrderNumberGenerator().basket_id(order_number)
+        try:
+            basket = Basket.objects.get(id=basket_id)
+            basket.strategy = strategy.Default()
+        except Basket.DoesNotExist:
+            logger.exception(
+                '[Dynamic Payment Methods] Basket %d does not exist for order %s and Payment Intent %s',
+                basket_id, order_number, payment_intent_id
+            )
+        else:
+            # Record successful processor response, record payment, and track event
+            total = basket.total_incl_tax
+            currency = basket.currency
+
+            properties = {
+                'basket_id': basket.id,
+                'processor_name': self.NAME,
+                'stripe_enabled': True,
+            }
+            try:
+                self.record_processor_response(payment_intent, transaction_id=payment_intent_id, basket=basket)
+                logger.info(
+                    '[Dynamic Payment Methods] Successfully confirmed Stripe payment intent [%s] '
+                    'for basket [%d] and order number [%s].',
+                    payment_intent_id,
+                    basket.id,
+                    basket.order_number,
+                )
+            except Exception as ex:
+                properties.update({'success': False, 'payment_error': type(ex).__name__, })
+                raise
+            else:
+                # Card number is required for Source object, it cannot be null (payment_source.label)
+                # Dynamic payment methods payment intents do not contain card information, adding DPM type instead.
+                label = 'Stripe {}'.format(payment_method_type)
+                handled_processor_response = HandledProcessorResponse(
+                    transaction_id=payment_intent_id,
+                    total=total,
+                    currency=currency,
+                    card_number=label,
+                    card_type=None
+                )
+                self.record_payment(basket, handled_processor_response)
+                properties.update({'total': handled_processor_response.total, 'success': True, })
+            finally:
+                # TODO: Differentiate event from regular payments?
+                track_segment_event(basket.site, basket.owner, 'Payment Processor Response', properties)
+
+            # Create Billing Address
+            billing_address_obj = self._get_address_from_token(payment_intent_id)
+            try:
+                billing_address = self.create_billing_address(
+                    user=basket.owner,
+                    billing_address=billing_address_obj
+                )
+            except Exception as err:  # pylint: disable=broad-except
+                logger.exception(
+                    '[Dynamic Payment Methods] Error creating billing address for basket [%d]: %s',
+                    basket.id, err
+                )
+                billing_address = None
+
+            try:
+                order = self.create_order(request, basket, billing_address)
+                self.handle_post_order(order)
+            except Exception:  # pylint: disable=broad-except
+                logger.exception(
+                    '[Dynamic Payment Methods] Error processing order for transaction [%s], '
+                    'with order [%s] and basket [%d]. Processed by [%s].',
+                    payment_intent_id,
+                    basket.order_number,
+                    basket.id,
+                    'stripe',
+                )

--- a/ecommerce/extensions/payment/tests/processors/test_webhooks.py
+++ b/ecommerce/extensions/payment/tests/processors/test_webhooks.py
@@ -7,7 +7,7 @@ from django.test import RequestFactory
 from oscar.core.loading import get_class, get_model
 
 from ecommerce.extensions.basket.utils import basket_add_payment_intent_id_attribute
-from ecommerce.extensions.payment.processors.webhooks import StripeWebhooksPayment
+from ecommerce.extensions.payment.processors.webhooks import StripeWebhooksProcessor
 from ecommerce.extensions.payment.tests.processors.mixins import PaymentProcessorTestCaseMixin
 from ecommerce.tests.factories import UserFactory
 from ecommerce.tests.testcases import TestCase
@@ -19,13 +19,13 @@ Country = get_model('address', 'Country')
 OrderNumberGenerator = get_class('order.utils', 'OrderNumberGenerator')
 
 
-class StripeWebhooksPaymentTests(PaymentProcessorTestCaseMixin, TestCase):
-    """ Tests StripeWebhooksPayment """
-    processor_class = StripeWebhooksPayment
+class StripeWebhooksProcessorTests(PaymentProcessorTestCaseMixin, TestCase):
+    """ Tests StripeWebhooksProcessor """
+    processor_class = StripeWebhooksProcessor
     processor_name = 'stripe'
 
     def setUp(self):
-        super(StripeWebhooksPaymentTests, self).setUp()
+        super(StripeWebhooksProcessorTests, self).setUp()
         self.site_configuration.client_side_payment_processor = 'stripe'
         self.site_configuration.save()
         Country.objects.create(iso_3166_1_a2='US', name='US')
@@ -106,7 +106,7 @@ class StripeWebhooksPaymentTests(PaymentProcessorTestCaseMixin, TestCase):
         """
         Tests configuration.
         """
-        self.skipTest('StripeWebhooksPayment processor does not currently require configuration.')
+        self.skipTest('StripeWebhooksProcessor processor does not currently require configuration.')
 
     def test_name(self):
         """
@@ -118,13 +118,13 @@ class StripeWebhooksPaymentTests(PaymentProcessorTestCaseMixin, TestCase):
         """
         Tests handle_processor_response.
         """
-        self.skipTest('StripeWebhooksPayment processor does not currently implement handle_processor_response.')
+        self.skipTest('StripeWebhooksProcessor processor does not currently implement handle_processor_response.')
 
     def test_get_transaction_parameters(self):
         """
         Tests transaction parameters.
         """
-        self.skipTest('StripeWebhooksPayment processor does not currently implement get_transaction_parameters.')
+        self.skipTest('StripeWebhooksProcessor processor does not currently implement get_transaction_parameters.')
 
     def test_issue_credit(self):
         """

--- a/ecommerce/extensions/payment/tests/processors/test_webhooks.py
+++ b/ecommerce/extensions/payment/tests/processors/test_webhooks.py
@@ -1,0 +1,204 @@
+
+
+import logging
+
+import mock
+from django.test import RequestFactory
+from oscar.core.loading import get_model
+
+from ecommerce.extensions.basket.constants import PAYMENT_INTENT_ID_ATTRIBUTE
+from ecommerce.extensions.payment.processors.webhooks import StripeWebhooksPayment
+from ecommerce.extensions.payment.tests.processors.mixins import PaymentProcessorTestCaseMixin
+from ecommerce.tests.factories import UserFactory
+from ecommerce.tests.testcases import TestCase
+
+log = logging.getLogger(__name__)
+
+BasketAttribute = get_model('basket', 'BasketAttribute')
+BasketAttributeType = get_model('basket', 'BasketAttributeType')
+BillingAddress = get_model('order', 'BillingAddress')
+Country = get_model('address', 'Country')
+
+
+class StripeWebhooksPaymentTests(PaymentProcessorTestCaseMixin, TestCase):
+    """ Tests StripeWebhooksPayment """
+    processor_class = StripeWebhooksPayment
+    processor_name = 'stripe'
+
+    def setUp(self):
+        super(StripeWebhooksPaymentTests, self).setUp()
+        self.site_configuration.client_side_payment_processor = 'stripe'
+        self.site_configuration.save()
+        Country.objects.create(iso_3166_1_a2='US', name='US')
+        self.request = RequestFactory()
+        self.request.site = self.site
+        self.request.user = UserFactory()
+        self.payment_intent = {
+            "id": "pi_3OzUOMH4caH7G0X114tkIL0X",
+            "object": "payment_intent",
+            "status": "succeeded",
+            "amount": 14900,
+            "amount_capturable": 0,
+            "amount_received": 14900,
+            "capture_method": "automatic",
+            "charges": {
+                "object": "list",
+                "data": [{
+                    "id": "py_3OzUOMH4caH7G0X11OOKbfIk",
+                    "object": "charge",
+                    "amount": 14900,
+                    "amount_captured": 14900,
+                    "amount_refunded": 0,
+                    "balance_transaction": "txn_3OzUOMH4caH7G0X11flKf5U4",
+                    "billing_details": {
+                        "address": {
+                            "city": "Beverly Hills",
+                            "country": "US",
+                            "line1": "Amsterdam Ave",
+                            "line2": "Apt 214",
+                            "postal_code": "10024",
+                            "state": "NY"
+                        },
+                        "email": "customer@email.us",
+                        "name": "Test Person-us",
+                    },
+                    "created": 1711676524,
+                    "currency": "usd",
+                    "description": "EDX-100001",
+                    "metadata": {
+                        "order_number": "EDX-100001"
+                    },
+                    "payment_intent": "pi_3OzUOMH4caH7G0X114tkIL0X",
+                    "payment_method": "pm_1OzURzH4caH7G0X19vH5rGBT",
+                    "payment_method_details": {
+                        "afterpay_clearpay": {
+                            "order_id": "JCkYW6Afa0hELU0p1Urf",
+                        },
+                        "type": "afterpay_clearpay"
+                    },
+                    "shipping": {
+                        "address": {
+                            "city": "Beverly Hills",
+                            "country": "US",
+                            "line1": "Amsterdam Ave",
+                            "line2": "Apt 214",
+                            "postal_code": "10024",
+                            "state": "NY"
+                        },
+                        "name": "Test Person-us",
+                    },
+                    "status": "succeeded",
+                }],
+                "total_count": 2,
+                "url": "/v1/charges?payment_intent=pi_3OzUOMH4caH7G0X114tkIL0X"
+            },
+            "client_secret": "pi_3OzUOMH4caH7G0X114tkIL0X_secret_SYz2fcAkT2hIWhpdRTqUwRFHF",
+            "confirmation_method": "automatic",
+            "created": 1711676282,
+            "currency": "usd",
+            "description": "EDX-100001",
+            "latest_charge": "py_3OzUOMH4caH7G0X11OOKbfIk",
+            "payment_method": "pm_1OzURzH4caH7G0X19vH5rGBT",
+            "payment_method_configuration_details": {
+                "id": "pmc_1LspDWH4caH7G0X1LXrN8QMJ",
+            },
+            "payment_method_options": {
+                "affirm": {
+                    "preferred_locale": "en"
+                },
+                "afterpay_clearpay": {
+                    "preferred_locale": "en"
+                },
+                "card": {
+                    "request_three_d_secure": "automatic"
+                },
+                "klarna": {
+                    "preferred_locale": "en"
+                }
+            },
+            "payment_method_types": [
+                "card",
+                "afterpay_clearpay",
+                "klarna",
+                "affirm"
+            ],
+            "secret_key_confirmation": "required",
+        }
+
+    def test_configuration(self):  # pylint: disable=arguments-differ
+        """
+        Tests configuration.
+        """
+        self.skipTest('StripeWebhooksPayment processor does not currently require configuration.')
+
+    def test_name(self):
+        """
+        Test that the name constant on the processor class is correct.
+        """
+        self.assertEqual(self.processor.NAME, self.processor_name)
+
+    def test_handle_processor_response(self):
+        """
+        Tests handle_processor_response.
+        """
+        self.skipTest('StripeWebhooksPayment processor does not currently implement handle_processor_response.')
+
+    def test_get_transaction_parameters(self):
+        """
+        Tests transaction parameters.
+        """
+        self.skipTest('StripeWebhooksPayment processor does not currently implement get_transaction_parameters.')
+
+    def test_issue_credit(self):
+        """
+        Test issue credit.
+        """
+        self.assertRaises(NotImplementedError, self.processor_class(self.site).issue_credit, None, None, None, 0, 'USD')
+
+    def test_issue_credit_error(self):
+        """
+        Tests that Webhooks payments processor does not support issuing credit.
+        """
+        self.skipTest('Webhooks payments processor does not yet support issuing credit.')
+
+    def test_handle_webhooks_payment(self):
+        """
+        Verify a payment received via Stripe webhooks is processed, an order is created and fulfilled.
+        """
+        # Need to associate the Payment Intent to the Basket
+        basket_attribute_type, _ = BasketAttributeType.objects.get_or_create(name=PAYMENT_INTENT_ID_ATTRIBUTE)
+        basket_attribute_type.save()
+        BasketAttribute.objects.get_or_create(
+            basket=self.basket,
+            attribute_type=basket_attribute_type,
+            value_text=self.payment_intent['id'],
+        )
+        with mock.patch('ecommerce.extensions.payment.processors.webhooks.track_segment_event') as mock_track:
+            with mock.patch('stripe.PaymentIntent.retrieve') as mock_retrieve:
+                with mock.patch(
+                    'ecommerce.extensions.checkout.mixins.EdxOrderPlacementMixin.handle_post_order'
+                ) as mock_handle_post_order:
+                    mock_retrieve.return_value = {
+                        'id': self.payment_intent['id'],
+                        'client_secret': self.payment_intent['client_secret'],
+                        'payment_method': {
+                            'id': self.payment_intent['payment_method'],
+                            'object': 'payment_method',
+                            'billing_details': self.payment_intent['charges']['data'][0]['billing_details'],
+                            'type': self.payment_intent['charges']['data'][0]['payment_method_details']['type']
+                        },
+                    }
+                    self.processor_class(self.site).handle_webhooks_payment(
+                        self.request, self.payment_intent, 'afterpay_clearpay'
+                    )
+                    properties = {
+                        'basket_id': self.basket.id,
+                        'processor_name': 'stripe',
+                        'stripe_enabled': True,
+                        'total': self.basket.total_incl_tax,
+                        'success': True,
+                    }
+                    mock_track.assert_called_once_with(
+                        self.basket.site, self.basket.owner, 'Payment Processor Response', properties
+                    )
+                    mock_handle_post_order.assert_called_once()

--- a/ecommerce/management/tests/test_utils.py
+++ b/ecommerce/management/tests/test_utils.py
@@ -13,6 +13,7 @@ from ecommerce.extensions.payment.constants import CARD_TYPES
 from ecommerce.extensions.payment.models import PaymentProcessorResponse
 from ecommerce.extensions.payment.processors.cybersource import Cybersource
 from ecommerce.extensions.payment.processors.paypal import Paypal
+from ecommerce.extensions.payment.processors.stripe import Stripe
 from ecommerce.extensions.test.factories import create_basket, prepare_voucher
 from ecommerce.management.utils import FulfillFrozenBaskets, refund_basket_transactions
 from ecommerce.tests.factories import UserFactory
@@ -60,13 +61,23 @@ class RefundBasketTransactionsTests(TestCase):
 class FulfillFrozenBasketsTests(TestCase):
     """ Test Fulfill Frozen Basket class"""
 
-    def _dummy_basket_data(self):
+    def _dummy_basket_data(self, payment_procesor=None):
         """ Creates dummy basket data for testing."""
         basket = create_basket(site=self.site)
         basket.status = 'Frozen'
         basket.save()
-        PaymentProcessorResponse.objects.create(basket=basket, transaction_id='PAY-123', processor_name='paypal',
-                                                response={'state': 'approved'})
+        response = {
+            'state': 'approved',
+            'payment_method': {
+                'type': 'affirm'
+            }
+        }
+        if payment_procesor:
+            PaymentProcessorResponse.objects.create(
+                basket=basket, transaction_id='pi_123dummy', processor_name=payment_procesor, response=response)
+        else:
+            PaymentProcessorResponse.objects.create(
+                basket=basket, transaction_id='PAY-123', processor_name='paypal', response={'state': 'approved'})
         return basket
 
     @staticmethod
@@ -124,6 +135,21 @@ class FulfillFrozenBasketsTests(TestCase):
             label='Paypal Account', card_type=None)
         PaymentEvent.objects.get(event_type__name=PaymentEventTypeName.PAID, amount=total,
                                  processor_name=Paypal.NAME)
+
+    def test_success_with_stripe_dynamic_payment_methods(self):
+        """ Test basket with Stripe DPM payment basket."""
+        basket = self._dummy_basket_data(payment_procesor='stripe')
+        assert FulfillFrozenBaskets().fulfill_basket(basket.id, self.site)
+
+        order = Order.objects.get(number=basket.order_number)
+        assert order.status == 'Complete'
+
+        total = basket.total_incl_tax_excl_discounts
+        Source.objects.get(
+            source_type__name=Stripe.NAME, currency=order.currency, amount_allocated=total, amount_debited=total,
+            label='Stripe affirm', card_type=None)
+        PaymentEvent.objects.get(event_type__name=PaymentEventTypeName.PAID, amount=total,
+                                 processor_name=Stripe.NAME)
 
     def test_multiple_transactions(self):
         """ Test utility against multiple payment processor responses."""

--- a/ecommerce/management/tests/test_utils.py
+++ b/ecommerce/management/tests/test_utils.py
@@ -147,7 +147,7 @@ class FulfillFrozenBasketsTests(TestCase):
         total = basket.total_incl_tax_excl_discounts
         Source.objects.get(
             source_type__name=Stripe.NAME, currency=order.currency, amount_allocated=total, amount_debited=total,
-            label='Stripe affirm', card_type=None)
+            label='affirm', card_type=None)
         PaymentEvent.objects.get(event_type__name=PaymentEventTypeName.PAID, amount=total,
                                  processor_name=Stripe.NAME)
 

--- a/ecommerce/management/tests/test_utils.py
+++ b/ecommerce/management/tests/test_utils.py
@@ -61,7 +61,7 @@ class RefundBasketTransactionsTests(TestCase):
 class FulfillFrozenBasketsTests(TestCase):
     """ Test Fulfill Frozen Basket class"""
 
-    def _dummy_basket_data(self, payment_procesor=None):
+    def _dummy_basket_data(self, payment_processor=None):
         """ Creates dummy basket data for testing."""
         basket = create_basket(site=self.site)
         basket.status = 'Frozen'
@@ -72,9 +72,9 @@ class FulfillFrozenBasketsTests(TestCase):
                 'type': 'affirm'
             }
         }
-        if payment_procesor:
+        if payment_processor:
             PaymentProcessorResponse.objects.create(
-                basket=basket, transaction_id='pi_123dummy', processor_name=payment_procesor, response=response)
+                basket=basket, transaction_id='pi_123dummy', processor_name=payment_processor, response=response)
         else:
             PaymentProcessorResponse.objects.create(
                 basket=basket, transaction_id='PAY-123', processor_name='paypal', response={'state': 'approved'})
@@ -138,7 +138,7 @@ class FulfillFrozenBasketsTests(TestCase):
 
     def test_success_with_stripe_dynamic_payment_methods(self):
         """ Test basket with Stripe DPM payment basket."""
-        basket = self._dummy_basket_data(payment_procesor='stripe')
+        basket = self._dummy_basket_data(payment_processor='stripe')
         assert FulfillFrozenBaskets().fulfill_basket(basket.id, self.site)
 
         order = Order.objects.get(number=basket.order_number)

--- a/ecommerce/management/utils.py
+++ b/ecommerce/management/utils.py
@@ -129,9 +129,14 @@ class FulfillFrozenBaskets(EdxOrderPlacementMixin):
             card_number = 'Paypal Account'
             card_type = None
         elif payment_notification.transaction_id.startswith('pi_'):
-            card_number = payment_notification.response['payment_method']['card']['last4']
-            stripe_card_type = payment_notification.response['payment_method']['card']['brand']
-            card_type = STRIPE_CARD_TYPE_MAP[stripe_card_type]
+            payment_type = payment_notification.response['payment_method']['type']
+            if payment_type == 'card':
+                card_number = payment_notification.response['payment_method']['card']['last4']
+                stripe_card_type = payment_notification.response['payment_method']['card']['brand']
+                card_type = STRIPE_CARD_TYPE_MAP[stripe_card_type]
+            else:
+                card_number = 'Stripe {}'.format(payment_type)
+                card_type = None
         else:
             card_number = payment_notification.response['req_card_number']
             cybersource_card_type = payment_notification.response['req_card_type']

--- a/ecommerce/management/utils.py
+++ b/ecommerce/management/utils.py
@@ -135,7 +135,7 @@ class FulfillFrozenBaskets(EdxOrderPlacementMixin):
                 stripe_card_type = payment_notification.response['payment_method']['card']['brand']
                 card_type = STRIPE_CARD_TYPE_MAP[stripe_card_type]
             else:
-                card_number = 'Stripe {}'.format(payment_type)
+                card_number = payment_type
                 card_type = None
         else:
             card_number = payment_notification.response['req_card_number']

--- a/ecommerce/templates/edx/checkout/receipt_not_found.html
+++ b/ecommerce/templates/edx/checkout/receipt_not_found.html
@@ -21,7 +21,7 @@
           </h3>
           <div class="copy">
             {% if is_dynamic_payment_methods %}
-            <p>{% trans "Your payment has been received and a receipt is being processed. Please re-load this page." as tmsg %}{{ tmsg | force_escape }}</p>
+            <p>{% trans "Your payment has been received and a receipt is being processed. Please reload this page." as tmsg %}{{ tmsg | force_escape }}</p>
             <br/>
             {% else %}
             <p>{% trans "The specified order could not be located. Please ensure that the URL is correct, and try again." as tmsg %}{{ tmsg | force_escape }}</p>

--- a/ecommerce/templates/edx/checkout/receipt_not_found.html
+++ b/ecommerce/templates/edx/checkout/receipt_not_found.html
@@ -20,16 +20,18 @@
             {{ error_summary }}
           </h3>
           <div class="copy">
+            {% if is_dynamic_payment_methods %}
+            <p>{% trans "Your payment has been received and a receipt is being processed. Please re-load this page." as tmsg %}{{ tmsg | force_escape }}</p>
+            <br/>
+            {% else %}
             <p>{% trans "The specified order could not be located. Please ensure that the URL is correct, and try again." as tmsg %}{{ tmsg | force_escape }}</p>
             <br/>
+            {% endif %}
           </div>
           <div class="msg">
             <p>
-              {% captureas link_start %}
-                <a href="{{ order_history_url }}">
-              {% endcaptureas %}
               {% blocktrans asvar tmsg %}
-                You may also view your previous orders on the {link_start}{order_history_url}{link_middle}{link_end}Account Settings{link_end}
+                You may also view your orders on the {link_start}{order_history_url}{link_middle}Order History{link_end}
                 page.
               {% endblocktrans %}
               {% interpolate_html tmsg link_start='<a href="'|safe link_middle='">'|safe link_end='</a>'|safe order_history_url=order_history_url|safe %}


### PR DESCRIPTION
[REV-3973](https://2u-internal.atlassian.net/browse/REV-3973).

Order creation, fulfillment, billing address creation must be addressed via webhook events for Dynamic Payment Methods.
Adding a WebhooksPayment class to handle all that is needed after a payment is successfully received.
Redirect to receipt URL will happen via payment MFE redirect.

This PR also adds/updates the receipt error page to include a message specific for DPM.