### PR TITLE
fix: Capture-context modification for existing Payment Intents

### DIFF
--- a/.github/workflows/migrations-mysql8.yml
+++ b/.github/workflows/migrations-mysql8.yml
@@ -53,7 +53,7 @@ jobs:
         pip uninstall -y mysqlclient
         pip install --no-binary mysqlclient mysqlclient
         pip uninstall -y xmlsec
-        pip install --no-binary xmlsec xmlsec
+        pip install --no-binary xmlsec xmlsec==1.3.13
 
     - name: Initiate Services
       run: |

--- a/ecommerce/extensions/payment/processors/stripe.py
+++ b/ecommerce/extensions/payment/processors/stripe.py
@@ -178,7 +178,16 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
             if payment_intent_id:
                 stripe_response = stripe.PaymentIntent.retrieve(id=payment_intent_id)
                 status = stripe_response['status']
-                if status != 'requires_payment_method' or status != 'requires_confirmation':
+                logger.info(
+                    'Stripe capture-context called for basket [%d] and order number [%s] with '
+                    'existing Payment Intent [%s] with status [%s]',
+                    basket.id,
+                    basket.order_number,
+                    payment_intent_id,
+                    status,
+                )
+                confirmable_statuses = ['requires_payment_method', 'requires_confirmation']
+                if status not in confirmable_statuses:
                     # Payment Intent is in a non-confirmable status, must create a new one
                     stripe_response = self.cancel_and_create_new_payment_intent_for_basket(basket, payment_intent_id)
                 # If a Payment Intent exists in a confirmable status, it will skip the below else statement,

--- a/ecommerce/extensions/payment/tests/views/test_stripe.py
+++ b/ecommerce/extensions/payment/tests/views/test_stripe.py
@@ -410,6 +410,7 @@ class StripeCheckoutViewTests(PaymentEventsMixin, TestCase):
                     attribute_type__name=PAYMENT_INTENT_ID_ATTRIBUTE
                 ).value_text
                 assert payment_intent_id == mock_retrieve.return_value['id']
+                assert retrieve_addr_resp['status'] == 'requires_confirmation'
 
     @file_data('fixtures/test_stripe_test_payment_flow.json')
     def test_capture_context_in_progress_payment(


### PR DESCRIPTION
[REV-3821](https://2u-internal.atlassian.net/browse/REV-3821).

Payment Intent will get into unexpected state if not in `requires_payment_method` or `requires_confirmation`.
There are other [statuses](https://docs.stripe.com/api/payment_intents/object#payment_intent_object-status) but the previous condition logic passed as true on one side of the condition.

**_Note:_**
- This is not currently causing any purchase issues, just more Payment Intents that are being created.
- Not related, `python-xmlsec` is being pinned at version `1.3.13` due to failure in running migration check build, see https://github.com/xmlsec/python-xmlsec/issues/314.
Created a follow up ticket to unpin this [REV-4005](https://2u-internal.atlassian.net/browse/REV-4005).