### PR TITLE
Fix: 500 after applying coupon for Quince

### DIFF
--- a/ecommerce/extensions/api/serializers.py
+++ b/ecommerce/extensions/api/serializers.py
@@ -956,6 +956,7 @@ class VoucherSerializer(serializers.ModelSerializer):
     is_available_to_user = serializers.SerializerMethodField()
     benefit = serializers.SerializerMethodField()
     redeem_url = serializers.SerializerMethodField()
+    end_datetime = serializers.DateTimeField(format=ISO_8601_FORMAT)
 
     def get_is_available_to_user(self, obj):
         request = self.context.get('request')

--- a/ecommerce/extensions/api/v2/tests/views/test_vouchers.py
+++ b/ecommerce/extensions/api/v2/tests/views/test_vouchers.py
@@ -68,6 +68,29 @@ class VoucherViewSetTests(DiscoveryMockMixin, DiscoveryTestMixin, LmsApiMockMixi
             coupon_vouchers.vouchers.add(voucher)
         return vouchers
 
+    def test_generate_correct_end_datetime(self):
+        """
+        Test that the 'end_datetime' parameter is generated in the correct format.
+        The 'end_datetime' parameter should be generated as a string in the
+        format '%Y-%m-%dT%H:%M:%SZ', representing the end date and time.
+        The created voucher's 'end_datetime' has the milliseconds part if to
+        retrieve it directly from the DB.
+        """
+        self.create_vouchers()
+        response = self.client.get(self.path)
+        response_data = response.json()
+        result = response_data['results'][0]
+        end_datetime = result['end_datetime']
+        is_valid_format = False
+
+        try:
+            datetime.datetime.strptime(end_datetime, '%Y-%m-%dT%H:%M:%SZ')
+            is_valid_format = True
+        except ValueError:
+            pass
+
+        self.assertTrue(is_valid_format)
+
     def test_list(self):
         """ Verify the endpoint lists all vouchers. """
         vouchers = self.create_vouchers(count=3)


### PR DESCRIPTION
**This is a [backport](https://github.com/openedx/ecommerce/pull/4003) from the master (already merged).**

## Description

Steps to Reproduce:

- Login by the user with staff rights
- During purchase click on the link "Click here to purchase multiple seats in this course"
- Confirm and pay
- Activate the course with one of the coupons sent to your email
- Open <lms>/dashboard page


<img width="1676" alt="dashboard" src="https://github.com/openedx/ecommerce/assets/98233552/4b48fab5-f7ff-4ef1-af54-6620c4c2a8ef">

The issue was that the date-time also included milliseconds, which is not acceptable for converting the date and time into the required format.

`ValueError: time data '2033-06-25T11:40:12.267999Z' does not match format '%Y-%m-%dT%H:%M:%SZ'`
