### PR TITLE
fix: Update Stripe DPM check in handle_processor_response

### DIFF
--- a/ecommerce/extensions/payment/processors/stripe.py
+++ b/ecommerce/extensions/payment/processors/stripe.py
@@ -276,7 +276,7 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
         # pretty sure we should simply return/error if basket is None, as not
         # sure what it would mean if there
         payment_intent_id = response.get('payment_intent_id', None)
-        dynamic_payment_methods_enabled = response.get('dynamic_payment_methods_enabled', None) == 'true'
+        dynamic_payment_methods_enabled = response.get('dynamic_payment_methods_enabled', None)
         # NOTE: In the future we may want to get/create a Customer. See https://stripe.com/docs/api#customers.
 
         # rewrite order amount so it's updated for coupon & quantity and unchanged by the user

--- a/ecommerce/extensions/payment/processors/stripe.py
+++ b/ecommerce/extensions/payment/processors/stripe.py
@@ -303,11 +303,12 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
 
         logger.info(
             'Confirmed Stripe payment intent [%s] for basket [%d] and order number [%s], '
-            'with dynamic_payment_methods_enabled [%s].',
+            'with dynamic_payment_methods_enabled [%s] and status [%s].',
             payment_intent_id,
             basket.id,
             basket.order_number,
-            dynamic_payment_methods_enabled
+            dynamic_payment_methods_enabled,
+            confirm_api_response['status']
         )
 
         # If the payment has another status other than 'succeeded', we want to return to the MFE something it can handle

--- a/ecommerce/extensions/payment/processors/stripe.py
+++ b/ecommerce/extensions/payment/processors/stripe.py
@@ -301,25 +301,33 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
             logger.exception('Card Error for basket [%d]: %s}', basket.id, err)
             raise
 
+        logger.info(
+            'Confirmed Stripe payment intent [%s] for basket [%d] and order number [%s], '
+            'with dynamic_payment_methods_enabled [%s].',
+            payment_intent_id,
+            basket.id,
+            basket.order_number,
+            dynamic_payment_methods_enabled
+        )
+
         # If the payment has another status other than 'succeeded', we want to return to the MFE something it can handle
-        if dynamic_payment_methods_enabled:
-            if confirm_api_response['status'] == 'requires_action':
-                return InProgressProcessorResponse(
-                    basket_id=basket.id,
-                    order_number=basket.order_number,
-                    status=confirm_api_response['status'],
-                    confirmation_client_secret=confirm_api_response['client_secret'],
-                    transaction_id=confirm_api_response['id'],
-                    payment_method=confirm_api_response['payment_method'],
-                    total=confirm_api_response['amount'],
-                )
+        if confirm_api_response['status'] == 'requires_action':
+            return InProgressProcessorResponse(
+                basket_id=basket.id,
+                order_number=basket.order_number,
+                status=confirm_api_response['status'],
+                confirmation_client_secret=confirm_api_response['client_secret'],
+                transaction_id=confirm_api_response['id'],
+                payment_method=confirm_api_response['payment_method'],
+                total=confirm_api_response['amount'],
+            )
 
         # proceed only if payment went through
         assert confirm_api_response['status'] == "succeeded"
         self.record_processor_response(confirm_api_response, transaction_id=payment_intent_id, basket=basket)
 
         logger.info(
-            'Successfully confirmed Stripe payment intent [%s] for basket [%d] and order number [%s].',
+            'Confirmed Stripe payment intent with succeeded status [%s] for basket [%d] and order number [%s].',
             payment_intent_id,
             basket.id,
             basket.order_number,

--- a/ecommerce/extensions/payment/tests/views/test_stripe.py
+++ b/ecommerce/extensions/payment/tests/views/test_stripe.py
@@ -552,11 +552,12 @@ class StripeCheckoutViewTests(PaymentEventsMixin, TestCase):
             expected_log = (
                 'INFO:ecommerce.extensions.payment.processors.stripe:'
                 'Confirmed Stripe payment intent [{}] for basket [{}] and order number [{}], '
-                'with dynamic_payment_methods_enabled [{}].'.format(
+                'with dynamic_payment_methods_enabled [{}] and status [{}].'.format(
                     payment_intent_id,
                     basket.id,
                     basket.order_number,
-                    dynamic_payment_methods_enabled
+                    dynamic_payment_methods_enabled,
+                    response.json()['status']
                 )
             )
             actual_log = log.output[6]


### PR DESCRIPTION
[REV-4019](https://2u-internal.atlassian.net/browse/REV-4019).

Locally, this is the data sent from the MFE
`{'payment_intent_id': 'pi_3PC2r5H4caH7G0X10gjfcFiy', 'skus': '8CF08E5', 'dynamic_payment_methods_enabled': 'true'}`

With content sent from the MFE as `application/x-www-form-urlencoded`, the Javascript boolean will be converted to a string representation of true/false in the backend, but we're having unexpected results, always evaluating to False.

I am removing the boolean conversion for this check and adding logs. I don't see an issue with this since on the `assert status == 'succeeded'` it will error if the status is anything other than `succeeded` or in the previous check `'requires_action'`.  This was added initially as a guard to prevent from getting into the DPM flow while the experiment is off.