### PR TITLE
Fix: Sync mobile seats expiry and price with web seat

### DIFF
--- a/ecommerce/extensions/iap/management/commands/sync_mobile_seats_price_and_expiry_with_web.py
+++ b/ecommerce/extensions/iap/management/commands/sync_mobile_seats_price_and_expiry_with_web.py
@@ -1,0 +1,54 @@
+"""
+This command sync mobile seat price and expiry with web seat price and expiry.
+"""
+import logging
+
+from django.core.management import BaseCommand
+
+from ecommerce.core.constants import SEAT_PRODUCT_CLASS_NAME
+from ecommerce.courses.constants import CertificateType
+from ecommerce.extensions.catalogue.models import Product
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Sync expiry and price of mobile seats with respective web seat.
+    """
+
+    help = 'Sync expiry and price of mobile seats with respective web seat.'
+
+    def handle(self, *args, **options):
+        mobile_enabled_products = Product.objects.filter(
+            structure=Product.PARENT,
+            product_class__name=SEAT_PRODUCT_CLASS_NAME,
+            children__attribute_values__attribute__name="certificate_type",
+            children__attribute_values__value_text=CertificateType.VERIFIED,
+            children__stockrecords__isnull=False,
+            children__stockrecords__partner_sku__icontains="mobile",
+        ).distinct()
+
+        for product in mobile_enabled_products:
+            mobile_seats = Product.objects.filter(
+                parent=product,
+                attribute_values__attribute__name="certificate_type",
+                attribute_values__value_text=CertificateType.VERIFIED,
+                stockrecords__partner_sku__icontains="mobile",
+            )
+
+            web_seat = Product.objects.filter(
+                parent=product,
+                attribute_values__attribute__name="certificate_type",
+                attribute_values__value_text=CertificateType.VERIFIED,
+            ).exclude(stockrecords__partner_sku__icontains="mobile").first()
+
+            for mobile_seat in mobile_seats:
+                info = 'Syncing {} with {}'.format(mobile_seat.title, web_seat.title)
+                logger.info(info)
+
+                stock_record = mobile_seat.stockrecords.all()[0]
+                stock_record.price_excl_tax = web_seat.stockrecords.all()[0].price_excl_tax
+                mobile_seat.expires = web_seat.expires
+                stock_record.save()
+                mobile_seat.save()

--- a/ecommerce/extensions/iap/management/commands/tests/test_sync_mobile_seats_price_and_expiry_with_web.py
+++ b/ecommerce/extensions/iap/management/commands/tests/test_sync_mobile_seats_price_and_expiry_with_web.py
@@ -1,0 +1,49 @@
+"""Tests for the sync_mobile_seats_price_and_expiry_with_web command"""
+from datetime import datetime
+
+from django.core.management import call_command
+
+from ecommerce.extensions.iap.management.commands.tests.testutils import BaseIAPManagementCommandTests
+
+
+class SyncMobileSeatsTests(BaseIAPManagementCommandTests):
+    """
+    Tests for the sync_mobile_seats_price_and_expiry_with_web command.
+    """
+    def setUp(self):
+        super().setUp()
+        self.command = 'sync_mobile_seats_price_and_expiry_with_web'
+        self.course_with_all_seats = self.create_course_and_seats(create_mobile_seats=True, create_web_seat=True)
+        self.course_with_web_seat_only = self.create_course_and_seats(create_mobile_seats=False, create_web_seat=True)
+        self.course_with_audit_seat = self.create_course_and_seats(create_mobile_seats=False, create_web_seat=False)
+        self.course_with_unsync_seats = self.create_course_and_seats(create_mobile_seats=True, create_web_seat=True)
+        self.course_with_unsync_seats2 = self.create_course_and_seats(create_mobile_seats=True, create_web_seat=True)
+        mobile_seats = self.get_mobile_seats_for_course(self.course_with_unsync_seats)
+        mobile_seats = list(mobile_seats) + list(self.get_mobile_seats_for_course(self.course_with_unsync_seats2))
+
+        for mobile_seat in mobile_seats:
+            mobile_seat.expiry = datetime.now()
+            mobile_seat.save()
+
+            stockrecord = mobile_seat.stockrecords.all()[0]
+            stockrecord.price_excl_tax += 10
+            stockrecord.save()
+
+    def test_sync_mobile_seat(self):
+        web_seat = self.get_web_seat_for_course(self.course_with_unsync_seats)
+        web_seat_expiry = web_seat.expires
+        web_seat_price = web_seat.stockrecords.all()[0].price_excl_tax
+
+        web_seat = self.get_web_seat_for_course(self.course_with_unsync_seats2)
+        web_seat_expiry2 = web_seat.expires
+        web_seat_price2 = web_seat.stockrecords.all()[0].price_excl_tax
+
+        call_command(self.command)
+        self.verify_course_seats_update(self.course_with_unsync_seats, web_seat_expiry, web_seat_price)
+        self.verify_course_seats_update(self.course_with_unsync_seats2, web_seat_expiry2, web_seat_price2)
+
+    def verify_course_seats_update(self, course, expiry, price):
+        mobile_seats = self.get_mobile_seats_for_course(course)
+        for mobile_seat in mobile_seats:
+            assert mobile_seat.expires == expiry
+            assert mobile_seat.stockrecords.all()[0].price_excl_tax == price

--- a/ecommerce/extensions/iap/management/commands/tests/testutils.py
+++ b/ecommerce/extensions/iap/management/commands/tests/testutils.py
@@ -1,0 +1,90 @@
+""" Test utilities for iap management commands """
+from decimal import Decimal
+
+from django.utils.timezone import now, timedelta
+
+from ecommerce.courses.constants import CertificateType
+from ecommerce.courses.tests.factories import CourseFactory
+from ecommerce.extensions.catalogue.models import Product
+from ecommerce.extensions.catalogue.tests.mixins import DiscoveryTestMixin
+from ecommerce.extensions.partner.models import StockRecord
+from ecommerce.tests.testcases import TransactionTestCase
+
+ANDROID_SKU_PREFIX = 'android'
+IOS_SKU_PREFIX = 'ios'
+
+
+class BaseIAPManagementCommandTests(DiscoveryTestMixin, TransactionTestCase):
+    """
+    Base class for iap management commands.
+    """
+    def create_course_and_seats(self, create_mobile_seats=False, expired_in_past=False, create_web_seat=True):
+        """
+        Create the specified number of courses with audit and verified seats. Create mobile seats
+        if specified.
+        """
+        course = CourseFactory(partner=self.partner)
+        course.create_or_update_seat('audit', False, 0)
+        if create_web_seat:
+            verified_seat = course.create_or_update_seat('verified', True, Decimal(10.0))
+            verified_seat.title = (
+                f'Seat in {course.name} with verified certificate (and ID verification)'
+            )
+            expires = now() - timedelta(days=10) if expired_in_past else now() + timedelta(days=10)
+            verified_seat.expires = expires
+            verified_seat.save()
+            if create_mobile_seats:
+                self.create_mobile_seat_for_course(course, ANDROID_SKU_PREFIX)
+                self.create_mobile_seat_for_course(course, IOS_SKU_PREFIX)
+
+        return course
+
+    def create_mobile_seat_for_course(self, course, sku_prefix):
+        """ Create a mobile seat for a course given the sku_prefix """
+        web_seat = self.get_web_seat_for_course(course)
+        web_stock_record = web_seat.stockrecords.first()
+        mobile_seat = Product.objects.create(
+            course=course,
+            parent=web_seat.parent,
+            structure=web_seat.structure,
+            expires=web_seat.expires,
+            is_public=web_seat.is_public,
+            title="{} {}".format(sku_prefix.capitalize(), web_seat.title.lower())
+        )
+
+        mobile_seat.attr.certificate_type = web_seat.attr.certificate_type
+        mobile_seat.attr.course_key = web_seat.attr.course_key
+        mobile_seat.attr.id_verification_required = web_seat.attr.id_verification_required
+        mobile_seat.attr.save()
+
+        StockRecord.objects.create(
+            partner=web_stock_record.partner,
+            product=mobile_seat,
+            partner_sku="mobile.{}.{}".format(sku_prefix.lower(), web_stock_record.partner_sku.lower()),
+            price_currency=web_stock_record.price_currency,
+            price_excl_tax=100
+        )
+        return mobile_seat
+
+    @staticmethod
+    def get_web_seat_for_course(course):
+        """ Get the default seat created for web for a course """
+        return Product.objects.filter(
+            parent__isnull=False,
+            course=course,
+            attributes__name="id_verification_required",
+            parent__product_class__name="Seat"
+        ).exclude(stockrecords__partner_sku__icontains="mobile").first()
+
+    @staticmethod
+    def get_mobile_seats_for_course(course):
+        """ Get mobile seats created for a course """
+        return Product.objects.filter(
+            parent__isnull=False,
+            course=course,
+            parent__product_class__name="Seat",
+            attribute_values__attribute__name="certificate_type",
+            attribute_values__value_text=CertificateType.VERIFIED,
+            stockrecords__isnull=False,
+            stockrecords__partner_sku__icontains="mobile",
+        )


### PR DESCRIPTION
LEARNER-10092

# ⛔️ MAIN BRANCH WARNING! 2U EMPLOYEES must make branches against the 2u/main BRANCH

- [ ] I have checked the branch to which I would like to merge.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Mobile seats are not syncing with any price or expiry change from discovery, therefore we have created this command to sync those seats. Meanwhile mobile team is working on how to fix this issue, we need to update already not synced mobile seats.

Useful information to include:
This change will effect mobile users only.

## Supporting information

Jira Ticket: https://2u-internal.atlassian.net/browse/LEARNER-10092
