### PR TITLE
fix: Update existing Payment Intent on every capture-context call

### DIFF
--- a/ecommerce/extensions/payment/processors/stripe.py
+++ b/ecommerce/extensions/payment/processors/stripe.py
@@ -207,7 +207,12 @@ class Stripe(ApplePayMixin, BaseClientSidePaymentProcessor):
                     # This includes canceled status, since if one is create with idempotency key for an existing
                     # payment with canceled status, it will not create a new Payment Intent.
                     stripe_response = self.cancel_and_create_new_payment_intent_for_basket(basket, payment_intent_id)
-
+                else:
+                    # Update the Payment Intent with the latest item in the cart
+                    stripe.PaymentIntent.modify(
+                        payment_intent_id,
+                        **self._build_payment_intent_parameters(basket),
+                    )
                 # If a Payment Intent exists in a confirmable status, it will skip the below else statement,
                 # aka not create another intent with the idempotency key this time around.
 


### PR DESCRIPTION
[REV-4034](https://2u-internal.atlassian.net/browse/REV-4034).

This is already done on the POST method, but we need to do this as well on the `/capture-context` call every time the checkout page is loaded to make sure the Payment Intent has the updated amount, since this is used to show BNPL Affirm or not (based on a range set by Affirm).