### PR TITLE
test: Stripe tests clean up and update

### DIFF
--- a/ecommerce/extensions/payment/processors/stripe.py
+++ b/ecommerce/extensions/payment/processors/stripe.py
@@ -275,8 +275,8 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
     def handle_processor_response(self, response, basket=None):
         # pretty sure we should simply return/error if basket is None, as not
         # sure what it would mean if there
-        payment_intent_id = response['payment_intent_id']
-        dynamic_payment_methods_enabled = response['dynamic_payment_methods_enabled']
+        payment_intent_id = response.get('payment_intent_id', None)
+        dynamic_payment_methods_enabled = response.get('dynamic_payment_methods_enabled', None) == 'true'
         # NOTE: In the future we may want to get/create a Customer. See https://stripe.com/docs/api#customers.
 
         # rewrite order amount so it's updated for coupon & quantity and unchanged by the user

--- a/ecommerce/extensions/payment/tests/views/test_stripe.py
+++ b/ecommerce/extensions/payment/tests/views/test_stripe.py
@@ -213,7 +213,7 @@ class StripeCheckoutViewTests(PaymentEventsMixin, TestCase):
                             data={
                                 'payment_intent_id': create_resp['id'],
                                 'skus': basket.lines.first().stockrecord.partner_sku,
-                                'dynamic_payment_methods_enabled': False,
+                                'dynamic_payment_methods_enabled': 'false',
                             },
                         )
                 assert mock_retrieve.call_count == 1
@@ -474,7 +474,7 @@ class StripeCheckoutViewTests(PaymentEventsMixin, TestCase):
             data={
                 'payment_intent_id': 'pi_3LsftNIadiFyUl1x2TWxaADZ',
                 'skus': '',
-                'dynamic_payment_methods_enabled': False,
+                'dynamic_payment_methods_enabled': 'false',
             },
         )
         assert response.status_code == 302
@@ -492,7 +492,7 @@ class StripeCheckoutViewTests(PaymentEventsMixin, TestCase):
                 {
                     'payment_intent_id': 'pi_3LsftNIadiFyUl1x2TWxaADZ',
                     'skus': 'totally_the_wrong_sku',
-                    'dynamic_payment_methods_enabled': False,
+                    'dynamic_payment_methods_enabled': 'false',
                 },
             )
             assert response.json() == {'sku_error': True}
@@ -519,7 +519,7 @@ class StripeCheckoutViewTests(PaymentEventsMixin, TestCase):
                 {
                     'payment_intent_id': 'pi_3LsftNIadiFyUl1x2TWxaADZ',
                     'skus': basket.lines.first().stockrecord.partner_sku,
-                    'dynamic_payment_methods_enabled': False,
+                    'dynamic_payment_methods_enabled': 'false',
                 },
             )
             assert response.status_code == 400
@@ -537,7 +537,7 @@ class StripeCheckoutViewTests(PaymentEventsMixin, TestCase):
             {
                 'payment_intent_id': 'pi_3LsftNIadiFyUl1x2TWxaADZ',
                 'skus': basket.lines.first().stockrecord.partner_sku,
-                'dynamic_payment_methods_enabled': True,
+                'dynamic_payment_methods_enabled': 'true',
             },
             in_progress_payment=True,
         )
@@ -558,7 +558,7 @@ class StripeCheckoutViewTests(PaymentEventsMixin, TestCase):
             {
                 'payment_intent_id': 'pi_3LsftNIadiFyUl1x2TWxaADZ',
                 'skus': basket.lines.first().stockrecord.partner_sku,
-                'dynamic_payment_methods_enabled': False,
+                'dynamic_payment_methods_enabled': 'false',
             },
             confirm_side_effect=stripe.error.CardError('Oops!', {}, 'card_declined'),
         )
@@ -579,7 +579,7 @@ class StripeCheckoutViewTests(PaymentEventsMixin, TestCase):
                 {
                     'payment_intent_id': 'pi_3LsftNIadiFyUl1x2TWxaADZ',
                     'skus': basket.lines.first().stockrecord.partner_sku,
-                    'dynamic_payment_methods_enabled': False,
+                    'dynamic_payment_methods_enabled': 'false',
                 },
             )
             assert response.status_code == 400


### PR DESCRIPTION
[REV-4019](https://2u-internal.atlassian.net/browse/REV-4019).

This PR uncomments and updates the `Stripe` class tests, and I also updates the `StripeCheckoutView` test to assert the processor response is recorded. Keeping both types of tests so it's clear we have tests for both classes, even though they overlap.

I am also updating `handle_processor_response` to convert a `'true'/'false'` value to Python bool, since this value comes from the frontend as a string. The current code does not cause an issue in production even though the check is not being used as expected, since there are no Payment Intents with status 'requires_action' yet, we are not using the Dynamic Payment Methods flow yet.