### PR TITLE
fix: replace deprecated github actions

### DIFF
--- a/.github/workflows/migrations-mysql8.yml
+++ b/.github/workflows/migrations-mysql8.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache-dir
       run: |
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
     - name: Cache pip dependencies
       id: cache-dependencies
       uses: actions/cache@v2


### PR DESCRIPTION
## Description
Github actions set-output is deprecated hence this PR replaces that according to the updated documentation