### PR TITLE
feat: Merged basket creation and checkout in one View

### DIFF
--- a/ecommerce/extensions/iap/api/v1/constants.py
+++ b/ecommerce/extensions/iap/api/v1/constants.py
@@ -1,6 +1,7 @@
 """ Constants for iap extension apis v1 """
 
 COURSE_ADDED_TO_BASKET = "Course added to the basket successfully"
+COURSE_ADDED_AND_CHECKED_OUT_BASKET = "Course added to the basket and basket checked out successfully"
 COURSE_ALREADY_PAID_ON_DEVICE = "The course upgrade has already been paid for by the user."
 DISABLE_REDUNDANT_PAYMENT_CHECK_MOBILE_SWITCH_NAME = "disable_redundant_payment_check_for_mobile"
 ERROR_ALREADY_PURCHASED = "You have already purchased these products"

--- a/ecommerce/extensions/iap/api/v1/urls.py
+++ b/ecommerce/extensions/iap/api/v1/urls.py
@@ -2,9 +2,9 @@ from django.conf.urls import url
 
 from ecommerce.extensions.iap.api.v1.views import (
     AndroidRefundView,
-    MobileBasketCheckoutView,
     IOSRefundView,
     MobileBasketAddItemsView,
+    MobileBasketCheckoutView,
     MobileCheckoutView,
     MobileCoursePurchaseExecutionView,
     MobileSkusCreationView

--- a/ecommerce/extensions/iap/api/v1/urls.py
+++ b/ecommerce/extensions/iap/api/v1/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import url
 
 from ecommerce.extensions.iap.api.v1.views import (
     AndroidRefundView,
-    BasketCheckoutView,
+    MobileBasketCheckoutView,
     IOSRefundView,
     MobileBasketAddItemsView,
     MobileCheckoutView,
@@ -11,7 +11,7 @@ from ecommerce.extensions.iap.api.v1.views import (
 )
 
 urlpatterns = [
-    url(r'^basket-checkout/$', BasketCheckoutView.as_view(), name='mobile-basket-checkout'),
+    url(r'^basket-checkout/$', MobileBasketCheckoutView.as_view(), name='mobile-basket-checkout'),
     url(r'^basket/add/$', MobileBasketAddItemsView.as_view(), name='mobile-basket-add'),
     url(r'^checkout/$', MobileCheckoutView.as_view(), name='iap-checkout'),
     url(r'^execute/$', MobileCoursePurchaseExecutionView.as_view(), name='iap-execute'),

--- a/ecommerce/extensions/iap/api/v1/urls.py
+++ b/ecommerce/extensions/iap/api/v1/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import url
 
 from ecommerce.extensions.iap.api.v1.views import (
     AndroidRefundView,
+    BasketCheckoutView,
     IOSRefundView,
     MobileBasketAddItemsView,
     MobileCheckoutView,
@@ -10,6 +11,7 @@ from ecommerce.extensions.iap.api.v1.views import (
 )
 
 urlpatterns = [
+    url(r'^basket-checkout/$', BasketCheckoutView.as_view(), name='mobile-basket-checkout'),
     url(r'^basket/add/$', MobileBasketAddItemsView.as_view(), name='mobile-basket-add'),
     url(r'^checkout/$', MobileCheckoutView.as_view(), name='iap-checkout'),
     url(r'^execute/$', MobileCoursePurchaseExecutionView.as_view(), name='iap-execute'),

--- a/ecommerce/extensions/iap/api/v1/views.py
+++ b/ecommerce/extensions/iap/api/v1/views.py
@@ -166,7 +166,7 @@ class MobileBasketAddItemsView(BasketLogicMixin, APIView):
         return available_products
 
 
-class BasketCheckoutView(MobileBasketAddItemsView):
+class MobileBasketCheckoutView(MobileBasketAddItemsView):
 
     permission_classes = (IsAuthenticated,)
 


### PR DESCRIPTION
# ⛔️ MAIN BRANCH WARNING! 2U EMPLOYEES must make branches against the 2u/main BRANCH

- [ ] I have checked the branch to which I would like to merge.

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description
Merged basket creation and checkout in one View. This view will now accept product sku and payment processor name and will return a checkout out basket id. After this call we can now move on with payment execution.


## Supporting information
https://2u-internal.atlassian.net/browse/LEARNER-9913

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
