### PR TITLE
fix: Replace newrelic ignore_transaction with edx_django_utils monitoring

### DIFF
--- a/ecommerce/core/tests/test_views.py
+++ b/ecommerce/core/tests/test_views.py
@@ -26,11 +26,11 @@ class HealthTests(TestCase):
         """Test that the endpoint reports when all services are healthy."""
         self._assert_health(status.HTTP_200_OK, Status.OK, Status.OK)
 
-    @mock.patch('newrelic.agent')
-    def test_health_check_is_ignored_by_new_relic(self, mock_newrelic_agent):
-        """Test that the health endpoint is ignored by NewRelic"""
+    @mock.patch('ecommerce.core.views.ignore_transaction')
+    def test_health_check_is_ignored(self, mock_ignore_transaction):
+        """Test that the health endpoint is ignored in performance monitoring"""
         self._assert_health(status.HTTP_200_OK, Status.OK, Status.OK)
-        self.assertTrue(mock_newrelic_agent.ignore_transaction.called)
+        self.assertTrue(mock_ignore_transaction.called)
 
     @mock.patch('django.contrib.sites.middleware.get_current_site', mock.Mock(return_value=None))
     @mock.patch('django.db.backends.base.base.BaseDatabaseWrapper.cursor', mock.Mock(side_effect=DatabaseError))

--- a/ecommerce/core/views.py
+++ b/ecommerce/core/views.py
@@ -13,13 +13,9 @@ from django.http import Http404, JsonResponse
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
 from django.views.generic import View
+from edx_django_utils.monitoring import ignore_transaction
 
 from ecommerce.core.constants import Status
-
-try:
-    import newrelic.agent
-except ImportError:  # pragma: no cover
-    newrelic = None  # pylint: disable=invalid-name
 
 logger = logging.getLogger(__name__)
 User = get_user_model()
@@ -44,8 +40,8 @@ def health(_):
         >>> response.content
         '{"overall_status": "OK", "detailed_status": {"database_status": "OK"}}'
     """
-    if newrelic:  # pragma: no cover
-        newrelic.agent.ignore_transaction()
+    # Ignores health check in performance monitoring so as to not artifically inflate our response time metrics
+    ignore_transaction()
 
     overall_status = database_status = Status.UNAVAILABLE
 


### PR DESCRIPTION
[REV-4059](https://2u-internal.atlassian.net/browse/REV-4059).

We use the `newrelic` package in ecommerce for telemetry purposes, specifically 2 methods: `ignore_transaction` and `function_trace`. Now that we've migrated to Datadog, we should use `edx_django_utils.monitoring` instead.

Separating this change in 2 separate PRs for easier/contained monitoring.
Other PR for `function_trace` - https://github.com/openedx/ecommerce/pull/4175

