### PR TITLE
fix: Fix iOS redundant payment error

### DIFF
--- a/ecommerce/extensions/iap/api/v1/ios_validator.py
+++ b/ecommerce/extensions/iap/api/v1/ios_validator.py
@@ -19,7 +19,7 @@ class IOSValidator:
         try:
             validation_result = validator.validate(
                 receipt.get('purchase_token', receipt.get('purchaseToken')),
-                exclude_old_transactions=False  # if True, include only the latest renewal transaction
+                exclude_old_transactions=True  # if True, include only the latest renewal transaction
             )
         except InAppPyValidationError as ex:
             # handle validation error

--- a/ecommerce/extensions/iap/processors/base_iap.py
+++ b/ecommerce/extensions/iap/processors/base_iap.py
@@ -179,7 +179,7 @@ class BaseIAP(BasePaymentProcessor):
         purchases = response['receipt'].get('in_app', [])
         for purchase in purchases:
             if purchase['product_id'] == product_id and \
-                    response['receipt']['receipt_creation_date_ms'] == purchase['purchase_date_ms']:
+                    response['receipt']['original_purchase_date_ms'] == purchase['original_purchase_date_ms']:
 
                 response['receipt']['in_app'] = [purchase]
                 break

--- a/ecommerce/extensions/iap/tests/processors/test_ios_iap.py
+++ b/ecommerce/extensions/iap/tests/processors/test_ios_iap.py
@@ -78,7 +78,7 @@ class IOSIAPTests(PaymentProcessorTestCaseMixin, TestCase):
                         'in_app_ownership_type': 'PURCHASED',
                         'original_transaction_id': 'old_purchase_id',
                         'product_id': 'org.edx.mobile.test_product3',
-                        'purchase_date_ms': '1676562544000',
+                        'purchase_date_ms': '1676562978000',
                         'transaction_id': 'old_purchase_id'
                     },
                     {
@@ -86,10 +86,12 @@ class IOSIAPTests(PaymentProcessorTestCaseMixin, TestCase):
                         'original_transaction_id': 'original_test_id',
                         'product_id': self.product_sku,
                         'purchase_date_ms': '1676562978000',
+                        'original_purchase_date_ms': '1676562978005',
                         'transaction_id': 'test_id'
                     }
                 ],
                 'receipt_creation_date_ms': '1676562978000',
+                'original_purchase_date_ms': '1676562978005'
             }
         }
         self.transaction_id = self.mock_validation_response['receipt']['in_app'][2]['transaction_id']


### PR DESCRIPTION
LEARNER-9999

# ⛔️ MAIN BRANCH WARNING! 2U EMPLOYEES must make branches against the 2u/main BRANCH

- [x] I have checked the branch to which I would like to merge.

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

iOS users are facing issue where they can't enroll into a course after payment. This is happening to some users because of date mismatch in iOS receipt. This fix has changed date matching attribute from 'receipt_creation_date_ms' to original_purchase_date_ms' which is the correct way to match transaction.
.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.

## Supporting information

Jira Ticket: https://2u-internal.atlassian.net/browse/LEARNER-9999

## Testing instructions

Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
