### PR TITLE
fix: Replace newrelic function_trace with edx_django_utils monitoring

### DIFF
--- a/ecommerce/extensions/basket/middleware.py
+++ b/ecommerce/extensions/basket/middleware.py
@@ -1,6 +1,5 @@
 
 
-import newrelic.agent
 from edx_django_utils import monitoring as monitoring_utils
 from oscar.apps.basket.middleware import BasketMiddleware as OscarBasketMiddleware
 from oscar.core.loading import get_model
@@ -81,6 +80,6 @@ class BasketMiddleware(OscarBasketMiddleware):
 
         return basket
 
-    @newrelic.agent.function_trace()
+    @monitoring_utils.function_trace('apply_offers_to_basket')
     def apply_offers_to_basket(self, request, basket):
         apply_offers_on_basket(request, basket)


### PR DESCRIPTION
[REV-4059](https://2u-internal.atlassian.net/browse/REV-4059).

We use the `newrelic` package in ecommerce for telemetry purposes, specifically 2 methods: `ignore_transaction` and `function_trace`. Now that we've migrated to Datadog, we should use `edx_django_utils.monitoring` instead.

Separating this change in 2 separate PRs for easier/contained monitoring.