### PR TITLE
fix: Remove redundant apple date match check

### DIFF
--- a/ecommerce/extensions/iap/processors/base_iap.py
+++ b/ecommerce/extensions/iap/processors/base_iap.py
@@ -178,8 +178,7 @@ class BaseIAP(BasePaymentProcessor):
         """
         purchases = response['receipt'].get('in_app', [])
         for purchase in purchases:
-            if purchase['product_id'] == product_id and \
-                    response['receipt']['original_purchase_date_ms'] == purchase['original_purchase_date_ms']:
+            if purchase['product_id'] == product_id:
 
                 response['receipt']['in_app'] = [purchase]
                 break


### PR DESCRIPTION
# ⛔️ MAIN BRANCH WARNING! 2U EMPLOYEES must make branches against the 2u/main BRANCH

- [x] I have checked the branch to which I would like to merge.

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Remove redundant apple date match check. This was an extra check, previously when it was added we had matching values in receipts. But upon further exploring it is found that we can not rely on this field.

Useful information to include:
This will impact ios users who made payments through mobile, their payments will go through after this fix.

## Supporting information

https://2u-internal.atlassian.net/browse/LEARNER-10134

