### PR TITLE
feat: add dd to celery

### DIFF
--- a/ecommerce/celery_app.py
+++ b/ecommerce/celery_app.py
@@ -1,8 +1,6 @@
 
-
-import os
 from celery import Celery
-
+import os
 
 
 # TEMP: This code will be removed by ARCH-BOM on 4/22/24

--- a/ecommerce/celery_app.py
+++ b/ecommerce/celery_app.py
@@ -4,6 +4,19 @@ import os
 
 from celery import Celery
 
+
+# TEMP: This code will be removed by ARCH-BOM on 4/22/24
+# ddtrace allows celery task logs to be traced by the dd agent.
+# TODO: remove this code.
+try:
+    from ddtrace import patch
+except ImportError:
+    pass
+try:
+    patch(celery=True)
+except NameError:
+    pass
+
 # Set the default configuration module, if one is not aleady defined.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ecommerce.settings.local')
 

--- a/ecommerce/celery_app.py
+++ b/ecommerce/celery_app.py
@@ -1,7 +1,6 @@
-
-from celery import Celery
 import os
 
+from celery import Celery
 
 # TEMP: This code will be removed by ARCH-BOM on 4/22/24
 # ddtrace allows celery task logs to be traced by the dd agent.

--- a/ecommerce/celery_app.py
+++ b/ecommerce/celery_app.py
@@ -1,8 +1,8 @@
 
 
 import os
-
 from celery import Celery
+
 
 
 # TEMP: This code will be removed by ARCH-BOM on 4/22/24


### PR DESCRIPTION
# ⛔️ MAIN BRANCH WARNING! 2U EMPLOYEES must make branches against the 2u/main BRANCH

- [ ] I have checked the branch to which I would like to merge.

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

## Description
this PR adds the ability for DD to gather traces in celery tasks, something NR does automatically. I know this is DD specific code, but a long-term solution will be coming soon.

## Supporting information
https://github.com/edx/edx-arch-experiments/issues/584

## Testing instructions

1. follow https://2u-internal.atlassian.net/wiki/spaces/~840928901/pages/813793298/OpenTelemetry+New+Relic+and+Datadog for devstack setup for DD, but set up the DD agent on CMS as usual
2. Follow https://2u-internal.atlassian.net/wiki/spaces/ENGAGE/pages/395673715/How+to+configure+Celery+worker+on+LMS+CMS+Devstack to set up celery workers on cms
3. Export a course
4. View the export on DD

## Deadline

This will be merged ASAP and reverted no later than 4/22. A revert PR will be linked in this PR soon.